### PR TITLE
docs: track all work on the GitHub Project board

### DIFF
--- a/.claude/scripts/project-item-id.sh
+++ b/.claude/scripts/project-item-id.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# project-item-id.sh — print the GitHub Project board item ID for an issue.
+#
+# Single responsibility: resolve <issue-number> -> board item ID (PVTI_…) on the
+# "🤖 Team" board (https://github.com/users/bostonaholic/projects/5).
+#
+# Dev-only, non-distributed (lives under .claude/, not hooks/) per the
+# runtime-vs-development split in CLAUDE.md / AGENTS.md.
+#
+# Usage:
+#   .claude/scripts/project-item-id.sh <issue-number>
+#
+# Writes the item ID to stdout (and nothing else, so it pipes cleanly); exits
+# non-zero if the issue is not on the board. Compose with project-set-status.sh:
+#   project-item-id.sh 42 | project-set-status.sh "In review"
+#
+# Requires: gh (authenticated) and jq.
+
+set -uo pipefail
+
+OWNER="bostonaholic"
+PROJECT_NUMBER="5"
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+[ "$#" -eq 1 ] || die "usage: $(basename "$0") <issue-number>"
+issue="$1"
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found"
+command -v jq >/dev/null 2>&1 || die "jq not found"
+
+case "$issue" in
+  ''|*[!0-9]*) die "issue number must be numeric: '$issue'" ;;
+esac
+
+item_id="$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json \
+  | jq -r --argjson n "$issue" '.items[] | select(.content.number == $n) | .id')" \
+  || die "failed to list project items (is gh authenticated?)"
+[ -n "$item_id" ] \
+  || die "issue #$issue is not on project $PROJECT_NUMBER — add it to the board first"
+
+printf '%s\n' "$item_id"

