### PR TITLE
feat: add PR-comment workflow for behavioral evals

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,126 @@
+# PR evals — diff-selected behavioral evals on pull requests, with a results comment.
+#
+# Run the evals relevant to a PR's diff, then upsert ONE comment summarizing
+# pass/fail and cost. Selection (which evals run)
+# is decided by the harness from `git diff <base>...HEAD` against each eval's
+# touchfiles (tests/helpers/touchfiles.ts) — cost scales with the diff, NOT the
+# whole suite. The weekly full periodic run stays in behavioral-evals.yml.
+#
+# ADVISORY: includes stochastic periodic evals, so this is intentionally NOT a
+# required merge check (TESTING.md: stochastic checks must not gate merges).
+#
+# SECURITY: same-repo PRs only. Fork PRs lack the EVALS_ANTHROPIC_API_KEY secret
+# and a write token, so both jobs are guarded on head.repo (mirrors
+# pr-title-sync.yml). No pull_request_target — avoids the secret-exfil surface.
+name: PR evals
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: evals-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  run-evals:
+    name: Diff-selected evals (${{ matrix.suite.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          # File path MUST be `./`-prefixed: bun treats a bare `tests/...` arg
+          # as a name filter (matches nothing), not a path.
+          - { name: code-reviewer, file: ./tests/code-reviewer.evals.ts }
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # diff-based selection needs history back to the base ref
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # The live suite spawns the `claude` CLI (tests/helpers/session-runner.ts).
+      # It is not a project dependency, so install it globally onto $PATH here.
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run ${{ matrix.suite.name }} evals (diff-selected)
+        env:
+          # The judge reads EVALS_ANTHROPIC_API_KEY (namespaced so a local agent
+          # won't auto-pick it up). In CI the agent under test has no logged-in
+          # session, so it gets its own credential via the bare ANTHROPIC_API_KEY,
+          # sourced from the same secret.
+          EVALS_ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_API_KEY }}
+          EVALS: "1"
+          # NOT EVALS_ALL and NOT EVALS_TIER: let the diff drive selection across
+          # all tiers, so cost scales with the change.
+          EVALS_BASE: origin/${{ github.event.pull_request.base.ref }}
+          SUITE_FILE: ${{ matrix.suite.file }}
+        run: bun test "$SUITE_FILE"
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-evals-${{ matrix.suite.name }}-${{ github.run_id }}
+          path: evals/results/
+          if-no-files-found: ignore  # nothing selected -> no JSON written
+          retention-days: 30
+
+  report:
+    name: Post results comment
+    needs: run-evals
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # PR comments are issue comments: the gh api issues/comments endpoints are
+      # gated by `issues: write`, not `pull-requests: write`. Both are needed.
+      pull-requests: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v6  # for scripts/eval-report.ts + its imports
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Download eval result artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: artifacts
+          pattern: pr-evals-*
+          merge-multiple: true
+
+      - name: Build and upsert results comment
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          BODY="$(bun run scripts/eval-report.ts artifacts)"
+          # Upsert: find our existing comment by the stable marker prefix and
+          # PATCH it; otherwise create a new one. Keeps one comment per PR.
+          ID="$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq '.[] | select(.body | startswith("## PR Evals")) | .id' | tail -1 || true)"
+          if [ -n "${ID:-}" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$ID" -f body="$BODY" >/dev/null
+            echo "Updated comment $ID"
+          else
+            printf '%s' "$BODY" | gh pr comment "$PR" --repo "$REPO" --body-file -
+            echo "Created comment"
+          fi

--- a/evals/README.md
+++ b/evals/README.md
@@ -165,6 +165,24 @@ regression).
 Manually: `bun run eval:compare evals/results/<a>.json evals/results/<b>.json`
 (exits non-zero on budget regression or verdict regression).
 
+## CI
+
+Two workflows run the evals:
+
+- **`.github/workflows/evals.yml`** runs on every pull request. It runs the
+  evals the diff selects (`git diff <base>...HEAD` against each eval's
+  touchfiles — no `EVALS_ALL`/`EVALS_TIER`, so cost scales with the change) and
+  upserts one `## PR Evals` comment on the PR with a per-suite pass/fail table
+  and cost. The comment body is produced by `scripts/eval-report.ts` (pure +
+  unit-tested in `tests/eval-report.test.ts`). It is **advisory** — it includes
+  stochastic periodic evals, which must not gate merges (see
+  [TESTING.md](../TESTING.md)) — and runs on **same-repo PRs only** (fork PRs
+  lack the `EVALS_ANTHROPIC_API_KEY` secret and a write token). When the diff
+  selects nothing, the comment says so.
+- **`.github/workflows/behavioral-evals.yml`** runs the full periodic tier
+  weekly (Monday 06:00 UTC) and on manual dispatch, uploading results as
+  artifacts.
+
 ## Blame protocol
 
 When an eval fails on your branch, rerun on the base before blaming the

--- a/scripts/eval-report.ts
+++ b/scripts/eval-report.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+// scripts/eval-report.ts
+//
+// CLI: `bun run scripts/eval-report.ts <results-dir>`
+// Formats one or more eval result JSONs (the schema written by
+// tests/helpers/eval-store.ts) into a Markdown body for a PR comment, then
+// prints it to stdout. Used by .github/workflows/evals.yml, which upserts the
+// body as a single `## PR Evals` comment on the PR.
+//
+// The body builder is a pure function (buildReportBody) so it is unit-tested
+// for free in tests/eval-report.test.ts. The CLI wrapper only reads files and
+// always exits 0 — formatting must never fail the workflow. The run-evals job
+// owns the real pass/fail signal via its own check status.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import type { EvalResult, EvalTestEntry } from "../tests/helpers/eval-store";
+
+// The marker prefix the workflow greps for when deciding whether to update an
+// existing comment or create a new one. MUST stay stable and in sync with the
+// upsert logic in .github/workflows/evals.yml (locked by a tripwire test).
+export const REPORT_MARKER = "## PR Evals";
+
+function fmtCost(usd: number): string {
+  return `$${usd.toFixed(2)}`;
+}
+
+/** The "no evals ran" body. A results JSON is always written even when diff
+ *  selection skips every test (total_tests: 0), so both an empty input and an
+ *  all-zero input land here. */
+function noEvalsBody(): string {
+  return (
+    `${REPORT_MARKER}: ⚠️ No evals selected\n\n` +
+    "No behavioral evals cover the files changed in this PR, so none ran. " +
+    "Evals run automatically when a PR touches the files an eval depends on " +
+    "(see `tests/helpers/touchfiles.ts`)."
+  );
+}
+
+/** Build the Markdown PR-comment body from the collected eval result files.
+ *  Pure: no I/O, no process state. */
+export function buildReportBody(results: EvalResult[]): string {
+  // Only results that actually ran a test carry signal; a skipped run still
+  // writes a total_tests: 0 file (eval-store finalize()), which we ignore.
+  const ran = results.filter((r) => r.total_tests > 0);
+  if (ran.length === 0) return noEvalsBody();
+
+  const tests: EvalTestEntry[] = ran.flatMap((r) => r.tests);
+  const total = tests.length;
+  const passed = tests.filter((t) => t.passed).length;
+  const failed = total - passed;
+  const cost = ran.reduce((sum, r) => sum + r.total_cost_usd, 0);
+
+  const status = failed > 0 ? "❌ FAIL" : "✅ PASS";
+
+  // One table row per suite, aggregating the tests that belong to it.
+  const suites = [...new Set(tests.map((t) => t.suite))].sort();
+  const rows = suites.map((suite) => {
+    const group = tests.filter((t) => t.suite === suite);
+    const sPassed = group.filter((t) => t.passed).length;
+    const sCost = group.reduce((sum, t) => sum + t.cost_usd, 0);
+    const icon = sPassed === group.length ? "✅" : "❌";
+    return `| ${suite} | ${sPassed}/${group.length} | ${icon} | ${fmtCost(sCost)} |`;
+  });
+
+  let body =
+    `${REPORT_MARKER}: ${status}\n\n` +
+    `**${passed}/${total}** tests passed | **${fmtCost(cost)}** total cost\n\n` +
+    "| Suite | Result | Status | Cost |\n" +
+    "|-------|--------|--------|------|\n" +
+    rows.join("\n");
+
+  if (failed > 0) {
+    const failLines = tests
+      .filter((t) => !t.passed)
+      .map((t) => `- ❌ ${t.name}: ${t.exit_reason ?? "unknown"}`)
+      .join("\n");
+    body += `\n\n### Failures\n${failLines}`;
+  }
+
+  return body;
+}
+
+/** Read and parse every *.json under dir (recursively), skipping any file that
+ *  is not a valid eval result. */
+export function readResultsDir(dir: string): EvalResult[] {
+  if (!existsSync(dir)) return [];
+  const out: EvalResult[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      out.push(...readResultsDir(path));
+      continue;
+    }
+    if (!entry.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as EvalResult;
+      if (typeof parsed.total_tests === "number" && Array.isArray(parsed.tests)) {
+        out.push(parsed);
+      }
+    } catch {
+      // Malformed artifact — skip it rather than fail the report.
+    }
+  }
+  return out;
+}
+
+if (import.meta.main) {
+  const dir = process.argv[2] ?? "artifacts";
+  process.stdout.write(buildReportBody(readResultsDir(dir)) + "\n");
+  process.exit(0);
+}

