### PR TITLE
docs(skills): tone down "blind" emphasis in remaining agents/skills

### DIFF
--- a/.claude/scripts/check-discovery-consistency.sh
+++ b/.claude/scripts/check-discovery-consistency.sh
@@ -6,7 +6,7 @@
 # runtime-vs-development split in CLAUDE.md. This is the committed consistency
 # gate for the skill-input-discovery feature: it asserts every archetype-A
 # skill carries the discovery block, the load-bearing fragments stay
-# byte-identical to canon, and the blind-research invariant holds.
+# byte-identical to canon, and the research-isolation invariant holds.
 #
 # It is the scope fence for the whole feature. If every assertion here passes,
 # the feature is intact; any failing assertion names a regression or drift.
@@ -260,13 +260,13 @@ fi
 \rm -f "$snippet"
 
 # =============================================================================
-# BLIND-INVARIANT (slices 2 & 6): team-research forwards exactly
+# RESEARCH-ISOLATION (slices 2 & 6): team-research forwards exactly
 # {questions.md, repos.md?} and never task.md / a description; the
-# ## Blindness invariant section is intact.
+# ## Scope isolation section is intact.
 # =============================================================================
 research_file="$SKILLS/team-research/SKILL.md"
 if [ ! -f "$research_file" ]; then
-  fail "team-research blind" "SKILL.md exists" "file not found"
+  fail "team-research isolation" "SKILL.md exists" "file not found"
 else
   # Isolate the dispatch step (## Execution step 2) to scope the assertions.
   dispatch="$(awk '
@@ -282,11 +282,11 @@ else
 
   # The dispatch step must NOT widen the forwarded set to task.md or a description.
   if printf '%s' "$dispatch" | grep -qiE 'pass[^.]*task\.md|forward[^.]*task\.md|include[^.]*task\.md'; then
-    fail "team-research dispatch" "never forwards task.md to blind agents" "dispatch step appears to pass task.md"
+    fail "team-research dispatch" "never forwards task.md to the research agents" "dispatch step appears to pass task.md"
   fi
 
-  grep -qF '## Blindness invariant' "$research_file" \
-    || fail "team-research" "## Blindness invariant section present" "section missing"
+  grep -qF '## Scope isolation' "$research_file" \
+    || fail "team-research" "## Scope isolation section present" "section missing"
 fi
 
 # =============================================================================

--- a/agents/file-finder.md
+++ b/agents/file-finder.md
@@ -12,7 +12,7 @@ You are a fast, thorough file-location specialist. Given the codebase scope
 and vocabulary in `questions.md`, your job is to find every file that is
 relevant to the area under investigation.
 
-## Blindness invariant
+## Scope isolation
 
 You see `docs/plans/<id>/questions.md` and may also read
 `docs/plans/<id>/repos.md` if it exists — `repos.md` lists the repos
@@ -84,7 +84,7 @@ slug is the `name` field from the matching entry in `repos.md`.
 
 ## Rules
 
-- **Blind.** Never read `task.md`. Never speculate about what the user wants.
+- **Scoped to `questions.md`.** Never read `task.md`. Never speculate about what the user wants.
 - Search broadly. It is better to include a file that turns out to be
   irrelevant than to miss one that matters.
 - Try at least three different search terms per concept before concluding

--- a/agents/questioner.md
+++ b/agents/questioner.md
@@ -66,7 +66,7 @@ In single-repo mode omit those fields (or set `reposPath: null` and
 `multiRepo: false`).
 
 **No `description` field, no `taskMd` field** — the orchestrator must
-not propagate the user's framing to blind agents.
+not propagate the user's framing to the research agents.
 
 ## The `topic` field
 

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -13,7 +13,7 @@ document a specific area of the codebase to answer a list of neutral research
 questions. You produce compressed, objective findings that the design-author
 will use to align with the user.
 
-## Blindness invariant
+## Scope isolation
 
 You do **not** know what is being built. The orchestrator passes you the
 path: `docs/plans/<id>/questions.md`. That file contains both the
@@ -103,8 +103,8 @@ matching entry in `repos.md`.
 ## Rules
 
 - **Read-only.** You do not write, edit, or create files. Ever.
