### PR TITLE
fix(team): keep worktree in place after PR-open for iteration

### DIFF
--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -115,11 +115,13 @@ done
 8. **Tracking ticket.** If `ticketId` is non-null, surface it in the
    completion report so the user can close it in their tracking system.
    The orchestrator does not close tickets automatically.
-9. **Worktree cleanup.** For each worktree that was created in the
-   Worktree phase, cherry-pick or rebase commits onto the target branch
-   in that repo, then let Claude Code (or `git -C <repo-path> worktree
-   remove`) remove the worktree. In multi-repo mode, run cleanup for
-   every involved repo.
+9. **Leave the worktree(s) in place.** Do not remove a worktree after
+   opening a PR — the user may need to iterate on the branch (push
+   follow-up commits, address review feedback). Clean up only after the
+   PR is merged or when the user explicitly asks. When that happens,
+   cherry-pick or rebase commits onto the target branch in that repo,
+   then let Claude Code (or `git -C <repo-path> worktree remove`) remove
+   the worktree; in multi-repo mode, run cleanup for every involved repo.
 
 ## PR Body Template
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -208,9 +208,15 @@ When the aggregate gate passes:
 4. If `task.md` frontmatter has `ticketId` set, surface it so the user
    can close the ticket. The orchestrator does not close tickets.
 5. Mark all TodoWrite items complete.
-6. For each worktree that was created, clean it up (cherry-pick or
-   rebase commits onto the target branch in that repo, then let Claude
-   Code or `git worktree remove` remove the worktree).
+6. **Leave the worktree(s) in place.** Do not remove a worktree when a
+   PR is opened — the user may need to iterate on the branch (push
+   follow-up commits, address review feedback). Clean up a worktree only
+   after its PR is merged or when the user explicitly asks. When cleanup
+   does happen, cherry-pick or rebase commits onto the target branch in
+   that repo, then let Claude Code or `git worktree remove` remove the
+   worktree. The same rule applies when the user chose **Keep commits
+   locally** or **Keep as-is** instead of opening a PR — leave the
+   worktree until they ask to remove it.
 
 ## Rules
 

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -114,7 +114,12 @@ files live. Main working trees are never touched.
 
 ### Ship (teardown)
 
-After shipping:
+Opening a PR does **not** tear down the worktree — the user may need to
+iterate on the branch (push follow-up commits, address review feedback).
+Keep the worktree until the PR is merged or the user explicitly asks to
+remove it. The same holds when commits are kept locally without a PR.
+
+When teardown is warranted (post-merge or on explicit request):
 
 1. For each worktree with commits ahead of its base branch, cherry-pick
    or rebase commits onto the target branch in that repo, then let


### PR DESCRIPTION
## Summary

The Team pipeline's PR/ship phase removed the worktree as soon as a PR was opened. That blocked the common need to **iterate on the branch after opening the PR** — pushing follow-up commits or addressing review feedback — because the isolated checkout was already gone.

This defers worktree teardown to **after the PR is merged, or an explicit user request**. Opening a PR (or keeping commits locally) now leaves the worktree in place.

## Changes

Three SKILL files documented the teardown; all now describe deferred cleanup:

- **`skills/team/SKILL.md`** — PR gate step 6: leave the worktree(s) in place after opening a PR (or keeping commits locally); clean up only post-merge or on request.
- **`skills/team-pr/SKILL.md`** — step 9: same, with the multi-repo cleanup instructions preserved for when teardown is actually warranted.
- **`skills/worktree-isolation/SKILL.md`** — "Ship (teardown)": a leading note that opening a PR does not tear down the worktree; the existing cleanup steps now run only when teardown is warranted.

No behavioral change to worktree *creation*, the phase table, or any gate. The cleanup commands themselves are unchanged — only *when* they run.

## Test plan

Documentation/behavioral-spec change to skill instructions (no code runtime):

- [x] No remaining reference instructs cleanup at PR-open time (`grep` for "worktree remove"/"teardown"/"clean it up" across `skills/`, `docs/`, `tests/` shows only deferred-cleanup language or unrelated hits)
- [x] Cleanup commands (`git worktree remove`, cherry-pick/rebase onto base, multi-repo loop) preserved for post-merge/on-request teardown
- [x] Commit scoped to the 3 skill files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)