### PR TITLE
v0.7.1 fix: continue from IMPLEMENT into PR phase in the same turn

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The full `/team` pipeline no longer stops after the implement phase — it continues into the PR phase and opens the draft PR in the same turn.** The v0.4.0 auto-draft-PR change made the PR phase prompt-free, but full pipeline runs could still end with a review-verdict summary and no PR: the `## Completion` section of `skills/team-implement/SKILL.md` ("Present all review verdicts and tell the user: *Next: run `/team-pr`*") was written for standalone `/team-implement` runs, and the orchestrator followed it during `/team` runs too, ending its turn before ever reaching the PR phase. The implement skill's step 8 and Completion section are now mode-aware — full pipeline (detected by the `PR` phase item `/team` seeds into the TodoWrite ledger) proceeds directly into `skills/team-pr/SKILL.md` in the same turn, standalone still suggests `/team-pr` — and `skills/team/SKILL.md` gains an explicit no-stop rule at the IMPLEMENT → PR seam (the phase loop pauses only at the design human gate, `openQuestions` envelopes, aggregate-cap escalation, and Minor-findings consultation; a turn that ends with review verdicts but no draft PR URL is a defect). The stale pre-0.4.0 "present shipping options to the user" wording in `docs/architecture.md` Phase 8 is corrected. Locked in by new tripwires in `tests/protocol.test.ts`.
+
 ## [0.7.0] - 2026-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-16
+
 ### Fixed
 
 - **The full `/team` pipeline no longer stops after the implement phase — it continues into the PR phase and opens the draft PR in the same turn.** The v0.4.0 auto-draft-PR change made the PR phase prompt-free, but full pipeline runs could still end with a review-verdict summary and no PR: the `## Completion` section of `skills/team-implement/SKILL.md` ("Present all review verdicts and tell the user: *Next: run `/team-pr`*") was written for standalone `/team-implement` runs, and the orchestrator followed it during `/team` runs too, ending its turn before ever reaching the PR phase. The implement skill's step 8 and Completion section are now mode-aware — full pipeline (detected by the `PR` phase item `/team` seeds into the TodoWrite ledger) proceeds directly into `skills/team-pr/SKILL.md` in the same turn, standalone still suggests `/team-pr` — and `skills/team/SKILL.md` gains an explicit no-stop rule at the IMPLEMENT → PR seam (the phase loop pauses only at the design human gate, `openQuestions` envelopes, aggregate-cap escalation, and Minor-findings consultation; a turn that ends with review verdicts but no draft PR URL is a defect). The stale pre-0.4.0 "present shipping options to the user" wording in `docs/architecture.md` Phase 8 is corrected. Locked in by new tripwires in `tests/protocol.test.ts`.
@@ -113,7 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/bostonaholic/team/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/bostonaholic/team/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/bostonaholic/team/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bostonaholic/team/compare/v0.5.1...v0.6.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,8 +236,9 @@ items to the TodoWrite ledger.
 **Predecessor:** aggregate gate passed
 
 Update CHANGELOG.md (filter for user-facing commits since last release),
-present shipping options to the user, execute the chosen action, and
-surface the tracking ticket (if `task.md` carries `ticketId`). The
+push the branch and open a draft PR automatically (`gh pr create
+--draft` — the PR phase is not a human gate, so it needs no approval),
+and surface the tracking ticket (if `task.md` carries `ticketId`). The
 worktree stays in place after the PR opens — teardown is deferred until
 the PR merges or the user asks, so the branch remains available for
 iteration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/team-implement/SKILL.md
+++ b/skills/team-implement/SKILL.md
@@ -155,7 +155,11 @@ Before any agent dispatch, decide where to work:
      finding is a defect.
 8. **Once Blocking and Major are clean:** if any **Minor-and-below** findings
    remain, present them to the user and let them decide (auto-fix,
-   defer, or skip). Then suggest `/team-pr`.
+   defer, or skip). Then:
+   - **Full pipeline** (the TodoWrite ledger carries a `PR` phase item —
+     `/team` seeded it): do **not** end the turn. Proceed directly to the
+     PR phase (`skills/team-pr/SKILL.md`) in the same turn.
+   - **Standalone**: suggest `/team-pr`.
 
 ## Quality Loop
 
@@ -184,5 +188,12 @@ For larger features, prefer `/team` (full pipeline) for the alignment gates.
 
 ## Completion
 
-Present all review verdicts and tell the user:
-**"Next: run `/team-pr docs/plans/<id>/`"**
+How the phase ends depends on how it was entered:
+
+- **Full pipeline** (the TodoWrite ledger carries a `PR` phase item —
+  `/team` seeded it): present all review verdicts, then continue straight
+  into the PR phase per `skills/team-pr/SKILL.md` — push the branch and
+  open the draft PR in the same turn. Ending the turn with verdicts but
+  no draft PR is a defect.
+- **Standalone**: present all review verdicts and tell the user:
+  **"Next: run `/team-pr docs/plans/<id>/`"**

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -242,7 +242,8 @@ returned:
 4. If at cap → escalate to the user with all unresolved findings.
 5. Once Blocking and Major are clean → if any **Minor-and-below** findings
    remain, present them to the user, who decides; otherwise advance
