### PR TITLE
feat: support multi-repo topics across QRSPI pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-repo topics.** A single `/team` pipeline can now span more than one repository. When the questioner detects multiple repos in the description (or the design-author confirms it during open-questions), it writes `docs/plans/<id>/repos.md` listing each involved repo's slug, absolute path, and role. The Worktree phase then creates a worktree per repo (`<repo>/.claude/worktrees/<id>`, all on the same `<id>` branch); the structure annotates each slice with the repos it touches; the planner prefixes each step with `[repo: <slug>]`; the implementer cd's between worktrees per step and produces one commit per repo; the PR phase opens one cross-linked PR per repo. Single-repo topics keep today's behavior — `repos.md` is optional and absent by default.
+
 ## [0.2.1] - 2026-05-07
 
 ### Changed

--- a/agents/design-author.md
+++ b/agents/design-author.md
@@ -22,6 +22,8 @@ read:
 - `docs/plans/<id>/task.md` — the user's intent
 - `docs/plans/<id>/questions.md` — the questions that drove research
 - `docs/plans/<id>/research.md` — factual codebase findings
+- `docs/plans/<id>/repos.md` — repo scope (only present when the topic
+  spans more than one repository)
 
 For revision dispatch (after a human gate rejection):
 
@@ -57,6 +59,30 @@ re-word, or combine it with the ticket id. Every artifact in
 
 Aim for ~200 lines (excluding frontmatter). Less is OK; more means you
 are doing the planner's job.
+
+## Confirm repo scope (before drafting)
+
+If `docs/plans/<id>/repos.md` is **present**, read it and treat the
+listed repos as the working assumption. The design must respect that
+scope — note in `## Decisions made` which repos each decision touches
+and why.
+
+If `repos.md` is **absent**, scan `research.md` for signals that the
+work plausibly spans more than one repo (cross-service contracts,
+shared schemas, references to "the other repo"). When you see such
+signals, raise the question via `AskUserQuestion` in your interactive
+step (see below) — header `Repos`, options:
+
+- **Single repo (Recommended unless clearly multi-repo)** — keep all
+  work in the current repo.
+- **Multi-repo** — list the additional repos; the user provides paths.
+
+If the user picks **Multi-repo**, write `docs/plans/<id>/repos.md`
+yourself (schema in `skills/qrspi-workflow/SKILL.md`) before continuing
+the design. If they pick **Single repo**, do not write `repos.md`.
+
+Never silently expand scope across repos. The design either ships
+single-repo or it asks first.
 
 ## MANDATORY interactive step
 

--- a/agents/file-finder.md
+++ b/agents/file-finder.md
@@ -14,25 +14,33 @@ relevant to the area under investigation.
 
 ## Blindness invariant
 
-You see exactly one file: `docs/plans/<id>/questions.md`. You **MUST NOT**
-read `docs/plans/<id>/task.md` or otherwise consume the user's original
-description. Find files that match the codebase scope and vocabulary in
-`questions.md` — not files that match an inferred goal.
+You see `docs/plans/<id>/questions.md` and may also read
+`docs/plans/<id>/repos.md` if it exists — `repos.md` lists the repos
+the topic touches (with paths and slug names) but does not state the
+goal. You **MUST NOT** read `docs/plans/<id>/task.md` or otherwise
+consume the user's original description. Find files that match the
+codebase scope and vocabulary in `questions.md` — not files that match
+an inferred goal.
 
 ## Search Strategy
 
 Work through these strategies in order. Cast a wide net first, then narrow.
+In multi-repo mode (when `repos.md` is present), repeat each strategy
+inside every listed repo and report findings namespaced by the repo's
+slug name.
 
 1. **Glob by naming convention** — Search for files whose names match the
    vocabulary terms in `questions.md` (e.g., `**/*auth*`, `**/*billing*`).
-   Try singular and plural forms.
+   Try singular and plural forms. In multi-repo mode, run each glob
+   inside each repo's absolute path.
 
 2. **Content search** — Grep for vocabulary terms, function names, class
    names, error messages. Try synonyms and related concepts.
 
 3. **Import/dependency tracing** — When you find a relevant file, read its
    imports and follow the dependency chain. Also search for files that import
-   the relevant file (reverse dependencies).
+   the relevant file (reverse dependencies). Cross-repo imports are
+   common in multi-repo topics — flag them in `## Notes`.
 
 4. **Directory exploration** — Read directory listings around discovered files
    to find siblings (test files, config files, related modules).
@@ -42,7 +50,10 @@ Work through these strategies in order. Cast a wide net first, then narrow.
 
 ## Output Format
 
-Return a structured report organized by category:
+Return a structured report organized by category. In multi-repo mode,
+prefix every file path with the repo slug, e.g.
+`frontend:src/App.tsx`, so the implementer can resolve it later. The
+slug is the `name` field from the matching entry in `repos.md`.
 
 ```
 ## Found Files
@@ -50,6 +61,7 @@ Return a structured report organized by category:
 ### Source Files
 - `path/to/file.ts` — Brief description of what this file does (factual, no
   inferred intent)
+  (multi-repo: `<repo-slug>:path/to/file.ts`)
 
 ### Test Files
 - `path/to/file.test.ts` — What it tests
@@ -67,6 +79,7 @@ Return a structured report organized by category:
 ## Notes
 - Any caveats, files that might be relevant but uncertain, or areas where
   the search may be incomplete.
+- Cross-repo imports / shared contracts (multi-repo only).
 ```
 
 ## Rules

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -25,8 +25,15 @@ The orchestrator dispatches you with the artifact directory
    slice list, file-level steps, and per-slice tests.
 2. **Read the approved structure** at `docs/plans/<id>/structure.md` to
    understand the order and verification checkpoints.
-3. **Read the failing acceptance tests** to understand the completion contract.
-   Run the test suite once to establish the baseline of failing tests.
+3. **Read `docs/plans/<id>/repos.md` if present.** It defines multi-repo
+   mode and lists each repo's slug, absolute path, and worktree path
+   (under `## Worktrees`). When present, every step that carries a
+   `[repo: <slug>]` annotation in the plan is applied inside that
+   repo's worktree — `cd` to the worktree path before running the
+   step's edits, tests, and commits.
+4. **Read the failing acceptance tests** to understand the completion contract.
+   Run the test suite once (in each involved worktree, in multi-repo
+   mode) to establish the baseline of failing tests.
 
 ### Review-fix dispatch (after a hard-gate failure)
 
@@ -87,18 +94,29 @@ Execute the plan one slice at a time, in the order the plan specifies.
 
 For each slice:
 
-1. **Read the slice spec** — the plan lists its acceptance tests and the
-   file-level steps.
+1. **Read the slice spec** — the plan lists its acceptance tests, the
+   file-level steps, and (multi-repo) the slice's `Repos:` field.
 2. **Implement the steps within the slice** in the order given. Steps marked
    `[parallel]` may be done in any order; `[sequential]` steps depend on
-   prior steps in the slice.
+   prior steps in the slice. In multi-repo mode, each step carries
+   `[repo: <slug>]`; cd into that repo's worktree before applying the
+   step. Cross-repo steps within one slice are routine — switch
+   directories as needed.
 3. **Run the slice's acceptance tests.** When they all pass and prior
-   slices' tests still pass, the slice is done.
-4. **Commit atomically.** One commit per slice, using the slice's
-   `Atomic commit message` from the plan as the subject. Include a body that
-   references the design and structure paths.
+   slices' tests still pass, the slice is done. In multi-repo mode, run
+   each test in the worktree where it lives (the test name in the plan
+   carries a `<repo>:` prefix).
+4. **Commit atomically.** Single-repo: one commit per slice using the
+   slice's `Commit:` line as the subject, body referencing the design
+   and structure paths. Multi-repo: when the slice's `Repos:` field
+   names more than one repo, produce **one commit per repo** in their
+   respective worktrees, using each per-repo `Commit:` subject from the
+   plan. Each commit body references the same design/structure paths
+   and notes "part of slice <N>: <name>" so reviewers can correlate.
 5. **Report the slice as complete** — return a brief summary to the
-   orchestrator: `{slice: <name>, testsPassing: [list], commit: <sha>}`.
+   orchestrator: `{slice: <name>, testsPassing: [list], commits: [
+   {repo: <slug>, sha: <sha>}, ... ]}` (`commits` is a single-entry
+   list in single-repo mode).
 6. **Move to the next slice.**
 
 When all slices are done, return a final implementation summary to the

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -24,6 +24,8 @@ The orchestrator dispatches you with the artifact directory
 - `docs/plans/<id>/structure.md` — the approved vertical-slice breakdown
 - `docs/plans/<id>/design.md` — context, decisions, patterns
 - `docs/plans/<id>/research.md` — codebase facts
