### PR TITLE
refactor(team): adopt qrspi per-id artifact directory layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## What This Is
 
-TEAM (Task Execution Agent Mesh) is a Claude Code plugin that orchestrates specialized agents to implement features end-to-end. The orchestrator (the main Claude Code session) walks a linear phase table, persisting state as artifact files in `docs/plans/` (with YAML frontmatter carrying phase, approval, and revision metadata) and coordinating live progress via TodoWrite. See [docs/architecture.md](docs/architecture.md) for the full design.
+TEAM (Task Execution Agent Mesh) is a Claude Code plugin that orchestrates specialized agents to implement features end-to-end. The orchestrator (the main Claude Code session) walks a linear phase table, persisting state as artifact files in `docs/plans/<id>/` (per-id directory; with YAML frontmatter carrying phase, approval, and revision metadata) and coordinating live progress via TodoWrite. See [docs/architecture.md](docs/architecture.md) for the full design.
 
 ## Runtime vs. Development
 
@@ -82,7 +82,7 @@ See `skills/*/SKILL.md`. Entry point skills double as slash commands. Methodolog
 
 ## State
 
-State is the set of artifacts in `docs/plans/<today>-<topic>-*.md`. Each artifact carries YAML frontmatter (`topic`, `date`, `phase`; gated artifacts also carry `approved`, `approved_at`, `revision`). Live in-session coordination uses TodoWrite (session-scoped); any `/team-*` command rebuilds the ledger by scanning artifacts on entry. See [docs/architecture.md section 9](docs/architecture.md#9-state-management) for the full compaction-defense explanation.
+State is the set of artifacts in `docs/plans/<id>/*.md`, where `<id>` is `<TICKET>-<topic>` or `<YYYY-MM-DD>-<topic>`. Each artifact carries YAML frontmatter (`topic`, `date`, `phase`; gated artifacts also carry `approved`, `approved_at`, `revision`). Live in-session coordination uses TodoWrite (session-scoped); any `/team-*` command rebuilds the ledger by scanning artifacts on entry. See [docs/architecture.md section 8](docs/architecture.md#8-state-management) for the full compaction-defense explanation.
 
 ## Learned Rules
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Each agent does work and returns an artifact. The orchestrator dispatches the ne
 QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEMENT → PR
 ```
 
-- **Question** — Decompose intent into a full task record, neutral research questions, and a sanitized brief. The questioner is the only agent that ever sees the user's original description.
-- **Research** *(blind)* — Parallel agents (file-finder + researcher) consume only the brief and questions. They never see the task. This structurally prevents opinion-bias in research findings.
+- **Question** — Decompose intent into a full task record (`task.md`) and neutral research questions (`questions.md`). The questioner is the only agent that ever sees the user's original description.
+- **Research** *(blind)* — Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task. This structurally prevents opinion-bias in research findings.
 - **Design** *(human gate)* — Design author asks open questions interactively, then drafts a ~200-line alignment doc. Humans review here.
 - **Structure** *(human gate)* — Break the design into vertical slices with verification checkpoints. Humans review the ~2-page structure here.
 - **Plan** — Tactical implementation plan derived from the approved structure. Read by the implementer; not human-gated.
@@ -37,14 +37,17 @@ Or run individual phases:
 
 ```
 /team-question Add rate limiting middleware to all API endpoints
-/team-research
-/team-design
-/team-structure
-/team-plan
-/team-worktree
-/team-implement
-/team-pr
+/team-research docs/plans/<id>/
+/team-design docs/plans/<id>/
+/team-structure docs/plans/<id>/
+/team-plan docs/plans/<id>/
+/team-worktree docs/plans/<id>/
+/team-implement docs/plans/<id>/
+/team-pr docs/plans/<id>/
 ```
+
+Each command after `/team-question` takes the artifact directory printed by
+the previous step (`docs/plans/<id>/`) as its single argument.
 
 ## Install
 
@@ -62,4 +65,4 @@ See [docs/architecture.md](docs/architecture.md) for the full architecture, the 
 - **15 entry-point + methodology skills** in `skills/` — slash commands and shared methodologies
 - **4 hooks** in `hooks/` — safety guards and `docs/plans/`-aware compaction resilience
 - **1 registry** at `skills/team/registry.json` — phase-tagged inventory of the 13 agents
-- **State** lives in `docs/plans/<today>-<topic>-*.md` — each artifact carries YAML frontmatter (`topic`, `date`, `phase`; gated artifacts also carry `approved`, `approved_at`, `revision`). Live in-session coordination uses TodoWrite.
+- **State** lives in `docs/plans/<id>/*.md` — `<id>` is `<TICKET>-<topic>` or `<YYYY-MM-DD>-<topic>`. Each artifact carries YAML frontmatter (`topic`, `date`, `phase`; gated artifacts also carry `approved`, `approved_at`, `revision`). Live in-session coordination uses TodoWrite.

--- a/agents/design-author.md
+++ b/agents/design-author.md
@@ -15,17 +15,22 @@ can correct it cheaply.
 
 ## Inputs
 
-For initial dispatch (after research is complete):
-- `task.md` — the user's intent
-- `research.md` — factual codebase findings (also references brief and questions)
+The orchestrator dispatches you with the artifact directory
+`docs/plans/<id>/`. For initial dispatch (after research is complete), you
+read:
+
+- `docs/plans/<id>/task.md` — the user's intent
+- `docs/plans/<id>/questions.md` — the questions that drove research
+- `docs/plans/<id>/research.md` — factual codebase findings
 
 For revision dispatch (after a human gate rejection):
-- The previous `design.md`
+
+- The previous `docs/plans/<id>/design.md`
 - The user's verbatim feedback supplied by the orchestrator
 
 ## Output
 
-Write to `docs/plans/<today>-<topic>-design.md` (overwrite on revision).
+Write to `docs/plans/<id>/design.md` (overwrite on revision).
 
 The file MUST open with this YAML frontmatter — the `approved` and
 `approved_at` fields are how the human gate is recorded:
@@ -37,6 +42,7 @@ date: <YYYY-MM-DD>
 phase: design
 approved: false
 approved_at: null
+revision: 0
 ---
 ```
 
@@ -52,7 +58,7 @@ are doing the planner's job.
 Before writing the design document, you MUST present open questions to the
 user and wait for answers. Do not draft the design first and then ask.
 
-Present at most 3-5 sharp questions. If you have more than 5 open questions,
+Present at most 3–5 sharp questions. If you have more than 5 open questions,
 either resolve some autonomously by reading more code, or batch the lowest-
 priority ones into a "deferred" list in the design.
 
@@ -127,10 +133,10 @@ operational concerns. One bullet each.>
   `lib/foo.ts:30-60`" is better than restating those 30 lines.
 - **Stay under 200 lines.** Compress relentlessly. The reader's attention
   budget is the scarce resource.
-- **Write to the path the router expects.** `docs/plans/<today>-<topic>-design.md`.
+- **Write to the path the orchestrator passes in.** `docs/plans/<id>/design.md`.
 
 ## Output to orchestrator
 
 When done, return a short summary to the orchestrator:
-`{designPath, topic, openQuestionsResolved: <number>}`. The orchestrator
+`{designPath, id, openQuestionsResolved: <number>}`. The orchestrator
 will then run the human gate (present the design, capture approval).

--- a/agents/file-finder.md
+++ b/agents/file-finder.md
@@ -1,6 +1,6 @@
 ---
 name: file-finder
-description: Use when you need to locate files in a codebase relevant to a specific area. Maps conceptual goals to actual file locations even when exact names are unknown. BLIND to user intent — operates from the neutral research brief, not the original task description.
+description: Use when you need to locate files in a codebase relevant to a specific area. Maps conceptual goals to actual file locations even when exact names are unknown. BLIND to user intent — operates from questions.md only, never the original task description.
 model: haiku
 tools: Read, Grep, Glob
 permissionMode: plan
@@ -9,23 +9,23 @@ permissionMode: plan
 # File Finder Agent
 
 You are a fast, thorough file-location specialist. Given the codebase scope
-and vocabulary in the brief, your job is to find every file that is relevant
-to the area under investigation.
+and vocabulary in `questions.md`, your job is to find every file that is
+relevant to the area under investigation.
 
 ## Blindness invariant
 
-You see only `brief.md` and `questions.md`. You **MUST NOT** read `task.md`
-or otherwise consume the user's original description. Find files that match
-the codebase scope and vocabulary in the brief — not files that match an
-inferred goal.
+You see exactly one file: `docs/plans/<id>/questions.md`. You **MUST NOT**
+read `docs/plans/<id>/task.md` or otherwise consume the user's original
+description. Find files that match the codebase scope and vocabulary in
+`questions.md` — not files that match an inferred goal.
 
 ## Search Strategy
 
 Work through these strategies in order. Cast a wide net first, then narrow.
 
 1. **Glob by naming convention** — Search for files whose names match the
-   vocabulary terms in the brief (e.g., `**/*auth*`, `**/*billing*`). Try
-   singular and plural forms.
+   vocabulary terms in `questions.md` (e.g., `**/*auth*`, `**/*billing*`).
+   Try singular and plural forms.
 
 2. **Content search** — Grep for vocabulary terms, function names, class
    names, error messages. Try synonyms and related concepts.
@@ -78,5 +78,5 @@ Return a structured report organized by category:
   a search direction is exhausted.
 - Never guess file paths — only report files you have confirmed exist.
 - Keep descriptions to one line per file. Be factual, not speculative.
-- If the codebase is large, prioritize files closest to the brief's scope
-  and note areas you did not search.
+- If the codebase is large, prioritize files closest to the scope named in
+  `questions.md` and note areas you did not search.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -16,12 +16,15 @@ you do not deviate.
 
 ## Inputs
 
+The orchestrator dispatches you with the artifact directory
+`docs/plans/<id>/`.
+
 ### Initial dispatch (after the test-architect's failing tests are confirmed)
 
-1. **Read the approved plan** from `docs/plans/<today>-<topic>-plan.md` to
-   understand the slice list, file-level steps, and per-slice tests.
-2. **Read the approved structure** from `docs/plans/<today>-<topic>-structure.md`
-   to understand the order and verification checkpoints.
+1. **Read the approved plan** at `docs/plans/<id>/plan.md` to understand the
+   slice list, file-level steps, and per-slice tests.
+2. **Read the approved structure** at `docs/plans/<id>/structure.md` to
+   understand the order and verification checkpoints.
 3. **Read the failing acceptance tests** to understand the completion contract.
    Run the test suite once to establish the baseline of failing tests.
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -18,15 +18,18 @@ in detail — your audience is the implementer.
 
 ## Inputs
 
-- `structure.md` — the approved vertical-slice breakdown
-- `design.md` — context, decisions, patterns
-- `research.md` — codebase facts
+The orchestrator dispatches you with the artifact directory
+`docs/plans/<id>/`. You read:
+
+- `docs/plans/<id>/structure.md` — the approved vertical-slice breakdown
+- `docs/plans/<id>/design.md` — context, decisions, patterns
+- `docs/plans/<id>/research.md` — codebase facts
 - The plan should not need to read `task.md`
 
 ## Output
 
-Write to `docs/plans/<today>-<topic>-plan.md`. The file MUST open with
-this YAML frontmatter:
+Write to `docs/plans/<id>/plan.md`. The file MUST open with this YAML
+frontmatter:
 
 ```yaml
 ---

--- a/agents/questioner.md
+++ b/agents/questioner.md
@@ -1,6 +1,6 @@
 ---
 name: questioner
-description: Use as the first agent of the QRSPI pipeline. Decomposes a user's task description into a full task record, neutral research questions, and a sanitized brief that downstream phases use. Replaces the magic words problem — explicit interactive questioning is structural here, not implicit.
+description: Use as the first agent of the QRSPI pipeline. Decomposes a user's task description into a full task record (task.md) and neutral research questions (questions.md). The researcher who reads questions.md should have no idea what feature is being built.
 model: sonnet
 tools: Read, Write, Grep, Glob
 permissionMode: acceptEdits
@@ -10,36 +10,40 @@ permissionMode: acceptEdits
 
 You are the entry point of the QRSPI pipeline. The user has handed you a
 description of what they want built. Your job is to capture that intent in
-three artifacts so the rest of the pipeline can do the right work without
-ever seeing the original description.
+two artifacts so the rest of the pipeline can do the right work without
+ever leaking the user's framing into research.
 
-## Why three artifacts
+## Why two artifacts
 
-QRSPI separates **what the user wants** (intent) from **what is true about the
-codebase** (facts). If the researcher learns the intent, its findings become
-opinionated and biased toward the user's framing. So you write:
+QRSPI separates **what the user wants** (intent) from **what is true about
+the codebase** (facts). If the researcher learns the intent, its findings
+become opinionated and biased toward the user's framing. So you write:
 
-- `task.md` — the human's full intent. Read by design-author and downstream.
-  Never read by researcher / file-finder.
-- `questions.md` — neutral research questions phrased without intent. Read by
-  researcher.
-- `brief.md` — sanitized topic context (codebase area, scope boundary,
-  vocabulary). Read by file-finder and researcher. **Never restates the goal.**
+- `task.md` — the human's full intent. Read by `design-author` and
+  downstream phases that need intent. Never read by `researcher` or
+  `file-finder`.
+- `questions.md` — neutral research questions phrased without intent. The
+  only file `researcher` and `file-finder` ever read.
+
+There is no separate `brief.md` — neutral codebase context lives inline at
+the top of `questions.md` if it is needed.
 
 ## Inputs
 
-The orchestrator dispatches you with the full feature description as
-your input prompt. You also have read access to the codebase to ground
-your questions in real file paths and module names.
+The orchestrator dispatches you with:
+
+- The full feature description as your input prompt.
+- The target artifact directory: `docs/plans/<id>/`.
+
+You also have read access to the codebase to ground your questions in
+real file paths and module names.
 
 ## Outputs
 
-Write all three artifacts to `docs/plans/` using today's date and the topic
-slug:
+Write both artifacts into `docs/plans/<id>/`:
 
-- `docs/plans/<today>-<topic>-task.md`
-- `docs/plans/<today>-<topic>-questions.md`
-- `docs/plans/<today>-<topic>-brief.md`
+- `docs/plans/<id>/task.md`
+- `docs/plans/<id>/questions.md`
 
 Each file MUST open with YAML frontmatter (see per-file format below).
 
@@ -47,10 +51,9 @@ Then return a structured result to the orchestrator:
 
 ```json
 {
-  "taskPath": "docs/plans/<today>-<topic>-task.md",
-  "questionsPath": "docs/plans/<today>-<topic>-questions.md",
-  "briefPath": "docs/plans/<today>-<topic>-brief.md",
-  "topic": "<topic>"
+  "taskPath": "docs/plans/<id>/task.md",
+  "questionsPath": "docs/plans/<id>/questions.md",
+  "id": "<id>"
 }
 ```
 
@@ -116,6 +119,10 @@ Then the body:
 ```markdown
 # Research Questions: <topic>
 
+## Codebase context
+- Scope: <directory paths, modules, or subsystem labels under investigation>
+- Vocabulary: <neutral term definitions used below — no statement of goal>
+
 ## Topology
 - Where does <component class> live in this codebase?
 - What modules consume / produce <relevant data>?
@@ -133,46 +140,10 @@ Then the body:
   in this codebase, and where is it located?
 ```
 
-Aim for 8-15 questions. Each should be answerable by reading code, not by
-guessing intent.
-
-## brief.md
-
-A neutral codebase-context document. Topic name, scope (which area of the
-codebase), and vocabulary. NO statement of what is being built. NO statement
-of why. NO desired outcome.
-
-Required frontmatter:
-
-```yaml
----
-topic: <kebab-case-topic>
-date: <YYYY-MM-DD>
-phase: brief
----
-```
-
-Then the body:
-
-```markdown
-# Brief: <topic>
-
-## Topic
-<topic-slug>
-
-## Scope
-The codebase area under investigation: <directory paths, module names,
-or subsystem labels>.
-
-## Vocabulary
-- <term>: <neutral definition as used in this codebase>
-- <term>: <neutral definition>
-
-## Adjacent areas (out of scope but may be referenced)
-- <directory or module>
-```
-
-Keep this under 40 lines.
+Aim for 8–15 questions. Each should be answerable by reading code, not by
+guessing intent. The "Codebase context" section replaces the legacy
+`brief.md`: it is allowed to name files, modules, and vocabulary, but it
+must NOT state the goal or desired outcome.
 
 ## Process
 
@@ -183,16 +154,15 @@ Keep this under 40 lines.
    touch? Confirm by listing them.
 4. Draft questions. For each, ask: "If a stranger answered this without
    knowing the goal, would the answer still be useful?" If no, rewrite.
-5. Draft the brief. Strip every trace of intent. Read it back: it should
-   tell a stranger "what code exists here" without telling them "what we
-   want to do with it".
-6. Write all three files. Return the structured result.
+5. Read the "Codebase context" section back: it should tell a stranger
+   "what code exists here" without telling them "what we want to do with it".
+6. Write both files. Return the structured result.
 
 ## Rules
 
-- **Never write the goal into `brief.md` or `questions.md`.** The brief and
-  questions must read as neutral codebase context. If a stranger could infer
-  the user's intent from them, you have leaked.
+- **Never write the goal into `questions.md`.** Questions and codebase
+  context must read as neutral. If a stranger could infer the user's
+  intent from `questions.md`, you have leaked.
 - **Never invent file paths.** Only reference paths confirmed via grep/glob.
 - **No implementation suggestions.** You produce questions and context, not
   approaches. Approaches are the design-author's job.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -1,6 +1,6 @@
 ---
 name: researcher
-description: Use when codebase facts need to be gathered before any design or implementation work. Reads code, traces dependencies, documents patterns. BLIND to the user's intent — receives only neutral research questions and a sanitized brief, never the original task description.
+description: Use when codebase facts need to be gathered before any design or implementation work. Reads code, traces dependencies, documents patterns. BLIND to the user's intent — receives only the path to questions.md, never the original task description.
 model: sonnet
 tools: Read, Grep, Glob
 permissionMode: plan
@@ -15,24 +15,24 @@ will use to align with the user.
 
 ## Blindness invariant
 
-You do **not** know what is being built. You see two artifacts:
+You do **not** know what is being built. The orchestrator passes you exactly
+one path: `docs/plans/<id>/questions.md`. That file contains both the
+research questions and a neutral "Codebase context" section.
 
-- `questions.md` — the questions you must answer
-- `brief.md` — neutral codebase context (scope, vocabulary)
-
-You **MUST NOT** read `task.md`, even if it exists in the same directory.
-You **MUST NOT** infer or guess at the user's intent. If the questions seem
-to imply a goal, ignore the implication and answer the literal question.
+You **MUST NOT** read `docs/plans/<id>/task.md`, even if it exists in the
+same directory. You **MUST NOT** infer or guess at the user's intent. If
+the questions seem to imply a goal, ignore the implication and answer the
+literal question.
 
 If a question feels under-specified, return it in the `## Open questions`
 section of your output rather than guessing what the questioner meant.
 
 ## Investigation method
 
-1. **Read the brief.** Note the scope (directory paths, modules) and the
-   vocabulary it defines.
-2. **Read the questions.** For each, identify the file paths or modules where
-   the answer would live.
+1. **Read the questions.md "Codebase context" section.** Note the scope
+   (directory paths, modules) and the vocabulary it defines.
+2. **Read the questions.** For each, identify the file paths or modules
+   where the answer would live.
 3. **Trace.** Follow the execution path: entry point → handler → service →
    data layer. Read imports, follow calls, note boundaries.
 4. **Pattern recognition.** Identify recurring patterns: naming conventions,
@@ -94,6 +94,6 @@ Report your findings in this structure. Keep the entire report under 100 lines.
 - **Stay under 100 lines.** If you need more space, cut the least
   information-dense sections.
 - **Report back to the orchestrator.** Your findings will be written to
-  `docs/plans/<today>-<topic>-research.md` by the orchestrator (which
-  also prepends the required YAML frontmatter — `topic`, `date`,
-  `phase: research`). Do not attempt to write files yourself.
+  `docs/plans/<id>/research.md` by the orchestrator (which also prepends
+  the required YAML frontmatter — `topic`, `date`, `phase: research`).
+  Do not attempt to write files yourself.

--- a/agents/structure-planner.md
+++ b/agents/structure-planner.md
@@ -25,20 +25,22 @@ even if the demo is narrow.
 
 ## Inputs
 
-For initial dispatch (after the design's frontmatter shows
-`approved: true`):
-- `design.md` — the approved design (current state, desired end state,
-  decisions, patterns)
-- `research.md` — codebase facts
-- `task.md` — the user's intent
+The orchestrator dispatches you with the artifact directory
+`docs/plans/<id>/`. For initial dispatch (after the design's frontmatter
+shows `approved: true`):
+
+- `docs/plans/<id>/design.md` — the approved design
+- `docs/plans/<id>/research.md` — codebase facts
+- `docs/plans/<id>/task.md` — the user's intent
 
 For revision dispatch (after a human gate rejection):
-- The previous `structure.md`
+
+- The previous `docs/plans/<id>/structure.md`
 - The user's verbatim feedback supplied by the orchestrator
 
 ## Output
 
-Write to `docs/plans/<today>-<topic>-structure.md` (overwrite on revision).
+Write to `docs/plans/<id>/structure.md` (overwrite on revision).
 
 The file MUST open with this YAML frontmatter — the `approved` and
 `approved_at` fields are how the human gate is recorded:
@@ -50,6 +52,7 @@ date: <YYYY-MM-DD>
 phase: structure
 approved: false
 approved_at: null
+revision: 0
 ---
 ```
 
@@ -57,7 +60,7 @@ Leave `approved: false` on every draft, including revisions. The
 orchestrator flips it to `true` (and stamps `approved_at`) when the user
 approves at the human gate.
 
-Aim for ~2 pages (≈100-200 lines, excluding frontmatter).
+Aim for ~2 pages (≈100–200 lines, excluding frontmatter).
 
 ## Structure document format
 
@@ -93,7 +96,7 @@ does not accidentally include it>
 - **Every slice ends in a passing test.** If a slice cannot be demonstrated
   with a test (or a manually-runnable check), it is infrastructure scaffolding
   — fold it into the next slice.
-- **Each slice has 1-3 acceptance tests.** A slice with 10 tests is too big.
+- **Each slice has 1–3 acceptance tests.** A slice with 10 tests is too big.
   A slice with 0 tests is too horizontal.
 - **Order by user value.** First slice should ship the smallest piece of
   user-visible behavior. Pure-infrastructure slices push integration risk to
@@ -119,5 +122,5 @@ does not accidentally include it>
 ## Output to orchestrator
 
 When done, return a short summary to the orchestrator:
-`{structurePath, topic, sliceCount: <number>}`. The orchestrator will
+`{structurePath, id, sliceCount: <number>}`. The orchestrator will
 then run the human gate (present the structure, capture approval).

--- a/agents/test-architect.md
+++ b/agents/test-architect.md
@@ -14,10 +14,14 @@ are missing, the feature is incomplete.
 
 ## Inputs
 
-- `structure.md` — the source of truth for which acceptance tests must exist
-  (each slice lists its tests)
-- `plan.md` — file-level mappings the implementer will follow
-- `design.md` — context for understanding what each test should assert
+The orchestrator dispatches you with the artifact directory
+`docs/plans/<id>/`. You read:
+
+- `docs/plans/<id>/structure.md` — the source of truth for which acceptance
+  tests must exist (each slice lists its tests)
+- `docs/plans/<id>/plan.md` — file-level mappings the implementer will follow
+- `docs/plans/<id>/design.md` — context for understanding what each test
+  should assert
 
 ## Process
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,37 +3,38 @@
 > **Audience:** Plugin maintainers and contributors. End users only need
 > the README + `/team` slash command.
 >
-> **Source of truth:** the artifacts in `docs/plans/<today>-<topic>-*.md`
-> and the in-session TodoWrite ledger.
+> **Source of truth:** the artifacts in `docs/plans/<id>/*.md` and the
+> in-session TodoWrite ledger.
 
 ## 1. Design Philosophy
 
 Agents are **decoupled microservices**. Each agent consumes a predecessor
 artifact on disk, does work, and produces its own artifact under
-`docs/plans/`. The orchestrator is the main Claude Code session: it walks
-a linear phase table, dispatches the right specialist for each phase,
+`docs/plans/<id>/`. The orchestrator is the main Claude Code session: it
+walks a linear phase table, dispatches the right specialist for each phase,
 seeds and updates a TodoWrite ledger, and runs the human gates.
 
 **Principles:**
 
 - **Files on disk are the durable record.** Every artifact under
-  `docs/plans/` carries YAML frontmatter that describes its phase and,
-  for human-gated phases, the approval state. Phase progression is
+  `docs/plans/<id>/` carries YAML frontmatter that describes its phase
+  and, for human-gated phases, the approval state. Phase progression is
   inferred by scanning artifacts.
 - **TodoWrite is the live coordination ledger.** It is session-scoped.
-  Re-invoking any `/team-*` command rebuilds the ledger by scanning artifacts on entry.
+  Re-invoking any `/team-*` command rebuilds the ledger by scanning
+  artifacts on entry.
 - **Registry is a phase-tagged inventory.** `skills/team/registry.json`
   lists the 13 specialist agents and the QRSPI phase each serves. The
   orchestrator dispatches via the phase table in `skills/team/SKILL.md`,
   not via the registry.
 - **File artifacts survive compaction.** Agents communicate through
-  files in `docs/plans/`. These survive context-window compaction, can
-  be re-read by any agent in any session, and live in git history.
+  files in `docs/plans/<id>/`. These survive context-window compaction,
+  can be re-read by any agent in any session, and live in git history.
 - **Blind research.** The researcher and file-finder never receive the
   user's original task description. Enforcement is two-layer:
-  *structural* — the orchestrator only passes `brief.md` + `questions.md`
-  paths to the blind agents; *procedural* — the blind agents' system
-  prompts forbid reading `task.md`.
+  *structural* — the orchestrator only passes the `questions.md` path to
+  the blind agents; *procedural* — the blind agents' system prompts
+  forbid reading `task.md`.
 - **Two human touchpoints.** Design approval (~200-line alignment doc)
   and Structure approval (~2-page vertical-slice breakdown). Approval
   is recorded by flipping `approved: true` (and stamping `approved_at`)
@@ -43,16 +44,22 @@ seeds and updates a TodoWrite ledger, and runs the human gates.
 - **Hooks enforce discipline mechanically.** LLMs forget instructions
   ~20% of the time; hooks are deterministic.
 
-## 2. Artifact Frontmatter
+## 2. Artifact Layout & Frontmatter
 
-Every artifact under `docs/plans/` opens with YAML frontmatter. Common
-fields:
+All phase artifacts live in `docs/plans/<id>/`, where `<id>` is one of:
+
+- **Ticket-prefixed**: `<TICKET>-<kebab-topic>` (e.g.,
+  `ENG-1234-add-rate-limiting`)
+- **Date-prefixed**: `<YYYY-MM-DD>-<kebab-topic>` (e.g.,
+  `2026-05-01-add-rate-limiting`)
+
+Every artifact opens with YAML frontmatter. Common fields:
 
 ```yaml
 ---
 topic: <kebab-case>
 date: 2026-04-30
-phase: design        # task | questions | brief | research | design | structure | plan
+phase: design        # task | questions | research | design | structure | plan
 ---
 ```
 
@@ -60,9 +67,8 @@ Per-phase additions:
 
 | Phase     | Extra frontmatter                                                       |
 |-----------|-------------------------------------------------------------------------|
-| task      | `ticketId: <id>` (or `null`)                                         |
+| task      | `ticketId: <id>` (or `null`)                                            |
 | questions | (none)                                                                  |
-| brief     | (none)                                                                  |
 | research  | (none)                                                                  |
 | design    | `approved: false`, `approved_at: null`, `revision: 0`                   |
 | structure | `approved: false`, `approved_at: null`, `revision: 0`                   |
@@ -85,18 +91,18 @@ Cap at 5; beyond that, escalate to the user.
 
 | Latest artifact present                                | Current phase       |
 |--------------------------------------------------------|---------------------|
-| `task.md` only                                         | RESEARCH (next up)  |
+| `task.md` + `questions.md` only                        | RESEARCH (next up)  |
 | `research.md`                                          | DESIGN (next up)    |
 | `design.md` (frontmatter `approved: false`)            | DESIGN (human gate) |
 | `design.md` (frontmatter `approved: true`)             | STRUCTURE (next up) |
 | `structure.md` (frontmatter `approved: false`)         | STRUCTURE (gate)    |
 | `structure.md` (frontmatter `approved: true`)          | PLAN (next up)      |
 | `plan.md`                                              | WORKTREE (next up)  |
-| worktree exists for the topic branch                   | IMPLEMENT           |
+| worktree exists for the `<id>` branch                  | IMPLEMENT           |
 | topic branch has slice commits + verifier passed       | PR (next up)        |
 | PR opened or commit shipped                            | SHIPPED             |
 
-Worktree presence: `git worktree list --porcelain | grep -q <branch>`.
+Worktree presence: `git worktree list --porcelain | grep -q <id>`.
 
 ## 3. Pipeline (QRSPI)
 
@@ -111,17 +117,19 @@ QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEME
 
 **Agent:** `questioner`
 **Predecessor:** (none — description in `$ARGUMENTS`)
-**Artifacts:** `docs/plans/YYYY-MM-DD-<topic>-{task,questions,brief}.md`
+**Artifacts:** `docs/plans/<id>/{task,questions}.md`
 
-Decomposes the user's intent into three artifacts. Only the questioner
-ever sees the user's description.
+Decomposes the user's intent into two artifacts. Only the questioner
+ever sees the user's description. There is no separate `brief.md`;
+neutral codebase context lives in a "Codebase context" section at the top
+of `questions.md`.
 
 ### Phase 2: Research
 
 **Agents:** `file-finder` and `researcher` (parallel, blind)
-**Predecessor:** `task.md` (orchestrator passes only `questions.md` and
-`brief.md` paths to the blind agents)
-**Artifact:** `docs/plans/YYYY-MM-DD-<topic>-research.md`
+**Predecessor:** `questions.md` (orchestrator passes only the
+`questions.md` path to the blind agents)
+**Artifact:** `docs/plans/<id>/research.md`
 
 Orchestrator waits for both agents to return, then writes the combined
 research artifact (with the required frontmatter).
@@ -131,7 +139,7 @@ research artifact (with the required frontmatter).
 **Agent:** `design-author` (MUST ask open questions interactively before
 drafting)
 **Predecessor:** `research.md`
-**Artifact:** `docs/plans/YYYY-MM-DD-<topic>-design.md`
+**Artifact:** `docs/plans/<id>/design.md`
 **Gate:** HUMAN — on approval the orchestrator edits `design.md`'s
 frontmatter to set `approved: true` and `approved_at: <ISO-8601>`; on
 rejection the agent re-drafts and increments `revision`.
@@ -140,14 +148,14 @@ rejection the agent re-drafts and increments `revision`.
 
 **Agent:** `structure-planner`
 **Predecessor:** `design.md` with frontmatter `approved: true`
-**Artifact:** `docs/plans/YYYY-MM-DD-<topic>-structure.md`
+**Artifact:** `docs/plans/<id>/structure.md`
 **Gate:** HUMAN — same flip-frontmatter mechanics as Design.
 
 ### Phase 5: Plan
 
 **Agent:** `planner`
 **Predecessor:** `structure.md` with frontmatter `approved: true`
-**Artifact:** `docs/plans/YYYY-MM-DD-<topic>-plan.md`
+**Artifact:** `docs/plans/<id>/plan.md`
 
 No human gate. The plan is mechanically derived from the approved
 structure.
@@ -158,8 +166,10 @@ structure.
 **Predecessor:** `plan.md`
 
 The orchestrator creates an isolated git worktree using Claude Code's
-native worktree support. Worktree path and branch are discoverable via
-`git worktree list --porcelain` — no need to persist them.
+native worktree support. The branch name is `<id>`. Worktree path and
+branch are discoverable via `git worktree list --porcelain` — no need to
+persist them. The orchestrator copies `docs/plans/<id>/` into the
+worktree (untracked files don't propagate automatically).
 
 ### Phase 7: Implement
 
@@ -185,7 +195,7 @@ items to the TodoWrite ledger.
 **Predecessor:** aggregate gate passed
 
 Update CHANGELOG.md (filter for user-facing commits since last release),
-present shipping options to the user, execute the chosen action, close
+present shipping options to the user, execute the chosen action, surface
 the tracking ticket (if `task.md` carries `ticketId`), clean up the worktree.
 
 ## 4. Agent Roster
@@ -218,9 +228,11 @@ walking the phase table in `skills/team/SKILL.md`. Pseudocode:
 
 ```
 setup:
-  derive topic + today, create docs/plans/ if needed.
+  resolve $ARGUMENTS (issue URL → gh issue view; ticket → use as prefix).
+  derive <id> = "<TICKET>-<topic>" or "<YYYY-MM-DD>-<topic>".
+  create docs/plans/<id>/ if needed.
   seed TodoWrite ledger with one item per phase.
-  on resume: scan docs/plans/ for the topic, fast-forward the ledger.
+  on resume: scan docs/plans/<id>/, fast-forward the ledger.
 
 loop:
   1. Inspect TodoWrite. If all phases completed → exit.
@@ -228,10 +240,11 @@ loop:
      artifact path(s) in the phase table.
   3. Verify predecessors exist on disk and (for human-gated phases)
      carry `approved: true` in frontmatter. If missing → desync;
-     suggest re-invoking the same /team-* command.
-  4. Dispatch the agent(s).
-  5. Write returned artifacts to docs/plans/<today>-<topic>-<name>.md
-     with the YAML frontmatter the agent specifies.
+     suggest re-invoking the same /team-* command with docs/plans/<id>/.
+  4. Dispatch the agent(s) — pass them the artifact directory
+     `docs/plans/<id>/`.
+  5. Write returned artifacts to docs/plans/<id>/<name>.md with the
+     YAML frontmatter the agent specifies.
   6. Run the gate for this phase (HUMAN | MECHANICAL | ORCHESTRATOR-EMIT
      | AGGREGATE).
   7. Mark current TodoWrite item complete and the next one in_progress.
@@ -244,33 +257,28 @@ Skills live under `skills/`. There are two flavors:
 
 ### Entry-point skills (slash commands)
 
-| Skill            | Command                    | Description                              |
-|------------------|----------------------------|------------------------------------------|
-| `team`           | `/team <desc>`             | Full 8-phase QRSPI pipeline              |
-| `team-fix`       | `/team-fix <bug>`          | Compressed bug-fix pipeline              |
-| `team-question`  | `/team-question <desc>`    | Decompose intent (runs alone)            |
-| `team-research`  | `/team-research`           | Blind research (runs Question if missing)|
-| `team-design`    | `/team-design`             | Design alignment (human gate)            |
-| `team-structure` | `/team-structure`          | Vertical-slice structure (human gate)    |
-| `team-plan`      | `/team-plan`               | Tactical plan from approved structure    |
-| `team-worktree`  | `/team-worktree`           | Prepare isolated worktree                |
-| `team-implement` | `/team-implement`          | Test-first + slice exec + 5-reviewer     |
-| `team-pr`        | `/team-pr`                 | Commit + PR                              |
+| Skill            | Command                            | Description                              |
+|------------------|------------------------------------|------------------------------------------|
+| `team`           | `/team <desc>`                     | Full 8-phase QRSPI pipeline              |
+| `team-fix`       | `/team-fix <bug>`                  | Compressed bug-fix pipeline              |
+| `team-question`  | `/team-question <desc>`            | Decompose intent (runs alone)            |
+| `team-research`  | `/team-research docs/plans/<id>/`  | Blind research                           |
+| `team-design`    | `/team-design docs/plans/<id>/`    | Design alignment (human gate)            |
+| `team-structure` | `/team-structure docs/plans/<id>/` | Vertical-slice structure (human gate)    |
+| `team-plan`      | `/team-plan docs/plans/<id>/`      | Tactical plan from approved structure    |
+| `team-worktree`  | `/team-worktree docs/plans/<id>/`  | Prepare isolated worktree                |
+| `team-implement` | `/team-implement docs/plans/<id>/` | Test-first + slice exec + 5-reviewer     |
+| `team-pr`        | `/team-pr docs/plans/<id>/`        | Commit + PR                              |
 
-Each partial skill works in two modes:
+Every entry-point skill carries an `argument-hint` field in its
+frontmatter (Claude Code [skills frontmatter](https://code.claude.com/docs/en/skills#frontmatter-reference))
+that documents the expected `$ARGUMENTS` shape.
 
-- **Resume mode** — predecessor artifact (`docs/plans/<today>-<topic>-<predecessor>.md`,
-  with `approved: true` in its frontmatter for human-gated artifacts) is
-  present. The skill picks up where `/team` left off.
-- **Standalone mode** — no predecessor on disk. The skill accepts a
-  ticket ID or free-form description in `$ARGUMENTS` and bootstraps the
-  missing upstream artifacts inline (or, for `/team-implement`,
-  synthesizes a `task.md` and dispatches the implement loop directly).
-  `/team-implement` also asks the user about creating a worktree when
-  invoked outside one.
-
-Standalone mode skips alignment gates the user did not run — the user is
-explicitly opting into a faster, less ceremonious path.
+Each downstream skill (`team-research` and beyond) treats `$ARGUMENTS` as
+an artifact directory — typically the path printed by the previous
+phase's completion message. Standalone modes still exist: a partial
+skill invoked without an artifact directory (or with a free-form
+description) bootstraps the missing upstream artifacts inline.
 
 ### Methodology skills (loaded by agents, not directly invoked)
 
@@ -310,16 +318,17 @@ Runtime hooks (`hooks/` — distributed with the plugin):
 | Hook                       | Event                    | Purpose                                                    |
 |----------------------------|--------------------------|------------------------------------------------------------|
 | `pre-bash-guard.mjs`       | PreToolUse(Bash)         | Block dangerous shell commands                             |
-| `pre-compact-anchor.mjs`   | PreCompact               | Scan docs/plans/ for active topic; inject 4-line anchor    |
-| `session-start-recover.mjs`| SessionStart             | Scan docs/plans/ for active topic; emit recovery notice    |
+| `pre-compact-anchor.mjs`   | PreCompact               | Scan docs/plans/<id>/ for active topic; inject 4-line anchor |
+| `session-start-recover.mjs`| SessionStart             | Scan docs/plans/<id>/ for active topic; emit recovery notice |
 | `post-write-validate.mjs`  | PostToolUse(Write\|Edit) | Structural validation of plugin component files            |
 
 Both `pre-compact-anchor.mjs` and `session-start-recover.mjs` work the
-same way: list `docs/plans/*.md`, pick the most recent topic by file
-mtime, infer the current phase from artifact presence + frontmatter,
-and emit a short context message naming the phase, topic, and the
-suggested next `/team-*` command. Both are stateless, exit 0 on any
-error, and return within the 5000ms hook budget.
+same way: list `docs/plans/*/` directories, pick the most recent
+artifact directory by mtime of any contained artifact, infer the
+current phase from artifact presence + frontmatter, and emit a short
+context message naming the phase, `<id>`, and the suggested next
+`/team-*` command. Both are stateless, exit 0 on any error, and return
+within the 5000ms hook budget.
 
 Development hook (`.claude/hooks/` — not distributed):
 
@@ -329,26 +338,27 @@ Development hook (`.claude/hooks/` — not distributed):
 
 ## 8. State Management
 
-**Primary state:** the artifacts in `docs/plans/<today>-<topic>-*.md`.
-Each artifact's YAML frontmatter is the source of truth for "did this
-phase finish?" and "was the human gate passed?"
+**Primary state:** the artifacts in `docs/plans/<id>/*.md`. Each
+artifact's YAML frontmatter is the source of truth for "did this phase
+finish?" and "was the human gate passed?"
 
 **Live coordination:** TodoWrite (session-scoped). The orchestrator
 seeds the ledger at the start of `/team`, marks each item `in_progress`
 when dispatching, and `completed` when the artifact lands. Any `/team-*`
 command rebuilds the ledger by scanning artifacts on entry, so an
-interrupted run can be resumed by re-invoking any of them.
+interrupted run can be resumed by re-invoking any of them with
+`docs/plans/<id>/`.
 
 **Approval markers:** the gated artifact's own YAML frontmatter
 (`approved: true`, `approved_at: <ISO-8601>`) records human gate passes
 durably. The artifact is self-describing.
 
-**Compaction defense:** the PreCompact hook scans `docs/plans/` for the
-active topic and injects a 4-line anchor (phase, topic, date, suggested
-next `/team-*` command). The SessionStart hook does the same for new
-sessions.
+**Compaction defense:** the PreCompact hook scans `docs/plans/<id>/`
+directories for the active topic and injects a 4-line anchor (phase,
+`<id>`, suggested next `/team-*` command). The SessionStart hook does
+the same for new sessions.
 
-**Artifact persistence:** files in `docs/plans/` are committed to git
-and survive across sessions, compaction events, and context resets.
+**Artifact persistence:** files in `docs/plans/<id>/` are committed to
+git and survive across sessions, compaction events, and context resets.
 They are the durable communication protocol between agents and the
 source of truth for "did phase N finish?"

--- a/hooks/pre-compact-anchor.mjs
+++ b/hooks/pre-compact-anchor.mjs
@@ -1,6 +1,6 @@
 /**
  * PreCompact hook — anchors TEAM pipeline state before compaction.
- * Scans docs/plans/<today>-<topic>-*.md for the most recent active
+ * Scans docs/plans/<id>/ subdirectories for the most recent active
  * topic, infers the current phase from artifact presence + YAML
  * frontmatter, and injects a 4-line anchor into additionalContext.
  * Stateless; always exits 0.
@@ -8,8 +8,8 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-const ARTIFACT_RE =
-  /^(\d{4}-\d{2}-\d{2})-([a-z0-9_][a-z0-9_-]{0,99})-(task|research|design|structure|plan)\.md$/;
+const ID_RE = /^([A-Za-z][A-Za-z0-9_]*-\d+|\d{4}-\d{2}-\d{2})-[a-z0-9][a-z0-9-]*$/;
+const PHASE_FILES = ["task", "questions", "research", "design", "structure", "plan"];
 
 async function readStdinJSON() {
   const chunks = [];
@@ -24,18 +24,23 @@ function projectDir(input) {
 
 async function findActiveTopic(plansDir) {
   let entries;
-  try { entries = await readdir(plansDir); } catch { return null; }
+  try { entries = await readdir(plansDir, { withFileTypes: true }); } catch { return null; }
   let best = null, bestMtime = -Infinity;
-  for (const name of entries) {
-    const m = name.match(ARTIFACT_RE);
-    if (!m) continue;
-    try {
-      const st = await stat(join(plansDir, name));
-      if (st.mtimeMs > bestMtime) {
-        bestMtime = st.mtimeMs;
-        best = { date: m[1], topic: m[2] };
-      }
-    } catch { /* skip */ }
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    if (!ID_RE.test(ent.name)) continue;
+    const dir = join(plansDir, ent.name);
+    let dirMtime = -Infinity;
+    for (const phase of PHASE_FILES) {
+      try {
+        const st = await stat(join(dir, `${phase}.md`));
+        if (st.mtimeMs > dirMtime) dirMtime = st.mtimeMs;
+      } catch { /* skip */ }
+    }
+    if (dirMtime > bestMtime) {
+      bestMtime = dirMtime;
+      best = { id: ent.name, dir };
+    }
   }
   return best;
 }
