### PR TITLE
fix(docs): hand-maintained TOC so it renders in GFM too

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,6 @@ description: "Team plugin architecture — agents as microservices, the QRSPI pi
 ---
 
 # Team Plugin — Architecture
-{:.no_toc}
 
 > **Audience:** Plugin maintainers and contributors. End users only need
 > the README + `/team` slash command.
@@ -13,10 +12,15 @@ description: "Team plugin architecture — agents as microservices, the QRSPI pi
 > in-session TodoWrite ledger.
 
 ## Contents
-{:.no_toc}
 
-* TOC
-{:toc}
+- [1. Design Philosophy](#1-design-philosophy)
+- [2. Artifact Layout & Frontmatter](#2-artifact-layout--frontmatter)
+- [3. Pipeline (QRSPI)](#3-pipeline-qrspi)
+- [4. Agent Roster](#4-agent-roster)
+- [5. Phase-Table Orchestrator](#5-phase-table-orchestrator)
+- [6. Skills](#6-skills)
+- [7. Hooks](#7-hooks)
+- [8. State Management](#8-state-management)
 
 ## 1. Design Philosophy
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,7 +4,6 @@ description: "The Team plugin's 27 skills — 11 entry-point slash commands and 
 ---
 
 # Team Plugin — Skills
-{:.no_toc}
 
 > **Audience:** Plugin maintainers and contributors. End users only need
 > the README + `/team` slash command.
@@ -14,10 +13,13 @@ description: "The Team plugin's 27 skills — 11 entry-point slash commands and 
 > `SKILL.md`, the `SKILL.md` wins.
 
 ## Contents
-{:.no_toc}
 
-* TOC
-{:toc}
+- [Two flavors of skill](#two-flavors-of-skill)
+- [Entry-point skills](#entry-point-skills)
+- [Methodology skills](#methodology-skills)
+- [Skill ↔ agent ↔ phase](#skill--agent--phase)
+- [Name-collision pairs](#name-collision-pairs)
+- [See also](#see-also)
 
 ## Two flavors of skill
 


### PR DESCRIPTION
## Summary

GitHub's blob view of `.md` files uses GFM, not Kramdown. The `{:.no_toc}` and `* TOC / {:toc}` Kramdown attribute syntax was rendering as literal text on github.com when readers viewed `docs/skills.md` and `docs/architecture.md`. The deployed Jekyll site at team.bostonaholic.dev continued to render correctly via Kramdown — this only affected GitHub's UI rendering.

Replace the auto-generated TOC with a hand-maintained Markdown bullet list that renders identically in both renderers.

## Changes

- **`docs/skills.md`** — drop `{:.no_toc}` on H1 and on the Contents heading; replace `* TOC` + `{:toc}` with an explicit 6-entry H2 link list.
- **`docs/architecture.md`** — same treatment; 8-entry H2 link list.

No other files affected (the only other `.md` files using these Kramdown markers are under `docs/plans/`, which is excluded from publish).

## Test plan

- [x] `cd docs && bundle exec jekyll build` exits 0
- [x] Zero `{:.no_toc}` / `* TOC` / `{:toc}` markers remain in the two edited files
- [x] Every TOC link target verified against the built `_site/` HTML — all 6 anchors in `skills.html` and all 8 in `architecture.html` resolve
- [x] Contents block renders as a proper `<ul>` (not literal `* TOC` text) in `_site/`

## Maintenance trade-off

The TOC list must be updated when H2 headings change. Modest cost — these are reference docs that don't churn heading-by-heading. The alternative (auto-`{:toc}`) only works in Kramdown and was the cause of the broken render on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)