### PR TITLE
v0.5.1 feat(agents): re-tier complex-work agents to opus (Fable 5 suspended)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-
 
 ## Agents (13)
 
-See `agents/*.md`. Each agent file uses only Claude Code's [supported frontmatter fields](https://code.claude.com/docs/en/agents#supported-frontmatter-fields) (no custom fields). Model tiering: haiku (mechanical), sonnet (judgment), opus (planning + implementation).
+See `agents/*.md`. Each agent file uses only Claude Code's [supported frontmatter fields](https://code.claude.com/docs/en/agents#supported-frontmatter-fields) (no custom fields). Model tiering: haiku (mechanical), sonnet (bounded judgment), and the most capable available model for complex work (research, planning, implementation, code review, security review). That model is currently opus — Fable 5 is the intended target but is temporarily suspended for all customers ([notice](https://www.anthropic.com/news/fable-mythos-access)). See [docs/architecture.md](docs/architecture.md#model-tiering) for the restoration path and overrides.
 
 **Invariant:** the agent inventory in `skills/team/registry.json` (which carries the `phase` mapping) and the files under `agents/` must always agree by name. When adding or renaming an agent, update both in the same commit. The dev hook `.claude/hooks/check-registry-sync.mjs` enforces this automatically.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-15
+
+### Changed
+
+- **Complex-work agents re-tiered to the most capable available model (`opus`).** Following a re-assessment of agent model assignments against Claude Code's model documentation, the tiering principle is now stated explicitly: complex work runs on the most capable available model, bounded single-pass judgment on `sonnet`, mechanical checks on `haiku`. Fable 5 was evaluated as the complex-work model but is [temporarily suspended for all customers](https://www.anthropic.com/news/fable-mythos-access) under a U.S. government export-control directive, so the most capable available model — and Fable's documented fallback target — is `opus` (Opus 4.8). Net effect: `researcher` and `code-reviewer` move `sonnet` → `opus`, joining the existing `opus` planning/implementation tier (`design-author`, `structure-planner`, `planner`, `implementer`); and `security-reviewer` moves `sonnet` → `opus`. `security-reviewer` stays on `opus` permanently even once Fable access returns, because Fable's cybersecurity safety classifiers refuse security-review content in non-interactive subagents. `opus` carries the 1M-token context window with no `[1m]` suffix (always-on via the Anthropic API; included with Max/Team/Enterprise subscriptions). `docs/architecture.md` records the tiering principle, the suspension, and the restoration path (flip complex-work agents `opus` → `fable` when access returns, except `security-reviewer`); the eval harness pricing table gains a `claude-fable-5` entry for when runs use it again.
+
 ## [0.5.0] - 2026-06-12
 
 ### Added
@@ -81,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/bostonaholic/team/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/bostonaholic/team/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/bostonaholic/team/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/bostonaholic/team/releases/tag/v0.3.0

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Use when an adversarial code review is needed after implementation. Reviews with fresh context and no shared conversation history to prevent self-evaluation bias. Produces a hard-gating verdict — REQUEST CHANGES blocks shipping. Example triggers — "review my changes", "code review the implementation", "check this PR for issues".
 color: orange
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, TodoWrite
 permissionMode: plan
 skills:

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -2,7 +2,7 @@
 name: researcher
 description: Use when codebase facts need to be gathered before any design or implementation work. Reads code, traces dependencies, documents patterns. Receives only the path to questions.md, never the original task description.
 color: blue
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, TodoWrite
 permissionMode: plan
 skills:

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -2,7 +2,7 @@
 name: security-reviewer
 description: Use when a security review is needed after implementation. Applies OWASP-style checks with fresh context. Critical findings are a hard gate — they block shipping until resolved. Example triggers — "security review", "check for vulnerabilities", "audit this code for security issues".
 color: red
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, TodoWrite
 permissionMode: plan
 skills:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,8 +259,46 @@ The dev hook `.claude/hooks/check-registry-sync.mjs` validates that
 the inventory in registry.json and the files under `agents/` agree by
 name.
 
