### PR TITLE
v0.10.0 feat: reuse an existing worktree when /team runs inside one

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.9.1"
+    "version": "0.10.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-18
+
 ### Changed
 
 - **Running `/team` from inside an existing git worktree on a feature branch now reuses that worktree instead of refusing.** Previously the leading WORKTREE phase unconditionally refused whenever the checkout was already inside a linked worktree ("nesting worktrees is not supported"), which blocked common setups like Conductor workspaces or any pre-created per-task worktree. The phase now detects a linked worktree using the canonical, layout-independent git check — a checkout is linked when its git dir differs from its common git dir (`git rev-parse --path-format=absolute --git-dir` vs `--git-common-dir`), with no assumptions about where worktrees live on disk — and branches on the checked-out ref: a **non-default branch** is reused in place (no new `<id>` branch, no artifact copy), while the **default branch** (main/master) still stops, since implementing directly on the default branch is never acceptable. In multi-repo mode the check applies per repo, so already-isolated repos are reused while the rest still get fresh `<id>`-branch worktrees. Documented across [`skills/team-worktree/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md), [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md), and the leading-worktree orchestrator gate in [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md); locked in by L2 tripwires in [`tests/protocol.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/protocol.test.ts) and a new L3 subprocess-snapshot suite ([`tests/worktree-detection.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/worktree-detection.test.ts)) that runs the documented detection snippet against real git worktree fixtures.
@@ -137,7 +139,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/bostonaholic/team/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/bostonaholic/team/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/bostonaholic/team/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/bostonaholic/team/compare/v0.7.1...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Running `/team` from inside an existing git worktree on a feature branch now reuses that worktree instead of refusing.** Previously the leading WORKTREE phase unconditionally refused whenever the checkout was already inside a linked worktree ("nesting worktrees is not supported"), which blocked common setups like Conductor workspaces or any pre-created per-task worktree. The phase now detects a linked worktree using the canonical, layout-independent git check — a checkout is linked when its git dir differs from its common git dir (`git rev-parse --path-format=absolute --git-dir` vs `--git-common-dir`), with no assumptions about where worktrees live on disk — and branches on the checked-out ref: a **non-default branch** is reused in place (no new `<id>` branch, no artifact copy), while the **default branch** (main/master) still stops, since implementing directly on the default branch is never acceptable. In multi-repo mode the check applies per repo, so already-isolated repos are reused while the rest still get fresh `<id>`-branch worktrees. Documented across [`skills/team-worktree/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md), [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md), and the leading-worktree orchestrator gate in [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md); locked in by L2 tripwires in [`tests/protocol.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/protocol.test.ts) and a new L3 subprocess-snapshot suite ([`tests/worktree-detection.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/worktree-detection.test.ts)) that runs the documented detection snippet against real git worktree fixtures.
+
 ## [0.9.1] - 2026-06-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/team-worktree/SKILL.md
+++ b/skills/team-worktree/SKILL.md
@@ -79,17 +79,47 @@ done
 3. If `repos.md` is absent, you are in **single-repo mode**: only the
    home repo (the one this command is running in) gets a worktree.
 
-## Refusal
+## Detect existing worktree
 
-**Refuse to create a nested worktree in any involved repo.** For each
-target repo, run `git -C <repo-path> rev-parse --absolute-git-dir` and
-check whether the resulting path contains `/worktrees/`. If any repo's
-current checkout is already inside a worktree, report that and stop —
-nesting worktrees is not supported. The user should resolve the nested
-worktree (or invoke `/team` from a non-worktree checkout) before retrying.
+**Never create a nested worktree.** For each target repo, determine
+whether the current checkout is a **linked worktree** — any working
+tree other than the repository's main working tree, wherever it lives
+on disk. In the main working tree the git dir and the common git dir
+are the same path; in a linked worktree they differ:
+
+```sh
+[ "$(git -C <repo-path> rev-parse --path-format=absolute --git-dir)" != \
+  "$(git -C <repo-path> rev-parse --path-format=absolute --git-common-dir)" ] \
+  && echo "linked worktree"
+```
+
+If the checkout is a linked worktree, check which branch it is on:
+
+```sh
+git -C <repo-path> rev-parse --abbrev-ref HEAD
+```
+
+Compare against the repo's default branch
+(`git -C <repo-path> symbolic-ref refs/remotes/origin/HEAD | sed
+'s@^refs/remotes/origin/@@'`, falling back to `main`/`master` if unset):
+
+- **Non-default branch** → **skip worktree creation for this repo.**
+  Announce once: "Already in worktree `<path>` on branch `<branch>` —
+  skipping worktree creation, continuing in place." Treat the current
+  checkout as this repo's worktree for the rest of the pipeline. Work
+  continues on the current branch — no `<id>` branch is created.
+- **Default branch** → report and stop. Implementing directly on the
+  default branch inside a worktree is never acceptable, and nesting
+  worktrees is not supported. The user should switch that worktree to a
+  feature branch (or invoke `/team` from a non-worktree checkout) before
+  retrying.
+
+If the checkout is **not** a linked worktree, this repo proceeds through
+the normal creation flow below.
 
 In multi-repo mode, this check applies to **every** listed repo, not
