### PR TITLE
fix(skills): forbid slashes in worktree branch names

### DIFF
--- a/skills/team-worktree/SKILL.md
+++ b/skills/team-worktree/SKILL.md
@@ -100,6 +100,17 @@ just the home repo.
   Claude Code's native worktree convention; see
   `skills/worktree-isolation/SKILL.md`)
 
+**Branch names must never contain a slash (`/`).** Use `-` as the only
+delimiter. A `/` in a branch name creates a nested ref path in
+`.git/refs/heads/` that collides with Claude Code's `.claude/worktrees/`
+directory convention and breaks worktree cleanup. The `<id>` produced by
+the questioner is already slash-free, but if `basename "$ARGUMENTS"` ever
+yields a name containing `/` (e.g. a ticket prefix like `TEAM/123`),
+replace every `/` with `-` first and use that sanitized name as **both**
+the branch name and the worktree directory name so the two stay in sync
+for cleanup: `branch="$(printf '%s' "$id" | tr '/' '-')"`. Only the
+`docs/plans/<id>/` artifact directory keeps the original `<id>`.
+
 ### Confirm with the user
 
 Single-repo:
@@ -134,12 +145,16 @@ Use `AskUserQuestion` with a `Worktree` header and **Proceed** /
 
 After the user confirms:
 
+Use the slash-sanitized name (`<branch>`, derived above) for both the
+worktree directory and the `-b` flag in every repo. In the common case
+`<branch>` equals `<id>`.
+
 - **Single-repo:** create the home worktree using Claude Code's native
   worktree support, branched off `origin/HEAD`.
 - **Multi-repo:** for each listed repo:
   ```
   git -C <repo-path> fetch origin --quiet
-  git -C <repo-path> worktree add .claude/worktrees/<id> -b <id> origin/HEAD
+  git -C <repo-path> worktree add .claude/worktrees/<branch> -b <branch> origin/HEAD
   ```
   If a repo lacks an `origin` remote or `origin/HEAD`, fall back to its
   current default branch and warn the user once for that repo.


### PR DESCRIPTION
## What

Teach the `team-worktree` skill — the skill that actually creates branches via `git worktree add -b` — to never put a slash (`/`) in a branch name. Use `-` as the only delimiter.

## Why

A `/` in a branch name nests a ref under `.git/refs/heads/` and collides with Claude Code's `.claude/worktrees/<id>` directory convention, which breaks worktree cleanup. The `<id>` produced by the questioner is already slash-free by its `ID_RE` regex, so this is a defensive guard for the edge case where a slash sneaks in (e.g. a ticket prefix like `TEAM/123`).

## Change

In the **Derive identifiers** step of `skills/team-worktree/SKILL.md`:

- Add an explicit rule that branch names must never contain `/`.
- If `basename "$ARGUMENTS"` yields a slash, sanitize with `tr '/' '-'` and use the sanitized name for **both** the branch and the worktree directory, so the two stay in sync for cleanup (`git branch -D` + `worktree remove`).
- The `docs/plans/<id>/` artifact directory keeps the original `<id>`.
- Update the `git worktree add` command to use the sanitized `<branch>` for both the path and the `-b` flag.

In the common case `<branch>` equals `<id>` and nothing changes.

## Test plan

- [ ] Normal slash-free `<id>` (e.g. `2026-06-01-add-rate-limiting`) — branch and worktree dir unchanged.
- [ ] Edge case `<id>` containing `/` (e.g. `TEAM/123-foo`) — branch and worktree dir become `TEAM-123-foo`; artifact dir keeps original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