+- `docs/plans/<id>/repos.md` — repo scope (only present when the topic
+  spans more than one repository); use it to map slugs to absolute paths
 - The plan should not need to read `task.md`
 
 ## Output
@@ -52,7 +54,9 @@ ticket id. Every artifact in `docs/plans/<id>/` carries the same
 ## Context
 
 Two to three sentences summarizing the change. Reference the approved
-structure by path.
+structure by path. In multi-repo mode, list the repo slugs and their
+worktree paths (read from repos.md `## Worktrees` once the worktrees
+exist) so the implementer knows where to cd for each step.
 
 ## Slices
 
@@ -60,21 +64,31 @@ For each slice from structure.md, expand it into file-level steps.
 
 ### Slice 1: <name from structure.md>
 
+**Repos:** <multi-repo only — comma-separated repo slugs>
 **Acceptance tests** (from structure.md):
 - `test_name_1` — what it asserts
+  (multi-repo: `<repo>:test_name_1`)
 - `test_name_2` — what it asserts
 
 **Steps:**
 
 1. `path/to/file.ts` — <what to add/modify/remove. Reference patterns to
    follow with file:line. Mark as `[parallel]` or `[sequential]`.>
+   (multi-repo: prefix the file path with the repo slug, e.g.
+   `[repo: api] path/to/file.ts` — the implementer cd's into that repo's
+   worktree before applying the step)
 
 2. `path/to/other.ts` — ...
 
 **Verification:** Run `<command>`. The slice is done when its acceptance
 tests pass and prior slices' tests still pass.