-just the home repo.
+just the home repo. Skipped repos reuse their current checkout; the
+remaining repos still get fresh `<id>`-branch worktrees.
 
 ## Execution
 
@@ -115,6 +145,11 @@ for cleanup: `branch="$(printf '%s' "$id" | tr '/' '-')"`. Only the
 `docs/plans/<id>/` artifact directory keeps the original `<id>`.
 
 ### Confirm with the user
+
+Confirm only the repos that actually need a worktree created. If **no**
+repo needs creation (single-repo mode where the detect step skipped the
+home repo), skip this dialog entirely — the reuse announcement above is
+sufficient; proceed to Completion.
 
 Single-repo:
 ```
@@ -146,7 +181,8 @@ Use `AskUserQuestion` with a `Worktree` header and **Proceed** /
 
 ### Create the worktree(s)
 
-After the user confirms:
+After the user confirms, create a worktree in each repo the detect step
+did **not** skip:
 
 Use the slash-sanitized name (`<branch>`, derived above) for both the
 worktree directory and the `-b` flag in every repo. In the common case
@@ -166,6 +202,7 @@ worktree directory and the `-b` flag in every repo. In the common case
 
 After all worktrees are created, append a `## Worktrees` section to the
 home worktree's `docs/plans/<id>/repos.md` listing each repo's worktree
+path. For repos the detect step skipped, record the current checkout's
 path. This becomes the discoverable record any later `/team-*` invocation
 reads to relocate the worktrees.
 
@@ -188,6 +225,9 @@ in-place implementation is allowed — no worktree needed.
 Report the worktree paths and tell the user:
 
 - Single-repo: **"Next: cd <home-worktree> and run `/team-implement docs/plans/<id>/`"**
