### PR TITLE
Apply Google Testing Blog wisdom to testing skills & agents

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -43,6 +43,14 @@ show. This isolation is intentional: it prevents self-evaluation bias.
      - LSP: do subtypes honor the base type's full contract?
      - ISP: does this interface force clients to depend on unused methods?
      - DIP: does business logic instantiate its own infrastructure dependencies?
+   - **Test files** — Walk every changed `*test*` / `*spec*` /
+     `__tests__/*` file against the test-quality flags in
+     `skills/code-review/SKILL.md` (Code Reviewer verdict section) and the
+     style rules in `skills/test-first-development/SKILL.md`. Flag
+     change-detector patterns, mock chains, full-equality assertions on
+     complex objects, `sleep()` for synchronization, logic in tests, and
+     method-named tests. A single occurrence is a `suggestion:`; multiple
+     occurrences across the diff become `issue:`.
 
 5. **Run tests.** Execute the project's test suite to verify tests pass. Report
    the command used and the result.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -159,6 +159,21 @@ incorrect):
 - Keep functions small and focused on a single responsibility.
 - Handle errors explicitly — fail fast, fail loud.
 - Prefer simple, readable code over clever abstractions.
+- **Construct with collaborators, call with work.** Constructors take the
+  long-lived dependencies (clock, DB, logger, HTTP client) that define
+  identity. Methods take the per-call work parameters (date range, request
+  body). Constructors do no work — no I/O, no static lookups, no expensive
+  computation.
+- **No mixed levels of abstraction in a function.** A function calls
+  functions one level below its own. If you find yourself doing high-level
+  orchestration and low-level byte-level work in the same function,
+  extract the low-level work into a helper named at the surrounding level.
+- **No primitive obsession in new domain types.** When adding a new domain
+  concept (Money, Duration, OrderId, EmailAddress), give it a type. Long
+  parameter lists with related primitives signal a missing value object.
+- **Targeted exception scopes only.** Wrap exactly the call that can
+  throw; catch the specific exception subclass; rethrow with the original
+  cause chained. Never `catch (Exception e)` around a large block.
 
 Apply SOLID principles when writing new code. Load `skills/solid-principles/SKILL.md`
 for the full methodology. Key checkpoints:

--- a/agents/test-architect.md
+++ b/agents/test-architect.md
@@ -65,6 +65,28 @@ the design's `## Edge cases` section names scenarios that are not
 covered, stop and report this to the orchestrator. Fix the gap upstream
 (structure phase) rather than silently inventing tests here.
 