-   to PR.
+   to PR **in the same turn** — do not summarize and end the turn. The
+   run is complete only when the draft PR URL is reported.
 
 **The loop is: IMPLEMENT → VERIFY (5 reviewers) → typed gate check →
 IMPLEMENT → VERIFY → ...** Each round is a complete re-review.
@@ -303,6 +304,12 @@ When the aggregate gate passes:
 - The only human gate is **design approval**. Never present the structure
   or the plan to the user for approval — design is the human contract; the
   structure and plan are autonomous tactical artifacts.
+- The phase loop pauses for the user only at (a) the human gate (design
+  approval), (b) `openQuestions` envelopes, (c) aggregate-cap escalation,
+  and (d) Minor-findings consultation. Everywhere else, advance phases
+  within the same turn. In particular, IMPLEMENT → PR is not a stopping
+  point — a turn that ends with review verdicts but no draft PR URL is
+  a defect.
 - The research-isolation invariant is non-negotiable. If a researcher's
   context contains the user's original description, the pipeline has a
   defect. Stop and report.

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -245,6 +245,45 @@ describe("multi-repo support", () => {
   });
 });
 
+describe("implement-to-pr continuation", () => {
+  const TEAM_IMPLEMENT = join(REPO_ROOT, "skills", "team-implement", "SKILL.md");
+  const TEAM_SKILL = join(REPO_ROOT, "skills", "team", "SKILL.md");
+  const ARCHITECTURE = join(REPO_ROOT, "docs", "architecture.md");
+
+  test("team-implement full-pipeline mode continues into the PR phase in the same turn", () => {
+    const text = read(TEAM_IMPLEMENT);
+    expect(text).toContain("do **not** end the turn");
+    expect(text).toContain("same turn");
+    expect(text).toContain("team-pr/SKILL.md");
+  });
+
+  test("team-implement still suggests /team-pr in standalone mode", () => {
+    expect(/\*\*Standalone\*\*.{0,200}\/team-pr/.test(flat(read(TEAM_IMPLEMENT)))).toBe(true);
+  });
+
+  test("team-implement completion calls turn-end without a draft PR a defect", () => {
+    expect(
+      /Ending the turn with verdicts but\s+no draft PR is a defect/.test(read(TEAM_IMPLEMENT)),
+    ).toBe(true);
+  });
+
+  test("team SKILL advances IMPLEMENT to PR in the same turn", () => {
+    const text = flat(read(TEAM_SKILL));
+    expect(/advance\s+to PR \*\*in the same turn\*\*/.test(text)).toBe(true);
+    expect(
+      /turn that ends with review\s+verdicts but no draft PR URL is\s+a defect/.test(
+        read(TEAM_SKILL),
+      ),
+    ).toBe(true);
+  });
+
+  test("architecture.md no longer presents shipping options", () => {
+    const text = read(ARCHITECTURE);
+    expect(text).not.toContain("present shipping options");
+    expect(text).toContain("gh pr create");
+  });
+});
+
 describe("topic consistency", () => {
   const QUESTIONER = join(REPO_ROOT, "agents", "questioner.md");
   const RESEARCHER = join(REPO_ROOT, "agents", "researcher.md");


### PR DESCRIPTION
## Problem

Running the full `/team` pipeline, the orchestrator could end its turn after the implement phase with a review-verdict summary and **no PR** — despite v0.4.0 making the PR phase fully automatic (`gh pr create --draft`, no human gate).

## Root cause

`skills/team-implement/SKILL.md` ended with instructions written for *standalone* `/team-implement` runs:

- Step 8: "...Then **suggest `/team-pr`**."
- `## Completion`: "Present all review verdicts and tell the user: **\"Next: run `/team-pr docs/plans/<id>/`\"**"

During full `/team` runs the orchestrator followed this completion instruction and ended its turn — never reaching the PR phase's "open a draft PR automatically — do not stop to ask" text. Secondary gap: `skills/team/SKILL.md` never explicitly forbade ending the turn at the IMPLEMENT→PR seam.

## Changes

- **`skills/team-implement/SKILL.md`** — step 8 + `## Completion` are now mode-aware. Full pipeline (detected by the `PR` phase item `/team` seeds into the TodoWrite ledger) proceeds directly into `skills/team-pr/SKILL.md` in the same turn; standalone still suggests `/team-pr`. Ending the turn with verdicts but no draft PR is named a defect.
- **`skills/team/SKILL.md`** — explicit no-stop rule: the phase loop pauses for the user only at the two human gates, `openQuestions` envelopes, aggregate-cap escalation, and Minor-findings consultation. Aggregate gate step 5 now says advance to PR **in the same turn**; the run is complete only when the draft PR URL is reported.
- **`docs/architecture.md`** — fixed stale pre-0.4.0 Phase 8 wording ("present shipping options to the user").
- **`tests/protocol.test.ts`** — new `implement-to-pr continuation` describe with 5 L2 tripwires locking in the continuation language.
- **`CHANGELOG.md`** — Unreleased entry.

Fixes #78

## Test plan

- [x] `bun test` passes (250 tests, includes the 5 new tripwires)
- [x] `grep -n "suggest \`/team-pr\`" skills/team-implement/SKILL.md` matches only the standalone branch
- [x] `grep -c "present shipping options" docs/architecture.md` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