--- a/.claude/scripts/project-set-status.sh
+++ b/.claude/scripts/project-set-status.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# project-set-status.sh — set a board item's Status column by name.
+#
+# Single responsibility: given a board item ID and a column name, set the
+# Status field of that item on the "🤖 Team" board
+# (https://github.com/users/bostonaholic/projects/5).
+#
+# Dev-only, non-distributed (lives under .claude/, not hooks/) per the
+# runtime-vs-development split in CLAUDE.md / AGENTS.md.
+#
+# Usage:
+#   .claude/scripts/project-set-status.sh <status> [item-id]
+#
+# The item ID comes from the second argument, or — when it is omitted or "-" —
+# from stdin, so this composes as the sink of a pipe:
+#   project-item-id.sh 42 | project-set-status.sh "In review"
+#
+# <status> is the column name, case-insensitive:
+#   Backlog | Ready | In progress | In review | Done
+#
+# Resolves the project, Status field, and target option IDs at runtime by name,
+# so it survives field/option recreation. Prints a confirmation to stderr;
+# stdout is left empty. Requires: gh (authenticated) and jq.
+
+set -uo pipefail
+
+OWNER="bostonaholic"
+PROJECT_NUMBER="5"
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+{ [ "$#" -ge 1 ] && [ "$#" -le 2 ]; } || die "usage: $(basename "$0") <status> [item-id]"
+status="$1"
+item_id="${2:--}"
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found"
+command -v jq >/dev/null 2>&1 || die "jq not found"
+
+# Item ID from stdin when not given as an argument.
+if [ "$item_id" = "-" ]; then
+  read -r item_id || true
+fi
+[ -n "${item_id:-}" ] \
+  || die "no item id — pass as an argument or pipe one in from project-item-id.sh"
+
+# Status field ID + the option ID for the requested column (case-insensitive).
+fields_json="$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json)" \
+  || die "failed to list project fields (is gh authenticated?)"
+read -r field_id option_id <<EOF
+$(printf '%s' "$fields_json" | jq -r --arg s "$status" '
+  .fields[] | select(.name == "Status") | .id as $fid
+  | .options[] | select((.name | ascii_downcase) == ($s | ascii_downcase))
+  | "\($fid) \(.id)"')
+EOF
+{ [ -n "${field_id:-}" ] && [ -n "${option_id:-}" ]; } \
+  || die "unknown status: '$status' (valid: Backlog, Ready, In progress, In review, Done)"
+
+project_id="$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.id')" \
+  || die "failed to resolve project id"
+
+gh project item-edit \
+  --project-id "$project_id" \
+  --id "$item_id" \
+  --field-id "$field_id" \
+  --single-select-option-id "$option_id" \
+  >/dev/null \
+  || die "item-edit failed"
+
+printf 'set %s -> "%s"\n' "$item_id" "$status" >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This project produces a **distributed plugin**. Two contexts exist:
 | Registry sync validation | `.claude/hooks/check-registry-sync.mjs` | Plugin developers |
 | Dev acceptance scripts | `.claude/scripts/` | Plugin developers |
 | Dev settings/hooks | `.claude/settings.json` | Plugin developers |
-| Issue tracking | `.beads/` | Plugin developers |
+| Work tracking | [GitHub Project board](https://github.com/users/bostonaholic/projects/5/views/1) | Plugin developers |
 | Behavioral regression harness | `tests/`, `evals/` | Plugin developers |
 
 **Rule of thumb:** If it validates that the plugin is *built correctly*, it's a dev concern (`.claude/`). If it runs *as part of the plugin's functionality*, it's runtime (`hooks/`).
@@ -96,6 +96,8 @@ State is the set of artifacts in `docs/plans/<id>/*.md`, where `<id>` is `<TICKE
 
 Behavioral regression harness for pipeline agents — TypeScript + Bun. Harness code lives in `tests/`; fixtures, rubrics, and stored runs live in `evals/`. `bun test` runs the free static gate; `bun run test:evals` runs the paid E2E + LLM-judge tiers (needs `EVALS_ANTHROPIC_API_KEY`). See [evals/README.md](evals/README.md).
 
-## Issue Tracking
+## Work Tracking
 
-This project uses **bd (beads)**. Run `bd prime` for full workflow context and commands. After a fresh clone, run `bd hooks install` once to activate the git hooks that keep `.beads/issues.jsonl` in sync (the hook logic lives in `.beads/hooks/`; the `.git/hooks/` wrappers are local and not versioned).
+All work — features, bugs, chores — is tracked on the [GitHub Project board](https://github.com/users/bostonaholic/projects/5/views/1). It is the single source of truth: if work is not on the board, it is not tracked. Create a GitHub issue in `bostonaholic/team`, add it to the project, and move its card across the kanban (**Backlog → Ready → In progress → In review → Done**) as the work progresses. See [docs/project-tracking.md](docs/project-tracking.md) for the full workflow.
+
+> The GitHub Project replaces the previous **bd (beads)** tracker. The `.beads/` directory remains for historical reference but is no longer the front door for new work.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEME
 - **Plan** — Tactical implementation plan derived from the approved structure. Read by the implementer; not human-gated.
 - **Worktree** — Orchestrator prepares an isolated git worktree.
 - **Implement** — Test-first (test-architect writes failing tests, mechanical gate confirms) → slice execution (implementer commits each vertical slice atomically) → adversarial verification (5 parallel reviewers + typed failure-class retry loop, max 5 rounds).
-- **PR** — Update changelog, commit, open pull request, close beads issue.
+- **PR** — Update changelog, commit, open pull request, surface the tracking item.
 
 ## Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,4 +53,5 @@ For a focused bug fix that skips the QRSPI ceremony:
 
 - **[Architecture](architecture.md)** — full design, artifact frontmatter, phase-inference rules.
 - **[Skills](skills.md)** — all 27 skills, their arguments, consumers, and behaviors.
+- **[Project Tracking](project-tracking.md)** — how work is tracked on the GitHub Project board.
 - **[GitHub repository](https://github.com/bostonaholic/team)** — source, agents, skills.

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -1,0 +1,175 @@
+---
+title: Project Tracking
+description: "How work on the Team plugin is tracked — the GitHub Project board is the single source of truth for features, bugs, and chores, moved across a Backlog → Ready → In progress → In review → Done kanban."
+---
+
+# Project Tracking
+
+> **Audience:** Plugin maintainers and contributors. End users do not need
+> this — it describes how work on the Team plugin *itself* is tracked.
+
+All work on the Team plugin is tracked on a single GitHub Project board:
+
+**→ [🤖 Team — Project Board](https://github.com/users/bostonaholic/projects/5/views/1)**
+
+This board is the **single source of truth** for what is planned, in
+flight, and done. Features, bugs, and chores all live here. If a piece of
+work is not on the board, it is not tracked.
+
+> **Note:** This board replaces the previous `bd` (beads) tracker. The
+> `.beads/` directory remains in the repo for historical reference, but new
+> work should be created and tracked on the GitHub Project, not in beads.
+
+## The board
+
+The board is backed by issues in the
+[`bostonaholic/team`](https://github.com/bostonaholic/team) repository. Each
+card is a GitHub issue (or a draft item that gets converted to one). Cards
+carry a few fields beyond title:
+
+| Field | Purpose |
+|-------|---------|
+| **Status** | Which kanban column the card is in (see below). |
+| **Priority** | `P0` (drop everything) … `P2` (eventually). |
+| **Size** | Rough effort estimate. |
+| **Labels** | What kind of work this is and how it should be handled — see [Labels](#labels). |
+| **Linked pull requests** | The PR(s) that implement the card. |
+
+## Creating work
+
+Create a card for every distinct piece of work — one card per feature, bug,
+or chore.
+
+1. **Open an issue** in `bostonaholic/team` describing the work. Use a clear,
+   action-oriented title (e.g. "Add rate limiting to API endpoints", "Fix
+   stale cache after profile update").
+   ```sh
+   gh issue create --repo bostonaholic/team \
+     --title "Fix stale cache after profile update" \
+     --label bug
+   ```
+2. **Add it to the board** and set its fields:
+   ```sh
+   gh issue edit <number> --repo bostonaholic/team \
+     --add-project "🤖 Team"
+   ```
+   Then set **Status**, **Priority**, **Size**, and its **type label** (see
+   [Labels](#labels)) from the board or the issue sidebar.
+3. **Quick capture** — for an idea you have not fully shaped yet, add a
+   *draft item* directly on the board (the "+ Add item" row). Convert it to a
+   real issue before anyone starts work on it.
+
+## Labels
+
+Labels classify *what a card is* and *how it should be handled* — the kanban
+column already tracks *where it is*, so labels never duplicate status. Reuse
+the existing labels; do not invent new ones casually. They fall into four
+groups.
+
+### Type — what the work is (apply exactly one)
+
+Every issue gets exactly one type label. This is the primary axis for
+filtering the board.
+
+| Label | Use it for |
+|-------|------------|
+| `bug` | Something isn't working — a defect in existing behavior. |
+| `enhancement` | A new feature or improvement to existing behavior. *(This is the "feature" label — there is no separate `feature` label.)* |
+| `documentation` | Improvements or additions to docs only — no behavior change. |
+
+### Resolution — why a card was closed (apply when closing)
+
+These are *close reasons*, not work to be done. Apply one **and close the
+issue** at the same time; never leave a resolution label on an open card.
+
+| Label | Apply when closing because… |
+|-------|------------------------------|
+| `duplicate` | The same issue or PR already exists. Link the original. |
+| `invalid` | The report doesn't hold up — not reproducible or out of scope. |
+| `wontfix` | A deliberate decision not to act on it. Say why in a comment. |
+
+### Discussion — not committed work
+
+| Label | Use it for |
+|-------|------------|
+| `question` | A request for information or a discussion, not a unit of work. Keep these in **Backlog** (or close once answered); don't pull them into *In progress*. |
+
+### Contributor signals — layer on top of a type label
+
+These help others find work; they never replace a type label.
+
+| Label | Meaning |
+|-------|---------|
+| `good first issue` | Self-contained and well-scoped — a good entry point for a newcomer. |
+| `help wanted` | Maintainers are actively looking for someone to take this. |
+
+### Area labels — mostly automated
+
+`dependencies` and `ruby` are applied automatically by Dependabot to the PRs
+it opens (dependency-file updates, and Ruby code updates respectively). Don't
+hand-apply them unless a PR genuinely fits and the bot missed it.
+
+### Rules of thumb
+
+- **One type label, always.** `bug`, `enhancement`, or `documentation` — pick
+  the one that fits. If it's none of these, it's probably a `question`.
+- **Resolution labels travel with a close.** `duplicate` / `invalid` /
+  `wontfix` on an *open* issue is a contradiction.
+- **Labels describe the work; the board column describes its progress.** Don't
+  add a "wip" or "in review" label — that's what Status is for.
+- **`good first issue` / `help wanted` are additive**, layered onto a type
+  label, never a substitute for one.
+- **Stick to the existing set.** Need a label that doesn't exist? Raise it
+  with the maintainer before creating one — label sprawl makes the board
+  harder to filter, not easier.
+
+```sh
+# Apply or change labels from the CLI:
+gh issue edit <number> --repo bostonaholic/team --add-label enhancement
+gh issue edit <number> --repo bostonaholic/team --add-label "good first issue"
+```
+
+## The kanban flow
+
+Cards move left to right through five columns. The column *is* the status of
+the work.
+
+| Column | Meaning | Move here when… |
+|--------|---------|-----------------|
+| **Backlog** | Captured but not started. Not yet committed to. | The card is created. |
+| **Ready** | Shaped and ready to be picked up. Has enough detail to start. | The work is well-understood and prioritized. |
+| **In progress** | Actively being worked on. | You start work — open a worktree, run `/team`, or begin coding. |
+| **In review** | Implementation complete; a PR is open and under review. | A pull request is opened for the card. |
+| **Done** | Merged and complete. | The PR is merged. |
+
+**Move the card as the work moves.** Pull a card into **In progress** when
+you start, not after. When the PR opens, move it to **In review**. When the
+PR merges, move it to **Done**.
+
+```sh
+# Update an item's Status field from the CLI (see `gh project --help`),
+# or just drag the card on the board UI.
+```
+
+## How it ties to the QRSPI pipeline
+
+A Team run (`/team`, or the individual `/team-*` phases) maps onto the board
+like this:
+
+- **Picking up work** → move the card from **Ready** to **In progress** before
+  you launch the pipeline.
+- **The PR phase** (`/team-pr`) opens a draft pull request. Link that PR to the
+  card and move the card to **In review**.
+- **Merge** → move the card to **Done**.
+
+The pipeline persists its own intermediate state as artifacts in
+`docs/plans/<id>/` and tracks live in-session progress with TodoWrite — see
+[Architecture § State Management](architecture.md#9-state-management). Those
+are *execution* state; the board is *work* state. The board answers "what are
+we doing and where is it?"; the artifacts answer "how is this specific feature
+being built?"
+
+## Read next
+
+- **[Overview](index.md)** — what Team is and how the pipeline runs.
+- **[Architecture](architecture.md)** — full design and artifact conventions.

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -63,70 +63,91 @@ or chore.
 
 Labels classify *what a card is* and *how it should be handled* — the kanban
 column already tracks *where it is*, so labels never duplicate status. Reuse
-the existing labels; do not invent new ones casually. They fall into four
-groups.
+the existing labels; do not invent new ones casually.
 
-### Type — what the work is (apply exactly one)
+These are the **only** labels in the repository. The "Definition" column is the
+label's own GitHub description; the "Assign when" column is the rule an agent
+follows to decide whether the label applies. They fall into four groups: pick
+**exactly one Type label** for every issue, then add other labels only when
+their "Assign when" rule is satisfied.
 
-Every issue gets exactly one type label. This is the primary axis for
-filtering the board.
+### Type — what the work is (assign exactly one)
 
-| Label | Use it for |
-|-------|------------|
-| `bug` | Something isn't working — a defect in existing behavior. |
-| `enhancement` | A new feature or improvement to existing behavior. *(This is the "feature" label — there is no separate `feature` label.)* |
-| `documentation` | Improvements or additions to docs only — no behavior change. |
+Every issue gets exactly one type label. This is the primary axis for filtering
+the board. If none of the three fits, the item is almost certainly a
+`question`, not work.
 
-### Resolution — why a card was closed (apply when closing)
+| Label | Definition | Assign when |
+|-------|------------|-------------|
+| `bug` | Something isn't working | Existing behavior is broken, incorrect, or crashes — a defect in shipped functionality. Reproduction steps belong in the issue. |
+| `enhancement` | New feature or request | New capability, or an improvement to existing behavior that works but should do more or do it better. **This is the "feature" label — there is no separate `feature` label.** |
+| `documentation` | Improvements or additions to documentation | The change is to docs only (`README`, `docs/`, `AGENTS.md`, code comments) with no behavior change. If code *and* docs change, use the code label (`bug`/`enhancement`), not this. |
 
-These are *close reasons*, not work to be done. Apply one **and close the
-issue** at the same time; never leave a resolution label on an open card.
+### Resolution — why a card was closed (assign only while closing)
 
-| Label | Apply when closing because… |
-|-------|------------------------------|
-| `duplicate` | The same issue or PR already exists. Link the original. |
-| `invalid` | The report doesn't hold up — not reproducible or out of scope. |
-| `wontfix` | A deliberate decision not to act on it. Say why in a comment. |
+These are *close reasons*, not work to be done. Assign one **at the moment you
+close the issue**; never leave a resolution label on an open card. They do not
+replace the Type label — an invalid bug keeps `bug` and gains `invalid`.
+
+| Label | Definition | Assign when |
+|-------|------------|-------------|
+| `duplicate` | This issue or pull request already exists | Closing because the same item is already tracked elsewhere. Link the original in a comment. |
+| `invalid` | This doesn't seem right | Closing because the report doesn't hold up — not reproducible, misfiled, or out of scope for this repo. |
+| `wontfix` | This will not be worked on | Closing by deliberate decision not to act, even though the item may be valid. State the reasoning in a comment. |
 
 ### Discussion — not committed work
 
-| Label | Use it for |
-|-------|------------|
-| `question` | A request for information or a discussion, not a unit of work. Keep these in **Backlog** (or close once answered); don't pull them into *In progress*. |
+| Label | Definition | Assign when |
+|-------|------------|-------------|
+| `question` | Further information is requested | The item is a request for information or a discussion, not a unit of work. Keep it in **Backlog** (or close once answered); never pull a `question` into *In progress*. Drop it once it converts into a `bug`/`enhancement`. |
 
-### Contributor signals — layer on top of a type label
+### Contributor signals — additive, layered on a Type label
 
-These help others find work; they never replace a type label.
+These help humans find work; they never replace a Type label and an agent
+rarely needs to apply them on its own.
 
-| Label | Meaning |
-|-------|---------|
-| `good first issue` | Self-contained and well-scoped — a good entry point for a newcomer. |
-| `help wanted` | Maintainers are actively looking for someone to take this. |
+| Label | Definition | Assign when |
+|-------|------------|-------------|
+| `good first issue` | Good for newcomers | The work is self-contained, well-scoped, and needs little repo context — a safe entry point for a first-time contributor. |
+| `help wanted` | Extra attention is needed | Maintainers are explicitly inviting someone else to pick this up. |
 
-### Area labels — mostly automated
+### Area — mostly automated
 
-`dependencies` and `ruby` are applied automatically by Dependabot to the PRs
-it opens (dependency-file updates, and Ruby code updates respectively). Don't
-hand-apply them unless a PR genuinely fits and the bot missed it.
+These mark *what part of the codebase* a change touches. Dependabot applies
+them automatically to the PRs it opens; an agent should hand-apply one only
+when a PR genuinely fits the area and the bot missed it.
 
-### Rules of thumb
+| Label | Definition | Assign when |
+|-------|------------|-------------|
+| `dependencies` | Pull requests that update a dependency file | A PR bumps or changes a dependency manifest/lockfile. Normally set by Dependabot. |
+| `ruby` | Pull requests that update ruby code | A PR changes Ruby code. Normally set by Dependabot. |
 
-- **One type label, always.** `bug`, `enhancement`, or `documentation` — pick
-  the one that fits. If it's none of these, it's probably a `question`.
-- **Resolution labels travel with a close.** `duplicate` / `invalid` /
-  `wontfix` on an *open* issue is a contradiction.
-- **Labels describe the work; the board column describes its progress.** Don't
-  add a "wip" or "in review" label — that's what Status is for.
-- **`good first issue` / `help wanted` are additive**, layered onto a type
-  label, never a substitute for one.
-- **Stick to the existing set.** Need a label that doesn't exist? Raise it
-  with the maintainer before creating one — label sprawl makes the board
-  harder to filter, not easier.
+### Decision procedure for an agent
+
+1. **Pick the one Type label** — `bug` if existing behavior is broken,
+   `enhancement` if it's new/better capability, `documentation` if it's docs
+   only. Can't pick one? It's a `question`.
+2. **Stop there for a normal open issue.** Type label (or `question`) is
+   usually the whole answer.
+3. **Add `good first issue` / `help wanted`** only if that signal is true — and
+   only on top of a Type label, never instead of one.
+4. **Add an Area label** (`dependencies` / `ruby`) only for a PR that fits it
+   and only if automation missed it.
+5. **Add a Resolution label** (`duplicate` / `invalid` / `wontfix`) *only* in
+   the same action that closes the issue, with a one-line reason in a comment.
+6. **Never** add a status-like label (no "wip", "in review", "blocked") — the
+   board's **Status** field owns progress. And never invent a label that isn't
+   in the tables above; if one is genuinely missing, raise it with the
+   maintainer first — label sprawl makes the board harder to filter, not
+   easier.
 
 ```sh
 # Apply or change labels from the CLI:
 gh issue edit <number> --repo bostonaholic/team --add-label enhancement
 gh issue edit <number> --repo bostonaholic/team --add-label "good first issue"
+
+# The authoritative list always lives here:
+gh label list --repo bostonaholic/team
 ```
 
 ## The kanban flow

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -167,26 +167,22 @@ the work.
 you start, not after. When the PR opens, move it to **In review**. When the
 PR merges, move it to **Done**.
 
-Dragging the card on the board UI is the simplest way. To do it from the CLI,
-look up the item's ID, then set its Status option:
+Dragging the card on the board UI is the simplest way. From the CLI, two small
+helper scripts in `.claude/scripts/` compose over a pipe — one resolves an
+issue number to its board item ID, the other sets a Status column by name:
 
 ```sh
-# 1. Find the board item ID (PVTI_…) for your issue number:
-gh project item-list 5 --owner bostonaholic --format json \
-  --jq '.items[] | select(.content.number == <issue-number>) | .id'
-
-# 2. Set its Status. The project, field, and option IDs below are fixed for
-#    the "🤖 Team" board; re-derive them any time with:
-#      gh project field-list 5 --owner bostonaholic --format json
-gh project item-edit \
-  --project-id PVT_kwHOAAWGos4BZZUB \
-  --id <item-id> \
-  --field-id PVTSSF_lAHOAAWGos4BZZUBzhUYPNQ \
-  --single-select-option-id df73e18b   # In review
-
-# Status option IDs:
-#   Backlog f75ad846 · Ready 61e4505c · In progress 47fc9ee4 · In review df73e18b · Done 98236657
+# Move issue #42's card to "In review":
+.claude/scripts/project-item-id.sh 42 | .claude/scripts/project-set-status.sh "In review"
 ```
+
+`project-item-id.sh <issue-number>` prints the board item ID to stdout (and
+nothing else, so it pipes cleanly). `project-set-status.sh <status> [item-id]`
+takes the column name (case-insensitive: `Backlog` / `Ready` / `In progress` /
+`In review` / `Done`) and reads the item ID from stdin or a second argument.
+Both resolve every GitHub node ID at runtime, so they keep working if a field
+or option is recreated. They are dev-only helpers (under `.claude/`), not part
+of the distributed plugin.
 
 ## How it ties to the QRSPI pipeline
 

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -167,9 +167,25 @@ the work.
 you start, not after. When the PR opens, move it to **In review**. When the
 PR merges, move it to **Done**.
 
+Dragging the card on the board UI is the simplest way. To do it from the CLI,
+look up the item's ID, then set its Status option:
+
 ```sh
-# Update an item's Status field from the CLI (see `gh project --help`),
-# or just drag the card on the board UI.
+# 1. Find the board item ID (PVTI_…) for your issue number:
+gh project item-list 5 --owner bostonaholic --format json \
+  --jq '.items[] | select(.content.number == <issue-number>) | .id'
+
+# 2. Set its Status. The project, field, and option IDs below are fixed for
+#    the "🤖 Team" board; re-derive them any time with:
+#      gh project field-list 5 --owner bostonaholic --format json
+gh project item-edit \
+  --project-id PVT_kwHOAAWGos4BZZUB \
+  --id <item-id> \
+  --field-id PVTSSF_lAHOAAWGos4BZZUBzhUYPNQ \
+  --single-select-option-id df73e18b   # In review
+
+# Status option IDs:
+#   Backlog f75ad846 · Ready 61e4505c · In progress 47fc9ee4 · In review df73e18b · Done 98236657
 ```
 
 ## How it ties to the QRSPI pipeline


### PR DESCRIPTION
## Summary
- Establish the [GitHub Project board](https://github.com/users/bostonaholic/projects/5/views/1) as the single source of truth for all work on the Team plugin, replacing the `bd` (beads) tracker as the documented front door.
- Add a new **Project Tracking** doc page covering the board, its fields, how to create work, the kanban flow, and correct GitHub-label usage.
- Repoint the existing docs (`AGENTS.md`, `README.md`, `docs/index.md`) away from beads.

## Changes
- **`docs/project-tracking.md`** *(new)* — links the board; explains Status / Priority / Size / Labels; how to create features/bugs/chores via `gh`; the **Backlog → Ready → In progress → In review → Done** kanban flow; a full **Labels** section grounded in the repo's actual label set (type / resolution / discussion / contributor / automated area labels) with rules of thumb; and how the board maps onto the QRSPI pipeline.
- **`AGENTS.md`** — Runtime/Dev table row `Issue tracking → .beads/` repointed to the board; `## Issue Tracking` rewritten as `## Work Tracking` linking the board + new doc page, noting beads is superseded.
- **`README.md`** — PR-phase bullet no longer says "close beads issue".
- **`docs/index.md`** — added a Project Tracking link to "Read next".
- **`.claude/scripts/project-item-id.sh` + `project-set-status.sh`** *(new)* — two single-responsibility, pipeable dev helpers to move a card's Status from the CLI (`project-item-id.sh 42 | project-set-status.sh "In review"`).

## Notes
- The `.beads/` tooling and the beads *skill* install entries (`dev.yml`, `skills-lock.json`) are intentionally left in place — this PR changes the documented front door, not the tooling.
- Runtime `agents/`/`skills/` were deliberately **not** edited: they ship to all plugin users, so hardcoding this private board URL there would leak project-specific config. Board-specific guidance lives in the development/contributor context only.

## How to Verify
- [x] Render `docs/project-tracking.md` — board link, field table, kanban table, and Labels section read correctly. *(Verified: `bundle exec jekyll build` exits 0; rendered `project-tracking.html` contains the board link, `<h2 id="labels">`, and all 7 tables; required sections + field/kanban rows all present; 7 tables column-consistent; internal anchors `#labels` and `architecture.md#9-state-management` resolve.)*
- [x] Labels documented match `gh label list --repo bostonaholic/team` (no invented `feature`/`chore` labels). *(Verified: the 11 documented labels exactly match the 11 live repo labels; the only extra `feature` token appears in the sentence explicitly stating no `feature` label exists; no `chore` label referenced.)*
- [x] `AGENTS.md`, `README.md`, `docs/index.md` no longer present beads as the work tracker. *(Verified: `README.md` and `docs/index.md` have zero beads mentions; `AGENTS.md`'s only mention is the "superseded — no longer the front door" note.)*
- [x] `.claude/scripts/` Status helpers work end-to-end and compose over a pipe. *(Verified against the live board: `project-item-id.sh 42` prints only the item ID to stdout; the pipe `project-item-id.sh 42 | project-set-status.sh "In review"` moved this PR's card from "In progress" to "In review" (exit 0); item-ID-as-arg form works; bad status name, non-board issue, non-numeric, and missing args all fail loud with non-zero exit.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)