-- **Blind.** Never read `task.md`. Never read the user's original description.
-  Never speculate about intent.
+- **Scoped to `questions.md`.** Never read `task.md`. Never read the user's
+  original description. Never speculate about intent.
 - **Objective findings only.** Report what IS, not what SHOULD BE. Do not
   recommend approaches.
 - **Compress, do not summarize.** Include specific function names, type

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -30,8 +30,8 @@ without knowing the goal.
 
 ### RESEARCH
 
-Explore the codebase to answer the questions. Researcher is **BLIND** to
-intent: it never reads `task.md`, only `questions.md`.
+Explore the codebase to answer the questions. The researcher reads only
+`questions.md` — never `task.md` or the user's intent.
 
 - **Artifact:** `docs/plans/<id>/research.md`
 - **Gate:** HARD — artifact must exist on disk before proceeding

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -87,7 +87,7 @@ loop:
 | Phase      | Agent(s)                                                | Predecessor artifact                                            | Next phase on pass |
 |------------|---------------------------------------------------------|-----------------------------------------------------------------|--------------------|
 | QUESTION   | `questioner`                                            | (none — description in `$ARGUMENTS`)                            | RESEARCH           |
-| RESEARCH   | `file-finder`, `researcher` (parallel, BLIND)           | `docs/plans/<id>/questions.md`                                  | DESIGN             |
+| RESEARCH   | `file-finder`, `researcher` (parallel, isolated)        | `docs/plans/<id>/questions.md`                                  | DESIGN             |
 | DESIGN     | `design-author` (→ human gate)                          | `docs/plans/<id>/research.md`                                   | STRUCTURE          |
 | STRUCTURE  | `structure-planner` (→ human gate)                      | `docs/plans/<id>/design.md` (frontmatter `approved: true`)      | PLAN               |
 | PLAN       | `planner`                                               | `docs/plans/<id>/structure.md` (frontmatter `approved: true`)   | WORKTREE           |
@@ -104,7 +104,7 @@ frontmatter the researcher's documentation specifies) before advancing.
 for documentation purposes only. The orchestrator dispatches based on
 the phase table above, not on registry contents.
 
-## Blind Research Invariant
+## Research Isolation Invariant
 
 The questioner is the only agent that ever sees the raw description from
 `$ARGUMENTS`. When dispatching the questioner, pass the full description.


### PR DESCRIPTION
## What

Finishes the "blind" tone-down begun in 257feac, fe7f76d, and cd35c5e. A few runtime agents/skills still leaned on "blind"/"blindness" phrasing for the research-isolation invariant. This replaces it with neutral language that describes *what the research agents read* — preserving the invariant (they never read `task.md`), just dropping the loaded word.

## Changes

| File | Before → After |
|---|---|
| `skills/team/SKILL.md` | "Blind Research Invariant" → "Research Isolation Invariant"; phase table `(parallel, BLIND)` → `(parallel, isolated)` |
| `skills/qrspi-workflow/SKILL.md` | "Researcher is **BLIND** to intent" → "reads only `questions.md`" |
| `agents/file-finder.md` | "## Blindness invariant" → "## Scope isolation"; `**Blind.**` rule → `**Scoped to questions.md.**` |
| `agents/researcher.md` | same two changes |
| `agents/questioner.md` | "blind agents" → "the research agents" |
| `.claude/scripts/check-discovery-consistency.sh` | **Stale-check fix** + tone-down (see below) |

## Stale dev-check fix

`check-discovery-consistency.sh` still grepped `team-research/SKILL.md` for `## Blindness invariant`, but `fe7f76d` had already renamed that heading to `## Scope isolation` — so the gate was failing on `main` independent of any new work. Updated the assertion (and its blind-worded labels) to match. **The full check now passes** (`All discovery-consistency assertions passed.`).

## Scope

Mirrors the established precedent: runtime `skills/` + `agents/` only. `docs/architecture.md`, `docs/index.md`, and `CLAUDE.md` still describe "blind research" as a concept and were left untouched (as the prior tone-down commits did) — happy to sweep those in a follow-up if you want full removal.

## Test plan

- [x] `grep -rni blind skills/ agents/` returns nothing.
- [x] `.claude/scripts/check-discovery-consistency.sh` exits 0 / "All discovery-consistency assertions passed." (was failing on `main`).
- [x] Invariant preserved: each touched file still forbids reading `task.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)