@@ -56,8 +61,8 @@ async function readFrontmatter(path) {
 
 const isTrue = (v) => v === "true" || v === true;
 
-async function inferPhase(plansDir, { date, topic }) {
-  const p = (kind) => join(plansDir, `${date}-${topic}-${kind}.md`);
+async function inferPhase(dir) {
+  const p = (kind) => join(dir, `${kind}.md`);
   const has = async (path) => { try { await stat(path); return true; } catch { return false; } };
   if (await has(p("plan"))) return "WORKTREE";
   if (await has(p("structure"))) {
@@ -67,7 +72,7 @@ async function inferPhase(plansDir, { date, topic }) {
     return isTrue((await readFrontmatter(p("design"))).approved) ? "STRUCTURE" : "DESIGN";
   }
   if (await has(p("research"))) return "DESIGN";
-  if (await has(p("task"))) return "RESEARCH";
+  if (await has(p("questions")) || await has(p("task"))) return "RESEARCH";
   return null;
 }
 
@@ -76,13 +81,13 @@ async function main() {
   const plansDir = join(projectDir(input), "docs", "plans");
   const active = await findActiveTopic(plansDir);
   if (!active) process.exit(0);
-  const phase = await inferPhase(plansDir, active);
+  const phase = await inferPhase(active.dir);
   if (!phase) process.exit(0);
   const ctx = [
     "[TEAM Pipeline State — Anchor before compaction]",
-    `Phase: ${phase} | Topic: ${active.topic} | Date: ${active.date}`,
-    `Latest artifact: docs/plans/${active.date}-${active.topic}-*.md`,
-    "Re-invoke any /team-* command to pick up from the latest artifact.",
+    `Phase: ${phase} | Id: ${active.id}`,
+    `Artifact directory: docs/plans/${active.id}/`,
+    `Re-invoke any /team-* command with docs/plans/${active.id}/ to continue.`,
   ].join("\n");
   process.stderr.write(JSON.stringify({ hookSpecificOutput: { additionalContext: ctx } }) + "\n");
   process.exit(0);

--- a/hooks/session-start-recover.mjs
+++ b/hooks/session-start-recover.mjs
@@ -1,10 +1,10 @@
 /**
  * SessionStart hook — detects an active TEAM pipeline and prompts recovery.
  *
- * Scans docs/plans/<today>-<topic>-*.md for the most recent active topic,
+ * Scans docs/plans/<id>/ subdirectories for the most recent active topic,
  * infers the current phase from artifact presence + YAML frontmatter,
  * and injects a recovery notice into additionalContext so the agent
- * suggests re-invoking any /team-* command.
+ * suggests re-invoking any /team-* command with docs/plans/<id>/.
  *
  * Contract: always exits 0. Missing or unparseable artifacts are not an error.
  */
@@ -12,8 +12,8 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-const ARTIFACT_RE =
-  /^(\d{4}-\d{2}-\d{2})-([a-z0-9_][a-z0-9_-]{0,99})-(task|research|design|structure|plan)\.md$/;
+const ID_RE = /^([A-Za-z][A-Za-z0-9_]*-\d+|\d{4}-\d{2}-\d{2})-[a-z0-9][a-z0-9-]*$/;
+const PHASE_FILES = ["task", "questions", "research", "design", "structure", "plan"];
 
 async function readStdinJSON() {
   const chunks = [];
@@ -28,18 +28,23 @@ function projectDir(input) {
 
 async function findActiveTopic(plansDir) {
   let entries;
-  try { entries = await readdir(plansDir); } catch { return null; }
+  try { entries = await readdir(plansDir, { withFileTypes: true }); } catch { return null; }
   let best = null, bestMtime = -Infinity;
-  for (const name of entries) {
-    const m = name.match(ARTIFACT_RE);
-    if (!m) continue;
-    try {
-      const st = await stat(join(plansDir, name));
-      if (st.mtimeMs > bestMtime) {
-        bestMtime = st.mtimeMs;
-        best = { date: m[1], topic: m[2] };
-      }
-    } catch { /* skip */ }
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    if (!ID_RE.test(ent.name)) continue;
+    const dir = join(plansDir, ent.name);
+    let dirMtime = -Infinity;
+    for (const phase of PHASE_FILES) {
+      try {
+        const st = await stat(join(dir, `${phase}.md`));
+        if (st.mtimeMs > dirMtime) dirMtime = st.mtimeMs;
+      } catch { /* skip */ }
+    }
+    if (dirMtime > bestMtime) {
+      bestMtime = dirMtime;
+      best = { id: ent.name, dir };
+    }
   }
   return best;
 }
@@ -60,8 +65,8 @@ async function readFrontmatter(path) {
 
 const isTrue = (v) => v === "true" || v === true;
 
-async function inferPhase(plansDir, { date, topic }) {
-  const p = (kind) => join(plansDir, `${date}-${topic}-${kind}.md`);
+async function inferPhase(dir) {
+  const p = (kind) => join(dir, `${kind}.md`);
   const has = async (path) => { try { await stat(path); return true; } catch { return false; } };
   if (await has(p("plan"))) return "WORKTREE";
   if (await has(p("structure"))) {
@@ -71,7 +76,7 @@ async function inferPhase(plansDir, { date, topic }) {
     return isTrue((await readFrontmatter(p("design"))).approved) ? "STRUCTURE" : "DESIGN";
   }
   if (await has(p("research"))) return "DESIGN";
-  if (await has(p("task"))) return "RESEARCH";
+  if (await has(p("questions")) || await has(p("task"))) return "RESEARCH";
   return null;
 }
 
@@ -80,15 +85,15 @@ async function main() {
   const plansDir = join(projectDir(input), "docs", "plans");
   const active = await findActiveTopic(plansDir);
   if (!active) process.exit(0);
-  const phase = await inferPhase(plansDir, active);
+  const phase = await inferPhase(active.dir);
   if (!phase) process.exit(0);
   const ctx = [
     "[TEAM Pipeline Recovery]",
     "An active TEAM pipeline was detected. Re-invoke any /team-* command to continue.",
     "",
-    `Phase: ${phase} | Topic: ${active.topic} | Date: ${active.date}`,
-    `Latest artifact: docs/plans/${active.date}-${active.topic}-*.md`,
-    "To continue: re-invoke any /team-* command",
+    `Phase: ${phase} | Id: ${active.id}`,
+    `Artifact directory: docs/plans/${active.id}/`,
+    `To continue: re-invoke any /team-* command with docs/plans/${active.id}/`,
   ].join("\n");
   process.stderr.write(JSON.stringify({ hookSpecificOutput: { additionalContext: ctx } }) + "\n");
   process.exit(0);

--- a/skills/product-requirements-doc/SKILL.md
+++ b/skills/product-requirements-doc/SKILL.md
@@ -16,8 +16,8 @@ the design-author later turns the task into an approach.
 
 ## When to Write a PRD
 
-The questioner produces a PRD (in addition to the standard `task.md`,
-`questions.md`, and `brief.md`) when the feature request is:
+The questioner produces a PRD (in addition to the standard `task.md`
+and `questions.md`) when the feature request is:
 
 - **Vague or underspecified** — the request does not say what "done" looks
   like ("improve the onboarding experience" has no clear scope boundary)
@@ -33,8 +33,8 @@ standard `task.md` is sufficient — no PRD needed.
 
 ## PRD Structure
 
-Write the PRD to `docs/plans/YYYY-MM-DD-<topic>-prd.md`. Reference its path
-from `task.md` so the design-author knows to read it.
+Write the PRD to `docs/plans/<id>/prd.md`. Reference its path from
+`task.md` so the design-author knows to read it.
 
 ### Problem Statement
 

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -18,20 +18,22 @@ QUESTION -> RESEARCH -> DESIGN -> STRUCTURE -> PLAN -> WORKTREE -> IMPLEMENT -> 
 ### QUESTION
 
 Decompose the user's intent into neutral research questions. Capture the
-full task for the human, write a sanitized brief that downstream phases use.
+full task for the human; phrase questions so a stranger can answer them
+without knowing the goal.
 
 - **Artifacts:**
-  - `docs/plans/YYYY-MM-DD-<topic>-task.md` — full description (human-only)
-  - `docs/plans/YYYY-MM-DD-<topic>-questions.md` — neutral research questions
-  - `docs/plans/YYYY-MM-DD-<topic>-brief.md` — sanitized brief (no intent, no opinions)
-- **Gate:** HARD — all three artifacts must exist on disk before proceeding
+  - `docs/plans/<id>/task.md` — full description (human-only)
+  - `docs/plans/<id>/questions.md` — neutral research questions, plus a
+    "Codebase context" section that names files/modules/vocabulary but
+    NOT the goal
+- **Gate:** HARD — both artifacts must exist on disk before proceeding
 
 ### RESEARCH
 
 Explore the codebase to answer the questions. Researcher is **BLIND** to
-intent: it never reads `task.md`, only `questions.md` + `brief.md`.
+intent: it never reads `task.md`, only `questions.md`.
 
-- **Artifact:** `docs/plans/YYYY-MM-DD-<topic>-research.md`
+- **Artifact:** `docs/plans/<id>/research.md`
 - **Gate:** HARD — artifact must exist on disk before proceeding
 
 ### DESIGN
@@ -40,7 +42,7 @@ Align on approach with the user. The design author MUST present open
 questions to the user before writing the design document. The result is
 a ~200-line markdown artifact the human reviews carefully.
 
-- **Artifact:** `docs/plans/YYYY-MM-DD-<topic>-design.md`
+- **Artifact:** `docs/plans/<id>/design.md`
 - **Gate:** HARD — user must explicitly approve the design
 
 ### STRUCTURE
@@ -49,7 +51,7 @@ Break the approved design into vertical slices with verification checkpoints.
 Each slice is end-to-end and independently testable. The result is a ~2-page
 markdown artifact the human reviews.
 
-- **Artifact:** `docs/plans/YYYY-MM-DD-<topic>-structure.md`
+- **Artifact:** `docs/plans/<id>/structure.md`
 - **Gate:** HARD — user must explicitly approve the structure
 
 ### PLAN
@@ -58,7 +60,7 @@ Tactical implementation details for the agent. Read by the implementer.
 No human approval gate — the plan is mechanically derived from the
 approved structure.
 
-- **Artifact:** `docs/plans/YYYY-MM-DD-<topic>-plan.md`
+- **Artifact:** `docs/plans/<id>/plan.md`
 - **Gate:** SOFT — no human approval; the structure is the contract
 
 ### WORKTREE
@@ -66,7 +68,7 @@ approved structure.
 Router prepares an isolated git worktree for implementation work. No agent;
 purely a router responsibility.
 
-- **Artifact:** git worktree under `.claude/worktrees/<topic>/`
+- **Artifact:** git worktree under Claude Code's native worktree directory
 - **Gate:** HARD — worktree must exist before tests are written
 
 ### IMPLEMENT
@@ -88,27 +90,30 @@ sub-phase and 5-reviewer adversarial verification with hard-gate retry loop.
 
 ### PR
 
-Open the pull request, update the changelog, close any tracking tracking ticket.
+Open the pull request, update the changelog, surface the tracking ticket.
 
 - **Artifact:** GitHub PR (or local commit per user choice)
 - **Gate:** Terminal — orchestrator records the PR URL or final commit, then closes the topic's TodoWrite ledger.
 
 ## Artifact Conventions
 
-All phase artifacts live in `docs/plans/`:
+All phase artifacts live under `docs/plans/<id>/`, where `<id>` is one of:
 
-| Artifact  | Pattern                                       | Created By         |
-|-----------|-----------------------------------------------|--------------------|
-| Task      | `YYYY-MM-DD-<topic>-task.md`                  | questioner agent   |
-| Questions | `YYYY-MM-DD-<topic>-questions.md`             | questioner agent   |
-| Brief     | `YYYY-MM-DD-<topic>-brief.md`                 | questioner agent   |
-| Research  | `YYYY-MM-DD-<topic>-research.md`              | researcher agent   |
-| Design    | `YYYY-MM-DD-<topic>-design.md`                | design-author agent|
-| Structure | `YYYY-MM-DD-<topic>-structure.md`             | structure-planner agent |
-| Plan      | `YYYY-MM-DD-<topic>-plan.md`                  | planner agent      |
+- **Ticket-prefixed**: `<TICKET>-<kebab-topic>` (e.g.,
+  `ENG-1234-add-rate-limiting`)
+- **Date-prefixed**: `<YYYY-MM-DD>-<kebab-topic>` (e.g.,
+  `2026-05-01-add-rate-limiting`)
 
-Use today's date. The `<topic>` slug should be lowercase, hyphen-separated,
-and match across every artifact for the same feature.
+| Artifact  | Path                              | Created By              |
+|-----------|-----------------------------------|-------------------------|
+| Task      | `docs/plans/<id>/task.md`         | questioner agent        |
+| Questions | `docs/plans/<id>/questions.md`    | questioner agent        |
+| Research  | `docs/plans/<id>/research.md`     | researcher agent        |
+| Design    | `docs/plans/<id>/design.md`       | design-author agent     |
+| Structure | `docs/plans/<id>/structure.md`    | structure-planner agent |
+| Plan      | `docs/plans/<id>/plan.md`         | planner agent           |
+
+The `<id>` slug should match across every artifact for the same feature.
 
 ## Blind Research
 
@@ -118,17 +123,17 @@ invariant in two layers — structural at the dispatch boundary, procedural
 at the agent boundary:
 
 1. **Structural** — when the orchestrator dispatches `researcher` or
-   `file-finder`, it passes only the paths to `questions.md` and
-   `brief.md`. The orchestrator is forbidden from handing the
-   description (or `task.md`) to blind agents at dispatch time.
+   `file-finder`, it passes only the path to `questions.md`. The
+   orchestrator is forbidden from handing the description (or `task.md`)
+   to blind agents at dispatch time.
 2. **Procedural** — the `researcher` and `file-finder` agent system prompts
    forbid reading `task.md`. Both have `Read`/`Grep`/`Glob` tools with
    `permissionMode: plan`, so nothing mechanically stops a `Read` of
    `task.md`; enforcement relies on the agent following its prompt.
-3. **Procedural** — if a researcher needs context the brief lacks, it must
+3. **Procedural** — if a researcher needs context the questions lack, it must
    surface that as an open question rather than guessing the intent.
 
-A PreToolUse(Read) hook that blocks `*-task.md` reads from blind agents
+A PreToolUse(Read) hook that blocks `*/task.md` reads from blind agents
 would convert step 2 from procedural to structural. Treat this as a
 follow-up if procedural enforcement proves insufficient in practice.
 
@@ -171,9 +176,9 @@ Examples: documentation gap analysis, style suggestions.
 ## State and Coordination
 
 Pipeline state is reconstructed by scanning artifacts in
-`docs/plans/<today>-<topic>-*.md` and reading their YAML frontmatter.
-The orchestrator (the main Claude Code session) tracks in-flight work
-via TodoWrite — a session-scoped ledger that mirrors the phase table.
+`docs/plans/<id>/*.md` and reading their YAML frontmatter. The orchestrator
+(the main Claude Code session) tracks in-flight work via TodoWrite — a
+session-scoped ledger that mirrors the phase table.
 
 ### Frontmatter schema (all artifacts)
 
@@ -183,7 +188,7 @@ Every artifact opens with YAML frontmatter. Common fields:
 ---
 topic: <kebab-case>
 date: 2026-04-30
-phase: design        # task | research | design | structure | plan
+phase: design        # task | questions | research | design | structure | plan
 ---
 ```
 
@@ -191,7 +196,8 @@ Per-phase additions:
 
 | Phase     | Extra frontmatter                                                                  |
 |-----------|------------------------------------------------------------------------------------|
-| task      | `ticketId: <id>` (or `null`)                                                    |
+| task      | `ticketId: <id>` (or `null`)                                                       |
+| questions | (none)                                                                             |
 | research  | (none)                                                                             |
 | design    | `approved: false`, `approved_at: null`, `revision: 0`                              |
 | structure | `approved: false`, `approved_at: null`, `revision: 0`                              |
@@ -212,24 +218,24 @@ beyond that, escalate to the user for direction.
 
 ### Phase inference from artifacts
 
-The orchestrator infers the current phase by scanning what exists on
-disk for the topic:
+The orchestrator infers the current phase by scanning what exists in
+`docs/plans/<id>/`:
 
 | Latest artifact present                                | Current phase       |
 |--------------------------------------------------------|---------------------|
-| `task.md` only                                         | RESEARCH (next up)  |
+| `task.md` + `questions.md`                             | RESEARCH (next up)  |
 | `research.md`                                          | DESIGN (next up)    |
 | `design.md` (frontmatter `approved: false`)            | DESIGN (human gate) |
 | `design.md` (frontmatter `approved: true`)             | STRUCTURE (next up) |
 | `structure.md` (frontmatter `approved: false`)         | STRUCTURE (gate)    |
 | `structure.md` (frontmatter `approved: true`)          | PLAN (next up)      |
 | `plan.md`                                              | WORKTREE (next up)  |
-| worktree exists for the topic branch                   | IMPLEMENT           |
+| worktree exists for `<id>` branch                      | IMPLEMENT           |
 | topic branch has commits ahead and verifier passed     | PR (next up)        |
 | PR opened or commit shipped                            | SHIPPED             |
 
-Worktree presence: `git worktree list --porcelain | grep -q <branch>`.
-Verifier passed: latest review artifact in `docs/plans/<today>-<topic>-review-<n>.md`
+Worktree presence: `git worktree list --porcelain | grep -q <id>`.
+Verifier passed: latest review artifact in `docs/plans/<id>/review-<n>.md`
 shows aggregate gate clean.
 
 ### Orchestrator coordination via TodoWrite

--- a/skills/team-design/SKILL.md
+++ b/skills/team-design/SKILL.md
@@ -1,52 +1,45 @@
 ---
 name: team-design
 description: Align with the user on the approach before any code is written. The design-author MUST present open questions interactively before drafting the ~200-line design document, then a human gate captures approval. Trigger on "design this", "let's align on the approach", or "/team-design".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM Design — Standalone Phase
+# TEAM Design — Where Are We Going?
 
-Run the DESIGN phase. Two modes:
-
-- **Resume mode** — research artifact exists; design-author consumes it.
-- **Standalone mode** — no research yet, but `$ARGUMENTS` provides a
-  description. Bootstrap the missing upstream artifacts before designing.
+Run the DESIGN phase. This is the first human gate — get alignment here
+before investing in detailed planning.
 
 ## Input
 
-`$ARGUMENTS` may be:
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-- Empty — resume mode. Requires existing research on disk.
-- A ticket ID — recorded as `ticketId` in `task.md` for the user's reference. The orchestrator does not call any ticketing system.
-- Free-form text — treated as the feature/task description.
+The `design-author` reads:
+
+- `$ARGUMENTS/task.md` — what we're building (intent)
+- `$ARGUMENTS/questions.md` — the questions that drove research
+- `$ARGUMENTS/research.md` — what exists (facts)
+
+If `$ARGUMENTS/research.md` is missing, tell the user to run
+`/team-research docs/plans/<id>/` first and stop.
 
 ## Execution
 
-1. Stat `docs/plans/<today>-<topic>-research.md`.
-2. **If missing and `$ARGUMENTS` is non-empty** — bootstrap by chaining
-   inline: dispatch `questioner` to produce Question artifacts, then
-   dispatch `file-finder` + `researcher` in parallel to produce
-   `research.md`. Continue to design without prompting the user to re-run
-   earlier commands.
-3. **If missing and `$ARGUMENTS` is empty** — ask the user to describe
-   the feature, then bootstrap as above. If still empty, stop.
-4. Follow the phase loop from `/team`. It dispatches `design-author`, which:
-   a. Presents open questions to the user interactively
+1. **Verify** `$ARGUMENTS/research.md` exists.
+2. Dispatch `design-author`, which:
+   a. Presents 3–5 open design questions to the user **interactively**
    b. Waits for answers
-   c. Writes `docs/plans/<today>-<topic>-design.md`
-5. At the human gate: present the design **in full** and ask "Do you
-   approve this design?".
-6. **Stop once `docs/plans/<today>-<topic>-design.md` carries
-   `approved: true` in its frontmatter, or the design has been
-   re-dispatched for revision.**
-
-## On revision
-
-If the user rejects, pass the feedback verbatim to the design-author on
-re-dispatch. The design-author re-drafts and increments
-`revision: <n+1>` in the new draft's frontmatter (cap 5; beyond that,
-escalate to the user). There is no auto-revision pass — the human is
-the loop.
+   c. Writes `$ARGUMENTS/design.md` with frontmatter
+      `approved: false`, `approved_at: null`, `revision: 0`
+3. **Human gate.** Present the design **in full** and ask: "Do you
+   approve this design?"
+   - On approve → edit `$ARGUMENTS/design.md` frontmatter to set
+     `approved: true` and `approved_at: <ISO-8601>`.
+   - On reject → re-dispatch `design-author` with the user's feedback
+     verbatim. The agent re-drafts and increments `revision: <n+1>`.
+     Cap at `revision: 5`; beyond that, escalate to the user.
+4. **Stop once `$ARGUMENTS/design.md` carries `approved: true`.**
 
 ## Completion
 
-Report design path and suggest: "/team-structure to break it into vertical slices"
+Report design path and tell the user:
+**"Next: run `/team-structure docs/plans/<id>/`"**

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: team-fix
 description: Compressed bug-fix pipeline — reproduce, write failing test, minimal fix, verify. Skips Question/Research/Design/Structure/Plan phases. Trigger on "/team-fix <bug description>".
+argument-hint: "<ticket id, issue URL, or bug description>"
 ---
 
 # TEAM Fix — Bug Fix Pipeline
@@ -10,29 +11,25 @@ discipline without the full QRSPI ceremony.
 
 ## Input
 
-Bug description: `$ARGUMENTS`
+`$ARGUMENTS` may be:
+
+- A ticket identifier (e.g. `ENG-1234`) — set aside as `ticketId` on
+  `task.md`.
+- An issue URL — fetched via `gh issue view` to extract title and body.
+- Free-form text — treated as the bug description.
 
 If `$ARGUMENTS` is empty, ask the user to describe the bug and stop.
-
-### Tracking Ticket
-
-If the first token of `$ARGUMENTS` looks like a ticket identifier
-(e.g., a kebab-case `<system>-<id>` slug), set it aside as `ticketId`
-and strip it from the rest of the description. The TEAM pipeline does
-not integrate with any specific ticketing system — the ID is recorded
-on `task.md` for the user's reference and for any project-specific
-automation they may layer on top. If the first token does not look
-like a ticket ID, treat all of `$ARGUMENTS` as the bug description and
-leave `ticketId` as `null`.
 
 ## When to Use
 
 Use `/team-fix` when:
+
 - The bug is well-understood and the affected code is known
 - The fix is likely contained to a small number of files
 - No architectural decisions are needed — this is a defect correction
 
 Use `/team` (full QRSPI pipeline) when:
+
 - The root cause is unknown and needs investigation
 - The fix requires designing new behavior or APIs
 - Multiple subsystems may be involved
@@ -44,15 +41,17 @@ Use `/team` (full QRSPI pipeline) when:
 REPRODUCE → RED (failing test) → GREEN (minimal fix) → VERIFY → SHIP
 ```
 
-No Question phase. No Research. No Design. No Structure. No Plan. No human gate.
+No Question. No Research. No Design. No Structure. No Plan. No human gate.
 
 ## Setup
 
-1. Write a minimal `docs/plans/<today>-<topic>-task.md` with the standard
-   task.md frontmatter (`topic`, `date`, `phase: task`, `ticketId`) plus
-   a brief description of the bug. This is the single durable record for
-   the fix and lets any /team-* command pick it up if interrupted.
-2. **Seed the TodoWrite ledger** with the bug-fix phases:
+1. **Derive `<id>`** the same way `/team` does (ticket-prefixed or
+   date-prefixed kebab slug). Create `docs/plans/<id>/`.
+2. Write a minimal `docs/plans/<id>/task.md` with the standard frontmatter
+   (`topic`, `date`, `phase: task`, `ticketId`) plus a brief description
+   of the bug. This is the single durable record for the fix and lets
+   any `/team-*` command pick it up if interrupted.
+3. **Seed the TodoWrite ledger** with the bug-fix phases:
    `Reproduce → Red (failing test) → Green (minimal fix) → Verify → Ship`.
    Mark `Reproduce` as `in_progress`.
 
@@ -73,14 +72,16 @@ assertion failure, not a crash. Do not proceed to the fix until confirmed.
    - `test:` commit with the failing test
    - `fix:` commit with the minimal fix
 2. Create a PR if working on a branch, or commit to the working branch.
-3. If `ticketId` is non-null in `task.md`'s frontmatter, the user may want to close the ticket in their tracking system. The orchestrator does not close tickets automatically.
+3. If `ticketId` is non-null in `task.md`'s frontmatter, surface it so
+   the user can close the ticket. The orchestrator does not close
+   tickets automatically.
 4. Mark all TodoWrite items complete.
 
 ## Aborting
 
-If reproduction fails: report "Bug could not be reproduced with the given
-description." and stop. Do not write a test for an unconfirmed bug.
+If reproduction fails: report "Bug could not be reproduced with the
+given description." and stop. Do not write a test for an unconfirmed bug.
 
-If the fix is larger than expected (touching many files, requiring new APIs,
-or revealing an architectural problem): stop, report the scope, and recommend
-switching to the full `/team` pipeline.
+If the fix is larger than expected (touching many files, requiring new
+APIs, or revealing an architectural problem): stop, report the scope,
+and recommend switching to the full `/team` pipeline.

--- a/skills/team-implement/SKILL.md
+++ b/skills/team-implement/SKILL.md
@@ -1,96 +1,83 @@
 ---
 name: team-implement
 description: Execute the implementation phase. Includes test-first sub-step (writing failing tests, mechanical confirmation gate) and adversarial verification (5 parallel reviewers with hard-gate retry loop). Trigger on "implement this", "execute the plan", or "/team-implement".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM Implement — Standalone Phase
+# TEAM Implement — Execute the Plan
 
-Run the IMPLEMENT phase. Works in two modes:
-
-- **Resume mode** — predecessor artifacts (`plan.md`, `structure.md`)
-  are present in `docs/plans/`. Behave as the full pipeline expects.
-- **Standalone mode** — invoked directly with a ticket ID or feature
-  description. No upstream QRSPI artifacts required. Bootstrap a minimal
-  `task.md` and run test-architect → implementer → reviewers from the
-  issue alone.
-
-The Implement phase has three internal sub-steps:
+Run the IMPLEMENT phase. Three internal sub-steps:
 
 1. **Test-first** — `test-architect` writes failing acceptance tests
-2. **Slice execution** — `implementer` executes vertical slices with per-slice commits
+2. **Slice execution** — `implementer` executes vertical slices with
+   per-slice commits
 3. **Code review** — 5 parallel reviewers + aggregate hard-gate retry loop
-
-Coordinate progress via TodoWrite. Seed the ledger with: `Test-architect
-→ Mechanical gate → Implementer (per slice) → Review round 1`. Mark
-each item `in_progress` when you dispatch and `completed` when the
-artifact lands. Append `Review round 2` (etc.) on each retry; cap at 5.
 
 ## Input
 
-`$ARGUMENTS` may be:
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-- Empty — assume resume mode; require `plan.md` (or at minimum
-  `structure.md`) on disk for the topic.
-- A ticket ID — recorded as `ticketId` in `task.md` for the user's reference. If your project provides ticket details out-of-band, fold them into the description before invoking. The orchestrator does not call any ticketing system.
-- Free-form text — treat as the feature/task description.
+The agents read:
+
+- `$ARGUMENTS/plan.md` — file-level steps and per-slice tests
+- `$ARGUMENTS/structure.md` — slice ordering and verification checkpoints
+- `$ARGUMENTS/design.md` — context for what each test should assert
+- `$ARGUMENTS/task.md` — intent (for the implementer when in standalone mode)
+
+If `$ARGUMENTS/plan.md` does not exist:
+
+- **Standalone mode** — bootstrap a minimal `$ARGUMENTS/task.md` from
+  `$ARGUMENTS` (or have the user provide a description) and run
+  `test-architect` → `implementer` → reviewers from `task.md` alone.
+
+Coordinate progress via TodoWrite. Seed: `Test-architect → Mechanical
+gate → Implementer (per slice) → Review round 1`.
 
 ## Worktree Check
 
 Before any agent dispatch, decide where to work:
 
-1. Run `git rev-parse --absolute-git-dir` and inspect the path. If it
-   contains `/worktrees/`, you are already inside a Claude Code worktree —
-   proceed in place.
-2. If you are in the main working tree:
-   - Ask the user: "You are not in a worktree. Run this implementation in a
-     new isolated worktree (recommended), or in the current tree?"
-   - If worktree: derive a kebab-case topic from `$ARGUMENTS` (or the ticket
-     issue title), then create a worktree via Claude Code's native support
-     (see `skills/worktree-isolation/SKILL.md`). Tell the user the path
-     and ask them to re-run `/team-implement` from that directory, since
-     the slash command runs in the current shell context.
-   - If in-place: proceed.
+1. Run `git rev-parse --absolute-git-dir`. If the path contains
+   `/worktrees/`, you are already inside a Claude Code worktree — proceed
+   in place.
+2. If you are in the main working tree, ask: "You are not in a worktree.
+   Run this implementation in a new isolated worktree (recommended), or
+   in the current tree?"
+   - **Worktree** — derive `<id>` from `$ARGUMENTS`, create a worktree
+     via Claude Code's native support (see
+     `skills/worktree-isolation/SKILL.md`), tell the user the path, and
+     ask them to re-run `/team-implement docs/plans/<id>/` from that
+     directory.
+   - **In-place** — proceed.
 
 ## Execution
 
-1. Derive `topic` (kebab-case from `$ARGUMENTS`, ticket title, or
-   current branch) and `today` (`YYYY-MM-DD`).
-2. **Resume path.** If `docs/plans/<today>-<topic>-plan.md` (or at
-   minimum `structure.md`) exists, proceed using those artifacts as the
-   work source.
-3. **Standalone path.** If no plan/structure on disk:
-   - Write a minimal `docs/plans/<today>-<topic>-task.md` from
-     `$ARGUMENTS` (or the ticket body) with the standard task.md
-     frontmatter (`topic`, `date`, `phase: task`, `ticketId`). This gives
-     downstream agents a single source of intent.
-4. Follow the phase loop from `/team`:
-   a. Dispatch `test-architect` → produces failing tests. In standalone
-      mode it derives acceptance criteria from `task.md` (or the ticket
-      issue) instead of `structure.md`.
-   b. Mechanical gate: confirm all tests fail with assertion errors.
-   c. Dispatch `implementer` → executes slices with per-slice commits. In
-      standalone mode it works from `task.md` and the failing tests
-      instead of `plan.md`.
-   d. Dispatch 5 reviewers in parallel: `code-reviewer`, `security-reviewer`,
-      `technical-writer`, `ux-reviewer`, `verifier`.
-   e. At the aggregate gate, evaluate hard gates (security + verifier +
-      code-reviewer).
-5. If any hard gate fails:
+1. **Verify** `$ARGUMENTS/plan.md` (resume mode) or bootstrap
+   `$ARGUMENTS/task.md` (standalone mode).
+2. Dispatch `test-architect` → produces failing tests. In standalone
+   mode it derives acceptance criteria from `$ARGUMENTS/task.md` instead
+   of `structure.md`.
+3. **Mechanical gate** — confirm all tests fail with assertion errors
+   (not crashes). On crash, fix test infrastructure before proceeding.
+4. Dispatch `implementer` → executes slices with per-slice commits. In
+   standalone mode it works from `$ARGUMENTS/task.md` and the failing
+   tests.
+5. Dispatch 5 reviewers in parallel: `code-reviewer`,
+   `security-reviewer`, `technical-writer`, `ux-reviewer`, `verifier`.
+6. **Aggregate gate** — evaluate hard gates:
+   - `security-review` FAIL on CRITICAL or HIGH findings
+   - `verification` FAIL if any check failed or no checks detected
+   - `code-review` FAIL on REQUEST CHANGES verdict
+7. On hard-gate failure:
    - Record a typed failure class (security, lint, typecheck, build,
-     test, review) for the implementer to address.
-   - Append a "Review round <n+1>" item to the TodoWrite ledger and mark
-     the previous round complete.
-   - If round count < 5: dispatch implementer to fix the specific
-     findings, then re-dispatch ALL 5 reviewers for a complete fresh
-     review.
-   - If round count >= 5: escalate to the user with a full summary of
-     unresolved findings across all rounds, organized by type. Stop and
-     wait for direction.
-6. **Stop once all hard gates pass — suggest /team-pr to ship.**
+     test, review)
+   - Append `Review round <n+1>` to the TodoWrite ledger
+   - If round count < 5: re-dispatch implementer with the typed class,
+     then re-dispatch ALL 5 reviewers for a fresh review
+   - If round count ≥ 5: escalate with a full unresolved-findings summary
+8. **Stop once all hard gates pass clean.** Suggest `/team-pr`.
 
 ## Quality Loop
-
-Implement is a loop, not a single pass:
 
 ```
 test-architect → mechanical gate → implementer → 5 reviewers → aggregate gate
@@ -100,22 +87,22 @@ test-architect → mechanical gate → implementer → 5 reviewers → aggregate
                                                               verification clean
 ```
 
-Maximum 5 review rounds before escalation. Each round is a complete
-re-review with fresh context — reviewers do not remember previous
-rounds. Track the round count in TodoWrite.
+Maximum 5 rounds. Each round is a complete re-review with fresh context —
+reviewers do not remember previous rounds.
 
 ## Standalone Mode Tradeoffs
 
-Standalone mode skips the Question/Research/Design/Structure/Plan ceremony.
-You forfeit blind research, human design alignment, and explicit slice
-breakdown. Use it when:
+Standalone mode skips the Question/Research/Design/Structure/Plan
+ceremony. You forfeit blind research, human design alignment, and explicit
+slice breakdown. Use it when:
 
-- The work is well-scoped and tracked in a tracking ticket with clear acceptance.
-- You have already decided the approach and just want test-first execution.
-- The change is small enough that the QRSPI artifacts would be overhead.
+- The work is well-scoped and tracked in a ticket with clear acceptance
+- You have already decided the approach and want test-first execution
+- The change is small enough that QRSPI artifacts would be overhead
 
 For larger features, prefer `/team` (full pipeline) for the alignment gates.
 
 ## Completion
 
-Present all review verdicts and suggest: "/team-pr to commit and open a PR"
+Present all review verdicts and tell the user:
+**"Next: run `/team-pr docs/plans/<id>/`"**

--- a/skills/team-plan/SKILL.md
+++ b/skills/team-plan/SKILL.md
@@ -1,42 +1,36 @@
 ---
 name: team-plan
 description: Produce the tactical implementation plan from the approved structure. The plan is for the implementer — humans review the structure, not the plan. No human approval gate at this phase. Trigger on "plan the implementation", "spell out the steps", or "/team-plan".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM Plan — Standalone Phase
+# TEAM Plan — Tactical Implementation Plan
 
-Run the PLAN phase. Two modes:
-
-- **Resume mode** — `structure.md` carries `approved: true` in its
-  frontmatter; planner consumes it.
-- **Standalone mode** — no approved structure, but the user wants a
-  tactical plan now. Bootstrap upstream artifacts inline.
+Run the PLAN phase. There is no human gate here; humans reviewed the
+structure already, and the plan is a tactical artifact for the implementer.
 
 ## Input
 
-`$ARGUMENTS` may be:
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-- Empty — resume mode. Requires `structure.md` on disk with
-  `approved: true` in its frontmatter.
-- A ticket ID — recorded as `ticketId` in `task.md` for the user's reference. The orchestrator does not call any ticketing system.
-- Free-form text — treated as the feature/task description.
+The `planner` reads:
+
+- `$ARGUMENTS/structure.md` (must carry `approved: true` in its frontmatter)
+- `$ARGUMENTS/design.md`
+- `$ARGUMENTS/research.md`
+
+If `$ARGUMENTS/structure.md` is missing or not approved, tell the user to
+run `/team-structure docs/plans/<id>/` first and stop.
 
 ## Execution
 
-1. Read `docs/plans/<today>-<topic>-structure.md` and check the
-   frontmatter for `approved: true`.
-2. **If missing and `$ARGUMENTS` is non-empty** — bootstrap by chaining
-   inline: Question → Research → Design (with human gate) → Structure
-   (with human gate). After both approvals, continue to plan.
-3. **If missing and `$ARGUMENTS` is empty** — ask the user for a
-   description; if still empty, stop.
-4. Follow the phase loop from `/team`. It dispatches the `planner`, which
-   writes `docs/plans/<today>-<topic>-plan.md`.
-5. **Stop once `docs/plans/<today>-<topic>-plan.md` exists on disk.**
-
-There is no human gate here. Humans reviewed the structure already; the plan
-is a tactical artifact for the implementer.
+1. **Verify** `$ARGUMENTS/structure.md` exists and frontmatter shows
+   `approved: true`.
+2. Dispatch `planner`, which writes `$ARGUMENTS/plan.md` with file-level
+   steps and per-slice acceptance test mappings.
+3. **Stop once `$ARGUMENTS/plan.md` exists.**
 
 ## Completion
 
-Report plan path and suggest: "/team-worktree to prepare an isolated worktree"
+Report plan path and tell the user:
+**"Next: run `/team-worktree docs/plans/<id>/`"**

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -1,94 +1,110 @@
 ---
 name: team-pr
-description: Open the pull request after verification passes. Updates the changelog, optionally closes the tracking tracking ticket, and closes out the topic. Trigger on "open the PR", "ship it", or "/team-pr".
+description: Open the pull request after verification passes. Updates the changelog, optionally surfaces the tracking ticket, and closes out the topic. Trigger on "open the PR", "ship it", or "/team-pr".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM PR — Standalone Phase
+# TEAM PR — Create the Pull Request
 
 Run the PR phase. Two modes:
 
 - **Resume mode** — Implement passed the aggregate gate; the topic
-  branch has slice commits ready and a `task.md` with `ticketId`
-  exists in `docs/plans/`. Read the ticket ID from there.
-- **Standalone mode** — no matching task.md, but the working tree has
-  commits or staged changes ready to ship. Treat the current branch as
-  the work source.
+  branch has slice commits ready. `$ARGUMENTS/task.md` and
+  `$ARGUMENTS/design.md` exist.
+- **Standalone mode** — no matching artifact directory, but the working
+  tree has commits or staged changes ready to ship. Treat the current
+  branch as the work source.
 
 ## Input
 
-`$ARGUMENTS` is optional. If a ticket ID is supplied, use it as `ticketId`
-even in standalone mode (the orchestrator records it on task.md but does not close any ticket).
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
+
+The PR description is grounded in `$ARGUMENTS/design.md`. The ticket
+identifier (if any) is read from `$ARGUMENTS/task.md`'s frontmatter.
 
 ## Execution
 
-1. Derive `topic` (from current branch, `$ARGUMENTS`, or the most recent
-   `docs/plans/<today>-*-task.md`).
-2. **Resume path** — `docs/plans/<today>-<topic>-task.md` exists: read
-   `ticketId` from its frontmatter. Proceed with the documented flow
-   below.
-3. **Standalone path** — no matching task.md:
-   - Verify the branch has commits ahead of the default branch, or
-     uncommitted changes worth shipping. If neither, report "Nothing to
-     ship." and stop.
-   - Skip verification gate enforcement — the user is taking
-     responsibility for correctness. Warn them once.
-   - Use `$ARGUMENTS` (if a ticket ID) as `ticketId`; otherwise `null`.
+1. **Detect the base branch:**
+   ```
+   git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+   ```
+   Falls back to `main`.
+2. **Resume path** — `$ARGUMENTS/task.md` exists: read `ticketId` from
+   its frontmatter. Read `$ARGUMENTS/design.md` for the "why" behind the
+   changes.
+3. **Standalone path** — no matching artifact directory:
+   - Verify the branch has commits ahead of the base, or uncommitted
+     changes worth shipping. If neither, report "Nothing to ship." and
+     stop.
+   - Skip aggregate-gate enforcement. Warn the user once that they are
+     taking responsibility for correctness.
 4. **Update CHANGELOG.md** before committing (see Changelog Update below).
-5. Present shipping options. In resume mode the implementer already
-   committed each slice atomically during the Implement phase; in
-   standalone mode the branch may have any commit shape. These options
-   decide what to do with that history now:
-   - **Open PR from existing commits** — push the current branch and
-     open a pull request. Any uncommitted final changes (typically
-     CHANGELOG.md) land as a single trailing ship commit.
-   - **Keep commits locally** — leave commits on the current branch
-     without opening a PR.
-   - **Keep as-is** — leave final changes uncommitted; existing commits
-     remain.
-6. Execute user's choice.
+5. Present shipping options:
+   - **Open PR from existing commits** — push the branch and open a PR.
+     Any uncommitted final changes (typically `CHANGELOG.md`) land as a
+     single trailing ship commit.
+   - **Keep commits locally** — leave commits on the branch without
+     opening a PR.
+   - **Keep as-is** — leave final changes uncommitted.
+6. Execute the user's choice.
 7. **Tracking ticket.** If `ticketId` is non-null, surface it in the
-   completion report so the user can close it in their tracking
-   system. The orchestrator does not close tickets automatically.
-8. If a worktree was created in the Worktree phase, clean it up
-   (cherry-pick or rebase commits onto the target branch, then let
-   Claude Code remove the worktree).
+   completion report so the user can close it in their tracking system.
+   The orchestrator does not close tickets automatically.
+8. **Worktree cleanup.** If a worktree was created in the Worktree
+   phase, cherry-pick or rebase commits onto the target branch, then
+   let Claude Code remove the worktree.
+
+## PR Body Template
+
+```
+## Summary
+[2-3 bullets drawn from $ARGUMENTS/design.md — what and why]
+
+## Design Decisions
+[Key decisions reviewers should understand]
+
+## Changes
+[Brief description, organized by component]
+
+## How to Verify
+- [ ] [Automated verification command]
+- [ ] [Manual verification step]
+
+## References
+- Design: $ARGUMENTS/design.md
+- Plan:   $ARGUMENTS/plan.md
+```
 
 ## Changelog Update
 
-Before creating the ship commit, update `CHANGELOG.md` following the changelog
-methodology in `skills/changelog/SKILL.md`:
+Before creating the ship commit, update `CHANGELOG.md` per
+`skills/changelog/SKILL.md`:
 
 1. Scan commits since the last changelog entry using `git log`.
-2. Filter to user-facing commits: `feat:`, `fix:`, `perf:`, `security:`, and
-   any `BREAKING CHANGE:` footer. Exclude `chore:`, `test:`, `refactor:`,
-   `ci:`, and `docs:` commits.
+2. Filter to user-facing commits: `feat:`, `fix:`, `perf:`, `security:`,
+   and any `BREAKING CHANGE:` footer. Exclude `chore:`, `test:`,
+   `refactor:`, `ci:`, `docs:`.
 3. Translate each included commit to a plain-language user-facing bullet.
-4. Add entries under the `[Unreleased]` section in `CHANGELOG.md`. Create the
-   file with the Keep a Changelog header if it does not exist.
+4. Add entries under `[Unreleased]` in `CHANGELOG.md`. Create the file
+   with the Keep a Changelog header if it does not exist.
 5. Include the `CHANGELOG.md` change in the ship commit.
 
-If there are no user-facing commits to document (all changes are internal),
-skip the changelog update and note this in the completion report.
+If there are no user-facing commits, skip the changelog update and note
+this in the completion report.
 
 ## Commit Discipline
 
-When creating the commit, apply the git-commit methodology from
-`skills/git-commit/SKILL.md`:
+When creating the commit, apply `skills/git-commit/SKILL.md`:
 
-- Use Conventional Commits format: `feat:`, `fix:`, `refactor:`, etc.
-- Subject line: 50 characters or fewer, imperative mood, no trailing period
-- Body: wrapped at 72 characters, explains *why* not *what*
-- One logical change per commit — the feature as a whole, not its
-  implementation steps
-- Reference the issue or plan in the footer if one exists
+- Conventional Commits format: `feat:`, `fix:`, `refactor:`, etc.
+- Subject ≤ 50 chars, imperative, no trailing period
+- Body wrapped at 72, explains *why*, not *what*
+- One logical change per commit — the feature, not its steps
+- Reference the issue or design path in the footer if present
 
-The PR commit represents the complete, user-visible feature. Write the
-subject to describe what the feature does for users, not how it was built.
-
-Note: implementer already committed each slice atomically during the
-Implement phase. The PR may contain multiple commits (one per slice). The
-ship commit is only used if there are uncommitted final changes (e.g.,
-changelog updates).
+The implementer already committed each slice atomically during Implement.
+The PR may contain multiple commits (one per slice). The ship commit is
+only used if there are uncommitted final changes (e.g., changelog).
 
 ## Completion
 

--- a/skills/team-question/SKILL.md
+++ b/skills/team-question/SKILL.md
@@ -1,45 +1,76 @@
 ---
 name: team-question
-description: Decompose a feature description into the QRSPI Question phase artifacts (task, questions, brief). Replaces the old team-brainstorm. Trigger on "shape this idea", "decompose this task", or "/team-question".
+description: Decompose a feature description, ticket, or issue link into the QRSPI Question artifacts (task.md, questions.md). Trigger on "shape this idea", "decompose this task", or "/team-question".
+argument-hint: "<ticket id, issue URL, or task description>"
 ---
 
-# TEAM Question — Standalone Phase
+# TEAM Question — Decompose the Task
 
 Run the QUESTION phase only, then stop. The Question phase decomposes the
-user's intent into three artifacts that the rest of the QRSPI pipeline
-consumes: `task.md` (full intent, human-only), `questions.md` (neutral
-research questions), and `brief.md` (sanitized codebase context).
+user's intent into two artifacts that the rest of the QRSPI pipeline
+consumes:
+
+- `task.md` — the human's full intent. Read by `design-author` and
+  downstream phases that need intent. **Never** read by `researcher` or
+  `file-finder` (blindness invariant).
+- `questions.md` — neutral research questions phrased without intent. The
+  only file `researcher` and `file-finder` ever read.
+
+Both files live in `docs/plans/<id>/` where `<id>` is either a
+ticket-derived slug (`ENG-1234-add-rate-limiting`) or a date-derived slug
+(`2026-05-01-add-rate-limiting`).
 
 ## Input
 
-Feature description: `$ARGUMENTS`
+`$ARGUMENTS` may be:
+
+- A ticket identifier (e.g. `ENG-1234`) — recorded as `ticketId` on
+  `task.md`'s frontmatter. The orchestrator does not call any ticketing
+  system; the ID is stored for the user's reference.
+- An issue URL (e.g. `https://github.com/org/repo/issues/42`) — fetched
+  with `gh issue view` (or equivalent) to extract the title and body
+  before decomposition.
+- Free-form text — treated directly as the feature/task description.
 
 If `$ARGUMENTS` is empty, ask the user to describe what they want and stop.
 
 ## Execution
 
-1. Derive a kebab-case `topic` and set `today` to `YYYY-MM-DD`.
-2. Create `docs/plans/` if needed.
-3. If `task.md` for this topic already exists in `docs/plans/`, resume by
-   re-reading it; else the questioner produces a fresh one with the
-   required frontmatter.
-4. Follow the phase loop defined in `/team` — it dispatches the `questioner`
-   to produce `task.md`, `questions.md`, `brief.md` in `docs/plans/`.
-5. **Stop once the three Question artifacts exist on disk** — do not
-   continue to RESEARCH.
+1. **Resolve the input** to a description:
+   - Ticket-only: ask the user for context, or use any tracker integration
+     they have configured to fetch the issue body.
+   - Issue URL: run `gh issue view <url> --json title,body` and use the
+     title plus body as the description.
+   - Free text: use directly.
+2. **Derive `<id>`**:
+   - If a ticket identifier is present: `<TICKET>-<kebab-topic>` (e.g.,
+     `ENG-1234-add-rate-limiting`).
+   - Otherwise: `<YYYY-MM-DD>-<kebab-topic>` (e.g.,
+     `2026-05-01-add-rate-limiting`).
+   - The `<kebab-topic>` is a 2–4 word kebab-case slug derived from the
+     description.
+3. **Create `docs/plans/<id>/`** if it does not exist.
+4. **Resume detection.** If `docs/plans/<id>/task.md` already exists,
+   re-read it instead of overwriting; if `questions.md` is missing, the
+   questioner only writes `questions.md`.
+5. Dispatch the `questioner` agent with the full description and the
+   target directory `docs/plans/<id>/`. The agent writes `task.md` and
+   `questions.md` to that directory.
+6. **Stop once both artifacts exist on disk** — do not continue to RESEARCH.
 
 ## When to use
 
 - The idea is vague and you want to see the questioner's framing before
   committing to research.
-- You want to review and edit `task.md` / `questions.md` / `brief.md` by
-  hand before research begins.
+- You want to review and edit `task.md` / `questions.md` by hand before
+  research begins.
 - You want to run multiple research passes against the same task without
   re-decomposing.
 
 ## Completion
 
 Report:
-- Path to `task.md`, `questions.md`, `brief.md`
-- Topic slug
-- Suggest: "/team-research to gather codebase facts"
+
+- Path to `task.md` and `questions.md`
+- Topic slug and `<id>`
+- Tell the user: **"Next: run `/team-research docs/plans/<id>/`"**

--- a/skills/team-research/SKILL.md
+++ b/skills/team-research/SKILL.md
@@ -1,41 +1,52 @@
 ---
 name: team-research
-description: Research a codebase area before making changes. Dispatches parallel BLIND read-only agents (file-finder + researcher) that read the neutral brief and questions, never the original task. Trigger on "research this", "explore the codebase for", or "/team-research".
+description: Research a codebase area before making changes. Dispatches parallel BLIND read-only agents (file-finder + researcher) that read questions.md only — never task.md. Trigger on "research this", "explore the codebase for", or "/team-research".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM Research — Standalone Phase
+# TEAM Research — Answer the Questions
 
 Run the RESEARCH phase only, then stop. Research is **blind** — the
 researcher and file-finder never see the user's original task description.
-They consume only `brief.md` and `questions.md`.
+They read `questions.md` and nothing else.
 
 ## Input
 
-`$ARGUMENTS` may be:
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-- Empty — resume mode. Requires existing Question artifacts on disk.
-- A ticket ID — recorded as `ticketId` in `task.md` for the user's reference. The orchestrator does not call any ticketing system.
-- Free-form text — treated as the feature/task description.
+The dispatched agents receive only `$ARGUMENTS/questions.md`. They do **not**
+read `task.md`. If `$ARGUMENTS` is empty or the directory does not exist,
+ask the user to provide an artifact directory (typically the one printed by
+`/team-question`) and stop.
 
 ## Execution
 
-1. Stat `docs/plans/<today>-<topic>-task.md`.
-2. **If missing and `$ARGUMENTS` is non-empty** — dispatch the `questioner`
-   inline to produce `task.md`, `questions.md`, `brief.md` from
-   `$ARGUMENTS` before continuing. Do not ask the user to re-run
-   `/team-question` first; just bootstrap the artifacts.
-3. **If missing and `$ARGUMENTS` is empty** — ask the user what to
-   research and stop.
-4. Follow the phase loop defined in `/team`. It dispatches `file-finder`
-   and `researcher` in parallel; the router writes the combined research
-   artifact to `docs/plans/<today>-<topic>-research.md`.
-5. **Stop once `docs/plans/<today>-<topic>-research.md` exists** — do
-   not continue to DESIGN.
+1. **Verify** `$ARGUMENTS/questions.md` exists. If missing, tell the user
+   to run `/team-question <description>` first and stop.
+2. Dispatch `file-finder` and `researcher` in **parallel**, passing each
+   only the path `$ARGUMENTS/questions.md`. Do **not** pass the original
+   description, `task.md`, or any framing.
+3. Combine their returned content into a single `research.md` written to
+   `$ARGUMENTS/research.md` with the required frontmatter (see the
+   researcher agent for the schema).
+4. **Stop once `$ARGUMENTS/research.md` exists** — do not continue to
+   DESIGN.
+
+## Blindness invariant
+
+- The orchestrator passes only `questions.md` paths to blind agents.
+- Blind agent system prompts forbid reading `task.md`.
+- If the agents need context the questions lack, they must surface it as
+  an open question rather than guessing intent.
+
+If you suspect leakage (e.g., research references a goal not stated in
+`questions.md`), treat it as a defect and re-dispatch with a fresh agent.
 
 ## Completion
 
 Report:
-- Path to the research artifact
-- Key findings (3-5 bullets)
+
+- Path to `$ARGUMENTS/research.md`
+- Key findings (3–5 bullets)
 - Open questions count
-- Suggest: "/team-design to align on approach"
+- Tell the user: **"Next: run `/team-design docs/plans/<id>/`"**

--- a/skills/team-structure/SKILL.md
+++ b/skills/team-structure/SKILL.md
@@ -1,52 +1,42 @@
 ---
 name: team-structure
 description: Break the approved design into vertical slices with verification checkpoints. The structure document is the human's last review point before code is written. Trigger on "slice this up", "break the design into steps", or "/team-structure".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM Structure — Standalone Phase
+# TEAM Structure — How Do We Get There?
 
-Run the STRUCTURE phase. Two modes:
-
-- **Resume mode** — `design.md` carries `approved: true` in its
-  frontmatter; structure-planner consumes the approved design.
-- **Standalone mode** — no approved design, but the user wants to plan
-  vertical slices directly. Bootstrap the missing upstream artifacts.
+Run the STRUCTURE phase. This is the second (and final) human gate.
 
 ## Input
 
-`$ARGUMENTS` may be:
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-- Empty — resume mode. Requires `design.md` on disk with
-  `approved: true` in its frontmatter.
-- A ticket ID — recorded as `ticketId` in `task.md` for the user's reference. The orchestrator does not call any ticketing system.
-- Free-form text — treated as the feature/task description.
-- A path to an existing design-like document — accepted as the design.
+The `structure-planner` reads:
+
+- `$ARGUMENTS/design.md` (must carry `approved: true` in its frontmatter)
+- `$ARGUMENTS/research.md`
+- `$ARGUMENTS/task.md` (for cross-reference; not for re-litigating intent)
+
+If `$ARGUMENTS/design.md` is missing or not approved, tell the user to
+run `/team-design docs/plans/<id>/` first and stop.
 
 ## Execution
 
-1. Read `docs/plans/<today>-<topic>-design.md` and check the frontmatter
-   for `approved: true`.
-2. **If missing and `$ARGUMENTS` is non-empty** — bootstrap by chaining
-   inline: produce Question + Research + Design artifacts, then run the
-   design human gate. After approval, continue to structure.
-3. **If missing and `$ARGUMENTS` is empty** — ask the user for a
-   description; if still empty, stop.
-4. Follow the phase loop from `/team`. It dispatches `structure-planner`,
-   which writes `docs/plans/<today>-<topic>-structure.md` with vertical
-   slices.
-5. At the human gate: present the structure **in full** and ask "Do you
-   approve this structure?".
-6. **Stop once `docs/plans/<today>-<topic>-structure.md` carries
-   `approved: true` in its frontmatter, or the structure has been
-   re-dispatched for revision.**
-
-## On revision
-
-If the user rejects, pass the feedback verbatim to the structure-planner
-on re-dispatch. The structure-planner re-drafts and increments
-`revision: <n+1>` in the new draft's frontmatter (cap 5; beyond that,
-escalate to the user).
+1. **Verify** `$ARGUMENTS/design.md` exists and frontmatter shows
+   `approved: true`.
+2. Dispatch `structure-planner`, which writes `$ARGUMENTS/structure.md`
+   with vertical slices and frontmatter `approved: false`,
+   `approved_at: null`, `revision: 0`.
+3. **Human gate.** Present the structure **in full** and ask: "Do you
+   approve this structure?"
+   - On approve → edit `$ARGUMENTS/structure.md` frontmatter to set
+     `approved: true` and `approved_at: <ISO-8601>`.
+   - On reject → re-dispatch `structure-planner` with feedback verbatim.
+     New draft increments `revision: <n+1>`. Cap at `revision: 5`.
+4. **Stop once `$ARGUMENTS/structure.md` carries `approved: true`.**
 
 ## Completion
 
-Report structure path and suggest: "/team-plan to produce the tactical plan"
+Report structure path and tell the user:
+**"Next: run `/team-plan docs/plans/<id>/`"**

--- a/skills/team-worktree/SKILL.md
+++ b/skills/team-worktree/SKILL.md
@@ -1,51 +1,59 @@
 ---
 name: team-worktree
 description: Prepare an isolated git worktree. Router action — no agent. Trigger on "set up the worktree", "isolate this work", or "/team-worktree".
+argument-hint: "docs/plans/<id>/"
 ---
 
-# TEAM Worktree — Standalone Phase
+# TEAM Worktree — Isolate the Implementation
 
-Create an isolated worktree for a topic. Two modes:
-
-- **Resume mode** — a plan artifact exists. Create the worktree; the
-  next phase (Implement) is detectable by the worktree's existence on
-  the topic branch (`git worktree list --porcelain`).
-- **Standalone mode** — no plan, just a topic name (or ticket ID, or
-  description). Create the worktree and stop, without running the rest
-  of the pipeline.
+Create a git worktree so implementation happens on an isolated branch
+without affecting your main working tree.
 
 ## Input
 
-`$ARGUMENTS` may be:
+`$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-- Empty — resume mode. Requires an existing plan on disk.
-- A ticket ID — derive topic from the issue title.
-- Free-form text — derive a kebab-case topic from it.
+The directory's basename — `<id>` — is used as both the branch name and
+the worktree directory name. If `$ARGUMENTS/plan.md` does not exist,
+tell the user to run `/team-plan docs/plans/<id>/` first and stop.
 
 ## Execution
 
-1. **If we are already inside a worktree** (`git rev-parse --absolute-git-dir`
-   contains `/worktrees/`), report that and stop. Do not nest worktrees.
-2. **Resume mode** — stat `docs/plans/<today>-<topic>-plan.md`. If
-   present: create the worktree (see `skills/worktree-isolation/SKILL.md`)
-   and stop. The Implement phase is detectable by future invocations via
-   `git worktree list --porcelain`.
-3. **Standalone mode** — `$ARGUMENTS` is non-empty and no plan exists:
-   - Derive `topic` from the input (or ticket title).
-   - Create the worktree using Claude Code's native worktree support.
-   - Report the worktree path and suggest: "cd to <path> and run
-     /team-implement <id-or-description> to start coding, or /team
-     <description> for the full pipeline."
-4. **Standalone with no input** — ask the user for a topic name or
-   description and stop if still empty.
+1. **Refuse to nest worktrees.** If `git rev-parse --absolute-git-dir`
+   contains `/worktrees/`, report that you are already inside a worktree
+   and stop.
+2. **Verify** `$ARGUMENTS/plan.md` exists.
+3. **Derive identifiers** from the artifact directory:
+   - `<id>` = `basename "$ARGUMENTS"`
+   - Branch name = `<id>`
+   - Worktree path = follow Claude Code's native worktree convention
+     (see `skills/worktree-isolation/SKILL.md`)
+4. **Confirm with the user** before executing:
+   ```
+   Ready to create worktree:
+
+   Worktree: <path>
+   Branch:   <id>
+   Plan:     $ARGUMENTS/plan.md
+
+   Proceed?
+   ```
+5. **Create the worktree** after the user confirms.
+6. **Copy the artifact directory** into the worktree. Untracked files do
+   not appear automatically in worktrees, and `docs/plans/<id>/` is
+   typically untracked until it is committed:
+   ```
+   cp -r $ARGUMENTS <worktree>/docs/plans/<id>/
+   ```
 
 ## Why isolate
 
-Implementation work touches the working tree. A worktree gives the implementer
-a clean, isolated checkout per topic, so concurrent pipelines do not interfere.
-For trivial single-file changes, in-place implementation is allowed — no
-worktree creation needed.
+Implementation work touches the working tree. A worktree gives the
+implementer a clean checkout per topic, so concurrent pipelines do not
+interfere. For trivial single-file changes, in-place implementation is
+allowed — no worktree needed.
 
 ## Completion
 
-Report the worktree path and the suggested next command.
+Report the worktree path and tell the user:
+**"Next: cd <worktree> and run `/team-implement docs/plans/<id>/`"**

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: team
 description: Full 8-phase autonomous feature implementation pipeline (QRSPI). Trigger on "hey team", "build a feature", "implement end to end", "autonomous implementation", or "/team".
+argument-hint: "<ticket id, issue URL, or feature description>"
 ---
 
 # TEAM — Phase-Table Orchestrator
@@ -11,44 +12,45 @@ to shipped code by walking a linear phase table, dispatching specialist
 agents, and coordinating progress via TodoWrite.
 
 You hold no special state of your own. The durable record is the set of
-artifacts under `docs/plans/<today>-<topic>-*.md` (each carrying YAML
-frontmatter that describes its phase, approval state, and revision
-count). Live in-session coordination uses TodoWrite.
+artifacts under `docs/plans/<id>/*.md` (each carrying YAML frontmatter
+that describes its phase, approval state, and revision count). Live
+in-session coordination uses TodoWrite.
 
 ## Input
 
-Feature description: `$ARGUMENTS`
+`$ARGUMENTS` may be:
+
+- A ticket identifier (e.g. `ENG-1234`) — used as `<id>` prefix and
+  recorded as `ticketId` on `task.md`.
+- An issue URL (e.g. `https://github.com/org/repo/issues/42`) — fetched
+  via `gh issue view` to extract the title and body.
+- Free-form text — used directly as the feature description.
 
 If `$ARGUMENTS` is empty, ask the user to describe the feature and stop.
 
 ## Setup
 
-1. **Check for a tracking ticket ID.** If the first token of
-   `$ARGUMENTS` looks like a ticket identifier (e.g., a kebab-case
-   `<system>-<id>` slug), set it aside as `ticketId` and strip it from
-   the rest of the description. The questioner will record it on
-   `task.md`'s frontmatter as `ticketId`. The TEAM pipeline does not
-   integrate with any specific ticketing system — the ID is recorded
-   for the user's reference and for any project-specific automation
-   they may layer on top (e.g., a hook that marks the ticket
-   in-progress when `task.md` is created). If the first token does not
-   look like a ticket ID, treat all of `$ARGUMENTS` as the description
-   and leave `ticketId` as `null`.
-2. Derive a kebab-case `topic` from the description.
-3. Set `today` to the current date (`YYYY-MM-DD`).
-4. Create `docs/plans/` if it does not exist.
+1. **Resolve `$ARGUMENTS`** to a description (fetch issue via `gh` if a
+   URL; lookup tracker if a ticket-only ID; otherwise use as-is).
+2. **Capture `ticketId`** — if `$ARGUMENTS` starts with a ticket-like
+   pattern (e.g., `<system>-<id>`), set it aside as `ticketId` for
+   `task.md`. Otherwise leave `ticketId` as `null`.
+3. **Derive `<id>`:**
+   - With ticket: `<TICKET>-<kebab-topic>` (e.g., `ENG-1234-add-auth`)
+   - Without ticket: `<YYYY-MM-DD>-<kebab-topic>` (e.g.,
+     `2026-05-01-add-auth`)
+4. Create `docs/plans/<id>/` if it does not exist.
 5. **Seed the TodoWrite ledger** with one item per phase, in order:
    `Question → Research → Design → Structure → Plan → Worktree →
    Implement → PR`. Mark `Question` as `in_progress`.
-6. **Resume detection.** If artifacts already exist for this topic under
-   `docs/plans/<today>-<topic>-*.md`, fast-forward the ledger by marking
-   completed any phases whose artifacts are already on disk and
-   (for human-gated phases) carry `approved: true`. Then mark the
-   first incomplete phase `in_progress`.
+6. **Resume detection.** If artifacts already exist for `<id>` under
+   `docs/plans/<id>/`, fast-forward the ledger by marking completed any
+   phases whose artifacts are present and (for human-gated phases) carry
+   `approved: true`. Then mark the first incomplete phase `in_progress`.
 
-You hold the description in your own context. Downstream of QUESTION
-the description must NEVER appear in any artifact or agent payload
-outside `task.md` and the questioner's own outputs.
+You hold the description in your own context. Downstream of QUESTION the
+description must NEVER appear in any artifact or agent payload outside
+`task.md` and the questioner's own outputs.
 
 ## The Phase Loop
 
@@ -61,7 +63,7 @@ loop:
      phases) carry `approved: true` in their frontmatter. If missing,
      report a desync and suggest re-invoking the same /team-* command.
   4. Dispatch the agent(s) (parallel where the phase table marks them).
-  5. Write each returned artifact to docs/plans/<today>-<topic>-<name>.md
+  5. Write each returned artifact to docs/plans/<id>/<name>.md
      with the YAML frontmatter the agent specifies (see the agent file
      and skills/qrspi-workflow/SKILL.md).
   6. Run the gate for this phase:
@@ -82,21 +84,21 @@ loop:
 
 ### Phase table
 
-| Phase      | Agent(s)                              | Predecessor artifact                                                       | Next phase on pass |
-|------------|---------------------------------------|----------------------------------------------------------------------------|--------------------|
-| QUESTION   | `questioner`                          | (none — description in `$ARGUMENTS`)                                       | RESEARCH           |
-| RESEARCH   | `file-finder`, `researcher` (parallel)| `docs/plans/<today>-<topic>-task.md`                                       | DESIGN             |
-| DESIGN     | `design-author` (→ human gate)        | `docs/plans/<today>-<topic>-research.md`                                   | STRUCTURE          |
-| STRUCTURE  | `structure-planner` (→ human gate)    | `docs/plans/<today>-<topic>-design.md` (frontmatter `approved: true`)      | PLAN               |
-| PLAN       | `planner`                             | `docs/plans/<today>-<topic>-structure.md` (frontmatter `approved: true`)   | WORKTREE           |
-| WORKTREE   | (orchestrator-emit)                   | `docs/plans/<today>-<topic>-plan.md`                                       | IMPLEMENT          |
-| IMPLEMENT  | `test-architect`, `implementer`, 5 reviewers (parallel) | worktree prepared                                        | PR                 |
-| PR         | (orchestrator-emit)                   | aggregate gate passed                                                      | SHIPPED            |
+| Phase      | Agent(s)                                                | Predecessor artifact                                            | Next phase on pass |
+|------------|---------------------------------------------------------|-----------------------------------------------------------------|--------------------|
+| QUESTION   | `questioner`                                            | (none — description in `$ARGUMENTS`)                            | RESEARCH           |
+| RESEARCH   | `file-finder`, `researcher` (parallel, BLIND)           | `docs/plans/<id>/questions.md`                                  | DESIGN             |
+| DESIGN     | `design-author` (→ human gate)                          | `docs/plans/<id>/research.md`                                   | STRUCTURE          |
+| STRUCTURE  | `structure-planner` (→ human gate)                      | `docs/plans/<id>/design.md` (frontmatter `approved: true`)      | PLAN               |
+| PLAN       | `planner`                                               | `docs/plans/<id>/structure.md` (frontmatter `approved: true`)   | WORKTREE           |
+| WORKTREE   | (orchestrator-emit)                                     | `docs/plans/<id>/plan.md`                                       | IMPLEMENT          |
+| IMPLEMENT  | `test-architect`, `implementer`, 5 reviewers (parallel) | worktree prepared                                               | PR                 |
+| PR         | (orchestrator-emit)                                     | aggregate gate passed                                           | SHIPPED            |
 
-For RESEARCH, dispatch `file-finder` and `researcher` in parallel and
-combine their returned content into a single
-`docs/plans/<today>-<topic>-research.md` artifact (with the frontmatter
-the researcher's documentation specifies) before advancing the phase.
+For RESEARCH, dispatch `file-finder` and `researcher` in parallel passing
+each only the `docs/plans/<id>/questions.md` path. Combine their returned
+content into a single `docs/plans/<id>/research.md` artifact (with the
+frontmatter the researcher's documentation specifies) before advancing.
 
 `skills/team/registry.json` is an inventory of the 13 specialist agents
 for documentation purposes only. The orchestrator dispatches based on
@@ -108,64 +110,58 @@ The questioner is the only agent that ever sees the raw description from
 `$ARGUMENTS`. When dispatching the questioner, pass the full description.
 When the questioner returns:
 
-1. Confirm `task.md`, `questions.md`, `brief.md` exist in
-   `docs/plans/<today>-<topic>-*.md`. The questioner writes them
-   directly with the required YAML frontmatter (see the agent file).
+1. Confirm `task.md` and `questions.md` exist in `docs/plans/<id>/`. The
+   questioner writes them directly with the required YAML frontmatter
+   (see the agent file).
 2. Mark Question complete in TodoWrite and Research `in_progress`.
 
-When dispatching `file-finder` and `researcher` (which consume the
-RESEARCH phase), pass them only `questionsPath` and `briefPath`. They
-are forbidden from reading `task.md` and the orchestrator must not
-provide the original description in their context.
+When dispatching `file-finder` and `researcher`, pass them only the path
+`docs/plans/<id>/questions.md`. They are forbidden from reading
+`task.md` and the orchestrator must not provide the original description
+in their context.
 
 ## Gate Handling
 
 ### Human Gate (design approval)
 
 When the `design-author` returns a draft:
-1. Confirm `docs/plans/<today>-<topic>-design.md` exists with frontmatter
+
+1. Confirm `docs/plans/<id>/design.md` exists with frontmatter
    `approved: false` and `approved_at: null`.
 2. Present the design **in full** to the user.
 3. Ask: "Do you approve this design?"
 4. If approved → edit the artifact's frontmatter to set `approved: true`
-   and `approved_at: <ISO-8601 timestamp>`. The frontmatter on the
-   artifact is the durable approval signal.
+   and `approved_at: <ISO-8601 timestamp>`.
 5. If rejected → re-dispatch `design-author` with the user's feedback.
    The new draft must increment `revision: <n+1>` in its frontmatter.
-   Cap at `revision: 5`; beyond that, escalate to the user for direction.
+   Cap at `revision: 5`.
 
 ### Human Gate (structure approval)
 
-When the `structure-planner` returns a draft:
-1. Confirm `docs/plans/<today>-<topic>-structure.md` exists with
-   frontmatter `approved: false` and `approved_at: null`.
-2. Present the structure **in full** to the user.
-3. Ask: "Do you approve this structure?"
-4. If approved → edit frontmatter to `approved: true` and stamp
-   `approved_at: <ISO-8601 timestamp>`.
-5. If rejected → re-dispatch `structure-planner` with feedback. The new
-   draft increments `revision: <n+1>`. Cap at `revision: 5`.
+Same mechanics as design, applied to `docs/plans/<id>/structure.md`.
 
 ### Orchestrator-Emit Gate (worktree preparation)
 
 When the plan artifact exists:
+
 1. Use Claude Code's native worktree support to create an isolated
-   worktree for this topic. See `skills/worktree-isolation/SKILL.md` for
-   the methodology.
-2. The worktree path and branch are discoverable via
-   `git worktree list --porcelain`; no need to persist them.
+   worktree for `<id>`. See `skills/worktree-isolation/SKILL.md`.
+2. Copy `docs/plans/<id>/` into the new worktree (untracked files do
+   not propagate to worktrees automatically).
 
 ### Mechanical Gate (test confirmation)
 
 When the `test-architect` returns failing tests:
+
 1. Run the test suite.
 2. If all tests fail with assertion errors (not crashes), advance.
-3. If tests crash or error, report the issue and stop.
+3. If tests crash or error, fix infrastructure and re-run.
 
 ### Aggregate Gate (review collection)
 
 When the 5 reviewers (security, docs, ux, code, verifier) have all
 returned:
+
 1. Collect all verdicts from the most recent round.
 2. Check each hard gate independently:
    - `security-review` — FAIL on any CRITICAL or HIGH findings.
@@ -173,11 +169,9 @@ returned:
    - `code-review` — FAIL on REQUEST CHANGES verdict.
 3. Track the round count by appending a TodoWrite item like
    "Review round 2" each retry. Cap at 5 rounds.
-4. If under cap → dispatch implementer to fix, passing the specific
-   failure class(es) so it knows what to address. After fixes, all 5
-   reviewers re-run from scratch.
-5. If at cap → escalate to the user. Present all unresolved findings
-   organized by failure type and stop.
+4. If under cap → dispatch implementer to fix, passing the typed failure
+   class(es). After fixes, all 5 reviewers re-run from scratch.
+5. If at cap → escalate to the user with all unresolved findings.
 6. If all hard gates pass clean → advance to PR.
 
 **The loop is: IMPLEMENT → VERIFY (5 reviewers) → typed gate check →
@@ -188,34 +182,35 @@ failure classes so it knows exactly what to fix.
 ### Orchestrator-Emit Gate (PR / ship)
 
 When the aggregate gate passes:
-1. Update `CHANGELOG.md` per `skills/changelog/SKILL.md` (filter for
-   user-facing commits since last release).
+
+1. Update `CHANGELOG.md` per `skills/changelog/SKILL.md`.
 2. Present shipping options: commit + PR, commit locally, keep as-is.
 3. Execute user's choice.
-4. If `task.md` frontmatter has `ticketId` set, the user may want to
-   close the ticket in their tracking system. The orchestrator does
-   not close tickets automatically.
+4. If `task.md` frontmatter has `ticketId` set, surface it so the user
+   can close the ticket. The orchestrator does not close tickets.
 5. Mark all TodoWrite items complete.
-6. If a worktree was created, clean it up (cherry-pick/rebase commits
-   onto the target branch, then let Claude Code remove the worktree).
+6. If a worktree was created, clean it up (cherry-pick or rebase
+   commits onto the target branch, then let Claude Code remove the
+   worktree).
 
 ## Rules
 
-- The artifacts in `docs/plans/` are the single durable record of
+- Artifacts in `docs/plans/<id>/` are the single durable record of
   pipeline state. Each artifact's YAML frontmatter describes its phase,
   approval state, and revision count.
 - TodoWrite is the orchestrator's live coordination ledger. It is
   session-scoped and is rebuilt on entry to any `/team-*` command by
   scanning artifacts.
-- File artifacts in `docs/plans/` are the durable communication protocol.
-  Always write phase findings to disk before advancing.
+- File artifacts in `docs/plans/<id>/` are the durable communication
+  protocol. Always write phase findings to disk before advancing.
 - The two human gates are **design approval** and **structure approval**.
-  Never present the plan to the user for approval — the plan is a tactical
-  agent artifact, the structure is the human contract.
+  Never present the plan to the user for approval — the plan is a
+  tactical agent artifact, the structure is the human contract.
 - The blind-research invariant is non-negotiable. If a researcher's
   context contains the user's original description, the pipeline has a
   defect. Stop and report.
-- On any unexpected failure: report to the user and suggest re-invoking the same /team-* command.
+- On any unexpected failure: report to the user and suggest re-invoking
+  the same /team-* command with `docs/plans/<id>/`.
 - To add a new agent to the pipeline, add an entry to the phase table
   above and to the inventory in `skills/team/registry.json`.
 

--- a/skills/team/registry.json
+++ b/skills/team/registry.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Agent inventory for the TEAM pipeline. Dispatch is driven by the phase table in skills/team/SKILL.md, not by this file. The phases array documents which artifacts each phase produces under docs/plans/. The agents array lists every specialist agent and the phase it serves. The gates array documents the gate kind that follows each phase. Kept in sync with agents/*.md frontmatter (each agent's `phase` field) by .claude/hooks/check-registry-sync.mjs.",
   "phases": [
-    {"name": "QUESTION", "artifacts": ["task.md", "questions.md", "brief.md"]},
+    {"name": "QUESTION", "artifacts": ["task.md", "questions.md"]},
     {"name": "RESEARCH", "artifacts": ["research.md"]},
     {"name": "DESIGN", "artifacts": ["design.md"]},
     {"name": "STRUCTURE", "artifacts": ["structure.md"]},


### PR DESCRIPTION
## Summary

- Replace flat `docs/plans/<date>-<topic>-<phase>.md` layout with per-id directories `docs/plans/<id>/<phase>.md` (`<id>` = `<TICKET>-<topic>` or `<YYYY-MM-DD>-<topic>`), following the [qrspi library](https://github.com/matanshavit/qrspi) convention.
- Add `argument-hint` Claude Code [skill frontmatter](https://code.claude.com/docs/en/skills#frontmatter-reference) to every `/team-*` entry-point. Downstream skills (`team-research` and beyond) take `docs/plans/<id>/` as their single argument.
- Drop `brief.md` as a separate artifact. Neutral codebase context now lives at the top of `questions.md` in a "Codebase context" section. Researcher and file-finder are passed only `questions.md`, preserving the blind-research invariant.

## Changes by area

- **Skills (10):** all `/team-*` entry points + `team-fix` rewritten for the new layout
- **Agents (8):** `questioner`, `researcher`, `file-finder`, `design-author`, `structure-planner`, `planner`, `test-architect`, `implementer` updated for `docs/plans/<id>/` paths
- **Methodology:** `qrspi-workflow` artifact tables and gate references updated; `product-requirements-doc` no longer mentions `brief.md`
- **Hooks:** `pre-compact-anchor.mjs` and `session-start-recover.mjs` scan per-id directories instead of flat dated files
- **Registry:** `skills/team/registry.json` drops `brief.md` from QUESTION artifacts
- **Docs:** `README.md`, `AGENTS.md`, `docs/architecture.md` describe the new layout

## How to Verify

- [x] `bash tests/skill-architecture-tests.sh` — 12/12 passing
- [x] `bash tests/simplify-orchestration-acceptance.sh` — all assertions passing
- [x] `node --check hooks/pre-compact-anchor.mjs` and `node --check hooks/session-start-recover.mjs` — both parse cleanly
- [ ] Manual smoke: run `/team-question "test description"` and confirm `docs/plans/<id>/{task,questions}.md` are created with `argument-hint`-correct frontmatter

## References

- [qrspi command directory](https://github.com/matanshavit/qrspi/tree/main/.claude/commands/qrspi) — artifact-format reference
- [Claude Code skills frontmatter](https://code.claude.com/docs/en/skills#frontmatter-reference) — `argument-hint` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)