### PR TITLE
chore(deps): switch Dependabot npm ecosystem to bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,10 @@
 #     what's available.
 version: 2
 updates:
-  # package.json — TS + Bun harness deps (@anthropic-ai/sdk, bun-types, typescript).
-  - package-ecosystem: "npm"
+  # package.json + bun.lock — TS + Bun harness deps (@anthropic-ai/sdk, bun-types, typescript).
+  # The "bun" ecosystem (GA since 2025-02) updates bun.lock alongside package.json;
+  # the "npm" ecosystem only touched package.json, breaking CI's --frozen-lockfile.
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Problem

Dependabot's `npm` package-ecosystem only updates `package.json`, leaving `bun.lock` stale. Every npm-group Dependabot PR therefore fails CI's `bun install --frozen-lockfile` gate (`error: lockfile had changes, but lockfile is frozen`). PR #49 needed a manual lockfile sync on the PR branch before it could merge, and `@dependabot recreate` reproduced the same broken state.

## Fix

Switch the ecosystem to `bun` — [GA since Feb 2025](https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/). It updates the text-based `bun.lock` (what this repo uses; the legacy binary `bun.lockb` is unsupported) alongside `package.json`. Grouping, schedule, and commit-message config carry over unchanged.

Closes #72

## Test plan

- [x] CI passes (config-only change; harness validation does not depend on dependabot.yml)
- [ ] Next Monday's Dependabot run produces npm-group PRs that include `bun.lock` and pass the frozen-lockfile gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