+### 2.5 Apply the test-quality bar
+
+Before moving to step 3, audit each test against this bar. Every "NO" is
+an issue to fix before confirming failures. The rules are spelled out in
+full in `skills/test-first-development/SKILL.md` under "Test Style Rules";
+the bar below is the audit checklist.
+
+| Check | Pass criterion |
+|-------|----------------|
+| Behavior-named | Test name describes the behavior, not the method. `sendsEmailWhenBalanceIsLow`, not `testProcess_1`. |
+| Narrow assertion | The assertion targets the specific field/effect under test. No full-equality on complex objects unless that IS the contract. |
+| Actionable failure | If the test fails, the failure message names the failing condition. `EXPECT_OK(...)` not `EXPECT_TRUE(...ok())`. |
+| No sleeps | No `sleep()` for synchronization. Use wait-for-condition primitives. |
+| No test logic | No `if`, no loops, no string-building inside the test body. |
+| One scenario per test | The test verifies one behavior and runs independently in any order. |
+| DAMP setup | Setup the reader needs to understand the test lives in the test (or a helper that takes the asserted value as a parameter). |
+| Fidelity ladder | Real > fake > mock. No mocks where a fake is feasible. No mocks for types you don't own — wrap them. |
+
+When reporting issues to the orchestrator, cite the failing check by name
+(e.g., "Test 7 fails the Narrow assertion bar — it asserts on the full
+order object when only `order.total` is the slice's contract").
+
 ### 3. Confirm tests fail correctly
 
 Run the full test suite. Every acceptance test you wrote must:

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -82,3 +82,18 @@ Exit code: 1
 - Keep output concise. For failures, include only the lines needed to
   understand what went wrong. Do not dump entire build logs.
 - If a check hangs for more than 120 seconds, kill it and report TIMEOUT.
+- **Do NOT retry to mask intermittent failures.** Each check runs once. If
+  a test or check fails, report it. If you happen to know the same test
+  passed in a previous run (e.g., the orchestrator re-dispatched after a
+  code fix), note the intermittency in the report
+  (`### Notes — Intermittent: testFoo passed on retry; the underlying race
+  condition is unresolved`). Reruns that turn red → green without a code
+  change are evidence of a flake or a real intermittent bug, not a
+  verdict of PASS.
+- **Coverage is reported, not gated.** If the project has a coverage tool
+  configured, run it and report the coverage delta for changed files
+  (e.g., "coverage on changed files: 73% → 78%"). Do NOT gate on an
+  absolute coverage threshold. Coverage tells you what is NOT tested; it
+  does not tell you what IS tested is good. Pair with mutation testing
+  when available; require coverage to trend upward rather than mandating
+  a fixed threshold.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -30,6 +30,27 @@ All review comments use the Conventional Comments format
 (https://conventionalcomments.org). Every comment MUST include a specific
 `file:line` reference.
 
+### Comment Style
+
+Critique the code, not the coder. Assume competence. The same finding can
+read as collaborative or hostile depending on phrasing:
+
+| Avoid (person-directed) | Prefer (code-directed) |
+|-------------------------|------------------------|
+| "Your approach is adding unnecessary complexity." | "The complexity this adds isn't worth the result." |
+| "You're not handling the null case." | "The null case isn't handled here." |
+| "This doesn't make any sense." | "I can't follow what this branch is doing — clarify?" |
+
+- Explain *why* the change is requested. A finding without a reason loses
+  the rationale for the next reader of the diff.
+- Reserve `issue:` for findings that materially affect correctness,
+  security, or maintainability. Use `suggestion:` or `nitpick:` for
+  preferences.
+- A high comment density on a single change is a design signal, not just a
+  style problem. When the count climbs past ~10 substantive comments,
+  propose splitting the change or escalating the design conversation out
+  of the review tool.
+
 ### Comment Types
 
 **issue (blocking):**
@@ -83,6 +104,25 @@ file: src/models/types.ts:7
 - **REQUEST CHANGES:** Blocking issues found. The pipeline MUST loop back to
   IMPLEMENT. No override — quality issues must be resolved before shipping.
 - **COMMENT:** Non-blocking suggestions only. Implementation is correct.
+
+**Test-quality flags.** Test files are part of the diff. Walk every changed
+`*test*` / `*spec*` / `__tests__/*` file against the rules in
+`skills/test-first-development/SKILL.md` ("Test Style Rules"). The
+following anti-patterns are `suggestion:` individually and `issue:` when
+they appear across multiple tests:
+
+- Change-detector tests — assertions on which collaborator methods were
+  called without verifying observable state
+- Mock-everything / mock chains — mocks for collaborators that have a
+  real or fake equivalent
+- Full-equality assertions on complex objects when one field carries the
+  contract
+- `sleep()` for synchronization
+- Logic in tests (`if`, loops, string-building) that can carry the same
+  bug as the code
+- Tests named after methods (`testProcessOrder_2`) rather than behaviors
+  (`refundsCardOnPartialFailure`)
+- DRY helpers that hide the asserted value
 
 ### UX Reviewer
 

--- a/skills/engineering-standards/SKILL.md
+++ b/skills/engineering-standards/SKILL.md
@@ -27,6 +27,13 @@ Six foundational perspectives guide every design and implementation decision:
 - **John Ousterhout**: Fight complexity by designing deep modules with simple
   interfaces. Pull complexity downward into implementations rather than
   exposing it to callers.
+- **Cost-benefit, not religion**: Every test, abstraction, and interface
+  has an ongoing cost — maintenance, runtime, false-positive triage,
+  cognitive load. A test that catches no real bug and slows the build is
+  a liability, not an asset. The same applies to abstractions — premature
+  DRY couples behaviors that need to evolve independently. Apply the Rule
+  of Three: tolerate duplication the second time, extract on the third
+  occurrence.
 
 ## Implementation Standards
 
@@ -114,6 +121,16 @@ Before considering any implementation complete, verify each item:
 8. **DRY** -- No unnecessary duplication (Rule of Three applied).
 9. **Performance Awareness** -- No unnecessary computation or memory
    allocation, but no premature optimization either.
+10. **Functional Core, Imperative Shell** -- Pure functions hold business
+    logic; a thin shell handles I/O. Pure logic is unit-testable in
+    isolation; the shell is swap-and-test as a thin integration layer.
+11. **No Primitive Obsession** -- Domain concepts (Money, Duration,
+    EmailAddress, OrderId) carry a type, not a raw `string`/`int`. Long
+    parameter lists with related primitives signal a missing value object.
+12. **Failures are actionable** -- Errors and test failures name the
+    failing condition with enough context that the next reader can start
+    debugging without rerunning. Avoid `assert(predicate)` when
+    `assert_eq(actual, expected)` would print the values.
 
 ## When Implementing
 

--- a/skills/refactoring-to-patterns/SKILL.md
+++ b/skills/refactoring-to-patterns/SKILL.md
@@ -144,6 +144,20 @@ time a new variant is added. Frequently accompanies Primitive Obsession.
 - **Decompose Conditional** — Extract the condition and its branches into
   named methods so the intent is readable.
 
+### Mixed Levels of Abstraction
+
+**Smell:** A single function alternates between high-level orchestration
+("save the order, charge the card, send the receipt") and low-level
+primitives ("for each line, format the price as fixed-width 8 chars").
+Readers must repeatedly swap mental contexts. Often a sign of an
+unextracted helper.
+
+**Refactorings:**
+- **Extract Method** — pull the low-level primitive into a function named
+  at the surrounding level's abstraction.
+- **Rule of thumb:** a function should call functions one level of
+  abstraction below its own; never two or more levels at once.
+
 ### Middle Man
 
 **Smell:** A class that delegates most of its methods to another class. If
@@ -153,6 +167,27 @@ the middle man adds no value.
 **Refactorings:**
 - **Remove Middle Man** — Let callers call the delegated class directly.
 - **Inline Method** — If a method just calls another, inline the delegation.
+
+### Constructor Doing Work
+
+**Smell:** A class instantiates its dependencies inside methods
+(`new HttpClient()` inside `fetchUser()`), takes per-call work parameters
+in the constructor (`new ReportGenerator(2024, 1, 1, 2024, 12, 31)`), or
+does I/O / static lookups in the constructor. No seam exists for tests to
+substitute collaborators.
+
+**Refactorings:**
+- **Construct with collaborators, call with work.** Move long-lived
+  dependencies (HTTP client, DB, clock, logger) to the constructor
+  signature. Inject them; do not `new` them inside.
+- **Move per-call work parameters to method signatures.** Date ranges,
+  query strings, and request bodies belong on the method, not the
+  constructor.
+- **Constructors do no work.** No I/O, no XML parsing, no static lookups,
+  no expensive computation. Just assign collaborators and return.
+
+This creates a seam: production wires real collaborators through DI;
+tests substitute fakes or stubs at construction.
 
 ## Safe Refactoring Procedure
 

--- a/skills/solid-principles/SKILL.md
+++ b/skills/solid-principles/SKILL.md
@@ -111,6 +111,12 @@ implement.
 
 - Business logic classes that instantiate their own dependencies with `new`
 - `import DatabaseClient from './database'` inside a domain service
+- Static method calls into infrastructure (`Database.query(...)`,
+  `Clock.now()`, `Config.get(...)`) — static calls have no seam, so tests
+  cannot substitute them
+- Singletons fetched from inside business code (`Registry.getInstance()`) —
+  the dependency is real but invisible in the signature, so the class lies
+  about what it needs
 - Tests that cannot run without real databases, network calls, or file system
   access
 - Difficult to test without mocking entire subsystems
@@ -122,6 +128,13 @@ implement.
   layer
 - Pass in collaborators as arguments rather than instantiating them inside
   the function
+- **Construct with collaborators; call with work.** The constructor takes
+  the long-lived collaborators that define what the object IS (its clients,
+  its loggers, its clock, its database handle). Methods take the per-call
+  work parameters. A `ReportGenerator(reportingDb, clock)` can serve many
+  date ranges via `generate(startDate, endDate)`. A
+  `ReportGenerator(reportingDb, clock, startDate, endDate)` creates a new
+  instance per query and conflates identity with work.
 
 ## Applying SOLID in the Implementer Role
 

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -27,6 +27,14 @@ picture of what is happening.
   narrows the search space dramatically.
 - **Record timestamps and sequence.** When did it start failing? What changed
   just before? Check git log, deployment history, and dependency updates.
+- **Treat intermittency as evidence, not noise.** A test that fails 1 in 10
+  runs is not "flaky" — it is reporting a real condition (timing, ordering,
+  resource contention, hidden global state) that most invocations don't hit.
+  The conditions that make a test intermittent are frequently the conditions
+  that make the product intermittently misbehave in production. Record the
+  failure rate (e.g., 3/30 runs), the variance across environments (local vs
+  CI), what is concurrent/asynchronous/stateful in the path, and any shared
+  state (`/tmp`, env vars, singletons, DB rows).
 
 Do not hypothesize during OBSERVE. Just collect.
 
@@ -59,6 +67,11 @@ elimination, not confirmation.
   and what actually happened — even for negative results.
 - **Eliminate definitively.** If a hypothesis is disproven, cross it off and
   do not revisit it unless new evidence emerges.
+- **When you have a working baseline and a failing tip, bisect.** Don't
+  reason from first principles about which of 40 commits broke it —
+  `git bisect` is faster and more reliable. Each step discriminates half the
+  commit range. The same logic applies to config changes, dependency
+  versions, and feature-flag rollouts.
 
 ### Phase 4: CONCLUDE
 

--- a/skills/test-driven-bug-fix/SKILL.md
+++ b/skills/test-driven-bug-fix/SKILL.md
@@ -14,6 +14,24 @@ regression. The test-driven bug fix discipline ensures that every fix is:
 3. **Fixed minimally** — the smallest change that makes the test pass
 4. **Verified** — no regression in existing behavior
 
+## Triage Before Reproducing
+
+Before reproducing, classify the failure into one of four buckets:
+
+| Bucket | Symptom | Action |
+|--------|---------|--------|
+| **Product** | Real defect in the code under test | Continue with the four-step discipline below |
+| **Test impl** | Test wrong; behavior correct | File a separate test-fix; do NOT change production code to satisfy a bad test |
+| **Infra** | CI environment, DB, network, container | Fix the env; do not encode the env-fix as a test |
+| **Tooling** | Test runner / build system | Fix the tool; the bug is not in the product |
+
+Intermittent failures are not a fifth bucket — they belong in one of the
+four above. Quarantining a test as "flaky" without classifying the failure
+hides the very intermittent product bug that the test surfaced. The
+conditions that make a test flaky are frequently the conditions that
+trigger the bug. Reproduce deterministically before fixing — see
+`skills/systematic-debugging/SKILL.md`.
+
 ## The Four-Step Discipline
 
 ### Step 1: Reproduce
@@ -83,9 +101,12 @@ After the fix:
    missing null check), search the codebase for the same pattern. File issues
    for related instances — do not fix them in this commit.
 
-4. **Review the minimal fix.** Is the fix correct, or did it just make the
-   symptom go away? A fix that hides the bug without addressing the root
-   cause will recur.
+4. **Review the minimal fix with a mutation check.** Temporarily revert one
+   line of the fix and re-run the new test. It must go red again. If it
+   still passes, the test does not exercise the fix — strengthen the
+   assertion or the reproduction inputs. This guards against fixes that
+   hide the symptom without addressing the root cause, and against tests
+   that drift away from the bug.
 
 ## Commit Structure
 

--- a/skills/test-first-development/SKILL.md
+++ b/skills/test-first-development/SKILL.md
@@ -101,6 +101,100 @@ fence.
 The distinction: acceptance tests define **what** must work. Step-level TDD
 helps build **how** it works.
 
+## Test Style Rules
+
+These rules govern every acceptance test written under this skill. Each rule
+catches a different class of test-suite decay.
+
+### Test behavior, not implementation
+
+Tests assert externally observable outcomes. A refactor that preserves
+behavior must leave every acceptance test green. Tests that break on
+internal restructuring are change-detectors — they produce noise on every
+refactor without proving the system works.
+
+- Assert on what the caller observes: return values, persisted state, effects
+  visible to other components.
+- Do not assert on which private methods were called in which order, unless
+  the call itself is the observable behavior (e.g., publishing a message to
+  an external channel).
+- Interaction tests verify state-changing calls only; never assert on
+  query-only calls.
+
+### Tests are DAMP, not DRY
+
+Test code is read far more than it is run. Inline the setup a reader needs to
+understand a failing test. Tolerate duplication; favor a linear
+arrange-act-assert story.
+
+- Pass the asserted value through helpers: `create_account(BALANCE)`, not
+  `create_account()` that hides the value the assertion checks.
+- No `if`, no loops, no string-building inside a test body — they can carry
+  the same bug as the code under test.
+- Extract helpers only when the same setup appears across many tests AND the
+  helper does not hide assertion-relevant inputs.
+
+### Narrow assertions
+
+Assert on the specific field the test cares about (`account.balance == 2000`),
+not full equality on a complex object. Reserve full-snapshot assertions for
+at most one default test per common case.
+
+Use subset matchers when available (`comparingExpectedFieldsOnly`,
+`UnorderedElementsAre`, `protocmp.FilterField`). Brittle failures are a
+signal that the test toolkit is missing a matcher — propose one rather than
+blaming the test author.
+
+### Test failures must be actionable
+
+A failing test must be diagnosable from name + assertion output alone,
+without rerunning.
+
+- `EXPECT_OK(loadMetadata())` beats `EXPECT_TRUE(loadMetadata().ok())`
+  because the failure prints the actual error.
+- `assertEqual(actual, expected)` beats `assert(predicate)` because it prints
+  both values.
+- Test names describe behavior, not method: `sendsEmailWhenBalanceIsLow`, not
+  `testProcessTransaction_1`.
+
+### Wait for the condition; never sleep
+
+Replace every fixed `sleep(N)` with a wait-for-condition primitive (exist,
+not-exist, wait-to-exist with timeout + interval). A fixed sleep both masks
+race-condition bugs and pads runtime when the system is fast.
+
+### Fidelity ladder: real > fake > mock
+
+When a test needs a collaborator, prefer in this order:
+
+1. **Real** — the production implementation. Highest fidelity.
+2. **Fake** — a lightweight in-memory equivalent maintained by the real
+   implementation's owner. Use when the real is too slow or network-bound.
+3. **Mock** — last resort, primarily for error-path injection or when neither
+   real nor fake exists.
+
+Default-to-mocking collapses fidelity and produces mock chains that mirror
+production graphs without surfacing real bugs.
+
+### Don't mock types you don't own
+
+If a vendor type needs to be substituted, wrap it behind your own interface
+and mock the wrapper. Upstream API changes then ripple through one boundary
+instead of through every test.
+
+### E2E reserved for critical user journeys
+
+End-to-end tests are expensive — budget about one engineer-week per quarter
+per E2E test to keep stable. Reserve them for a small list of user
+goal-plus-task workflows. Do not chase exhaustive E2E coverage.
+
+### Test workflows, not just features
+
+Features ship into a system; bugs live at the seams. When the design
+introduces a feature whose behavior overlaps an existing one, the
+acceptance-test list must include at least one cross-feature interaction
+test.
+
 ## Completion Contract
 
 Implementation is done when:


### PR DESCRIPTION
## Summary

Folds 20 years of Google Testing Blog (2007-2026, ~500 posts mined, 369 cited insights deduped cross-era) into this project's testing-related skills and agents as 19 concrete additions across 11 files. Sourced from a parallel-research synthesis ([`/tmp/gtb-research/SYNTHESIS.md`](#) — kept local, not committed).

## Changes by commit

**1. `docs(skills): add test-execution discipline ...`** — `test-first-development`, `test-driven-bug-fix`, `systematic-debugging`
- Test Style Rules section: behavior-not-implementation, DAMP-over-DRY, narrow assertions, actionable failures, wait-not-sleep, real > fake > mock fidelity ladder, don't-mock-types-you-don't-own, CUJ-bounded E2E, cross-feature workflow tests
- Bug-fix triage table (product / test impl / infra / tooling) + mutation check on the fix
- Intermittency-as-evidence in OBSERVE; bisect-when-stuck in TEST

**2. `docs(skills): add code-quality discipline ...`** — `code-review`, `refactoring-to-patterns`, `engineering-standards`, `solid-principles`
- Comment-style: critique the code, not the coder + test-quality flags reviewers must catch
- New named smells: Mixed Levels of Abstraction, Constructor Doing Work
- New quality-checklist items: functional core / no primitive obsession / actionable failures
- New DIP smells: static infrastructure calls, singleton-from-business-code
- "Construct with collaborators, call with work" as a DIP application rule

**3. `docs(agents): apply test/code-quality bars ...`** — `test-architect`, `code-reviewer`, `verifier`, `implementer`
- `test-architect`: new sub-step 2.5 test-quality bar (8-row audit checklist) referencing the test-first-development style rules
- `code-reviewer`: explicit test-file review checklist pointing at the new flags
- `verifier`: rerun-is-not-a-fix rule + coverage-reported-not-gated rule
- `implementer`: construct-with-collaborators, no-mixed-abstraction, no-primitive-obsession, targeted-exception-scopes in code-quality bullets

## Method

A parallel research team (5 era miners + 1 synthesizer) walked the blog archive year-by-year, sampled high-signal posts, extracted patterns / anti-patterns / principles / quotes per era, then deduped across eras with 2-3 best source URLs per insight. Each recommendation in the synthesis cites the specific posts behind it.

## What was deliberately NOT changed

Two synthesis-surfaced tensions where the project's stance is already correct:

- **Boy Scout vs scope-fence:** Google advises opportunistic cleanup; this project's scope fence is intentional and the cruft post itself says cleanup belongs in separate CLs. Left alone.
- **TDD as religion vs as discipline:** Google warns against TDD-as-religion; this project's "non-negotiable" rule applies only to acceptance tests (scope fence), not step-level TDD. The existing skill already draws this distinction in "Two Levels of Testing". Left alone.

## Test plan

- [ ] `agents/*.md` frontmatter still parses (no field changes were made, only body content)
- [ ] `skills/team/registry.json` still in sync with `agents/` (no agents added/removed)
- [ ] Markdown renders correctly on GitHub for the new tables and sections
- [ ] Spot-check that the test-architect's referenced "Test Style Rules" section actually exists in `skills/test-first-development/SKILL.md`
- [ ] Spot-check that the code-reviewer's referenced flags exist in `skills/code-review/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)