### PR TITLE
docs: tone down "blind" emphasis in published docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Agents are **decoupled microservices**. Each consumes a predecessor artifact on 
 QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEMENT → PR
 ```
 
-Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-PR). Two human gates: **Design approval** (~200-line alignment doc) and **Structure approval** (~2-page vertical-slice breakdown). Research is **blind** — the researcher never sees the user's original task description. The Plan is a tactical artifact for the implementer, not for human review. Implement is a sub-pipeline (test-first → slice execution → 5-reviewer adversarial verify with hard-gate retry loop). Everything outside the two human gates is autonomous with mechanical gates.
+Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-PR). Two human gates: **Design approval** (~200-line alignment doc) and **Structure approval** (~2-page vertical-slice breakdown). Research is **isolated** — the researcher reads only `questions.md`, never `task.md` or the user's framing. The Plan is a tactical artifact for the implementer, not for human review. Implement is a sub-pipeline (test-first → slice execution → 5-reviewer adversarial verify with hard-gate retry loop). Everything outside the two human gates is autonomous with mechanical gates.
 
 ## Entry Points
 
@@ -46,7 +46,7 @@ Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-
 | `/team <desc>` | Full 8-phase QRSPI pipeline |
 | `/team-fix <bug>` | Compressed bug-fix pipeline (no QRSPI ceremony) |
 | `/team-question <desc>` | Decompose intent into task + questions + brief |
-| `/team-research` | Blind codebase research (runs Question if missing) |
+| `/team-research` | Isolated codebase research (runs Question if missing) |
 | `/team-design` | Align with user on approach (human gate) |
 | `/eng-design-doc-review` | *(optional)* Adversarial fresh-context audit of `design.md` before the human gate |
 | `/team-structure` | Break design into vertical slices (human gate) |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEME
 ```
 
 - **Question** — Decompose intent into a full task record (`task.md`) and neutral research questions (`questions.md`). The questioner is the only agent that ever sees the user's original description.
-- **Research** *(blind)* — Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task. This structurally prevents opinion-bias in research findings.
+- **Research** *(isolated)* — Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task. This structurally prevents opinion-bias in research findings.
 - **Design** *(human gate)* — Design author asks open questions interactively, then drafts a ~200-line alignment doc. Humans review here.
 - **Structure** *(human gate)* — Break the design into vertical slices with verification checkpoints. Humans review the ~2-page structure here.
 - **Plan** — Tactical implementation plan derived from the approved structure. Read by the implementer; not human-gated.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,10 +42,10 @@ seeds and updates a TodoWrite ledger, and runs the human gates.
 - **File artifacts survive compaction.** Agents communicate through
   files in `docs/plans/<id>/`. These survive context-window compaction,
   can be re-read by any agent in any session, and live in git history.
-- **Blind research.** The researcher and file-finder never receive the
-  user's original task description. Enforcement is two-layer:
+- **Research isolation.** The researcher and file-finder never receive
+  the user's original task description. Enforcement is two-layer:
   *structural* — the orchestrator only passes the `questions.md` path to
-  the blind agents; *procedural* — the blind agents' system prompts
+  the research agents; *procedural* — the research agents' system prompts
   forbid reading `task.md`.
 - **Two human touchpoints.** Design approval (~200-line alignment doc)
   and Structure approval (~2-page vertical-slice breakdown). Approval
@@ -138,9 +138,9 @@ of `questions.md`.
 
 ### Phase 2: Research
 
-**Agents:** `file-finder` and `researcher` (parallel, blind)
+**Agents:** `file-finder` and `researcher` (parallel, isolated)
 **Predecessor:** `questions.md` (orchestrator passes only the
-`questions.md` path to the blind agents)
+`questions.md` path to the research agents)
 **Artifact:** `docs/plans/<id>/research.md`
 
 Orchestrator waits for both agents to return, then writes the combined
@@ -296,7 +296,7 @@ Skills live under `skills/`. There are two flavors:
 | `team`           | `/team <desc>`                       | Full 8-phase QRSPI pipeline              |
 | `team-fix`       | `/team-fix <bug>`                    | Compressed bug-fix pipeline              |
 | `team-question`  | `/team-question <desc>`              | Decompose intent (runs alone)            |
