### PR TITLE
docs: clarify WORKTREE phase-6 placement (no behavior change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Multi-repo topics.** A single `/team` pipeline can now span more than one repository. When the questioner detects multiple repos in the description (or the design-author confirms it during open-questions), it writes `docs/plans/<id>/repos.md` listing each involved repo's slug, absolute path, and role. The Worktree phase then creates a worktree per repo (`<repo>/.claude/worktrees/<id>`, all on the same `<id>` branch); the structure annotates each slice with the repos it touches; the planner prefixes each step with `[repo: <slug>]`; the implementer cd's between worktrees per step and produces one commit per repo; the PR phase opens one cross-linked PR per repo. Single-repo topics keep today's behavior — `repos.md` is optional and absent by default.
 
+### Fixed
+
+- **Worktree-isolation skill documented phase 6 placement.** `skills/worktree-isolation/SKILL.md` previously said worktree creation happens "before any agent is dispatched," which contradicted the phase table at `skills/team/SKILL.md` (WORKTREE is phase 6 of 8, after PLAN and before IMPLEMENT). The Setup section is rewritten to describe phase-6 placement directly, a new "Why late" subsection captures the two load-bearing rationales (human gates land on `main`; branch scope is a Plan output), and `skills/qrspi-workflow/SKILL.md` now cross-links to that rationale from its WORKTREE phase block. **No behavior change** — every phase still runs where it ran before.
+
 ## [0.2.1] - 2026-05-07
 
 ### Changed

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -68,8 +68,8 @@ approved structure.
 Router prepares an isolated git worktree for implementation work. No agent;
 purely a router responsibility.
 
-*Why phase 6?* See the "Why late" subsection in
-`skills/worktree-isolation/SKILL.md`.
+For the rationale behind the phase-6 placement, see the "Why late"
+subsection in `skills/worktree-isolation/SKILL.md`.
 
 - **Artifact:** git worktree under Claude Code's native worktree directory
 - **Gate:** HARD — worktree must exist before tests are written

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -68,6 +68,9 @@ approved structure.
 Router prepares an isolated git worktree for implementation work. No agent;
 purely a router responsibility.
 
+*Why phase 6?* See the "Why late" subsection in
+`skills/worktree-isolation/SKILL.md`.
+
 - **Artifact:** git worktree under Claude Code's native worktree directory
 - **Gate:** HARD — worktree must exist before tests are written
 

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -87,6 +87,25 @@ phase are:
    the artifact files under the home worktree's `docs/plans/<id>/`
    directory; live coordination uses TodoWrite (session-scoped).
 
+### Why late
+
+Worktree creation lands at phase 6 rather than phase 0 for two
+load-bearing reasons.
+
+First, the two human gates — DESIGN and STRUCTURE — are reviewed on
+the home tree where the user invoked `/team`. That is the same
+context any reviewer already has open; moving those gates inside a
+worktree would force a `cd` or `git worktree list` before reading
+the artifact in an editor.
+
+Second, branch scope is a Plan output, not a Setup-time guess. By
+the time WORKTREE runs the structure has been approved and the plan
+exists, so the branch name and (in multi-repo mode) the per-repo
+worktree set are derivable from artifacts rather than guessed.
+
+Together these make phase-6 placement a deliberate, articulable
+choice rather than inertia.
+
 ### During the pipeline
 
 All agents — researcher, planner, test-architect, implementer, reviewers —

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -64,16 +64,28 @@ difference downstream.
 
 ### Setup (router responsibility)
 
-During the router's Setup phase, before any agent is dispatched:
+Worktree creation runs at the WORKTREE phase — phase 6 of 8, after
+PLAN and before IMPLEMENT. By that point the approved structure and
+the tactical plan already exist on the home tree, so the branch name
+(`<id>`) and the set of repos to isolate are derivable from
+artifacts rather than guessed. The router's responsibilities at this
+phase are:
 
-1. Create the home repo's worktree. If `repos.md` is present, create a
-   worktree in each additional repo it lists (same `<id>` branch in each).
-2. All subsequent agent dispatches operate within the appropriate
-   worktree (the home worktree by default; per-repo worktrees when a
-   slice or step carries a `[repo: <name>]` annotation).
-3. The durable inter-agent protocol is the artifact files under the
-   home worktree's `docs/plans/<id>/` directory. Live coordination uses
-   TodoWrite (session-scoped).
+1. Create the home repo's worktree. If `repos.md` is present, create
+   a worktree in each additional repo it lists (same `<id>` branch
+   in each).
+2. Carry the artifact directory into the home worktree. Untracked
+   files do not propagate automatically into a fresh worktree, so
+   the orchestrator copies `docs/plans/<id>/` into the home worktree
+   after creation (see `skills/team-worktree/SKILL.md` for the
+   procedure). In multi-repo mode only the home worktree gets the
+   copy.
+3. After this phase, all IMPLEMENT-phase agent dispatches operate
+   within the appropriate worktree (the home worktree by default;
+   per-repo worktrees when a slice or step carries a
+   `[repo: <name>]` annotation). The durable inter-agent protocol is
+   the artifact files under the home worktree's `docs/plans/<id>/`
+   directory; live coordination uses TodoWrite (session-scoped).
 
 ### During the pipeline
 

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -65,11 +65,8 @@ difference downstream.
 ### Setup (router responsibility)
 
 Worktree creation runs at the WORKTREE phase — phase 6 of 8, after
-PLAN and before IMPLEMENT. By that point the approved structure and
-the tactical plan already exist on the home tree, so the branch name
-(`<id>`) and the set of repos to isolate are derivable from
-artifacts rather than guessed. The router's responsibilities at this
-phase are:
+PLAN and before IMPLEMENT (see [Why late](#why-late) below for the
+rationale). The router's responsibilities at this phase are:
 
 1. Create the home repo's worktree. If `repos.md` is present, create
    a worktree in each additional repo it lists (same `<id>` branch
@@ -77,9 +74,9 @@ phase are:
 2. Carry the artifact directory into the home worktree. Untracked
    files do not propagate automatically into a fresh worktree, so
    the orchestrator copies `docs/plans/<id>/` into the home worktree
-   after creation (see `skills/team-worktree/SKILL.md` for the
-   procedure). In multi-repo mode only the home worktree gets the
-   copy.
+   after creation (see "Carry the artifact directory into the home
+   worktree" in `skills/team-worktree/SKILL.md`). In multi-repo mode
+   only the home worktree gets the copy.
 3. After this phase, all IMPLEMENT-phase agent dispatches operate
    within the appropriate worktree (the home worktree by default;
    per-repo worktrees when a slice or step carries a


### PR DESCRIPTION
## Summary

Documentation-only fix. Resolves an internal contradiction where `skills/worktree-isolation/SKILL.md` said worktree creation happens "before any agent is dispatched" while the phase table in `skills/team/SKILL.md`, the phase sequence in `skills/qrspi-workflow/SKILL.md`, and the registry all correctly placed WORKTREE at phase 6 (after PLAN, before IMPLEMENT). The phase table wins; the isolation skill is rewritten to agree, and a new "Why late" subsection documents the two load-bearing reasons (human gates land on `main`; branch scope is a Plan output) so the placement is articulable rather than inertia.

**No behavior change.** No phase reordering, no agent changes, no hook changes, no plugin manifest changes, no JSON/JS code changes. Only Markdown prose moves.

> Note on branch name: the directory `docs/plans/2026-05-15-worktree-first-pipeline/` and branch name predate a mid-pipeline direction reversal (design rev 1 proposed moving WORKTREE to phase 0; the user rejected it at the human gate). The approved revision 2 is the docs-only fix shipped here. See `docs/plans/2026-05-15-worktree-first-pipeline/design.md` for the pivot story.

## Commits (5)

| # | Slice | Commit |
|---|-------|--------|
| 1 | Rewrite Setup section | `docs(skills/worktree-isolation): describe phase-6 placement in Setup section` |
| 2 | Add "Why late" rationale subsection | `docs(skills/worktree-isolation): document why worktree creation is late (phase 6)` |
| 3 | Cross-link from qrspi-workflow | `docs(skills/qrspi-workflow): cross-link WORKTREE phase to "Why late" rationale` |
| 5 | CHANGELOG entry under Unreleased | `docs(changelog): note worktree-isolation phase-6 documentation fix under Unreleased` |
| - | Polish after reviewer feedback | `docs(skills/worktree-isolation): polish prose after review` |

Slice 4 (sweep adjacent files for latent contradictions) produced zero edits — `skills/team/SKILL.md`, `skills/team-worktree/SKILL.md`, `docs/architecture.md`, all 13 files in `agents/`, `README.md`, `AGENTS.md`, and `CLAUDE.md` were all read end-to-end and confirmed not to re-assert the bug.

## Test plan

- [x] `grep "before any agent is dispatched" skills/worktree-isolation/SKILL.md` returns no results
- [x] `grep -nE "^#+ .*[Ww]hy late" skills/worktree-isolation/SKILL.md` returns exactly one heading match (line 87)
- [x] `grep -nE "Why late|worktree-isolation" skills/qrspi-workflow/SKILL.md` matches inside the WORKTREE phase block (lines 71-72)
- [x] `grep -nE "^### Fixed" CHANGELOG.md` matches under `## [Unreleased]` (line 14)
- [x] `grep -rn "before any agent is dispatched" skills/ docs/ agents/ README.md AGENTS.md CLAUDE.md --exclude-dir=2026-05-15-worktree-first-pipeline` returns zero results
- [x] `claude plugin validate .` → PASS
- [x] All 5 test suites pass (53 tests total): topic-consistency, ask-user-question-tool, engineering-standards-methodology, multi-repo, skill-architecture
- [x] 5-reviewer adversarial verification: code-reviewer APPROVE, security-reviewer APPROVE (0 findings), verifier PASS, ux-reviewer APPROVE, technical-writer APPROVE (0 REQUIRED)

## Pipeline artifacts

Full QRSPI artifacts live in `docs/plans/2026-05-15-worktree-first-pipeline/` (intentionally not committed in this PR per the plan; they remain on the home tree as historical record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)