+(multi-repo: list one verification command per repo, scoped to that
+repo's worktree)
 
 **Commit:** `<conventional-commit subject for this slice>`
+(multi-repo: when the slice spans repos, list one **Commit** per repo;
+the implementer creates one commit per repo, all with the same slice
+context referenced in the body)
 
 ### Slice 2: <name>
 ...
@@ -84,6 +98,8 @@ tests pass and prior slices' tests still pass.
 - All acceptance tests for every slice pass
 - No regressions in existing tests
 - Any additional criteria specific to this feature
+- (multi-repo) every involved repo's worktree has only the commits this
+  topic produced — no incidental edits in other repos
 ```
 
 ## Rules

--- a/agents/questioner.md
+++ b/agents/questioner.md
@@ -1,8 +1,8 @@
 ---
 name: questioner
-description: Use as the first agent of the QRSPI pipeline. Decomposes a user's task description into a full task record (task.md) and neutral research questions (questions.md). The researcher who reads questions.md should have no idea what feature is being built.
+description: Use as the first agent of the QRSPI pipeline. Decomposes a user's task description into a full task record (task.md) and neutral research questions (questions.md), and — when the description names more than one repository — a repos.md listing the repos the topic touches. The researcher who reads questions.md should have no idea what feature is being built.
 model: sonnet
-tools: Read, Write, Grep, Glob
+tools: Read, Write, Grep, Glob, Bash, AskUserQuestion
 permissionMode: acceptEdits
 ---
 
@@ -40,10 +40,12 @@ real file paths and module names.
 
 ## Outputs
 
-Write both artifacts into `docs/plans/<id>/`:
+Write into `docs/plans/<id>/`:
 
-- `docs/plans/<id>/task.md`
-- `docs/plans/<id>/questions.md`
+- `docs/plans/<id>/task.md` — always
+- `docs/plans/<id>/questions.md` — always
+- `docs/plans/<id>/repos.md` — only when the topic spans more than one
+  repository (see "Multi-repo detection" below)
 
 Each file MUST open with YAML frontmatter (see per-file format below).
 
@@ -53,9 +55,15 @@ Then return a structured result to the orchestrator:
 {
   "taskPath": "docs/plans/<id>/task.md",
   "questionsPath": "docs/plans/<id>/questions.md",
-  "id": "<id>"
+  "reposPath": "docs/plans/<id>/repos.md",
+  "id": "<id>",
+  "multiRepo": true
 }
 ```
+
+`reposPath` and `multiRepo: true` appear only when you wrote `repos.md`.
+In single-repo mode omit those fields (or set `reposPath: null` and
+`multiRepo: false`).
 
 **No `description` field, no `taskMd` field** — the orchestrator must
 not propagate the user's framing to blind agents.
@@ -166,18 +174,83 @@ guessing intent. The "Codebase context" section replaces the legacy
 `brief.md`: it is allowed to name files, modules, and vocabulary, but it
 must NOT state the goal or desired outcome.
 
+## Multi-repo detection
+
+A topic may legitimately span more than one repository — frontend +
+backend, an API + a shared SDK, a service + its infrastructure repo. If
+that is the case, you must record the repos so the rest of the pipeline
+can run worktrees, slices, plan steps, and PRs in each.
+
+### When to suspect a multi-repo topic
+
+Watch for these signals in the description:
+
+- The user names two or more directories or projects (e.g. "the `web`
+  app and the `api` service").
+- The description says "across", "spans", "in both", or refers to a
+  protocol/contract that lives in a third repo.
+- The user references repos by absolute paths or by names that do not
+  exist as subdirectories of the current repo (run `ls` to confirm).
+
+If you suspect multi-repo, ask the user via `AskUserQuestion` before
+writing any artifacts. Use a single question with a `Repos` header and
+two options:
+
+- **Single repo (Recommended if unsure)** — the work happens entirely in
+  the current repo.
+- **Multi-repo** — the work spans the current repo and one or more
+  others; the user will provide the additional paths.
+
+If the user picks **Multi-repo**, follow up with a free-text
+`AskUserQuestion` for the absolute paths and short slug names of each
+additional repo. Validate each path exists and is a git working tree
+(`git -C <path> rev-parse --git-dir`).
+
+### Writing `repos.md`
+
+Required frontmatter:
+
+```yaml
+---
+topic: <kebab-case-topic>
+date: <YYYY-MM-DD>
+phase: repos
+---
+```
+
+Body — see the schema in `skills/qrspi-workflow/SKILL.md`. The home
+repo is whichever repo the orchestrator dispatched you in (the one
+holding `docs/plans/<id>/`); use its absolute path. Each additional
+repo gets a name slug (unique, kebab-case) and an absolute path.
+
+Do not yet write the `## Worktrees` section — that is the orchestrator's
+job during the WORKTREE phase.
+
+### Don't infer multi-repo
+
+If the description does not name additional repos and the user does not
+confirm them, stay in single-repo mode. Inventing extra repos would
+expand scope without consent. When in doubt, ask.
+
 ## Process
 
 1. Read the user's description carefully. If it references existing code
    (file names, modules, error messages), grep/glob to confirm those exist.
-2. Decide the topic slug (kebab-case, ~3 words).
-3. Identify the codebase scope: which directories or modules will research
-   touch? Confirm by listing them.
-4. Draft questions. For each, ask: "If a stranger answered this without
+2. **Decide repo scope.** Look for the multi-repo signals above. If
+   present, ask the user via `AskUserQuestion` and (if confirmed)
+   collect the additional repo paths.
+3. Decide the topic slug (kebab-case, ~3 words).
+4. Identify the codebase scope: which directories or modules — and in
+   multi-repo mode, which repos — will research touch? Confirm by
+   listing them.
+5. Draft questions. For each, ask: "If a stranger answered this without
    knowing the goal, would the answer still be useful?" If no, rewrite.
-5. Read the "Codebase context" section back: it should tell a stranger
+   In multi-repo mode, scope each question to "in repo `<name>`, ..."
+   so research can answer it in the correct repo.
+6. Read the "Codebase context" section back: it should tell a stranger
    "what code exists here" without telling them "what we want to do with it".
-6. Write both files. Return the structured result.
+7. Write `task.md` and `questions.md`. In multi-repo mode also write
+   `repos.md`. Return the structured result.
 
 ## Rules
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -15,14 +15,19 @@ will use to align with the user.
 
 ## Blindness invariant
 
-You do **not** know what is being built. The orchestrator passes you exactly
-one path: `docs/plans/<id>/questions.md`. That file contains both the
+You do **not** know what is being built. The orchestrator passes you the
+path: `docs/plans/<id>/questions.md`. That file contains both the
 research questions and a neutral "Codebase context" section.
 
-You **MUST NOT** read `docs/plans/<id>/task.md`, even if it exists in the
-same directory. You **MUST NOT** infer or guess at the user's intent. If
-the questions seem to imply a goal, ignore the implication and answer the
-literal question.
+You **MAY** also read `docs/plans/<id>/repos.md` if it exists. It lists
+the repos the topic touches (with absolute paths and short slug names)
+but does not state the goal — it carries scope, not intent. Use it to
+know where to look for each question.
+
+You **MUST NOT** read `docs/plans/<id>/task.md`, even if it exists in
+the same directory. You **MUST NOT** infer or guess at the user's
+intent. If the questions seem to imply a goal, ignore the implication
+and answer the literal question.
 
 If a question feels under-specified, return it in the `## Open questions`
 section of your output rather than guessing what the questioner meant.
@@ -30,27 +35,40 @@ section of your output rather than guessing what the questioner meant.
 ## Investigation method
 
 1. **Read the questions.md "Codebase context" section.** Note the scope
-   (directory paths, modules) and the vocabulary it defines.
+   (directory paths, modules) and the vocabulary it defines. If
+   `repos.md` is present, also note the repo slugs and absolute paths.
 2. **Read the questions.** For each, identify the file paths or modules
-   where the answer would live.
+   where the answer would live. In multi-repo mode, also identify which
+   repo each question targets.
 3. **Trace.** Follow the execution path: entry point → handler → service →
-   data layer. Read imports, follow calls, note boundaries.
+   data layer. Read imports, follow calls, note boundaries. In
+   multi-repo mode, follow contracts that cross repo boundaries
+   (shared types, API schemas) and report them in `## Constraints`.
 4. **Pattern recognition.** Identify recurring patterns: naming conventions,
-   error handling style, test structure, module organization.
+   error handling style, test structure, module organization. In
+   multi-repo mode, note where conventions differ between repos.
 5. **Constraint discovery.** Find things that will constrain implementation:
    type definitions, validation rules, database schemas, API contracts,
    environment requirements.
 
 ## Output format
 
-Report your findings in this structure. Keep the entire report under 100 lines.
+Report your findings in this structure. Keep the entire report under 100
+lines (under 150 in multi-repo mode — extra budget for the per-repo
+sections).
+
+In multi-repo mode, prefix every file reference with the repo slug,
+e.g. `frontend:src/App.tsx:42`. The slug is the `name` field from the
+matching entry in `repos.md`.
 
 ```
 ## Tech Stack
 - Language, framework, key libraries with versions if visible
+  (multi-repo: list per repo, e.g. "frontend: React 18; api: Go 1.22")
 
 ## Directory Conventions
 - How the codebase is organized, where things go
+  (multi-repo: one bullet per repo)
 
 ## Answers to Questions
 ### Q1: <restate question>

--- a/agents/structure-planner.md
+++ b/agents/structure-planner.md
@@ -32,6 +32,8 @@ shows `approved: true`):
 - `docs/plans/<id>/design.md` — the approved design
 - `docs/plans/<id>/research.md` — codebase facts
 - `docs/plans/<id>/task.md` — the user's intent
+- `docs/plans/<id>/repos.md` — repo scope (only present when the topic
+  spans more than one repository)
 
 For revision dispatch (after a human gate rejection):
 
@@ -76,11 +78,16 @@ Aim for ~2 pages (≈100–200 lines, excluding frontmatter).
 
 ### Slice 1: <name>
 **Goal:** <one sentence describing the user-visible behavior this slice ships>
+**Repos:** <multi-repo only — comma-separated repo slugs from repos.md
+that this slice touches; e.g. `frontend, api`>
 **Layers touched:** <e.g., migration, repository, service, API handler, client>
-**Tests:** <list of acceptance test names that prove this slice is done>
+**Tests:** <list of acceptance test names that prove this slice is done.
+In multi-repo mode prefix each with `<repo>:` to say where it lives.>
 **Verification checkpoint:** <how the human or CI confirms this slice works in
 isolation, even if later slices are not yet written>
-**Atomic commit message:** <conventional-commit subject for this slice>
+**Atomic commit message:** <conventional-commit subject for this slice.
+In multi-repo mode, if the slice spans repos, use a separate
+**Atomic commit message per repo:** block listing one subject per repo.>
 
 ### Slice 2: <name>
 ...
@@ -88,7 +95,9 @@ isolation, even if later slices are not yet written>
 ## Cross-slice concerns
 <things that span slices — shared types, configuration, feature flags. Each
 should be either pulled into the earliest slice that needs it, or called out
-explicitly.>
+explicitly. In multi-repo mode, contracts between repos (API schemas,
+shared types, protobufs) are common cross-slice concerns — name the
+contract and the slice that defines it.>
 
 ## Out of structure
 <work the design called out as "out of scope" — restated here so the planner
@@ -122,6 +131,14 @@ does not accidentally include it>
   internals are fine, but the user-visible surface must work).
 - **Migrations alone are never a slice.** A migration without a consumer is
   infrastructure scaffolding. Pair it with the read/write that uses it.
+- **Multi-repo: a slice may span repos.** A vertical slice that needs
+  the API and the UI shipped together to demo is one slice that touches
+  two repos, not two slices. Record this in the slice's `**Repos:**`
+  field and produce one atomic commit per repo (each commit is its
+  own atomic unit; the slice as a whole ships when both commits land).
+- **Multi-repo: contract-first when ordering matters.** If repo A's
+  consumer depends on repo B's contract, the slice that defines the
+  contract goes first, and the slice that consumes it cites it.
 
 ## Output to orchestrator
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,13 +168,26 @@ structure.
 ### Phase 6: Worktree
 
 **Action:** orchestrator-emit
-**Predecessor:** `plan.md`
+**Predecessor:** `plan.md` (and optionally `repos.md`)
 
-The orchestrator creates an isolated git worktree using Claude Code's
-native worktree support. The branch name is `<id>`. Worktree path and
-branch are discoverable via `git worktree list --porcelain` — no need to
-persist them. The orchestrator copies `docs/plans/<id>/` into the
-worktree (untracked files don't propagate automatically).
+The orchestrator creates an isolated git worktree per involved repo. The
+branch name is `<id>` in every repo. Worktree paths and branches are
+discoverable via `git -C <repo-path> worktree list --porcelain` per repo
+— for multi-repo topics the orchestrator also writes a `## Worktrees`
+section to `repos.md` so any later `/team-*` invocation can rediscover
+all paths from one file.
+
+**Single-repo (default):** `repos.md` is absent. The orchestrator uses
+Claude Code's native worktree support to create one worktree at
+`<repo>/.claude/worktrees/<id>` and copies `docs/plans/<id>/` into it
+(untracked files don't propagate automatically).
+
+**Multi-repo:** `repos.md` is present. The orchestrator iterates over
+the listed repos, creating one worktree per repo with `git -C
+<repo-path> worktree add .claude/worktrees/<id> -b <id> origin/HEAD`.
+Only the home repo's worktree carries `docs/plans/<id>/`; other repos'
+worktrees do not duplicate the artifacts. See
+`skills/worktree-isolation/SKILL.md` for full topology.
 
 ### Phase 7: Implement
 

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -104,16 +104,70 @@ All phase artifacts live under `docs/plans/<id>/`, where `<id>` is one of:
 - **Date-prefixed**: `<YYYY-MM-DD>-<kebab-topic>` (e.g.,
   `2026-05-01-add-rate-limiting`)
 
-| Artifact  | Path                              | Created By              |
-|-----------|-----------------------------------|-------------------------|
-| Task      | `docs/plans/<id>/task.md`         | questioner agent        |
-| Questions | `docs/plans/<id>/questions.md`    | questioner agent        |
-| Research  | `docs/plans/<id>/research.md`     | researcher agent        |
-| Design    | `docs/plans/<id>/design.md`       | design-author agent     |
-| Structure | `docs/plans/<id>/structure.md`    | structure-planner agent |
-| Plan      | `docs/plans/<id>/plan.md`         | planner agent           |
+| Artifact  | Path                              | Created By              | Required? |
+|-----------|-----------------------------------|-------------------------|-----------|
+| Task      | `docs/plans/<id>/task.md`         | questioner agent        | yes       |
+| Questions | `docs/plans/<id>/questions.md`    | questioner agent        | yes       |
+| Repos     | `docs/plans/<id>/repos.md`        | questioner / design-author | when topic spans repos |
+| Research  | `docs/plans/<id>/research.md`     | researcher agent        | yes       |
+| Design    | `docs/plans/<id>/design.md`       | design-author agent     | yes       |
+| Structure | `docs/plans/<id>/structure.md`    | structure-planner agent | yes       |
+| Plan      | `docs/plans/<id>/plan.md`         | planner agent           | yes       |
 
 The `<id>` slug should match across every artifact for the same feature.
+
+### Repos artifact (`repos.md`)
+
+When a topic touches **more than one repository**, the questioner or
+design-author writes `docs/plans/<id>/repos.md` to enumerate the repos
+involved. The presence of this file switches the WORKTREE phase into
+multi-repo mode (one worktree per listed repo, see
+`skills/worktree-isolation/SKILL.md`). Its absence keeps the pipeline in
+single-repo mode — today's default.
+
+`repos.md` schema:
+
+```yaml
+---
+topic: <kebab-case-topic>
+date: <YYYY-MM-DD>
+phase: repos
+---
+
+# Repos: <topic>
+
+## Home repo
+- **name:** <short-slug>
+- **path:** <absolute-path>
+- **role:** One sentence describing what kind of work happens here.
+
+## Additional repos
+- **name:** <short-slug>
+  **path:** <absolute-path>
+  **role:** One sentence describing what kind of work happens here.
+- **name:** <short-slug>
+  **path:** <absolute-path>
+  **role:** ...
+
+## Worktrees
+<written by the orchestrator after WORKTREE phase succeeds>
+- home: <home-worktree-path>
+- <repo-name>: <repo-path>/.claude/worktrees/<id>
+- ...
+```
+
+Rules:
+
+- **Names are short slugs** (e.g. `frontend`, `api`, `shared-types`) used
+  in slice and plan annotations like `[repo: api]`. Names must be unique
+  across `repos.md`.
+- **Paths are absolute.** Each must be a git working tree.
+- **The home repo is the one the user invoked `/team` from.** Its
+  `docs/plans/<id>/` directory is the canonical artifact location;
+  other repos' worktrees do not carry duplicate artifacts.
+- **The `## Worktrees` section is written by the orchestrator** during
+  the WORKTREE phase, not by the questioner or design-author. Until that
+  phase runs, `repos.md` lists only the repos to be involved.
 
 ### Topic consistency invariant
 
@@ -255,11 +309,14 @@ The orchestrator infers the current phase by scanning what exists in
 | `structure.md` (frontmatter `approved: false`)         | STRUCTURE (gate)    |
 | `structure.md` (frontmatter `approved: true`)          | PLAN (next up)      |
 | `plan.md`                                              | WORKTREE (next up)  |
-| worktree exists for `<id>` branch                      | IMPLEMENT           |
+| worktree exists for `<id>` branch in every involved repo | IMPLEMENT         |
 | topic branch has commits ahead and verifier passed     | PR (next up)        |
-| PR opened or commit shipped                            | SHIPPED             |
+| PR(s) opened or commit(s) shipped                      | SHIPPED             |
 
-Worktree presence: `git worktree list --porcelain | grep -q <id>`.
+Worktree presence (single-repo): `git worktree list --porcelain | grep -q <id>`.
+Worktree presence (multi-repo): for each repo path in
+`docs/plans/<id>/repos.md`, `git -C <repo-path> worktree list --porcelain
+| grep -q <id>`.
 Verifier passed: latest review artifact in `docs/plans/<id>/review-<n>.md`
 shows aggregate gate clean.
 

--- a/skills/team-implement/SKILL.md
+++ b/skills/team-implement/SKILL.md
@@ -22,6 +22,9 @@ The agents read:
 - `$ARGUMENTS/plan.md` — file-level steps and per-slice tests
 - `$ARGUMENTS/structure.md` — slice ordering and verification checkpoints
 - `$ARGUMENTS/design.md` — context for what each test should assert
+- `$ARGUMENTS/repos.md` — repo scope (only present when the topic spans
+  more than one repository); the implementer cd's between worktrees as
+  the plan steps require
 - `$ARGUMENTS/task.md` — intent (for the implementer when in standalone mode)
 
 If `$ARGUMENTS/plan.md` does not exist:
@@ -37,23 +40,30 @@ gate → Implementer (per slice) → Review round 1`.
 
 Before any agent dispatch, decide where to work:
 
-1. Run `git rev-parse --absolute-git-dir`. If the path contains
-   `/worktrees/`, you are already inside a Claude Code worktree — proceed
-   in place.
-2. If you are in the main working tree, use `AskUserQuestion` to ask
+1. **Read `$ARGUMENTS/repos.md` if present.** When present, you are in
+   multi-repo mode. Confirm a worktree exists in **every** listed repo
+   (read the `## Worktrees` section). If any are missing, tell the
+   user to run `/team-worktree docs/plans/<id>/` and stop.
+2. Run `git rev-parse --absolute-git-dir`. If the path contains
+   `/worktrees/`, you are already inside a Claude Code worktree —
+   proceed in place. In multi-repo mode this should be the home repo's
+   worktree; the implementer cd's into the other repos' worktrees as
+   the plan steps require.
+3. If you are in the main working tree, use `AskUserQuestion` to ask
    where to run the implementation. Use a single question with a
    `Worktree` header and these options:
    - **Worktree (Recommended)** — isolate this implementation in a new
-     git worktree.
+     git worktree (or set of worktrees in multi-repo mode).
    - **In-place** — implement on the current branch in the main working
      tree.
 
-   - On **Worktree** — derive `<id>` from `$ARGUMENTS`, create a worktree
-     via Claude Code's native support (see
-     `skills/worktree-isolation/SKILL.md`), tell the user the path, and
-     ask them to re-run `/team-implement docs/plans/<id>/` from that
-     directory.
-   - On **In-place** — proceed.
+   - On **Worktree** — derive `<id>` from `$ARGUMENTS`, create the
+     worktree(s) via `/team-worktree docs/plans/<id>/`, tell the user
+     the home worktree path, and ask them to re-run
+     `/team-implement docs/plans/<id>/` from that directory.
+   - On **In-place** — proceed. (In-place is single-repo only — refuse
+     in-place if `repos.md` is present and tell the user that
+     multi-repo work requires worktrees.)
 
 ## Execution
 

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -24,36 +24,51 @@ identifier (if any) is read from `$ARGUMENTS/task.md`'s frontmatter.
 
 ## Execution
 
-1. **Detect the base branch:**
+1. **Detect mode and inventory worktrees with commits.**
+   - Read `$ARGUMENTS/repos.md` if present. When present, you are in
+     **multi-repo mode** — read the `## Worktrees` section to get each
+     repo's worktree path.
+   - For each involved worktree (single-repo: just the current one;
+     multi-repo: every repo's worktree from `repos.md`), check whether
+     it has commits ahead of its base branch. Skip any with no commits.
+2. **Detect the base branch (per repo):**
    ```
-   git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+   git -C <worktree-path> symbolic-ref refs/remotes/origin/HEAD \
+     | sed 's@^refs/remotes/origin/@@'
    ```
-   Falls back to `main`.
-2. **Resume path** — `$ARGUMENTS/task.md` exists: read `ticketId` from
+   Falls back to `main` per repo.
+3. **Resume path** — `$ARGUMENTS/task.md` exists: read `ticketId` from
    its frontmatter. Read `$ARGUMENTS/design.md` for the "why" behind the
    changes.
-3. **Standalone path** — no matching artifact directory:
+4. **Standalone path** — no matching artifact directory:
    - Verify the branch has commits ahead of the base, or uncommitted
      changes worth shipping. If neither, report "Nothing to ship." and
-     stop.
+     stop. (Standalone mode is single-repo only.)
    - Skip aggregate-gate enforcement. Warn the user once that they are
      taking responsibility for correctness.
-4. **Update CHANGELOG.md** before committing (see Changelog Update below).
-5. Present shipping options via `AskUserQuestion`. Use a single question
+5. **Update CHANGELOG.md** before committing (see Changelog Update below).
+   In multi-repo mode, update each repo's `CHANGELOG.md` with the
+   entries belonging to that repo's commits.
+6. Present shipping options via `AskUserQuestion`. Use a single question
    with a `Ship` header and these options:
    - **Open PR (Recommended)** — push the branch and open a PR. Any
      uncommitted final changes (typically `CHANGELOG.md`) land as a
-     single trailing ship commit.
-   - **Keep commits locally** — leave commits on the branch without
-     opening a PR.
+     single trailing ship commit. In multi-repo mode this opens **one
+     PR per repo with commits** and cross-links them.
+   - **Keep commits locally** — leave commits on the branch(es) without
+     opening any PR.
    - **Keep as-is** — leave final changes uncommitted.
-6. Execute the user's choice.
-7. **Tracking ticket.** If `ticketId` is non-null, surface it in the
+7. Execute the user's choice. In multi-repo mode, push each repo's
+   branch independently and open one PR per repo. Cross-link the PRs
+   in their bodies (see PR Body Template below).
+8. **Tracking ticket.** If `ticketId` is non-null, surface it in the
    completion report so the user can close it in their tracking system.
    The orchestrator does not close tickets automatically.
-8. **Worktree cleanup.** If a worktree was created in the Worktree
-   phase, cherry-pick or rebase commits onto the target branch, then
-   let Claude Code remove the worktree.
+9. **Worktree cleanup.** For each worktree that was created in the
+   Worktree phase, cherry-pick or rebase commits onto the target branch
+   in that repo, then let Claude Code (or `git -C <repo-path> worktree
+   remove`) remove the worktree. In multi-repo mode, run cleanup for
+   every involved repo.
 
 ## PR Body Template
 
@@ -75,6 +90,20 @@ identifier (if any) is read from `$ARGUMENTS/task.md`'s frontmatter.
 - Design: $ARGUMENTS/design.md
 - Plan:   $ARGUMENTS/plan.md
 ```
+
+In multi-repo mode, append a `## Companion PRs` section to each PR
+listing the URLs of every other PR opened for the same topic, so a
+reviewer can navigate the full change set:
+
+```
+## Companion PRs
+This change spans multiple repos. The companion PRs are:
+- [<repo-name>] <pr-url>
+- [<repo-name>] <pr-url>
+```
+
+Open the PRs first to obtain URLs, then edit each PR's body to add the
+section once all URLs are known.
 
 ## Changelog Update
 

--- a/skills/team-question/SKILL.md
+++ b/skills/team-question/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: "<ticket id, issue URL, or task description>"
 # TEAM Question — Decompose the Task
 
 Run the QUESTION phase only, then stop. The Question phase decomposes the
-user's intent into two artifacts that the rest of the QRSPI pipeline
+user's intent into the artifacts that the rest of the QRSPI pipeline
 consumes:
 
 - `task.md` — the human's full intent. Read by `design-author` and
@@ -15,8 +15,14 @@ consumes:
   `file-finder` (blindness invariant).
 - `questions.md` — neutral research questions phrased without intent. The
   only file `researcher` and `file-finder` ever read.
+- `repos.md` — written **only when the topic spans more than one
+  repository**. Lists each involved repo's slug, absolute path, and
+  role. Its presence switches the rest of the pipeline into multi-repo
+  mode (one worktree per repo, slice/step `[repo: <slug>]` annotations,
+  one PR per repo). See `skills/qrspi-workflow/SKILL.md` for the schema
+  and `agents/questioner.md` for the detection rules.
 
-Both files live in `docs/plans/<id>/` where `<id>` is either a
+These files live in `docs/plans/<id>/` where `<id>` is either a
 ticket-derived slug (`ENG-1234-add-rate-limiting`) or a date-derived slug
 (`2026-05-01-add-rate-limiting`).
 
@@ -55,8 +61,11 @@ If `$ARGUMENTS` is empty, ask the user to describe what they want and stop.
    questioner only writes `questions.md`.
 5. Dispatch the `questioner` agent with the full description and the
    target directory `docs/plans/<id>/`. The agent writes `task.md` and
-   `questions.md` to that directory.
-6. **Stop once both artifacts exist on disk** — do not continue to RESEARCH.
+   `questions.md`, plus `repos.md` when it confirms with the user that
+   the topic spans multiple repos.
+6. **Stop once `task.md` and `questions.md` exist on disk** — do not
+   continue to RESEARCH. (`repos.md` may also exist if multi-repo was
+   confirmed; that does not change the stop condition.)
 
 ## When to use
 
@@ -71,6 +80,8 @@ If `$ARGUMENTS` is empty, ask the user to describe what they want and stop.
 
 Report:
 
-- Path to `task.md` and `questions.md`
+- Path to `task.md` and `questions.md` (and `repos.md` when written)
 - Topic slug and `<id>`
+- Mode: single-repo or multi-repo (with the list of involved repo slugs
+  if multi-repo)
 - Tell the user: **"Next: run `/team-research docs/plans/<id>/`"**

--- a/skills/team-research/SKILL.md
+++ b/skills/team-research/SKILL.md
@@ -14,9 +14,10 @@ They read `questions.md` and nothing else.
 
 `$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
-The dispatched agents receive only `$ARGUMENTS/questions.md`. They do **not**
-read `task.md`. If `$ARGUMENTS` is empty or the directory does not exist,
-ask the user to provide an artifact directory (typically the one printed by
+The dispatched agents receive `$ARGUMENTS/questions.md` and (when it
+exists) `$ARGUMENTS/repos.md`. They do **not** read `task.md`. If
+`$ARGUMENTS` is empty or the directory does not exist, ask the user to
+provide an artifact directory (typically the one printed by
 `/team-question`) and stop.
 
 ## Execution
@@ -24,20 +25,27 @@ ask the user to provide an artifact directory (typically the one printed by
 1. **Verify** `$ARGUMENTS/questions.md` exists. If missing, tell the user
    to run `/team-question <description>` first and stop.
 2. Dispatch `file-finder` and `researcher` in **parallel**, passing each
-   only the path `$ARGUMENTS/questions.md`. Do **not** pass the original
+   the path `$ARGUMENTS/questions.md`. If `$ARGUMENTS/repos.md` exists,
+   include its path too — `repos.md` carries scope (which repos and
+   where) without leaking intent. Do **not** pass the original
    description, `task.md`, or any framing.
 3. Combine their returned content into a single `research.md` written to
    `$ARGUMENTS/research.md` with the required frontmatter (see the
    researcher agent for the schema). The `topic` value MUST be read
    from `$ARGUMENTS/questions.md`'s frontmatter and copied verbatim —
-   never improvised, never combined with the ticket id.
+   never improvised, never combined with the ticket id. In multi-repo
+   mode, preserve the repo-slug prefix on every file reference (e.g.
+   `frontend:src/App.tsx:42`).
 4. **Stop once `$ARGUMENTS/research.md` exists** — do not continue to
    DESIGN.
 
 ## Blindness invariant
 
-- The orchestrator passes only `questions.md` paths to blind agents.
-- Blind agent system prompts forbid reading `task.md`.
+- The orchestrator passes blind agents only `questions.md` (and
+  optionally `repos.md` for scope). Never `task.md`, never the
+  description.
+- Blind agent system prompts forbid reading `task.md`. They are allowed
+  to read `repos.md` because it carries scope, not intent.
 - If the agents need context the questions lack, they must surface it as
   an open question rather than guessing intent.
 

--- a/skills/team-worktree/SKILL.md
+++ b/skills/team-worktree/SKILL.md
@@ -1,59 +1,142 @@
 ---
 name: team-worktree
-description: Prepare an isolated git worktree. Router action — no agent. Trigger on "set up the worktree", "isolate this work", or "/team-worktree".
+description: Prepare one or more isolated git worktrees — one per repository the topic touches. Router action — no agent. Trigger on "set up the worktree", "isolate this work", or "/team-worktree".
 argument-hint: "docs/plans/<id>/"
 ---
 
 # TEAM Worktree — Isolate the Implementation
 
-Create a git worktree so implementation happens on an isolated branch
-without affecting your main working tree.
+Create a git worktree per involved repository so implementation happens on
+isolated branches without affecting any main working tree. In single-repo
+mode (the default) this is one worktree in the home repo. In multi-repo
+mode (when `docs/plans/<id>/repos.md` is present) it is one worktree per
+listed repo, all sharing the same `<id>` branch name.
 
 ## Input
 
 `$ARGUMENTS` is the artifact directory: `docs/plans/<id>/`.
 
 The directory's basename — `<id>` — is used as both the branch name and
-the worktree directory name. If `$ARGUMENTS/plan.md` does not exist,
-tell the user to run `/team-plan docs/plans/<id>/` first and stop.
+the worktree directory name in every involved repo. If `$ARGUMENTS/plan.md`
+does not exist, tell the user to run `/team-plan docs/plans/<id>/` first
+and stop.
+
+## Detect mode
+
+1. **Verify** `$ARGUMENTS/plan.md` exists.
+2. **Read `$ARGUMENTS/repos.md`** if present:
+   - Parse the home repo path and the list of additional repos (each with
+     `path:` and `name:` fields). See `skills/qrspi-workflow/SKILL.md`
+     for the schema.
+   - This puts you in **multi-repo mode**.
+3. If `repos.md` is absent, you are in **single-repo mode**: only the
+   home repo (the one this command is running in) gets a worktree.
+
+## Refusal
+
+**Refuse to create a nested worktree in any involved repo.** For each
+target repo, run `git -C <repo-path> rev-parse --absolute-git-dir` and
+check whether the resulting path contains `/worktrees/`. If any repo's
+current checkout is already inside a worktree, report that and stop —
+nesting worktrees is not supported. The user should resolve the nested
+worktree (or invoke `/team` from a non-worktree checkout) before retrying.
+
+In multi-repo mode, this check applies to **every** listed repo, not
+just the home repo.
 
 ## Execution
 
-1. **Refuse to nest worktrees.** If `git rev-parse --absolute-git-dir`
-   contains `/worktrees/`, report that you are already inside a worktree
-   and stop.
-2. **Verify** `$ARGUMENTS/plan.md` exists.
-3. **Derive identifiers** from the artifact directory:
-   - `<id>` = `basename "$ARGUMENTS"`
-   - Branch name = `<id>`
-   - Worktree path = follow Claude Code's native worktree convention
-     (see `skills/worktree-isolation/SKILL.md`)
-4. **Confirm with the user** before executing:
-   ```
-   Ready to create worktree:
+### Derive identifiers
 
-   Worktree: <path>
-   Branch:   <id>
-   Plan:     $ARGUMENTS/plan.md
+- `<id>` = `basename "$ARGUMENTS"`
+- Branch name = `<id>` (in every involved repo)
+- Worktree path per repo = `<repo-path>/.claude/worktrees/<id>` (per
+  Claude Code's native worktree convention; see
+  `skills/worktree-isolation/SKILL.md`)
 
-   Proceed?
-   ```
-5. **Create the worktree** after the user confirms.
-6. **Copy the artifact directory** into the worktree. Untracked files do
-   not appear automatically in worktrees, and `docs/plans/<id>/` is
-   typically untracked until it is committed:
-   ```
-   cp -r $ARGUMENTS <worktree>/docs/plans/<id>/
-   ```
+### Confirm with the user
+
+Single-repo:
+```
+Ready to create worktree:
+
+Worktree: <home-worktree-path>
+Branch:   <id>
+Plan:     $ARGUMENTS/plan.md
+
+Proceed?
+```
+
+Multi-repo:
+```
+Ready to create N worktrees (one per listed repo):
+
+  <repo-1-name> @ <repo-1-path>/.claude/worktrees/<id>
+  <repo-2-name> @ <repo-2-path>/.claude/worktrees/<id>
+  ...
+
+Branch in each: <id>
+Plan:           $ARGUMENTS/plan.md
+
+Proceed?
+```
+
+Use `AskUserQuestion` with a `Worktree` header and **Proceed** /
+**Cancel** options.
+
+### Create the worktree(s)
+
+After the user confirms:
+
+- **Single-repo:** create the home worktree using Claude Code's native
+  worktree support, branched off `origin/HEAD`.
+- **Multi-repo:** for each listed repo:
+  ```
+  git -C <repo-path> fetch origin --quiet
+  git -C <repo-path> worktree add .claude/worktrees/<id> -b <id> origin/HEAD
+  ```
+  If a repo lacks an `origin` remote or `origin/HEAD`, fall back to its
+  current default branch and warn the user once for that repo.
+
+### Carry the artifact directory into the home worktree
+
+Untracked files do not appear automatically in worktrees, and
+`docs/plans/<id>/` is typically untracked until it is committed:
+
+```
+cp -r $ARGUMENTS <home-worktree>/docs/plans/<id>/
+```
+
+In multi-repo mode, **only the home worktree** gets the artifact
+directory. Agents working in additional repos read artifacts from the
+home worktree path, which the orchestrator passes in.
+
+### Record the worktree paths (multi-repo only)
+
+After all worktrees are created, append a `## Worktrees` section to the
+home worktree's `docs/plans/<id>/repos.md` listing each repo's worktree
+path. This becomes the discoverable record any later `/team-*` invocation
+reads to relocate the worktrees.
+
+```markdown
+## Worktrees
+- home: <home-worktree-path>
+- <repo-name>: <repo-path>/.claude/worktrees/<id>
+- ...
+```
 
 ## Why isolate
 
-Implementation work touches the working tree. A worktree gives the
-implementer a clean checkout per topic, so concurrent pipelines do not
-interfere. For trivial single-file changes, in-place implementation is
-allowed — no worktree needed.
+Implementation work touches the working tree. A worktree per repo gives
+the implementer a clean checkout per topic in every involved repo, so
+concurrent pipelines do not interfere. For trivial single-file changes,
+in-place implementation is allowed — no worktree needed.
 
 ## Completion
 
-Report the worktree path and tell the user:
-**"Next: cd <worktree> and run `/team-implement docs/plans/<id>/`"**
+Report the worktree paths and tell the user:
+
+- Single-repo: **"Next: cd <home-worktree> and run `/team-implement docs/plans/<id>/`"**
+- Multi-repo: **"Next: cd <home-worktree> and run `/team-implement
+  docs/plans/<id>/`. The implementer will navigate between the
+  per-repo worktrees as the plan steps require."**

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -149,10 +149,18 @@ Use `AskUserQuestion` for the verdict the same way.
 
 When the plan artifact exists:
 
-1. Use Claude Code's native worktree support to create an isolated
-   worktree for `<id>`. See `skills/worktree-isolation/SKILL.md`.
-2. Copy `docs/plans/<id>/` into the new worktree (untracked files do
-   not propagate to worktrees automatically).
+1. **Detect mode.** If `docs/plans/<id>/repos.md` exists, you are in
+   **multi-repo mode** — create one worktree per repo listed in that
+   file, all on the same `<id>` branch. Otherwise you are in
+   **single-repo mode** — create one worktree in the current repo.
+   See `skills/worktree-isolation/SKILL.md` for the topology and
+   `skills/team-worktree/SKILL.md` for the procedure.
+2. Copy `docs/plans/<id>/` into the **home worktree** only (other
+   repos' worktrees do not duplicate the artifacts; agents that need
+   them read from the home worktree path the orchestrator passes in).
+3. In multi-repo mode, append a `## Worktrees` section to `repos.md`
+   recording each repo's worktree path so later `/team-*` invocations
+   can rediscover them.
 
 ### Mechanical Gate (test confirmation)
 
@@ -188,17 +196,21 @@ failure classes so it knows exactly what to fix.
 
 When the aggregate gate passes:
 
-1. Update `CHANGELOG.md` per `skills/changelog/SKILL.md`.
+1. Update `CHANGELOG.md` per `skills/changelog/SKILL.md`. In multi-repo
+   mode, update each repo's `CHANGELOG.md` with the entries belonging
+   to that repo's commits.
 2. Present shipping options via `AskUserQuestion` (header `Ship`):
    **Open PR**, **Keep commits locally**, **Keep as-is**. See
    `skills/team-pr/SKILL.md` for the canonical option text.
-3. Execute user's choice.
+3. Execute user's choice. In multi-repo mode this opens **one PR per
+   repo with commits ahead**, and the PR bodies cross-link to each
+   other so reviewers can see the full change set.
 4. If `task.md` frontmatter has `ticketId` set, surface it so the user
    can close the ticket. The orchestrator does not close tickets.
 5. Mark all TodoWrite items complete.
-6. If a worktree was created, clean it up (cherry-pick or rebase
-   commits onto the target branch, then let Claude Code remove the
-   worktree).
+6. For each worktree that was created, clean it up (cherry-pick or
+   rebase commits onto the target branch in that repo, then let Claude
+   Code or `git worktree remove` remove the worktree).
 
 ## Rules
 
@@ -226,6 +238,19 @@ When the aggregate gate passes:
   the same /team-* command with `docs/plans/<id>/`.
 - To add a new agent to the pipeline, add an entry to the phase table
   above and to the inventory in `skills/team/registry.json`.
+
+### Multi-repo topics
+
+A topic that touches more than one repository is recorded in
+`docs/plans/<id>/repos.md` (schema in `skills/qrspi-workflow/SKILL.md`).
+The questioner creates `repos.md` if the user's description names
+multiple repos; the design-author confirms or amends the list during
+the open-questions step. Once `repos.md` exists, every downstream phase
+respects it: research spans every listed repo, slices and plan steps
+carry `[repo: <name>]` annotations, the WORKTREE phase creates a
+worktree per repo, the implementer changes directory between them per
+step, and PR opens one PR per repo. When `repos.md` is absent, the
+pipeline runs in single-repo mode (today's default).
 
 ### Approval marker convention
 

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -1,32 +1,64 @@
 ---
 name: worktree-isolation
-description: Worktree isolation methodology — loaded by the router to run the entire TEAM pipeline in an isolated git worktree using Claude Code's native worktree support, enabling parallel /team runs
+description: Worktree isolation methodology — loaded by the router to run the entire TEAM pipeline in one or more isolated git worktrees, enabling parallel /team runs and features that span multiple repositories
 ---
 
 # Worktree Isolation
 
-Every `/team` pipeline run operates in its own isolated git worktree. The
-worktree boundary is at the **router level** — not per-agent. This means:
+Every `/team` pipeline run operates in **one or more** isolated git
+worktrees — one per repository the topic touches. The worktree boundary
+is at the **router level** — not per-agent. This means:
 
 1. **Parallel pipelines.** Multiple `/team` runs can execute simultaneously
-   without file conflicts. Each gets its own worktree.
-2. **Clean main tree.** The user's working tree is never polluted by
-   in-progress implementation, test scaffolding, or intermediate commits.
+   without file conflicts. Each gets its own worktree(s).
+2. **Clean main tree(s).** The user's working tree in every involved repo
+   is never polluted by in-progress implementation, test scaffolding, or
+   intermediate commits.
 3. **Simple agents.** No agent needs to know about isolation. They operate
-   in whatever directory they're given.
+   in whatever directory the orchestrator hands them.
+4. **Multi-repo features.** A single topic can span repos (e.g. frontend
+   + backend + shared types) by listing them in `docs/plans/<id>/repos.md`.
+   The router creates a worktree in each, branched off the same `<id>`.
 
-## Claude Code Native Worktrees
+## Single-repo (default)
 
-Claude Code has built-in worktree support. The router creates the worktree
-at setup time using `--worktree <topic>` or by dispatching into a worktree
-context. Claude Code handles everything:
+When `docs/plans/<id>/repos.md` is **absent**, the topic touches only the
+home repo (the repo the user invoked `/team` from). The router creates
+exactly one worktree using Claude Code's native worktree support:
 
-- Creates a worktree at `<repo>/.claude/worktrees/<name>`
-- Branches from the default remote branch (`origin/HEAD`)
-- Provides an isolated copy of the repository
+- Worktree path: `<repo>/.claude/worktrees/<id>`
+- Branch: `<id>`, branched from the default remote branch (`origin/HEAD`)
 - Cleans up automatically if no changes remain after exit
 
 No custom worktree creation, path management, or teardown logic is needed.
+
+## Multi-repo
+
+When `docs/plans/<id>/repos.md` is **present**, the topic spans multiple
+repos. The router creates **one worktree per listed repo**, all sharing
+the same branch name `<id>`:
+
+- For each repo with absolute path `<repo-path>` in `repos.md`:
+  - Worktree path: `<repo-path>/.claude/worktrees/<id>`
+  - Branch: `<id>`, branched from that repo's `origin/HEAD`
+  - Created via `git -C <repo-path> worktree add .claude/worktrees/<id> -b <id> origin/HEAD`
+- The **home repo's worktree** holds the canonical `docs/plans/<id>/`
+  artifact directory. The other repos' worktrees do not duplicate the
+  artifacts; agents that need them read from the home worktree's path,
+  which the orchestrator passes in.
+
+After all worktrees are created, the orchestrator appends a `## Worktrees`
+section to `repos.md` recording the per-repo worktree paths. Any later
+`/team-*` invocation rediscovers them by reading that one file.
+
+## Claude Code Native Worktrees
+
+For the home repo, Claude Code has built-in worktree support (`--worktree
+<topic>` or dispatch into a worktree context). For additional repos in
+multi-repo mode, the router uses plain `git worktree add` because Claude
+Code's native flag only knows about the repo it was launched from. Either
+mechanism produces a standard git worktree — there is no behavioral
+difference downstream.
 
 ## Lifecycle
 
@@ -34,28 +66,34 @@ No custom worktree creation, path management, or teardown logic is needed.
 
 During the router's Setup phase, before any agent is dispatched:
 
-1. Create an isolated worktree for this pipeline run.
-2. All subsequent agent dispatches operate within the worktree.
+1. Create the home repo's worktree. If `repos.md` is present, create a
+   worktree in each additional repo it lists (same `<id>` branch in each).
+2. All subsequent agent dispatches operate within the appropriate
+   worktree (the home worktree by default; per-repo worktrees when a
+   slice or step carries a `[repo: <name>]` annotation).
 3. The durable inter-agent protocol is the artifact files under the
-   worktree's `docs/plans/` directory (design.md, structure.md, with
-   `approved: true` flipped in their frontmatter on human approval,
-   etc.). The orchestrator's live coordination uses TodoWrite
-   (session-scoped).
+   home worktree's `docs/plans/<id>/` directory. Live coordination uses
+   TodoWrite (session-scoped).
 
 ### During the pipeline
 
 All agents — researcher, planner, test-architect, implementer, reviewers —
-run inside the same worktree. They read and write files, run tests, and make
-commits within the worktree's branch. The main working tree is untouched.
+run inside whichever worktree the orchestrator hands them for the current
+slice or step. In single-repo mode that is always the home worktree. In
+multi-repo mode the implementer changes directory between repos as the
+plan steps require, committing each slice in the worktree where its
+files live. Main working trees are never touched.
 
 ### Ship (teardown)
 
 After shipping:
 
-1. Cherry-pick or rebase commits from the worktree branch onto the target branch.
-2. Claude Code removes the worktree automatically if no uncommitted changes remain.
-3. If manual cleanup is needed: `git worktree remove <path>` and
-   `git branch -D <branch>`.
+1. For each worktree with commits ahead of its base branch, cherry-pick
+   or rebase commits onto the target branch in that repo, then let
+   Claude Code (or `git worktree remove`) remove the worktree.
+2. Empty worktrees clean up automatically.
+3. If manual cleanup is needed: `git -C <repo-path> worktree remove
+   <worktree-path>` and `git -C <repo-path> branch -D <id>`.
 
 ## Gitignored Files
 
@@ -68,15 +106,20 @@ file to the project root using `.gitignore` syntax:
 .env.local
 ```
 
-Only files matching a pattern that are also gitignored get copied.
+Only files matching a pattern that are also gitignored get copied. In
+multi-repo mode, each repo honors its own `.worktreeinclude` independently.
 
 ## Fallback
 
-If worktree creation fails (shallow clones, certain CI systems):
+If worktree creation fails in any repo (shallow clones, certain CI systems):
 
-1. Report the failure: "Worktree creation failed. Falling back to main tree."
-2. Continue the entire pipeline in the main working tree.
-3. The orchestrator proceeds with in-place work — no isolation, but the pipeline still runs.
+1. Report the failure for that repo: "Worktree creation failed in <name>.
+   Falling back to main tree for that repo."
+2. Continue the pipeline. Other repos still get worktrees; the failing
+   repo's portion of the work runs in its main working tree.
+3. If creation fails in the home repo, the orchestrator proceeds with
+   in-place work for the entire pipeline — no isolation, but the pipeline
+   still runs.
 
 Never block the pipeline because worktree creation failed — isolation is
 a best-practice enhancement, not a hard requirement.

--- a/tests/multi-repo-tests.sh
+++ b/tests/multi-repo-tests.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Acceptance tests for multi-repo topic support.
+#
+# Asserts that the QRSPI pipeline carries the multi-repo extension end to
+# end: the questioner can write `repos.md`, the design-author confirms it,
+# the worktree skill creates a worktree per repo, the structure/planner
+# annotate slices and steps with [repo: <name>], the implementer cd's
+# between worktrees, and team-pr opens cross-linked PRs.
+#
+# Run from the repository root: bash tests/multi-repo-tests.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+
+pass() {
+  echo "PASS  $1"
+}
+
+fail() {
+  echo "FAIL  $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+QRSPI="$REPO_ROOT/skills/qrspi-workflow/SKILL.md"
+WORKTREE_ISO="$REPO_ROOT/skills/worktree-isolation/SKILL.md"
+TEAM_WT="$REPO_ROOT/skills/team-worktree/SKILL.md"
+TEAM_IMPL="$REPO_ROOT/skills/team-implement/SKILL.md"
+TEAM_PR="$REPO_ROOT/skills/team-pr/SKILL.md"
+TEAM_RES="$REPO_ROOT/skills/team-research/SKILL.md"
+TEAM="$REPO_ROOT/skills/team/SKILL.md"
+QUESTIONER="$REPO_ROOT/agents/questioner.md"
+DESIGN_AUTHOR="$REPO_ROOT/agents/design-author.md"
+RESEARCHER="$REPO_ROOT/agents/researcher.md"
+FILE_FINDER="$REPO_ROOT/agents/file-finder.md"
+STRUCTURE_PLANNER="$REPO_ROOT/agents/structure-planner.md"
+PLANNER="$REPO_ROOT/agents/planner.md"
+IMPLEMENTER="$REPO_ROOT/agents/implementer.md"
+
+# T1 — qrspi-workflow documents repos.md as an artifact and gives a schema
+if grep -q "repos.md" "$QRSPI" \
+  && grep -q "phase: repos" "$QRSPI"; then
+  pass "T1: qrspi-workflow documents repos.md artifact + schema"
+else
+  fail "T1: qrspi-workflow does not document repos.md schema"
+fi
+
+# T2 — worktree-isolation explains multi-repo topology
+if grep -q "Multi-repo" "$WORKTREE_ISO" \
+  && grep -q "one worktree per listed repo" "$WORKTREE_ISO"; then
+  pass "T2: worktree-isolation documents multi-repo topology"
+else
+  fail "T2: worktree-isolation does not document multi-repo topology"
+fi
+
+# T3 — team-worktree reads repos.md and creates per-repo worktrees
+if grep -q "repos.md" "$TEAM_WT" \
+  && grep -Eq "git -C .* worktree add" "$TEAM_WT"; then
+  pass "T3: team-worktree reads repos.md and runs per-repo worktree add"
+else
+  fail "T3: team-worktree does not handle multi-repo worktree creation"
+fi
+
+# T4 — team-worktree records per-repo worktree paths back into repos.md
+if grep -q "## Worktrees" "$TEAM_WT"; then
+  pass "T4: team-worktree records ## Worktrees section in repos.md"
+else
+  fail "T4: team-worktree does not record worktree paths back into repos.md"
+fi
+
+# T5 — questioner has AskUserQuestion tool and a multi-repo detection step
+if grep -Eq "^tools:.*AskUserQuestion" "$QUESTIONER" \
+  && grep -q "Multi-repo detection" "$QUESTIONER"; then
+  pass "T5: questioner has AskUserQuestion tool + multi-repo detection"
+else
+  fail "T5: questioner missing AskUserQuestion tool or multi-repo step"
+fi
+
+# T6 — design-author confirms repo scope before drafting
+if grep -q "Confirm repo scope" "$DESIGN_AUTHOR"; then
+  pass "T6: design-author confirms repo scope before drafting"
+else
+  fail "T6: design-author does not confirm repo scope"
+fi
+
+# T7 — researcher and file-finder may read repos.md (scope-not-intent)
+if grep -q "repos.md" "$RESEARCHER" \
+  && grep -q "scope, not intent" "$RESEARCHER"; then
+  pass "T7: researcher allowed to read repos.md (scope, not intent)"
+else
+  fail "T7: researcher does not document repos.md as readable scope"
+fi
+if grep -q "repos.md" "$FILE_FINDER"; then
+  pass "T7b: file-finder references repos.md"
+else
+  fail "T7b: file-finder does not reference repos.md"
+fi
+
+# T8 — team-research passes repos.md path alongside questions.md
+if grep -q "repos.md" "$TEAM_RES"; then
+  pass "T8: team-research includes repos.md path in dispatch"
+else
+  fail "T8: team-research does not include repos.md path"
+fi
+
+# T9 — structure-planner and planner support [repo: <name>] / Repos: field
+if grep -q "Repos:" "$STRUCTURE_PLANNER"; then
+  pass "T9a: structure-planner supports per-slice Repos: field"
+else
+  fail "T9a: structure-planner does not support Repos: field"
+fi
+if grep -q "\[repo: <slug>\]\|\[repo: " "$PLANNER"; then
+  pass "T9b: planner uses [repo: <slug>] step prefix"
+else
+  fail "T9b: planner does not use [repo: <slug>] step prefix"
+fi
+
+# T10 — implementer cd's between worktrees per [repo: <slug>] annotation
+if grep -q "\[repo: <slug>\]\|\[repo: " "$IMPLEMENTER" \
+  && grep -q "cd " "$IMPLEMENTER"; then
+  pass "T10: implementer cd's into per-repo worktrees per step"
+else
+  fail "T10: implementer does not cd between per-repo worktrees"
+fi
+
+# T11 — team-implement detects multi-repo mode and refuses in-place when
+# repos.md is present
+if grep -q "repos.md" "$TEAM_IMPL" \
+  && grep -q "multi-repo work requires worktrees" "$TEAM_IMPL"; then
+  pass "T11: team-implement detects multi-repo and refuses in-place"
+else
+  fail "T11: team-implement does not enforce worktrees for multi-repo"
+fi
+
+# T12 — team-pr opens cross-linked PRs in multi-repo mode
+if grep -q "Companion PRs" "$TEAM_PR" \
+  && grep -q "one PR per repo" "$TEAM_PR"; then
+  pass "T12: team-pr opens cross-linked PRs in multi-repo mode"
+else
+  fail "T12: team-pr does not open cross-linked multi-repo PRs"
+fi
+
+# T13 — main team SKILL describes multi-repo flow in WORKTREE and PR phases
+if grep -q "Multi-repo topics" "$TEAM" \
+  && grep -q "multi-repo mode" "$TEAM"; then
+  pass "T13: team SKILL describes multi-repo flow"
+else
+  fail "T13: team SKILL does not describe multi-repo flow"
+fi
+
+if [[ $FAILURES -eq 0 ]]; then
+  echo
+  echo "All tests passed"
+  exit 0
+fi
+echo
+echo "$FAILURES test(s) failed"
+exit 1


### PR DESCRIPTION
## Summary

- Adds an optional `docs/plans/<id>/repos.md` artifact that switches the QRSPI pipeline into multi-repo mode — one worktree per listed repo, all on the same `<id>` branch
- Slices carry a `Repos:` field; plan steps are prefixed `[repo: <slug>]`; the implementer cd's between worktrees and produces one commit per repo
- `team-pr` opens one PR per repo with cross-links via a `Companion PRs` section
- Single-repo topics keep today's behavior — `repos.md` is optional and absent by default

## Design Decisions

- **One artifact, mode-switched.** A single `repos.md` file is the only piece of state that distinguishes multi-repo from single-repo. Every downstream phase reads it (or notices its absence) — no parallel code paths, no flags.
- **Home-repo holds the artifacts.** `docs/plans/<id>/` lives in only one of the worktrees. Other repos' worktrees do not duplicate the artifacts; agents read them from the home worktree path the orchestrator passes in.
- **Blind agents may read `repos.md`.** It carries scope (which repos and where), not intent. `task.md` remains off-limits.
- **`git -C <repo-path> worktree add` for additional repos.** Claude Code's native `--worktree` flag only knows about the launching repo, so multi-repo uses plain `git worktree add` per repo. Same on-disk layout, same branch name.

## Changes

- **Skills**: `worktree-isolation`, `team-worktree`, `team-implement`, `team-pr`, `team-research`, `team-question`, `team`, `qrspi-workflow`
- **Agents**: `questioner`, `design-author`, `researcher`, `file-finder`, `structure-planner`, `planner`, `implementer`
- **Docs**: `docs/architecture.md` (Worktree-phase section reflects both modes), `CHANGELOG.md` (Unreleased entry)
- **Tests**: new `tests/multi-repo-tests.sh` (15 assertions)

## How to Verify

- [x] `bash tests/multi-repo-tests.sh` — 15 new assertions pass
- [x] `bash tests/topic-consistency-tests.sh` — still passes
- [x] `bash tests/skill-architecture-tests.sh` — still passes
- [x] `bash tests/ask-user-question-tool-tests.sh` — still passes
- [x] `bash tests/engineering-standards-methodology-tests.sh` — still passes
- [x] `bash tests/simplify-orchestration-acceptance.sh` — still passes
- [x] `node .claude/hooks/check-registry-sync.mjs` — clean
- [ ] End-to-end: run `/team` on a real multi-repo topic and confirm worktrees, slices, commits, and PRs land in each repo

## References

- Design constraint: `skills/qrspi-workflow/SKILL.md` (`repos.md` schema)
- Topology: `skills/worktree-isolation/SKILL.md` (multi-repo section)