### PR TITLE
docs(code-review): drop praise from reviewer comment types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Code reviews no longer emit praise comments.** The `praise` Conventional Comments type is removed from `skills/code-review/SKILL.md`, and the matching inline list + "Be fair. Acknowledge what is done well…" rule are removed from `agents/code-reviewer.md`. Reviewer output is restricted to types that require author action or attention (`issue`, `suggestion`, `nitpick`), raising signal-to-noise. Verdict criteria, gate types, and aggregation rules are unchanged.
 - **Edge-case enumeration is mandatory in design and tests.** The `design-author` agent now writes a dedicated `## Edge cases` section walking six categories (boundary values, invalid inputs, failure paths, concurrency, authorization, resource limits); the `structure-planner` pulls those scenarios into each slice's acceptance tests; the `test-architect` writes them with the same care as happy-path tests and reports any gap as an upstream structure defect rather than inventing tests. Reinforced by methodology updates in `test-first-development`, `technical-design-doc`, and `engineering-standards`.
 
 ### Added

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -53,8 +53,8 @@ Load `skills/code-review/SKILL.md` for the full review methodology. This
 agent applies generator-evaluator separation (fresh context, no shared history)
 with a **HARD** gate type. Key points:
 
-- Use Conventional Comments format for all findings (issue, suggestion, nitpick,
-  praise). Every comment includes a `file:line` reference.
+- Use Conventional Comments format for all findings (issue, suggestion, nitpick).
+  Every comment includes a `file:line` reference.
 - End with a verdict: **APPROVE** (no blocking issues), **REQUEST CHANGES**
   (blocking issues found — user decides whether to proceed), or **COMMENT**
   (non-blocking suggestions only).
@@ -68,7 +68,6 @@ with a **HARD** gate type. Key points:
   the changes (e.g., a caller whose contract changed).
 - Be specific. "This could be better" is not a useful comment. Say exactly
   what is wrong and why it matters.
-- Be fair. Acknowledge what is done well, not just what is wrong.
 - **Apply engineering standards.** Load `skills/engineering-standards/SKILL.md` and use
   the "When Reviewing" section as additional review criteria. Evaluate each
   quality checklist item for every changed file and cite the specific checklist

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -53,13 +53,6 @@ nitpick: "data" is too vague — consider "userProfile" to match the domain.
 file: src/models/types.ts:7
 ```
 
-**praise:**
-Acknowledges good work. Reinforces positive patterns.
-```
-praise: Clean separation of side effects from pure logic here.
-file: src/services/billing.ts:30-45
-```
-
 ## Gate Types by Reviewer
 
 | Reviewer | Gate Type | Blocks Ship? |


### PR DESCRIPTION
## Summary

- Removes the `praise` Conventional Comments type from `skills/code-review/SKILL.md` (lines 56-61 deleted)
- Drops `praise` from the inline parenthetical at `agents/code-reviewer.md:57` and deletes the `Be fair. Acknowledge what is done well, not just what is wrong.` rule at `:71`
- Restricts reviewer output to types that require author action or attention (`issue`, `suggestion`, `nitpick`), raising signal-to-noise per the user request: "praise is unnecessary because it creates too much noise when the signal should be higher."

Verdict criteria, gate types, and aggregation rules in the skill are unchanged. No other reviewer agent is edited — `security-reviewer`, `technical-writer`, and `ux-reviewer` all `Load` the skill and inherit the change automatically.

Pipeline artifacts at `docs/plans/2026-05-22-eliminate-reviewer-praise/` (task, questions, research, design, structure, plan — design and structure approved at human gates) are intentionally not committed in this branch; they live as local working notes.

## Test plan

- [x] `grep -rni praise skills/ agents/` returns nothing
- [x] `grep -n "Acknowledge what is done well" agents/code-reviewer.md` returns nothing
- [x] `grep -cE '^\*\*(issue|suggestion|nitpick|praise)' skills/code-review/SKILL.md` returns `3`
- [x] `node .claude/hooks/check-registry-sync.mjs` passes
- [x] Code review (adversarial, fresh context) — APPROVE
- [x] Security review — PASS
- [x] Technical writer review — PASS
- [x] UX review — APPROVE
- [x] Verifier — PASS
- [x] CHANGELOG entry under `[Unreleased] → Changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)