-| `team-research`  | `/team-research [docs/plans/<id>/]`  | Blind research                           |
+| `team-research`  | `/team-research [docs/plans/<id>/]`  | Isolated research                        |
 | `team-design`    | `/team-design [docs/plans/<id>/]`    | Design alignment (human gate)            |
 | `team-structure` | `/team-structure [docs/plans/<id>/]` | Vertical-slice structure (human gate)    |
 | `team-plan`      | `/team-plan [docs/plans/<id>/]`      | Tactical plan from approved structure    |
@@ -398,7 +398,7 @@ acceptance tooling run by plugin developers. `check-discovery-consistency.sh`
 is the committed consistency gate for the input-discovery feature: it asserts
 every archetype-A skill carries the discovery block, the load-bearing fragments
 (`ID_RE`, `PHASE_FILES`, approval grep, `docs/plans/` root) stay byte-identical
-to canon, and the blind-research invariant holds.
+to canon, and the research-isolation invariant holds.
 
 ## 8. State Management
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ The autonomous engineering mesh for Claude Code.
 
 ## What is Team?
 
-Team orchestrates **13 specialized agents** — from blind researchers to adversarial reviewers — that drive a feature through an 8-phase pipeline (QRSPI) and deliver a verified pull request. Agents are decoupled microservices: each consumes a predecessor artifact on disk, does its work, and writes its own artifact. The orchestrator (the main Claude Code session) walks a linear phase table and runs two human approval gates.
+Team orchestrates **13 specialized agents** — from isolated researchers to adversarial reviewers — that drive a feature through an 8-phase pipeline (QRSPI) and deliver a verified pull request. Agents are decoupled microservices: each consumes a predecessor artifact on disk, does its work, and writes its own artifact. The orchestrator (the main Claude Code session) walks a linear phase table and runs two human approval gates.
 
 ## The Pipeline
 
@@ -21,7 +21,7 @@ QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEME
 | Phase | What happens |
 |-------|-------------|
 | **Question** | Decompose intent into `task.md` + neutral `questions.md`. The questioner is the only agent that ever sees your original description. |
-| **Research** *(blind)* | Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task — structurally preventing opinion-bias. |
+| **Research** *(isolated)* | Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task — structurally preventing opinion-bias. |
 | **Design** *(human gate)* | The design author runs an interactive interview, then drafts a ~200-line alignment doc. You review here. |
 | **Structure** *(human gate)* | Break the design into vertical slices with verification checkpoints. ~2-page doc. You review here. |
 | **Plan** | Tactical implementation plan derived from the approved structure. Read by the implementer; not human-gated. |


### PR DESCRIPTION
## Summary

Follow-up to PR #24. PR #24 (and the earlier `fe7f76d` / `cd35c5e`) replaced "blind" / "BLIND" / "Blindness" language across `agents/` and `skills/` with "isolation" wording, but did not touch the published docs or top-level README/AGENTS files. After that PR, the runtime files had **zero** "blind" usages while the docs still carried 11 of them, creating a tone inconsistency. This sweeps the remaining surviving usages so the whole publishable surface speaks the same language.

## Changes

| File | Hits | Treatment |
|------|------|-----------|
| `docs/architecture.md` | 6 | Design Philosophy bullet ("Blind research" → "Research isolation"); Phase 2 block ("(parallel, blind)" → "(parallel, isolated)", "the blind agents" → "the research agents"); entry-point skills table row ("Blind research" → "Isolated research"); dev consistency note ("blind-research invariant" → "research-isolation invariant") |
| `docs/index.md` | 2 | Intro paragraph ("blind researchers" → "isolated researchers"); phase table row ("*(blind)*" → "*(isolated)*") |
| `README.md` | 1 | Pipeline bullet ("*(blind)*" → "*(isolated)*") |
| `AGENTS.md` | 2 | Pipeline narrative ("Research is **blind**" rewrote to describe the mechanism); entry-point table row ("Blind codebase research" → "Isolated codebase research"). `CLAUDE.md` is a symlink to `AGENTS.md` and updates automatically. |

## Intentionally **not** changed

- `CHANGELOG.md` — historical release entries; per Keep a Changelog conventions, prior-release language is not retroactively edited.
- `docs/plans/2026-04-22-simplify-orchestration-*.md` — old planning artifacts (Question/Research/Design/Structure/Plan snapshots); immutable historical record.

## Test plan

Documentation-only change:

- [x] `cd docs && bundle exec jekyll build` exits 0
- [x] Zero \"blind\"/\"Blind\" usages remain in the 4 edited files (\`grep -nE 'blind|Blind'\`)
- [x] Repo-wide grep confirms the only surviving \"blind\" usages are in the historical files listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)