### PR TITLE
fix(evals): install + authenticate claude CLI in behavioral-evals CI

### DIFF
--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -45,9 +45,19 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # The live suite spawns the `claude` CLI (tests/helpers/session-runner.ts).
+      # It is not a project dependency, so install it globally onto $PATH here.
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run ${{ matrix.suite.name }} agent live
         env:
+          # The judge reads EVALS_ANTHROPIC_API_KEY (namespaced so the spawned
+          # agent won't auto-pick it up in local dev). In CI there is no
+          # logged-in session, so the agent under test gets its own credential
+          # via the bare ANTHROPIC_API_KEY, sourced from the same secret.
           EVALS_ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_API_KEY }}
           EVALS: "1"
           EVALS_ALL: "1"
           EVALS_TIER: periodic

--- a/docs/plans/2026-06-01-evals-ci-install-claude-cli/task.md
+++ b/docs/plans/2026-06-01-evals-ci-install-claude-cli/task.md
@@ -1,0 +1,44 @@
+---
+topic: evals-ci-install-claude-cli
+date: 2026-06-01
+phase: task
+ticketId: null
+---
+
+# Bug: behavioral-evals CI fails — `claude` CLI not installed/authenticated
+
+The weekly `Behavioral evals` workflow
+([run 26742546297](https://github.com/bostonaholic/team/actions/runs/26742546297))
+fails at the "Run code-reviewer agent live" step with:
+
+```
+error: Executable not found in $PATH: "claude"
+  syscall: "spawn claude"
+     code: "ENOENT"
+  at runAgentTest (tests/helpers/session-runner.ts:275)
+```
+
+## Root cause
+
+`.github/workflows/behavioral-evals.yml` installs Bun and project deps, then
+runs `bun test ./tests/code-reviewer.evals.ts`. That suite calls
+`runAgentTest`, which `spawn("claude", ...)`. The workflow never installs the
+Claude Code CLI, so the executable is absent from `$PATH`.
+
+A second latent failure sits right behind it: the spawned agent has no
+credentials. `EVALS_ANTHROPIC_API_KEY` is *deliberately namespaced* for the
+LLM judge only (`evals/README.md:70`) so the agent-under-test won't auto-pick
+it up. In local dev the agent rides the developer's logged-in Claude Code
+session; CI has none. Installing the CLI alone would just move the failure to
+an auth error on the next cron.
+
+## Fix
+
+In `behavioral-evals.yml`:
+1. Add a step installing the Claude Code CLI (`npm install -g
+   @anthropic-ai/claude-code`) before the live-agent step.
+2. Expose `ANTHROPIC_API_KEY` (sourced from the `EVALS_ANTHROPIC_API_KEY`
+   secret) to the live-agent step so the spawned agent authenticates.
+
+Guard the regression with a static-gate test asserting the workflow installs
+the CLI and provides agent auth.

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -12,6 +12,12 @@ import { loadFixture } from "./helpers/fixtures";
 
 const FIXTURE_ROOT = join(process.cwd(), "evals", "fixtures");
 const RUBRIC_ROOT = join(process.cwd(), "evals", "rubrics");
+const EVALS_WORKFLOW = join(
+  process.cwd(),
+  ".github",
+  "workflows",
+  "behavioral-evals.yml",
+);
 const FIXTURE_SIZE_CAP = 50 * 1024;
 
 function enumerate(): { agent: string; caseName: string }[] {
@@ -58,6 +64,35 @@ describe("static gate: fixtures", () => {
       const rubric = join(RUBRIC_ROOT, `${agent}.md`);
       expect(existsSync(rubric)).toBe(true);
     }
+  });
+});
+
+// The behavioral-evals workflow spawns the `claude` CLI live
+// (tests/helpers/session-runner.ts). A scheduled run is the only place this
+// fires, so a missing CLI install or missing agent credentials surfaces only
+// once a week, in CI, with no PR signal. These guards keep that contract
+// visible in the free gate that runs on every PR.
+describe("static gate: behavioral-evals workflow", () => {
+  const workflow = existsSync(EVALS_WORKFLOW)
+    ? readFileSync(EVALS_WORKFLOW, "utf8")
+    : "";
+
+  test("workflow file exists", () => {
+    expect(existsSync(EVALS_WORKFLOW)).toBe(true);
+  });
+
+  test("installs the Claude Code CLI before spawning the agent", () => {
+    // The live suite calls spawn("claude", ...); without this install the
+    // step dies with `ENOENT: claude not in $PATH`.
+    expect(workflow).toContain("@anthropic-ai/claude-code");
+  });
+
+  test("exposes ANTHROPIC_API_KEY so the spawned agent can authenticate", () => {
+    // EVALS_ANTHROPIC_API_KEY is namespaced for the judge only; the agent
+    // under test needs its own credential or it fails auth on every run.
+    // Anchor to the bare key at line start so the existing namespaced
+    // EVALS_ANTHROPIC_API_KEY: entry does not satisfy this on its own.
+    expect(/^\s*ANTHROPIC_API_KEY:/m.test(workflow)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

The weekly **Behavioral evals** workflow fails on every scheduled run. [Run 26742546297](https://github.com/bostonaholic/team/actions/runs/26742546297) died at *Run code-reviewer agent live*:

```
error: Executable not found in $PATH: "claude"
  syscall: "spawn claude"
     code: "ENOENT"
  at runAgentTest (tests/helpers/session-runner.ts:275)
```

## Root cause

`behavioral-evals.yml` installs Bun + project deps, then runs the live suite, which `spawn("claude", ...)`. The workflow never installs the Claude Code CLI, so the executable is absent from `$PATH`.

A second latent failure sits right behind it: the spawned agent has no credentials. `EVALS_ANTHROPIC_API_KEY` is **deliberately namespaced** for the LLM judge only (`evals/README.md:70`) so the agent-under-test won't auto-pick it up. Locally the agent rides the developer's logged-in Claude Code session; CI has none. Installing the CLI alone would just move the failure to an auth error on the next cron.

## Fix

- Add an `npm install -g @anthropic-ai/claude-code` step before the live-agent step.
- Expose a bare `ANTHROPIC_API_KEY` (sourced from the existing `EVALS_ANTHROPIC_API_KEY` secret) to that step so the spawned agent authenticates.

## Guard

This workflow only fires on a weekly cron, so regressions never show up on a PR. Added two `static-gate.test.ts` guards (free tier, runs on every PR) asserting the workflow installs the CLI and provides bare agent auth. The auth assertion anchors to line start so the namespaced `EVALS_ANTHROPIC_API_KEY` does not satisfy it on its own.

## Test plan

- [x] New guards fail against the pre-fix workflow (assertion failure, not crash)
- [x] New guards pass after the fix
- [x] Full `bun test` gate green (186 pass, 0 fail)
- [x] Manual `workflow_dispatch` against this branch reaches the live agent run without `ENOENT` — [run 26766065092](https://github.com/bostonaholic/team/actions/runs/26766065092) succeeded end-to-end (CLI installed, agent authenticated + ran, judge scored, job green in 39s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)