### PR TITLE
docs(skills): replace "residue" with "the remaining findings"

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,8 +221,8 @@ worktrees do not duplicate the artifacts. See
    remains, it dispatches the implementer to fix the typed failure
    class and re-runs all 5 reviewers — automatically, never consulting
    the user (the *consult guard*). Cap at 5 rounds; beyond that,
-   escalate. Once Blocking and Major are clean, any Minor-and-below
-   residue is presented to the user, who decides.
+   escalate. Once Blocking and Major are clean, any remaining
+   Minor-and-below findings are presented to the user, who decides.
 
 The orchestrator tracks the round count by appending "Review round N"
 items to the TodoWrite ledger.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -94,7 +94,7 @@ argument shape.
   aggregate gate sorts every finding into Blocking / Major / Minor-and-below
   tiers and auto-loops on any Blocking or Major (the consult guard: the
   user is never asked about a Blocking or Major finding), surfacing only
-  the Minor-and-below residue. Its body is organized as `## Input`,
+  the remaining Minor-and-below findings. Its body is organized as `## Input`,
   `## Setup`, `## The Phase Loop`, `## Gate Handling`, and `## Rules` —
   not the downstream Input / Execution / Completion template.
 
@@ -168,7 +168,7 @@ argument shape.
   / Minor-and-below tiers; while any Blocking or Major remains it
   re-dispatches the implementer automatically without consulting the user
   (the consult guard), capped at 5 rounds. Only the Minor-and-below
-  residue is surfaced once Blocking and Major are clean.
+  findings are surfaced once Blocking and Major are clean.
 - **Standalone Mode:** Invoked with no resolvable directory, it bootstraps
   the missing upstream artifacts inline rather than hard-erroring.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -158,7 +158,7 @@ in exactly one tier.
 **The consult guard (non-negotiable).** While *any* Blocking or Major finding
 remains unresolved, the orchestrator MUST NOT present findings to the user or
 ask which ones to address. It loops the implementer automatically. The user is
-consulted exclusively for the Minor-and-below residue, and only once the loop
+consulted exclusively for the remaining Minor-and-below findings, and only once the loop
 has driven Blocking and Major to zero. A consult prompt that lists a blocking
 or major finding is a defect.
 
@@ -170,7 +170,7 @@ pipeline gate decision:
 1. If ANY Blocking or Major finding exists -> pipeline gate FAILS — loop back
    to IMPLEMENT automatically, with no consult.
 2. If only Minor-and-below findings remain -> pipeline gate is CONDITIONAL:
-   present that residue to the user, who decides. If none remain, proceed to
+   present them to the user, who decides. If none remain, proceed to
    SHIP.
 3. If no findings remain -> pipeline gate PASSES (proceed to SHIP).
 

--- a/skills/team-implement/SKILL.md
+++ b/skills/team-implement/SKILL.md
@@ -154,7 +154,7 @@ Before any agent dispatch, decide where to work:
      this is the consult guard. A prompt that lists a blocking or major
      finding is a defect.
 8. **Once Blocking and Major are clean:** if any **Minor-and-below** findings
-   remain, present that residue to the user and let them decide (auto-fix,
+   remain, present them to the user and let them decide (auto-fix,
    defer, or skip). Then suggest `/team-pr`.
 
 ## Quality Loop

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -238,7 +238,7 @@ returned:
    Blocking or Major finding is open — loop automatically (the consult guard).
 4. If at cap → escalate to the user with all unresolved findings.
 5. Once Blocking and Major are clean → if any **Minor-and-below** findings
-   remain, present that residue to the user, who decides; otherwise advance
+   remain, present them to the user, who decides; otherwise advance
    to PR.
 
 **The loop is: IMPLEMENT → VERIFY (5 reviewers) → typed gate check →


### PR DESCRIPTION
## Summary

Replaces every use of the word **"residue"** in the skills and docs with plain, non-metaphorical wording. The metaphor framed legitimate Minor-and-below review findings as waste/byproduct, which misrepresents them. Standalone references read "the remaining findings"; where the surrounding sentence already says "findings remain," they read "present them" to avoid repetition.

Source files touched:

| File | Change |
|------|--------|
| `skills/code-review/SKILL.md` | consult guard + aggregate-verdict step |
| `skills/team/SKILL.md` | retry-loop step |
| `skills/team-implement/SKILL.md` | post-clean step |
| `docs/architecture.md` | aggregate-gate description |
| `docs/skills.md` | two spots |

`docs/_site/` (generated HTML) is intentionally untouched — it regenerates from the docs.

## Test plan

- [x] No "residue" remains in source (`grep -rin residue skills/ agents/ docs/ --exclude-dir=_site --exclude-dir=vendor` returns nothing)
- [x] Wording reads naturally in each edited location

🤖 Generated with [Claude Code](https://claude.com/claude-code)