### PR TITLE
ci: gate LLM-token-consuming CI jobs on PR author trust

### DIFF
--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -10,6 +10,11 @@
 # Runs Monday 06:00 UTC. Offline harness checks live in harness-checks.yml.
 name: Behavioral evals
 
+# Hard ban (issue #51, design Decision 5): token/secret-consuming jobs
+# MUST NOT trigger on pull_request_target. That event runs in base-repo
+# context with secrets available — a known exfiltration vector if PR code is
+# ever checked out. Paid execution stays on schedule / workflow_dispatch or
+# trust-gated pull_request only.
 on:
   schedule:
     - cron: '0 6 * * 1'  # Monday 06:00 UTC
@@ -26,6 +31,13 @@ jobs:
     # via a pull_request. Event-aware so schedule/workflow_dispatch (no PR
     # context) stay ungated; only pull_request events are author-gated.
     if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    # Backstop (issue #51, design Decision 1): scope EVALS_ANTHROPIC_API_KEY to
+    # the protected `evals` environment so only this opted-in job can read it;
+    # fails closed (secret simply unavailable) if the environment is absent.
+    # ONE-TIME SETUP: create the `evals` environment under repo Settings →
+    # Environments, attach EVALS_ANTHROPIC_API_KEY as an environment secret,
+    # and set required reviewers and/or restrict deployment branches to `main`.
+    environment: evals
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -96,6 +96,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          # Direct ${{ }} expansion (not the SUITE_FILE env-indirection
+          # pattern above): a `with:` field is evaluated by the runner before
+          # any shell, so it cannot read a `$VAR` — env indirection is not
+          # possible here. Safe regardless: matrix.suite.name is a
+          # repo-controlled YAML literal, and GitHub sanitizes artifact names.
           name: behavioral-evals-${{ matrix.suite.name }}-${{ github.run_id }}
           path: evals/results/
           retention-days: 90

--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -30,6 +30,9 @@ jobs:
     # Author gate (issue #51): only OWNER/MEMBER/COLLABORATOR may spend tokens
     # via a pull_request. Event-aware so schedule/workflow_dispatch (no PR
     # context) stay ungated; only pull_request events are author-gated.
+    # Forward-proofing: this `if:` is dormant today (no pull_request trigger
+    # above) and stays dormant until one is added — do NOT delete it as dead
+    # code; it is the live gate the moment PRs can trigger this workflow.
     if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     # Backstop (issue #51, design Decision 1): scope EVALS_ANTHROPIC_API_KEY to
     # the protected `evals` environment so only this opted-in job can read it;

--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -3,9 +3,10 @@
 # This is the actual eval tier: spawns `claude -p` against fixtures under
 # evals/fixtures/<agent>/<case>/, then runs the LLM-judge over the agent's
 # output. Detects behavior regression when the underlying model changes.
-# Requires an Anthropic API key (stored as the EVALS_ANTHROPIC_API_KEY repo
-# secret, exposed to the harness under the same name) and runs only on
-# the weekly cron or via manual workflow_dispatch.
+# Requires an Anthropic API key (an environment secret named
+# EVALS_ANTHROPIC_API_KEY scoped to the `evals` environment, exposed to the
+# harness under the same name) and runs only on the weekly cron or via manual
+# workflow_dispatch.
 #
 # Runs Monday 06:00 UTC. Offline harness checks live in harness-checks.yml.
 name: Behavioral evals
@@ -32,7 +33,11 @@ jobs:
     # context) stay ungated; only pull_request events are author-gated.
     # Forward-proofing: this `if:` is dormant today (no pull_request trigger
     # above) and stays dormant until one is added — do NOT delete it as dead
-    # code; it is the live gate the moment PRs can trigger this workflow.
+    # code; it is the live gate the moment PRs can trigger this workflow. The
+    # guard covers ANY event where github.event.pull_request.author_association
+    # is set (e.g. pull_request and its variants), not just the literal
+    # `pull_request` event name, so future trigger additions consult the gate
+    # rather than bypass it.
     if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     # Backstop (issue #51, design Decision 1): scope EVALS_ANTHROPIC_API_KEY to
     # the protected `evals` environment so only this opted-in job can read it;

--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -30,15 +30,16 @@ jobs:
     name: Live agent runs (${{ matrix.suite.name }})
     # Author gate (issue #51): only OWNER/MEMBER/COLLABORATOR may spend tokens
     # via a pull_request. Event-aware so schedule/workflow_dispatch (no PR
-    # context) stay ungated; only pull_request events are author-gated.
+    # context) stay ungated; only pull_request* events are author-gated.
     # Forward-proofing: this `if:` is dormant today (no pull_request trigger
     # above) and stays dormant until one is added — do NOT delete it as dead
     # code; it is the live gate the moment PRs can trigger this workflow. The