--- a/tests/eval-report.test.ts
+++ b/tests/eval-report.test.ts
@@ -1,0 +1,101 @@
+// tests/eval-report.test.ts
+//
+// L1 unit test for the PR-comment formatter (scripts/eval-report.ts). The body
+// builder is a pure f(EvalResult[]) -> markdown, so it is fully testable here
+// for free — no model calls, no GitHub API. Locks the `## PR Evals` marker that
+// the workflow's upsert logic greps for.
+
+import { describe, expect, test } from "bun:test";
+
+import { buildReportBody, REPORT_MARKER } from "../scripts/eval-report";
+import type { EvalResult, EvalTestEntry } from "./helpers/eval-store";
+
+function entry(over: Partial<EvalTestEntry> = {}): EvalTestEntry {
+  return {
+    name: "planted-null-deref",
+    suite: "code-reviewer-e2e",
+    tier: "e2e",
+    passed: true,
+    duration_ms: 1000,
+    cost_usd: 0.02,
+    ...over,
+  };
+}
+
+function result(over: Partial<EvalResult> = {}): EvalResult {
+  const tests = over.tests ?? [entry()];
+  const passed = tests.filter((t) => t.passed).length;
+  return {
+    schema_version: 1,
+    version: "0.6.0",
+    branch: "test",
+    git_sha: "abc",
+    timestamp: "2026-06-13T00:00:00.000Z",
+    hostname: "ci",
+    tier: "e2e",
+    total_tests: tests.length,
+    passed,
+    failed: tests.length - passed,
+    total_cost_usd: tests.reduce((s, t) => s + t.cost_usd, 0),
+    total_duration_ms: tests.reduce((s, t) => s + t.duration_ms, 0),
+    tests,
+    ...over,
+  };
+}
+
+describe("buildReportBody", () => {
+  test("all-pass: PASS header, counts, cost, no Failures section", () => {
+    const body = buildReportBody([result({ tests: [entry(), entry({ name: "b" })] })]);
+    expect(body).toContain(`${REPORT_MARKER}: ✅ PASS`);
+    expect(body).toContain("**2/2** tests passed");
+    expect(body).toContain("$0.04");
+    expect(body).toContain("| code-reviewer-e2e | 2/2 | ✅ |");
+    expect(body).not.toContain("### Failures");
+  });
+
+  test("one fail: FAIL header and Failures section with name + exit_reason", () => {
+    const body = buildReportBody([
+      result({ tests: [entry(), entry({ name: "broke", passed: false, exit_reason: "timeout" })] }),
+    ]);
+    expect(body).toContain(`${REPORT_MARKER}: ❌ FAIL`);
+    expect(body).toContain("**1/2** tests passed");
+    expect(body).toContain("### Failures");
+    expect(body).toContain("- ❌ broke: timeout");
+  });
+
+  test("missing exit_reason falls back to 'unknown'", () => {
+    const body = buildReportBody([result({ tests: [entry({ passed: false })] })]);
+    expect(body).toContain("- ❌ planted-null-deref: unknown");
+  });
+
+  test("empty input: No evals selected", () => {
+    const body = buildReportBody([]);
+    expect(body).toContain(`${REPORT_MARKER}: ⚠️ No evals selected`);
+    expect(body).not.toContain("### Failures");
+  });
+
+  test("total_tests:0 result is treated as no evals", () => {
+    const body = buildReportBody([result({ tests: [], total_tests: 0, passed: 0, failed: 0 })]);
+    expect(body).toContain(`${REPORT_MARKER}: ⚠️ No evals selected`);
+  });
+
+  test("aggregates across multiple result files (per tier)", () => {
+    const body = buildReportBody([
+      result({ tier: "e2e", tests: [entry()] }),
+      result({ tier: "llm-judge", tests: [entry({ name: "judge", suite: "code-reviewer-llm" })] }),
+    ]);
+    expect(body).toContain("**2/2** tests passed");
+    expect(body).toContain("| code-reviewer-e2e | 1/1 |");
+    expect(body).toContain("| code-reviewer-llm | 1/1 |");
+  });
+
+  test("every variant carries the upsert marker prefix", () => {
+    for (const body of [
+      buildReportBody([]),
+      buildReportBody([result()]),
+      buildReportBody([result({ tests: [entry({ passed: false })] })]),
+    ]) {
+      expect(body.startsWith(REPORT_MARKER)).toBe(true);
+    }
+  });
+});

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -24,6 +24,12 @@ const HARNESS_WORKFLOW = join(
   "workflows",
   "harness-checks.yml",
 );