+- Home repo skipped (already in its worktree): **"Next: run
+  `/team-implement docs/plans/<id>/`"** — no `cd` needed; work continues
+  in the current checkout on the current branch.
 - Multi-repo: **"Next: cd <home-worktree> and run `/team-implement
   docs/plans/<id>/`. The implementer will navigate between the
   per-repo worktrees as the plan steps require."**

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -197,7 +197,11 @@ from phase 1, keeping the home checkout's `git status` clean for the whole run.
    `skills/team-worktree/SKILL.md` → "Create the worktree(s)"). Only the home
    repo gets a worktree at this phase; multi-repo secondary worktrees are
    deferred until after the design gate (see "Orchestrator-Emit Gate
-   (post-design-gate secondary worktrees)" below).
+   (post-design-gate secondary worktrees)" below). **If the run was started
+   from inside a linked worktree on a non-default branch, reuse it instead of
+   creating a new one** (see "Detect existing worktree" in
+   `skills/team-worktree/SKILL.md`); if that worktree is on the default branch,
+   stop rather than implement on it.
 2. **Create `docs/plans/<id>/` inside the worktree.** The artifact directory
    lives in the worktree from the start, so no copy is ever needed.
 3. **Compute the worktree's absolute path once** and thread it into every

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -81,6 +81,19 @@ rationale). The router's responsibilities are:
    worktree's `docs/plans/<id>/` directory; live coordination uses
    TodoWrite (session-scoped).
 
+### Reusing an existing worktree
+
+If the session is already running inside a **linked worktree** — any
+working tree other than the repository's main working tree, detected by
+the checkout's git dir differing from its common git dir — on a
+**non-default branch**, the WORKTREE phase reuses it instead of creating
+a new one: no new branch, no artifact copy — work continues in place on
+the current branch. If that worktree is checked out on the default
+branch (main/master), the phase refuses and stops — implementing
+directly on the default branch is never acceptable, and nesting
+worktrees is not supported. See "Detect existing worktree" in
+`skills/team-worktree/SKILL.md` for the procedure.
+
 ### Why first
 
 Worktree creation is the leading phase — it runs first, before QUESTION —

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -184,6 +184,22 @@ describe("multi-repo support", () => {
     expect(read(TEAM_WT)).toContain("## Worktrees");
   });
 
+  test("team-worktree skips creation when already in a non-default-branch worktree", () => {
+    const text = read(TEAM_WT);
+    // Linked-worktree detection must be layout-independent: git dir vs common git dir.
+    expect(text).toContain("--git-common-dir");
+    expect(text).toContain("skip worktree creation for this repo");
+    expect(text).toContain("Non-default branch");
+    // Default-branch worktrees still refuse — never implement on main/master.
+    expect(text).toContain("Default branch** → report and stop");
+  });
+
+  test("worktree-isolation documents worktree reuse", () => {
+    const text = read(WORKTREE_ISO);
+    expect(text).toContain("Reusing an existing worktree");
+    expect(text).toContain("non-default branch");
+  });
+
   test("questioner excludes AskUserQuestion + multi-repo detection uses openQuestions envelope", () => {
     const text = read(QUESTIONER);
     const fm = frontmatter(text);

--- a/tests/worktree-detection.test.ts
+++ b/tests/worktree-detection.test.ts
@@ -1,0 +1,114 @@
+// L3 subprocess-snapshot tests (see TESTING.md §2) for the linked-worktree
+// detection documented in skills/team-worktree/SKILL.md. The snippet under
+// test is EXTRACTED from the SKILL.md code block — the docs are the single
+// source of truth, so the documented command and the tested command cannot
+// drift. Real `git` runs against hermetic temp repos; free and deterministic.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+const TEAM_WT = join(REPO_ROOT, "skills", "team-worktree", "SKILL.md");
+
+// Pull the detection snippet out of the "## Detect existing worktree"
+// section's sh code block (the one comparing --git-dir to --git-common-dir).
+function detectionSnippet(): string {
+  const text = read(TEAM_WT);
+  const blocks = [...text.matchAll(/```sh\n([\s\S]*?)```/g)].map((m) => m[1]);
+  const matches = blocks.filter((b) => b.includes("--git-common-dir"));
+  expect(matches.length).toBe(1); // guard: exactly one documented detection block
+  return matches[0];
+}
+
+// Run the documented snippet against a repo path. Detection prints
+// "linked worktree" when the checkout is a linked worktree, nothing otherwise.
+function runDetection(repoPath: string): string {
+  const script = detectionSnippet().replaceAll("<repo-path>", repoPath);
+  const res = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+  return res.stdout.trim();
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const res = spawnSync(
+    "git",
+    ["-c", "user.email=test@test", "-c", "user.name=test", ...args],
+    { cwd, encoding: "utf8" },
+  );
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  }
+  return res.stdout.trim();
+}
+
+let root: string;
+let mainRepo: string; // main working tree, branch `main`
+let featureWt: string; // linked worktree at an arbitrary user-chosen path
+let defaultWt: string; // linked worktree checked out on the default branch
+let trickyRepo: string; // MAIN working tree whose path contains /worktrees/
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "worktree-detection-test-"));
+
+  mainRepo = join(root, "repo");
+  mkdirSync(mainRepo);
+  git(mainRepo, "init", "-b", "main");
+  git(mainRepo, "commit", "--allow-empty", "-m", "init");
+
+  // Linked worktree at an arbitrary path — deliberately NOT under
+  // .claude/worktrees/ or any path containing "worktrees", to prove the
+  // detection is independent of where the user puts worktrees on disk.
+  featureWt = join(root, "anywhere", "my-feature");
+  git(mainRepo, "worktree", "add", "-b", "feature-x", featureWt);
+
+  // Linked worktree checked out on the default branch (main moved aside
+  // first, since a branch can only be checked out in one worktree).
+  git(mainRepo, "switch", "-c", "parked");
+  defaultWt = join(root, "on-default");
+  git(mainRepo, "worktree", "add", defaultWt, "main");
+
+  // Regression fixture for the old substring heuristic: a MAIN working
+  // tree whose own path contains /worktrees/ must not read as linked.
+  trickyRepo = join(root, "worktrees", "standalone");
+  mkdirSync(trickyRepo, { recursive: true });
+  git(trickyRepo, "init", "-b", "main");
+  git(trickyRepo, "commit", "--allow-empty", "-m", "init");
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("linked-worktree detection (snippet from team-worktree SKILL.md)", () => {
+  test("main working tree is not detected as linked", () => {
+    expect(runDetection(mainRepo)).toBe("");
+  });
+
+  test("linked worktree at an arbitrary path is detected", () => {
+    expect(runDetection(featureWt)).toBe("linked worktree");
+  });
+
+  test("linked worktree on the default branch is still detected (refusal is the branch check's job)", () => {
+    expect(runDetection(defaultWt)).toBe("linked worktree");
+  });
+
+  test("main working tree whose path contains /worktrees/ is not detected (old heuristic's false positive)", () => {
+    expect(runDetection(trickyRepo)).toBe("");
+  });
+});
+
+describe("branch check inputs for the skip-vs-refuse rule", () => {
+  // The documented rule: skip when the linked worktree is on a non-default
+  // branch; refuse when it sits on the default branch. Verify the documented
+  // command yields the branch names that drive that decision.
+  test("feature worktree reports its non-default branch", () => {
+    expect(git(featureWt, "rev-parse", "--abbrev-ref", "HEAD")).toBe("feature-x");
+  });
+
+  test("default-branch worktree reports the default branch", () => {
+    expect(git(defaultWt, "rev-parse", "--abbrev-ref", "HEAD")).toBe("main");
+  });
+});


### PR DESCRIPTION
## Summary

Running `/team` from inside an existing linked git worktree previously hit `team-worktree`'s unconditional Refusal gate ("nesting worktrees is not supported"). This PR replaces that gate with a **detect step**:

- **Linked worktree on a non-default branch** → skip worktree creation and continue in place on the current branch (no `<id>` branch, no artifact copy, no confirmation dialog).
- **Linked worktree on the default branch (main/master)** → still refuse and stop — implementing directly on the default branch is never acceptable, and nesting worktrees remains unsupported.
- **Multi-repo mode** → the check applies per repo: skipped repos reuse their checkout; remaining repos still get fresh `<id>`-branch worktrees.

Detection is the canonical, layout-independent git check — a checkout is a linked worktree iff `git rev-parse --path-format=absolute --git-dir` differs from `--git-common-dir` (equal only in the main working tree). No path-substring heuristics, no assumptions about where worktrees live on disk.

## Changes

| File | Change |
|------|--------|
| `skills/team-worktree/SKILL.md` | `## Refusal` → `## Detect existing worktree`; conditional confirm/create/record/completion steps |
| `skills/worktree-isolation/SKILL.md` | New "Reusing an existing worktree" lifecycle subsection |
| `skills/team/SKILL.md` | Reuse note added to the leading-worktree orchestrator gate (step 1), pointing at the skill |
| `tests/protocol.test.ts` | L2 tripwires pinning the skip contract, `--git-common-dir` detection, and reuse docs |
| `tests/worktree-detection.test.ts` | New L3 subprocess-snapshot suite — extracts the detection snippet from the SKILL.md and executes it with real git against hermetic temp fixtures, so docs and tested code cannot drift |

Downstream is unaffected: `team-implement` already proceeds in place when inside a worktree, and `team-pr` is branch-agnostic.

## Test plan

- [x] `bun test` — 366 pass, 0 fail (free static gate: L2 tripwires + L3 detection suite), rebased onto current `main`
- [x] Detection fixtures cover: main working tree (not linked), linked worktree at an arbitrary user-chosen path (linked), default-branch worktree (linked; refusal driven by branch check), and a main checkout whose path contains `/worktrees/` (old heuristic's false positive — not linked)
- [x] Live sanity check in a real linked worktree on a feature branch → detection yields "skip — reuse current worktree"; main checkout → git-dir equals common-dir (normal creation flow)
- [x] Paid tier (`bun run test:evals`) not run — `EVALS_ANTHROPIC_API_KEY` unavailable in this workspace; the only eval targets the code-reviewer agent, untouched by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