-    # guard covers ANY event where github.event.pull_request.author_association
-    # is set (e.g. pull_request and its variants), not just the literal
-    # `pull_request` event name, so future trigger additions consult the gate
-    # rather than bypass it.
-    if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    # `startsWith` prefix match covers ANY pull_request* event (pull_request AND
+    # pull_request_target and any future variant), so adding such a trigger
+    # consults the allowlist instead of short-circuiting the left side and
+    # bypassing the gate entirely. Non-PR events (schedule/dispatch) fail the
+    # startsWith and stay ungated.
+    if: ${{ !startsWith(github.event_name, 'pull_request') || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
     # Backstop (issue #51, design Decision 1): scope EVALS_ANTHROPIC_API_KEY to
     # the protected `evals` environment so only this opted-in job can read it;
     # fails closed (secret simply unavailable) if the environment is absent.

--- a/.github/workflows/behavioral-evals.yml
+++ b/.github/workflows/behavioral-evals.yml
@@ -22,6 +22,10 @@ concurrency:
 jobs:
   behavioral-evals:
     name: Live agent runs (${{ matrix.suite.name }})
+    # Author gate (issue #51): only OWNER/MEMBER/COLLABORATOR may spend tokens
+    # via a pull_request. Event-aware so schedule/workflow_dispatch (no PR
+    # context) stay ungated; only pull_request events are author-gated.
+    if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/harness-checks.yml
+++ b/.github/workflows/harness-checks.yml
@@ -29,7 +29,7 @@ jobs:
     # no `claude` spawn), so the job itself stays UNGATED — fork authors keep
     # free CI. But any step that consumes a secret or spawns `claude` MUST
     # carry this trust `if:`:
-    #   ${{ contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
+    #   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     # When PR #32's "Run gate-tier evals" step attaches paid execution here,
     # it inherits this gate so untrusted PR authors never spend tokens.
     steps:

--- a/.github/workflows/harness-checks.yml
+++ b/.github/workflows/harness-checks.yml
@@ -32,6 +32,10 @@ jobs:
     #   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     # When PR #32's "Run gate-tier evals" step attaches paid execution here,
     # it inherits this gate so untrusted PR authors never spend tokens.
+    # Canonical in-use example: behavioral-evals.yml wires exactly this
+    # allowlist into a live job-level `if:` (wrapped event-aware with
+    # startsWith(github.event_name, 'pull_request')) — copy that form when
+    # adding the paid step here.
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/harness-checks.yml
+++ b/.github/workflows/harness-checks.yml
@@ -14,7 +14,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: harness-checks-${{ github.head_ref || github.run_id }}
+  # Key on the PR number (never the attacker-controlled branch name) so a
+  # crafted head_ref can't collide with or cancel another PR's group.
+  group: harness-checks-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/harness-checks.yml
+++ b/.github/workflows/harness-checks.yml
@@ -23,6 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Author gate contract (issue #51): the steps below are free (no secret,
+    # no `claude` spawn), so the job itself stays UNGATED — fork authors keep
+    # free CI. But any step that consumes a secret or spawns `claude` MUST
+    # carry this trust `if:`:
+    #   ${{ contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
+    # When PR #32's "Run gate-tier evals" step attaches paid execution here,
+    # it inherits this gate so untrusted PR authors never spend tokens.
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -510,8 +510,17 @@ env-var knobs, and the rerun-on-base blame protocol.
 **CI wiring.** Two GitHub Actions workflows in `.github/workflows/`:
 `harness-checks.yml` runs the offline harness validation on every PR
 (no secrets, ~5s); `behavioral-evals.yml` runs the live-agent regression
-check on a weekly cron (Monday 06:00 UTC) with the `EVALS_ANTHROPIC_API_KEY`
-repo secret.
+check on a weekly cron (Monday 06:00 UTC) with `EVALS_ANTHROPIC_API_KEY`.
+That key is an **environment secret** scoped to the `evals` GitHub
+Environment — a one-time Settings → Environments setup (create the `evals`
+environment, attach the secret, optionally set required reviewers / a
+main-only branch restriction). The job declares `environment: evals` and
+**fails closed** if the environment is absent: the secret simply resolves
+to empty, so no token spend leaks. `pull_request_target` is hard-banned for
+this and any secret-consuming / `claude`-spawning job — it runs in
+base-repo context with secrets available, a base-repo-context exfiltration
+vector — and the ban is enforced by a static tripwire in
+`tests/static-gate.test.ts`.
 
 These three tiers are the paid frontier of Team's broader six-layer testing
 model — see [Testing](testing.md) for where every check belongs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -520,7 +520,10 @@ to empty, so no token spend leaks. `pull_request_target` is hard-banned for
 this and any secret-consuming / `claude`-spawning job — it runs in
 base-repo context with secrets available, a base-repo-context exfiltration
 vector — and the ban is enforced by a static tripwire in
-`tests/static-gate.test.ts`.
+`tests/static-gate.test.ts`. Live jobs that run on `pull_request` events
+additionally gate on PR-author trust: only OWNER/MEMBER/COLLABORATOR authors
+may spend tokens, so untrusted PRs (forks, Dependabot, first-time
+contributors) never trigger paid execution.
 
 These three tiers are the paid frontier of Team's broader six-layer testing
 model — see [Testing](testing.md) for where every check belongs.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -247,6 +247,11 @@ test poisons the whole base. A tripwire that greps tests for forbidden paid
 calls (`grep` for the model CLI / SDK import in the free test roots) is a good
 L2 guard for exactly this.
 
+Token-consuming CI jobs are additionally restricted to trusted PR authors
+(OWNER/MEMBER/COLLABORATOR); untrusted PRs (forks, Dependabot, first-time
+contributors) skip them — a security control against token-spend griefing,
+not just a cost optimization.
+
 ---
 
 ## 6. Meta-tests: test the test system

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -250,7 +250,11 @@ L2 guard for exactly this.
 Token-consuming CI jobs are additionally restricted to trusted PR authors
 (OWNER/MEMBER/COLLABORATOR); untrusted PRs (forks, Dependabot, first-time
 contributors) skip them — a security control against token-spend griefing,
-not just a cost optimization.
+not just a cost optimization. This is forward-proofing: the
+`behavioral-evals.yml` gate is dormant until a `pull_request` trigger is added,
+while `harness-checks.yml` carries the trust expression as a documented-only
+contract for the same reason — so the control is already in place the moment a
+paid step attaches.
 
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -69,10 +69,10 @@ the test runs or is registered as `test.skip`. `EVALS_ALL=1` forces all.
 | `EVALS_MOCK_JUDGE` | JSON file replayed instead of calling the LLM judge | unset |
 | `EVALS_ANTHROPIC_API_KEY` | Anthropic API key for the judge (paid tiers). Namespaced so an ambient Claude Code session (incl. the spawned agent under test) won't auto-pick it up; passed explicitly to the judge's Anthropic SDK client. | — |
 
-When this key is absent or empty and `EVALS_MOCK_AGENT` is unset, the live
-path now **throws immediately** ("refusing live spawn") rather than spawning
-`claude` and failing later at CLI auth. Set `EVALS_MOCK_AGENT` to replay a
-fixture without a key.
+When this key is absent, empty, or whitespace-only and `EVALS_MOCK_AGENT` is
+unset, the live path now **throws immediately** ("refusing live spawn") rather
+than spawning `claude` and failing later at CLI auth. Set `EVALS_MOCK_AGENT` to
+replay a fixture without a key.
 
 In CI the key is an **`evals` environment secret** (not a plain repo secret),
 reachable only by the job declaring `environment: evals`. Token-consuming

--- a/evals/README.md
+++ b/evals/README.md
@@ -69,6 +69,17 @@ the test runs or is registered as `test.skip`. `EVALS_ALL=1` forces all.
 | `EVALS_MOCK_JUDGE` | JSON file replayed instead of calling the LLM judge | unset |
 | `EVALS_ANTHROPIC_API_KEY` | Anthropic API key for the judge (paid tiers). Namespaced so an ambient Claude Code session (incl. the spawned agent under test) won't auto-pick it up; passed explicitly to the judge's Anthropic SDK client. | — |
 
+When this key is absent or empty and `EVALS_MOCK_AGENT` is unset, the live
+path now **throws immediately** ("refusing live spawn") rather than spawning
+`claude` and failing later at CLI auth. Set `EVALS_MOCK_AGENT` to replay a
+fixture without a key.
+
+In CI the key is an **`evals` environment secret** (not a plain repo secret),
+reachable only by the job declaring `environment: evals`. Token-consuming
+jobs are additionally **skipped for PR authors who are not
+OWNER/MEMBER/COLLABORATOR** — fork PRs, Dependabot (`CONTRIBUTOR`), and
+first-time contributors skip by design, so no tokens are spent on their PRs.
+
 ## Fixture format
 
 `evals/fixtures/<agent>/<case>/input.md`:
@@ -177,5 +188,11 @@ If it fails there too, the regression predates your change.
    diff selection applies.
 5. `bun test` — verify the gate validates the new schemas.
 6. `bun test ./tests/<agent>.evals.ts` — run end-to-end (needs `EVALS_ANTHROPIC_API_KEY`).
+
+Any **new CI step** that consumes `EVALS_ANTHROPIC_API_KEY` or spawns
+`claude` on a `pull_request` event MUST carry the canonical trust `if:` so
+untrusted authors never spend tokens. Copy the expression from the contract
+comment on the `harness-checks` job in
+`.github/workflows/harness-checks.yml`.
 
 Run `bun run eval:list` to see the registered tests and their tiers.

--- a/evals/README.md
+++ b/evals/README.md
@@ -191,8 +191,12 @@ If it fails there too, the regression predates your change.
 
 Any **new CI step** that consumes `EVALS_ANTHROPIC_API_KEY` or spawns
 `claude` on a `pull_request` event MUST carry the canonical trust `if:` so
-untrusted authors never spend tokens. Copy the expression from the contract
-comment on the `harness-checks` job in
-`.github/workflows/harness-checks.yml`.
+untrusted authors never spend tokens. Copy the expression from the live
+job-level `if:` on the `behavioral-evals` job in
+`.github/workflows/behavioral-evals.yml` — that is the authoritative,
+event-aware copy source (`!startsWith(github.event_name, 'pull_request') ||
+contains(...)`). The contract comment on the `harness-checks` job in
+`.github/workflows/harness-checks.yml` carries the same expression for
+reference, but the live `if:` is the canonical form to copy.
 
 Run `bun run eval:list` to see the registered tests and their tiers.

--- a/tests/helpers/session-runner.test.ts
+++ b/tests/helpers/session-runner.test.ts
@@ -4,7 +4,7 @@
 // under `bun test` with no env vars and no subprocess; they cost $0.
 
 import { test, expect, describe } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -161,6 +161,93 @@ describe("runAgentTest with EVALS_MOCK_AGENT", () => {
       expect(result.costEstimate.estimatedCost).toBeGreaterThan(0);
     } finally {
       delete process.env.EVALS_MOCK_AGENT;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// The live path must fail fast when EVALS_ANTHROPIC_API_KEY is empty or
+// unset: throw a named error BEFORE spawning `claude`, instead of spawning
+// and failing at auth (or silently burning a logged-in session's tokens).
+// The guard sits after the EVALS_MOCK_AGENT seam, so mock replay never
+// needs a key.
+describe("runAgentTest live-path API-key guard", () => {
+  test("throws on empty API key at live path", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "session-runner-test-"));
+    // Hermetic fake `claude` on PATH: if the guard is missing or misplaced,
+    // runAgentTest spawns this stub — never the real CLI, no auth, no
+    // tokens. The stub drains stdin (so the prompt write can't EPIPE) and
+    // drops a sentinel file proving a spawn happened.
+    const fakeBin = join(tmp, "bin");
+    mkdirSync(fakeBin);
+    const sentinel = join(tmp, "spawned.sentinel");
+    writeFileSync(
+      join(fakeBin, "claude"),
+      `#!/bin/sh\ncat > /dev/null\ntouch "${sentinel}"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const savedPath = process.env.PATH;
+    const savedMock = process.env.EVALS_MOCK_AGENT;
+    const savedKey = process.env.EVALS_ANTHROPIC_API_KEY;
+    process.env.PATH = `${fakeBin}:${savedPath ?? ""}`;
+    delete process.env.EVALS_MOCK_AGENT;
+    delete process.env.EVALS_ANTHROPIC_API_KEY;
+    try {
+      await expect(
+        runAgentTest({
+          prompt: "Review x.ts.",
+          workingDirectory: tmp,
+          testName: "live-empty-key",
+          // Watchdog bound only: the guard must reject before any spawn, so
+          // this timer should never fire. It keeps a misbehaving stub from
+          // hitting bun's own per-test timeout (which would error, not fail).
+          timeout: 2_000,
+        }),
+      ).rejects.toThrow(/EVALS_ANTHROPIC_API_KEY is empty/);
+      // "Never spawns": the guard fired before spawn, so the stub never ran.
+      expect(existsSync(sentinel)).toBe(false);
+    } finally {
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
+      if (savedMock !== undefined) process.env.EVALS_MOCK_AGENT = savedMock;
+      if (savedKey !== undefined) process.env.EVALS_ANTHROPIC_API_KEY = savedKey;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("mock path unaffected by empty key", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "session-runner-test-"));
+    const mockPath = join(tmp, "mock.ndjson");
+    const events = [
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Mock replay ran." }] },
+      },
+      { type: "result", usage: { input_tokens: 5, output_tokens: 2 } },
+    ];
+    writeFileSync(
+      mockPath,
+      events.map((e) => JSON.stringify(e)).join("\n") + "\n",
+      "utf8",
+    );
+
+    const savedMock = process.env.EVALS_MOCK_AGENT;
+    const savedKey = process.env.EVALS_ANTHROPIC_API_KEY;
+    process.env.EVALS_MOCK_AGENT = mockPath;
+    delete process.env.EVALS_ANTHROPIC_API_KEY;
+    try {
+      const result = await runAgentTest({
+        prompt: "Review x.ts.",
+        workingDirectory: tmp,
+        testName: "mock-empty-key",
+      });
+      // The guard sits AFTER the mock seam: local mock dev needs no key.
+      expect(result.exitReason).toBe("success");
+    } finally {
+      if (savedMock === undefined) delete process.env.EVALS_MOCK_AGENT;
+      else process.env.EVALS_MOCK_AGENT = savedMock;
+      if (savedKey !== undefined) process.env.EVALS_ANTHROPIC_API_KEY = savedKey;
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/tests/helpers/session-runner.test.ts
+++ b/tests/helpers/session-runner.test.ts
@@ -166,11 +166,11 @@ describe("runAgentTest with EVALS_MOCK_AGENT", () => {
   });
 });
 
-// The live path must fail fast when EVALS_ANTHROPIC_API_KEY is empty or
-// unset: throw a named error BEFORE spawning `claude`, instead of spawning
-// and failing at auth (or silently burning a logged-in session's tokens).
-// The guard sits after the EVALS_MOCK_AGENT seam, so mock replay never
-// needs a key.
+// The live path must fail fast when EVALS_ANTHROPIC_API_KEY is empty, unset,
+// or whitespace-only: throw a named error BEFORE spawning `claude`, instead
+// of spawning and failing at auth (or silently burning a logged-in session's
+// tokens). The guard sits after the EVALS_MOCK_AGENT seam, so mock replay
+// never needs a key.
 describe("runAgentTest live-path API-key guard", () => {
   test("throws on empty API key at live path", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "session-runner-test-"));
@@ -212,6 +212,46 @@ describe("runAgentTest live-path API-key guard", () => {
       else process.env.PATH = savedPath;
       if (savedMock !== undefined) process.env.EVALS_MOCK_AGENT = savedMock;
       if (savedKey !== undefined) process.env.EVALS_ANTHROPIC_API_KEY = savedKey;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("throws on whitespace-only API key at live path", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "session-runner-test-"));
+    // Same hermetic fake `claude` sentinel pattern: a whitespace-only key is
+    // as useless as an empty one, so the guard must reject it before any spawn.
+    const fakeBin = join(tmp, "bin");
+    mkdirSync(fakeBin);
+    const sentinel = join(tmp, "spawned.sentinel");
+    writeFileSync(
+      join(fakeBin, "claude"),
+      `#!/bin/sh\ncat > /dev/null\ntouch "${sentinel}"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const savedPath = process.env.PATH;
+    const savedMock = process.env.EVALS_MOCK_AGENT;
+    const savedKey = process.env.EVALS_ANTHROPIC_API_KEY;
+    process.env.PATH = `${fakeBin}:${savedPath ?? ""}`;
+    delete process.env.EVALS_MOCK_AGENT;
+    process.env.EVALS_ANTHROPIC_API_KEY = "   ";
+    try {
+      await expect(
+        runAgentTest({
+          prompt: "Review x.ts.",
+          workingDirectory: tmp,
+          testName: "live-whitespace-key",
+          // Watchdog bound only: the guard must reject before any spawn.
+          timeout: 2_000,
+        }),
+      ).rejects.toThrow(/EVALS_ANTHROPIC_API_KEY is empty/);
+      expect(existsSync(sentinel)).toBe(false);
+    } finally {
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
+      if (savedMock !== undefined) process.env.EVALS_MOCK_AGENT = savedMock;
+      if (savedKey === undefined) delete process.env.EVALS_ANTHROPIC_API_KEY;
+      else process.env.EVALS_ANTHROPIC_API_KEY = savedKey;
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/tests/helpers/session-runner.ts
+++ b/tests/helpers/session-runner.ts
@@ -258,6 +258,14 @@ export async function runAgentTest(
       return runMocked(mockPath, model, startMs);
     }
 
+    // Live-path guard: fail fast and loud rather than spawning `claude` with
+    // no credential and failing at auth (or silently burning a logged-in
+    // session). Sits AFTER the mock seam, so mock replay never needs a key.
+    const apiKey = process.env.EVALS_ANTHROPIC_API_KEY;
+    if (apiKey === undefined || apiKey === "") {
+      throw new Error("EVALS_ANTHROPIC_API_KEY is empty; refusing live spawn");
+    }
+
     const args: string[] = [
       "-p",
       "--model",

--- a/tests/helpers/session-runner.ts
+++ b/tests/helpers/session-runner.ts
@@ -263,7 +263,10 @@ export async function runAgentTest(
     // session). Sits AFTER the mock seam, so mock replay never needs a key.
     const apiKey = process.env.EVALS_ANTHROPIC_API_KEY;
     if (apiKey === undefined || apiKey === "") {
-      throw new Error("EVALS_ANTHROPIC_API_KEY is empty; refusing live spawn");
+      throw new Error(
+        "EVALS_ANTHROPIC_API_KEY is empty; refusing live spawn " +
+          "(set it to a valid Anthropic API key, or set EVALS_MOCK_AGENT to replay a fixture)",
+      );
     }
 
     const args: string[] = [

--- a/tests/helpers/session-runner.ts
+++ b/tests/helpers/session-runner.ts
@@ -262,7 +262,7 @@ export async function runAgentTest(
     // no credential and failing at auth (or silently burning a logged-in
     // session). Sits AFTER the mock seam, so mock replay never needs a key.
     const apiKey = process.env.EVALS_ANTHROPIC_API_KEY;
-    if (apiKey === undefined || apiKey === "") {
+    if (apiKey === undefined || apiKey.trim() === "") {
       throw new Error(
         "EVALS_ANTHROPIC_API_KEY is empty; refusing live spawn " +
           "(set it to a valid Anthropic API key, or set EVALS_MOCK_AGENT to replay a fixture)",

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -213,6 +213,18 @@ describe("static gate: evals environment backstop", () => {
     expect(/^\s*pull_request_target:/m.test(evalsWorkflow)).toBe(false);
     expect(/^\s*pull_request_target:/m.test(harnessWorkflow)).toBe(false);
   });
+
+  test("behavioral-evals stays off pull_request triggers until the gate is deliberately activated", () => {
+    // The author gate's `if:` is dormant today: behavioral-evals.yml triggers
+    // only on schedule + workflow_dispatch, so no untrusted author can reach
+    // the token job. Adding a live `pull_request:` trigger would activate that
+    // gate — and its sufficiency (does the allowlist cover every author state
+    // we care about? is checkout safe?) must be reviewed deliberately, not
+    // slipped in. This forbidden-key tripwire fails the free gate the moment a
+    // live `pull_request:` trigger appears, forcing that review. A comment
+    // mention (which is indented under `#`) does not match the bare-key regex.
+    expect(/^\s*pull_request:/m.test(evalsWorkflow)).toBe(false);
+  });
 });
 
 describe("static gate: rubrics", () => {

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -18,7 +18,20 @@ const EVALS_WORKFLOW = join(
   "workflows",
   "behavioral-evals.yml",
 );
+const HARNESS_WORKFLOW = join(
+  process.cwd(),
+  ".github",
+  "workflows",
+  "harness-checks.yml",
+);
 const FIXTURE_SIZE_CAP = 50 * 1024;
+
+// Canonical trust expression — the cross-workflow contract from
+// docs/plans/2026-06-09-gate-llm-ci-jobs-on-pr-author/structure.md.
+// Every job/step that consumes a secret or spawns `claude` on a
+// pull_request event applies this expression VERBATIM, which is what lets
+// the tripwires below match it as a plain substring.
+const TRUST_EXPR = `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)`;
 
 function enumerate(): { agent: string; caseName: string }[] {
   if (!existsSync(FIXTURE_ROOT)) return [];
@@ -93,6 +106,93 @@ describe("static gate: behavioral-evals workflow", () => {
     // Anchor to the bare key at line start so the existing namespaced
     // EVALS_ANTHROPIC_API_KEY: entry does not satisfy this on its own.
     expect(/^\s*ANTHROPIC_API_KEY:/m.test(workflow)).toBe(true);
+  });
+});
+
+// Token-consuming CI must never run for an untrusted PR author (issue #51):
+// a fork PR from CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE (Dependabot is
+// CONTRIBUTOR) must skip every job/step that consumes a secret or spawns
+// `claude`. Scheduled and workflow_dispatch runs carry no pull_request
+// context, so the gate is applied event-aware and leaves them unaffected.
+describe("static gate: author gate", () => {
+  const harnessWorkflow = existsSync(HARNESS_WORKFLOW)
+    ? readFileSync(HARNESS_WORKFLOW, "utf8")
+    : "";
+  const evalsWorkflow = existsSync(EVALS_WORKFLOW)
+    ? readFileSync(EVALS_WORKFLOW, "utf8")
+    : "";
+
+  test("author gate", () => {
+    // harness-checks.yml is the PR-triggered workflow where paid execution
+    // attaches next (#32's mocked gate-eval step). The canonical trust
+    // expression must be present at that seam — today as the documented
+    // contract any future token step inherits.
+    expect(harnessWorkflow).toContain(TRUST_EXPR);
+  });
+
+  test("untrusted authors excluded", () => {
+    // Pull the actual allowlist literal(s) out of the workflow files (not
+    // this test's own constant) so drift in a live `if:` trips the gate.
+    const allowlistRe =
+      /fromJSON\('(\[[^\]]+\])'\), github\.event\.pull_request\.author_association/g;
+    const allowlists = [
+      ...harnessWorkflow.matchAll(allowlistRe),
+      ...evalsWorkflow.matchAll(allowlistRe),
+    ].map((m) => JSON.parse(m[1] ?? "[]") as string[]);
+
+    // The trust allowlist must exist somewhere before exclusion means anything.
+    expect(allowlists.length).toBeGreaterThan(0);
+    for (const allowlist of allowlists) {
+      expect(allowlist).not.toContain("CONTRIBUTOR");
+      expect(allowlist).not.toContain("FIRST_TIME_CONTRIBUTOR");
+      expect(allowlist).not.toContain("NONE");
+    }
+  });
+
+  test("gate sits on every token job", () => {
+    // behavioral-evals.yml is the only workflow that consumes
+    // EVALS_ANTHROPIC_API_KEY today; its secret-consuming job must carry the
+    // trust expression wired as a live `if:` condition (not just a comment),
+    // so a future pull_request trigger cannot spend tokens for untrusted
+    // authors. Asserts on substring presence, not job/matrix shape, so it
+    // tolerates either #47's static matrix or #32's dynamic discover matrix.
+    expect(evalsWorkflow).toContain(TRUST_EXPR);
+    expect(/^\s*if:.*author_association/m.test(evalsWorkflow)).toBe(true);
+  });
+});
+
+// Backstop layer: even if a YAML gate is bypassed, the secret itself is
+// scoped to the protected `evals` GitHub environment, and the
+// `pull_request_target` exfiltration vector is hard-banned (design
+// Decisions 1 and 5).
+describe("static gate: evals environment backstop", () => {
+  const harnessWorkflow = existsSync(HARNESS_WORKFLOW)
+    ? readFileSync(HARNESS_WORKFLOW, "utf8")
+    : "";
+  const evalsWorkflow = existsSync(EVALS_WORKFLOW)
+    ? readFileSync(EVALS_WORKFLOW, "utf8")
+    : "";
+
+  test("evals environment declared", () => {
+    // The token job must declare `environment: evals` so the secret is
+    // reachable only inside the protected environment — fails closed
+    // (secret simply unavailable) if the environment is missing.
+    expect(/^\s*environment:\s*evals\s*$/m.test(evalsWorkflow)).toBe(true);
+    // The hard ban must be stated in the workflow: token/secret-consuming
+    // jobs MUST NOT trigger on pull_request_target (base-repo context with
+    // secrets — exfiltration vector). Anchor on the ban phrasing plus a
+    // comment line so an incidental mention can't satisfy this.
+    expect(evalsWorkflow).toContain("MUST NOT trigger on");
+    expect(/^\s*#.*pull_request_target/m.test(evalsWorkflow)).toBe(true);
+  });
+
+  test("no pull_request_target token trigger", () => {
+    // The forbidden form is a live trigger key under `on:`; a comment
+    // mention (the ban itself) is allowed. Forbidden-pattern tripwire:
+    // already satisfied today, exists to fail the build if the trigger
+    // ever appears.
+    expect(/^\s*pull_request_target:/m.test(evalsWorkflow)).toBe(false);
+    expect(/^\s*pull_request_target:/m.test(harnessWorkflow)).toBe(false);
   });
 });
 

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -133,23 +133,30 @@ describe("static gate: author gate", () => {
     expect(harnessWorkflow).toContain(TRUST_EXPR);
   });
 
-  test("untrusted authors excluded", () => {
-    // Pull the actual allowlist literal(s) out of the workflow files (not
-    // this test's own constant) so drift in a live `if:` trips the gate.
-    const allowlistRe =
-      /fromJSON\('(\[[^\]]+\])'\), github\.event\.pull_request\.author_association/g;
-    const allowlists = [
-      ...harnessWorkflow.matchAll(allowlistRe),
-      ...evalsWorkflow.matchAll(allowlistRe),
-    ].map((m) => JSON.parse(m[1] ?? "[]") as string[]);
+  // Pull the actual allowlist literal out of a workflow file (not this test's
+  // own constant) so drift in a live `if:` or contract comment trips the gate.
+  const allowlistRe =
+    /fromJSON\('(\[[^\]]+\])'\), github\.event\.pull_request\.author_association/;
+  function extractAllowlist(workflow: string): string[] | null {
+    const m = workflow.match(allowlistRe);
+    if (m === null) return null;
+    return JSON.parse(m[1] ?? "[]") as string[];
+  }
 
-    // The trust allowlist must exist somewhere before exclusion means anything.
-    expect(allowlists.length).toBeGreaterThan(0);
-    for (const allowlist of allowlists) {
-      expect(allowlist).not.toContain("CONTRIBUTOR");
-      expect(allowlist).not.toContain("FIRST_TIME_CONTRIBUTOR");
-      expect(allowlist).not.toContain("NONE");
-    }
+  test("untrusted authors excluded", () => {
+    // Assert each workflow's allowlist independently — no loop, so a failure
+    // names exactly which workflow drifted.
+    const harnessAllowlist = extractAllowlist(harnessWorkflow);
+    expect(harnessAllowlist).not.toBeNull();
+    expect(harnessAllowlist).not.toContain("CONTRIBUTOR");
+    expect(harnessAllowlist).not.toContain("FIRST_TIME_CONTRIBUTOR");
+    expect(harnessAllowlist).not.toContain("NONE");
+
+    const evalsAllowlist = extractAllowlist(evalsWorkflow);
+    expect(evalsAllowlist).not.toBeNull();
+    expect(evalsAllowlist).not.toContain("CONTRIBUTOR");
+    expect(evalsAllowlist).not.toContain("FIRST_TIME_CONTRIBUTOR");
+    expect(evalsAllowlist).not.toContain("NONE");
   });
 
   test("canonical trust expression present in behavioral-evals.yml", () => {

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -122,11 +122,14 @@ describe("static gate: author gate", () => {
     ? readFileSync(EVALS_WORKFLOW, "utf8")
     : "";
 
-  test("author gate", () => {
+  test("trust expression documented as the contract at the future paid seam in harness-checks.yml", () => {
     // harness-checks.yml is the PR-triggered workflow where paid execution
-    // attaches next (#32's mocked gate-eval step). The canonical trust
-    // expression must be present at that seam — today as the documented
-    // contract any future token step inherits.
+    // attaches next (#32's mocked gate-eval step). Today the canonical trust
+    // expression lives ONLY inside the contract comment block on the
+    // harness-checks job — NOT as a live `if:`. The free `bun test` job stays
+    // ungated by design (fork authors keep free CI). When a paid step attaches
+    // here it inherits this documented contract as its live `if:`. This
+    // tripwire pins the contract text so the comment can't be deleted.
     expect(harnessWorkflow).toContain(TRUST_EXPR);
   });
 
@@ -149,14 +152,20 @@ describe("static gate: author gate", () => {
     }
   });
 
-  test("gate sits on every token job", () => {
+  test("canonical trust expression present in behavioral-evals.yml", () => {
     // behavioral-evals.yml is the only workflow that consumes
-    // EVALS_ANTHROPIC_API_KEY today; its secret-consuming job must carry the
-    // trust expression wired as a live `if:` condition (not just a comment),
-    // so a future pull_request trigger cannot spend tokens for untrusted
-    // authors. Asserts on substring presence, not job/matrix shape, so it
-    // tolerates either #47's static matrix or #32's dynamic discover matrix.
+    // EVALS_ANTHROPIC_API_KEY today; the canonical trust expression must
+    // appear verbatim so the gate reads identically across token jobs.
+    // Asserts on substring presence, not job/matrix shape, so it tolerates
+    // either #47's static matrix or #32's dynamic discover matrix.
     expect(evalsWorkflow).toContain(TRUST_EXPR);
+  });
+
+  test("trust expression wired as a live `if:` on behavioral-evals.yml's token job", () => {
+    // Unlike harness-checks.yml's documented-only contract, behavioral-evals'
+    // secret-consuming job carries the trust expression as a live `if:`
+    // condition (not just a comment), so a future pull_request trigger cannot
+    // spend tokens for untrusted authors.
     expect(/^\s*if:.*author_association/m.test(evalsWorkflow)).toBe(true);
   });
 });
@@ -173,11 +182,14 @@ describe("static gate: evals environment backstop", () => {
     ? readFileSync(EVALS_WORKFLOW, "utf8")
     : "";
 
-  test("evals environment declared", () => {
+  test("evals environment declared on the token job", () => {
     // The token job must declare `environment: evals` so the secret is
     // reachable only inside the protected environment — fails closed
     // (secret simply unavailable) if the environment is missing.
     expect(/^\s*environment:\s*evals\s*$/m.test(evalsWorkflow)).toBe(true);
+  });
+
+  test("pull_request_target ban stated as a workflow comment", () => {
     // The hard ban must be stated in the workflow: token/secret-consuming
     // jobs MUST NOT trigger on pull_request_target (base-repo context with
     // secrets — exfiltration vector). Anchor on the ban phrasing plus a


### PR DESCRIPTION
## Summary

Implements #51: prevent any GitHub Actions job that spends Anthropic API tokens from being triggered by an untrusted PR (forks, external contributors, Dependabot), closing the token-cost-griefing and accidental-burn threat.

The **primary controls are two repo settings, now configured** — this PR is the in-repo, code-reviewable hardening that covers the gaps those settings structurally can't.

### Primary controls (server-side, already set)

1. **Require approval for all external contributors** (Settings → Actions) — holds every workflow run from an external fork PR until a maintainer approves, blocking fork-based griefing before anything executes.
2. **`evals` GitHub Environment, branch-restricted to `main`** — `EVALS_ANTHROPIC_API_KEY` is now an environment secret reachable only from `main`-context runs (the weekly cron / dispatch-from-main). Any PR branch — fork or internal, approved or not — that declares `environment: evals` is denied the key.

### What this PR adds (the gaps the settings can't cover)

- **`environment: evals` declaration** on the token job in `behavioral-evals.yml` — the YAML half of control #2 above.
- **Per-job author gate** `if: ${{ !startsWith(github.event_name, 'pull_request') || contains(fromJSON('[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association) }}`. The external-contributor setting approves whole *runs*; this gates per *job*, so a future paid step on a `pull_request` trigger isn't run just because a contributor's free CI was approved. The `startsWith` form also covers Dependabot/internal-branch PRs (not "external contributors") and every `pull_request*` variant. Dormant today — `behavioral-evals.yml` has no `pull_request` trigger — and commented as forward-proofing.
- **`pull_request_target` hard ban** for token jobs. That trigger is *exempt* from the external-contributor approval setting (it runs with base-repo secrets by design), so the ban + static tripwire is non-redundant protection.
- **Fail-fast key guard** in `tests/helpers/session-runner.ts`: the live path throws immediately when `EVALS_ANTHROPIC_API_KEY` is absent/empty/whitespace-only, instead of spawning `claude` and burning a runner to a CLI auth failure. Orthogonal to CI gating. Mock replay (`EVALS_MOCK_AGENT`) is unaffected.
- **`harness-checks.yml`**: free job stays ungated (fork authors keep free CI); concurrency keyed on PR number, not the attacker-controlled branch name; carries the canonical trust expression as a documented contract for any future paid step.
- **8 static-gate tripwires + unit tests** (`tests/static-gate.test.ts`, `tests/helpers/session-runner.test.ts`) pin all of the above: trust expression present and wired as a live `if:`, untrusted associations excluded, `environment: evals` declared, no live `pull_request:`/`pull_request_target:` triggers, the fail-fast guard.
- Docs: `docs/architecture.md` §8, `docs/testing.md` §5, `evals/README.md`.

No changelog entry: this is a development/plugin-maintenance change (CI + eval harness + dev docs), none of which ships to plugin users — outside the changelog's "user-facing only" scope.

## Files changed (8)

```
.github/workflows/behavioral-evals.yml
.github/workflows/harness-checks.yml
docs/architecture.md
docs/testing.md
evals/README.md
tests/helpers/session-runner.ts
tests/helpers/session-runner.test.ts
tests/static-gate.test.ts
```

## Test plan

- [x] `bun test` — 337 pass / 0 fail, free tier only (no model calls, no API key)
- [x] All 8 acceptance tests written first (red), then turned green slice by slice
- [x] 5-reviewer adversarial gate × 5 rounds — Blocking/Major clean; Minor findings triaged and fixed
- [x] YAML validity of both workflows verified
- [x] Rebased onto latest `main` (0.8.0); branch is a clean fast-forward
- [x] `evals` environment configured (secret moved in, branch-restricted to `main`)
- [x] "Require approval for all external contributors" enabled

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)