+const PR_EVALS_WORKFLOW = join(
+  process.cwd(),
+  ".github",
+  "workflows",
+  "evals.yml",
+);
 const FIXTURE_SIZE_CAP = 50 * 1024;
 
 // Canonical trust expression — the cross-workflow contract from
@@ -224,6 +230,58 @@ describe("static gate: evals environment backstop", () => {
     // live `pull_request:` trigger appears, forcing that review. A comment
     // mention (which is indented under `#`) does not match the bare-key regex.
     expect(/^\s*pull_request:/m.test(evalsWorkflow)).toBe(false);
+  });
+});
+
+// The PR evals workflow (evals.yml) runs diff-selected evals on pull requests
+// and upserts a `## PR Evals` comment. These guards lock the contracts that, if
+// broken, would silently stop evals running or stop the comment posting — and
+// would otherwise only surface live in CI on a real PR.
+describe("static gate: PR evals workflow", () => {
+  const workflow = existsSync(PR_EVALS_WORKFLOW)
+    ? readFileSync(PR_EVALS_WORKFLOW, "utf8")
+    : "";
+  const reportScript = existsSync(join(process.cwd(), "scripts", "eval-report.ts"))
+    ? readFileSync(join(process.cwd(), "scripts", "eval-report.ts"), "utf8")
+    : "";
+
+  test("workflow file exists", () => {
+    expect(existsSync(PR_EVALS_WORKFLOW)).toBe(true);
+  });
+
+  test("triggers on pull_request", () => {
+    expect(/^on:\s*$/m.test(workflow)).toBe(true);
+    expect(workflow).toContain("pull_request:");
+  });
+
+  test("installs the Claude Code CLI before spawning the agent", () => {
+    expect(workflow).toContain("@anthropic-ai/claude-code");
+  });
+
+  test("exposes ANTHROPIC_API_KEY so the spawned agent can authenticate", () => {
+    expect(/^\s*ANTHROPIC_API_KEY:/m.test(workflow)).toBe(true);
+  });
+
+  test("lets the diff drive selection: no EVALS_ALL, no EVALS_TIER", () => {
+    // Setting either as an env key would override diff selection (run
+    // everything / filter to one tier), defeating cost-scales-with-the-diff.
+    // Match assignments only, so the explanatory comment doesn't trip this.
+    expect(/^\s*EVALS_ALL:/m.test(workflow)).toBe(false);
+    expect(/^\s*EVALS_TIER:/m.test(workflow)).toBe(false);
+  });
+
+  test("report job can post PR comments (issues + pull-requests write)", () => {
+    // PR comments are issue comments: the gh api issues/comments endpoints need
+    // `issues: write`; without it the upsert 401s on every PR with results.
+    expect(/^\s*issues:\s*write\s*$/m.test(workflow)).toBe(true);
+    expect(/^\s*pull-requests:\s*write\s*$/m.test(workflow)).toBe(true);
+  });
+
+  test("comment marker stays in sync between workflow and formatter", () => {
+    // The workflow greps for this exact prefix to decide update-vs-create; the
+    // formatter emits it. If they drift, the upsert silently duplicates.
+    expect(workflow).toContain('startswith("## PR Evals")');
+    expect(reportScript).toContain('"## PR Evals"');
   });
 });
 