-Model tiering: `haiku` (mechanical), `sonnet` (judgment), `opus`
-(planning + implementation).
+### Model tiering
+
+The principle: **complex work runs on the most capable available
+model; bounded judgment on `sonnet`; mechanical checks on `haiku`.**
+
+The most capable model is currently `opus` (Opus 4.8). Fable 5 was the
+intended complex-work model, but it is **temporarily suspended for all
+customers** under a U.S. government export-control directive (see
+[Anthropic's notice](https://www.anthropic.com/news/fable-mythos-access)).
+Until access is restored, complex work runs on `opus`, the documented
+fallback target for Fable and Anthropic's most capable Opus-tier model.
+
+- **`opus` — complex work:** `researcher`, `design-author`,
+  `structure-planner`, `planner`, `implementer`, `code-reviewer`, and
+  `security-reviewer`.
+- **`sonnet` — bounded single-pass judgment:** `questioner`,
+  `ux-reviewer`, `technical-writer`.
+- **`haiku` — mechanical checks:** `file-finder`, `verifier`.
+- **`inherit`:** `test-architect` follows the session model.
+
+Notes:
+
+- **1M context window comes for free at the opus tier.** Opus 4.8
+  always runs with the 1M window on the Anthropic API, and
+  Max/Team/Enterprise plans include the 1M upgrade with the
+  subscription (Pro degrades gracefully to 200K) — so the opus agents
+  need no `[1m]` suffix. The sonnet agents stay at 200K (bounded
+  single-pass work, nowhere near the ceiling); haiku does not support
+  1M.
+- **When Fable access is restored**, flip the complex-work agents from
+  `opus` to `fable` — *except* `security-reviewer`, which stays on
+  `opus` permanently: Fable 5's cybersecurity safety classifiers flag
+  security-review content, and in non-interactive subagent contexts a
+  flagged request ends the turn with a refusal instead of falling
+  back. Fable requires Claude Code ≥ v2.1.170 and Fable access (not
+  available under zero data retention; pin `ANTHROPIC_DEFAULT_FABLE_MODEL`
+  on Bedrock/Vertex/Foundry).
+- Users can override any agent's model with `CLAUDE_CODE_SUBAGENT_MODEL`
+  (applies to all subagents), or copy an agent file into
+  `.claude/agents/` with a different `model:`.
 
 ## 5. Phase-Table Orchestrator
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/tests/helpers/session-runner.ts
+++ b/tests/helpers/session-runner.ts
@@ -61,6 +61,7 @@ const PRICING_PER_MILLION: Record<string, { input: number; output: number }> = {
   "claude-sonnet-4-6": { input: 3, output: 15 },
   "claude-sonnet-4-7": { input: 3, output: 15 },
   "claude-opus-4-7": { input: 15, output: 75 },
+  "claude-fable-5": { input: 10, output: 50 },
   "claude-haiku-4-5-20251001": { input: 1, output: 5 },
 };
 


### PR DESCRIPTION
## Summary

Re-assess all 13 pipeline agents' model assignments against Claude Code's model documentation.

**Tiering principle:** complex work runs on the **most capable available model**; bounded single-pass judgment on `sonnet`; mechanical checks on `haiku`.

Fable 5 was evaluated as the complex-work model, but it is **[temporarily suspended for all customers](https://www.anthropic.com/news/fable-mythos-access)** under a U.S. government export-control directive. So the most capable available model — and Fable's documented fallback target — is **`opus`** (Opus 4.8).

## Changes vs. main

- `researcher`, `code-reviewer`: **`sonnet` → `opus`** — complex reasoning; join the existing opus planning/implementation tier.
- `security-reviewer`: **`sonnet` → `opus`** — and it stays opus **permanently** even after Fable returns, because Fable's cybersecurity classifiers refuse security-review content in non-interactive subagents.
- `design-author`, `structure-planner`, `planner`, `implementer`: already `opus`, **unchanged** (they round-tripped opus→fable→opus during review; net zero).
- `docs/architecture.md`: records the tiering principle, the Fable suspension, the restoration path (flip complex-work agents opus→fable when access returns, except security-reviewer), and that opus gets the 1M context window with no `[1m]` suffix.
- `tests/helpers/session-runner.ts`: `claude-fable-5` pricing entry for when eval runs use it again.

**Final roster:** 7× opus (researcher, design-author, structure-planner, planner, implementer, code-reviewer, security-reviewer), 3× sonnet (questioner, ux-reviewer, technical-writer), 2× haiku (file-finder, verifier), 1× inherit (test-architect).

## Restoration path

When Fable access is restored, flip the six complex-work agents `opus` → `fable` (keep `security-reviewer` on `opus`). Documented in `docs/architecture.md`.

## Test plan

- [x] `bun test` passes (251 tests — static gate, registry sync, version consistency, frontmatter structure)
- [x] `grep -h "^model:" agents/*.md | sort | uniq -c` shows 7× opus, 3× sonnet, 2× haiku, 1× inherit (13 agents)
- [x] Version bumped to 0.5.1 across all four strings + dated CHANGELOG section (version-gate)
- [x] `docs/architecture.md` Model tiering section renders correctly under § 4 Agent Roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)