### PR DESCRIPTION
## What & why

The eval harness only runs on a weekly cron (`behavioral-evals.yml`) and dumps artifacts no one reads. gstack solved this by running evals on every PR and upserting a single results comment ([example](https://github.com/garrytan/gstack/pull/1659#issuecomment-4520562685)). This brings the same to `team`: when a PR changes files an eval covers, the eval runs and a `## PR Evals` comment is posted/updated with a pass/fail table and cost.

## How

- **`.github/workflows/evals.yml`** (new) — `pull_request` trigger.
  - `run-evals`: matrix per suite, same setup as `behavioral-evals.yml` (ubuntu + Bun + claude CLI). The **diff drives selection** (no `EVALS_ALL`/`EVALS_TIER`), so cost scales with the change. Uploads `evals/results/` as an artifact.
  - `report`: downloads artifacts, builds the comment with `scripts/eval-report.ts`, and **upserts** one comment (find by `## PR Evals` prefix → PATCH, else create). Needs both `issues: write` and `pull-requests: write`.
  - **Advisory**, not a required check (it includes stochastic periodic evals, which per `TESTING.md` must not gate merges). **Same-repo PRs only** — fork PRs lack the `EVALS_ANTHROPIC_API_KEY` secret + write token (mirrors `pr-title-sync.yml`); no `pull_request_target`.
- **`scripts/eval-report.ts`** (new) — pure `buildReportBody(EvalResult[]) -> markdown` + thin CLI wrapper that always exits 0. Reuses the `EvalResult` schema from `tests/helpers/eval-store.ts`. Treats a `total_tests: 0` results file (written even when selection skips everything) as "no evals selected."
- **`tests/eval-report.test.ts`** (new) — L1 unit coverage: pass / fail / empty / zero-tests / marker-prefix.
- **`tests/static-gate.test.ts`** — tripwire locking the selection, comment-permission, and marker-sync contracts so they can't silently drift.
- CHANGELOG entry + `evals/README.md` CI note.

> **Note on current behavior:** the only eval today (`code-reviewer` / `planted-null-deref`) is periodic-tier with touchfiles `agents/code-reviewer.md` + `skills/code-review/**`. So this PR's diff selects nothing → the comment says "No evals selected." That's the correct, honest behavior; the machinery is ready for the first eval whose touchfiles a PR actually changes.

## Test plan

- [x] `bun test` green (265 pass, 0 fail), including the new formatter test + tripwires
- [x] Formatter spot-checked against hand-made result JSONs (pass / fail / empty / zero-tests) — output matches the gstack comment format
- [x] Live on this PR: workflow triggered, selected nothing (no eval touchfiles changed), posted the "No evals selected" comment
- [x] On a second push: comment is **updated, not duplicated** (upsert) — re-ran, still exactly 1 `## PR Evals` comment
- [ ] On a PR touching `skills/code-review/**`: confirm a real `## PR Evals` pass/fail table posts _(needs a diff that touches those files; machinery proven — selection ran, run job executes `bun test`, secret wired)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
