### PR TITLE
feat(docs): restyle documentation site to terminal aesthetic

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,8 +1,7 @@
 # minima was intentionally removed: the site is hand-rolled via
-# _layouts/default.html + assets/css/site.css (plain CSS ported from
-# matthewboston.com) + assets/js/theme-toggle.js. Run locally with
-# `bundle exec jekyll serve` from docs/. `minima` still appears in
-# Gemfile.lock only as a transitive dep of github-pages, NOT as the theme.
+# _layouts/default.html + assets/css/site.css + assets/js/theme-toggle.js.
+# Run locally with `bundle exec jekyll serve` from docs/. `minima` still
+# appears in Gemfile.lock only as a transitive dep of github-pages, NOT as the theme.
 title: Team
 description: Autonomous feature delivery for Claude Code
 url: "https://team.bostonaholic.dev"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,11 @@ url: "https://team.bostonaholic.dev"
 baseurl: ""
 author: Matthew Boston
 
-theme: minima
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
 
 plugins:
   - jekyll-relative-links

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,8 @@
+# minima was intentionally removed: the site is hand-rolled via
+# _layouts/default.html + assets/css/site.css (plain CSS ported from
+# matthewboston.com) + assets/js/theme-toggle.js. Run locally with
+# `bundle exec jekyll serve` from docs/. `minima` still appears in
+# Gemfile.lock only as a transitive dep of github-pages, NOT as the theme.
 title: Team
 description: Autonomous feature delivery for Claude Code
 url: "https://team.bostonaholic.dev"

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer>
   <div class="container">
     <span class="copyright">© 2026 {{ site.author | escape }}</span>
-    <a href="https://github.com/bostonaholic/team">GitHub</a>
+    <a href="https://github.com/bostonaholic/team" rel="noreferrer noopener">github</a>
   </div>
 </footer>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,44 +1,6 @@
-<footer class="site-footer h-card">
-  <data class="u-url" href="{{ "/" | relative_url }}"></data>
-
-  <div class="wrapper">
-
-    <h2 class="footer-heading">{{ site.title | escape }}</h2>
-
-    <div class="footer-col-wrapper">
-      <div class="footer-col footer-col-1">
-        <ul class="contact-list">
-          <li class="p-name">
-            {%- if site.author -%}
-              {{ site.author | escape }}
-            {%- else -%}
-              {{ site.title | escape }}
-            {%- endif -%}
-            </li>
-            {%- if site.email -%}
-            <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-            {%- endif -%}
-        </ul>
-      </div>
-
-      <div class="footer-col footer-col-2">
-        <ul class="social-media-list">
-          <li>
-            <a href="https://github.com/bostonaholic/team">
-              <svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#github' | relative_url }}"></use></svg>
-              <span class="username">GitHub</span>
-            </a>
-          </li>
-        </ul>
-      </div>
-
-      <div class="footer-col footer-col-3">
-        <p>{{- site.description | escape -}}</p>
-      </div>
-    </div>
-
-    <p class="footer-copyright">© 2026 {{ site.author | escape }}</p>
-
+<footer>
+  <div class="container">
+    <span class="copyright">© 2026 {{ site.author | escape }}</span>
+    <a href="https://github.com/bostonaholic/team">GitHub</a>
   </div>
-
 </footer>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {%- seo -%}
+    <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title | downcase }}</a>
+        <nav>
+          <a href="{{ '/' | relative_url }}">home</a>
+          <a href="{{ '/architecture' | relative_url }}">architecture</a>
+          <a href="{{ '/skills' | relative_url }}">skills</a>
+          <a href="{{ '/versioning' | relative_url }}">versioning</a>
+          <a href="{{ '/project-tracking' | relative_url }}">project-tracking</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">{{ content }}</main>
+    {% include footer.html %}
+  </body>
+</html>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,7 +16,7 @@
     {%- seo -%}
     <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
   </head>
-  <body>
+  <body class="{% if page.url == '/' %}home{% endif %}">
     <header>
       <div class="container">
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title | downcase }}</a>
@@ -26,7 +26,7 @@
           <a href="{{ '/skills' | relative_url }}">skills</a>
           <a href="{{ '/versioning' | relative_url }}">versioning</a>
           <a href="{{ '/project-tracking' | relative_url }}">project-tracking</a>
-          <button class="theme-toggle" type="button">◑</button>
+          <button class="theme-toggle" type="button" aria-label="Theme: system. Activate to switch to light." aria-pressed="false">◑</button>
         </nav>
       </div>
     </header>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,7 +16,7 @@
     {%- seo -%}
     <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
   </head>
-  <body class="{% if page.url == '/' %}home{% endif %}">
+  <body {% if page.url == '/' %}class="home"{% endif %}>
     <header>
       <div class="container">
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title | downcase }}</a>
@@ -26,7 +26,7 @@
           <a href="{{ '/skills' | relative_url }}">skills</a>
           <a href="{{ '/versioning' | relative_url }}">versioning</a>
           <a href="{{ '/project-tracking' | relative_url }}">project-tracking</a>
-          <button class="theme-toggle" type="button" aria-label="Theme: system. Activate to switch to light." aria-pressed="false">◑</button>
+          <button class="theme-toggle" type="button" aria-label="Toggle color theme">◑</button>
         </nav>
       </div>
     </header>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('theme');
+          if (t === 'light' || t === 'dark') {
+            document.documentElement.dataset.theme = t;
+          }
+        } catch (e) {}
+      })();
+    </script>
     {%- seo -%}
     <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
   </head>
@@ -16,10 +26,12 @@
           <a href="{{ '/skills' | relative_url }}">skills</a>
           <a href="{{ '/versioning' | relative_url }}">versioning</a>
           <a href="{{ '/project-tracking' | relative_url }}">project-tracking</a>
+          <button class="theme-toggle" type="button">◑</button>
         </nav>
       </div>
     </header>
     <main class="container">{{ content }}</main>
     {% include footer.html %}
+    <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
   </body>
 </html>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1,9 +1,7 @@
 /* ==========================================================================
-   site.css — terminal aesthetic for the Team docs, ported verbatim from
-   matthewboston.com/stylesheets/site.css. Plain CSS, no front matter.
-
-   Custom-property name set (declared once, here). Slices 3+ only RE-VALUE
-   these names in new selector blocks; they never rename or invent names.
+   site.css — terminal aesthetic for the Team docs. Plain CSS, no front matter.
+   Theme custom properties are declared once here and only re-valued (never
+   renamed) in the theme blocks below.
    ========================================================================== */
 :root {
   --bg: #fff;

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -308,6 +308,60 @@ blockquote p:last-child {
   margin-bottom: 0;
 }
 
+/* --- home-only blinking block cursor ------------------------------------- */
+@keyframes blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+body.home main>h1::after {
+  content: "█";
+  margin-left: 2px;
+  color: var(--muted);
+  animation: blink 1.1s steps(1) 1.6s infinite;
+}
+
+/* --- focus-visible (sharp outline) --------------------------------------- */
+a:focus-visible,
+.theme-toggle:focus-visible {
+  outline: 2px dashed var(--fg);
+  outline-offset: 2px;
+}
+
+/* --- theme toggle button ------------------------------------------------- */
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 1.1em;
+  color: var(--muted);
+  padding: 0.25rem;
+  margin-left: 1rem;
+  line-height: 1;
+}
+
+.theme-toggle:hover {
+  color: var(--fg);
+}
+
+/* --- reduced motion: cursor visible, no blink; no hover transition ------- */
+@media (prefers-reduced-motion: reduce) {
+  body.home main>h1::after {
+    animation: none;
+  }
+
+  a {
+    transition: none;
+  }
+}
+
 /* --- responsive header reflow (narrow viewports) ------------------------- */
 @media (max-width: 600px) {
   header .container {

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1,0 +1,29 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+header {
+  padding: 1rem 0;
+}
+
+header nav a + a {
+  margin-left: 1rem;
+}
+
+main.container {
+  width: 100%;
+}

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -1,29 +1,294 @@
+/* ==========================================================================
+   site.css — terminal aesthetic for the Team docs, ported verbatim from
+   matthewboston.com/stylesheets/site.css. Plain CSS, no front matter.
+
+   Custom-property name set (declared once, here). Slices 3+ only RE-VALUE
+   these names in new selector blocks; they never rename or invent names.
+   ========================================================================== */
+:root {
+  --bg: #fff;
+  --fg: #111;
+  --border: rgba(0, 0, 0, 0.12);
+  --accent: #111;
+  --code-bg: rgba(0, 0, 0, 0.04);
+  --admonition-bg: rgba(0, 0, 0, 0.04);
+  --muted: #5a5a5a;
+  --muted-2: #8a8a8a;
+}
+
+/* --- reset ---------------------------------------------------------------- */
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+  border-radius: 0;
 }
 
+/* --- base typography ----------------------------------------------------- */
 body {
   margin: 0;
-  font-size: 16px;
-  line-height: 1.6;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Courier New", monospace;
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--fg);
+  background: var(--bg);
+  /* sticky footer */
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
+::selection {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+strong,
+b {
+  font-weight: 600;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+  line-height: 1.4;
+  text-transform: lowercase;
+}
+
+h1 {
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  line-height: 1.3;
+}
+
+h2 {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.25px;
+}
+
+h3 {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.25px;
+}
+
+p {
+  margin: 1em 0;
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.1;
+  margin: 3em 0 2.25em;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* --- links + inverted hover ---------------------------------------------- */
+a {
+  color: inherit;
+  text-decoration: none;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 100% 1px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  padding-bottom: 1px;
+  transition: background 0.15s ease, color 0.15s ease;
+  opacity: 0.9;
+}
+
+a:hover {
+  color: var(--bg);
+  background: var(--fg);
+  opacity: 1;
+}
+
+/* --- layout / sticky footer ---------------------------------------------- */
 .container {
   max-width: 800px;
   margin: 0 auto;
   padding: 0 1rem;
 }
 
+main.container {
+  width: 100%;
+  flex: 1;
+}
+
+/* --- header / nav -------------------------------------------------------- */
 header {
   padding: 1rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+header .container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+header .site-title {
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  color: var(--fg);
+  text-transform: lowercase;
+  background: none;
+  opacity: 1;
+}
+
+header .site-title:hover {
+  color: var(--bg);
+  background: var(--fg);
 }
 
 header nav a + a {
-  margin-left: 1rem;
+  margin-left: 1.1rem;
 }
 
-main.container {
+header nav a {
+  text-transform: lowercase;
+  color: var(--muted);
+  background: none;
+  opacity: 1;
+}
+
+header nav a:hover {
+  color: var(--bg);
+  background: var(--fg);
+}
+
+/* --- footer -------------------------------------------------------------- */
+footer {
+  margin-top: auto;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--border);
+  font-size: 0.9em;
+  color: var(--muted);
+}
+
+footer .container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+footer a {
+  text-transform: lowercase;
+  color: var(--muted);
+  background: none;
+  opacity: 1;
+}
+
+footer a:hover {
+  color: var(--bg);
+  background: var(--fg);
+}
+
+footer .copyright {
+  color: var(--muted-2);
+  font-size: 0.85em;
+}
+
+/* --- code / pre ---------------------------------------------------------- */
+code,
+pre {
+  font-family: inherit;
+  font-size: 13px;
+}
+
+code {
+  background: var(--code-bg);
+  padding: 0.1em 0.3em;
+}
+
+pre {
+  padding: 1rem;
+  overflow-x: auto;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  line-height: 1.6;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* --- tables (thin borders, header tint, no zebra) ------------------------ */
+table {
   width: 100%;
+  border-collapse: collapse;
+  margin: 1em 0;
+  font-size: 13px;
+}
+
+th,
+td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+}
+
+th {
+  background: var(--code-bg);
+  font-weight: 600;
+}
+
+/* --- blockquote admonitions (left accent border + faint tint) ------------ */
+blockquote {
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  border-left: 4px solid var(--accent);
+  background: var(--admonition-bg);
+  color: var(--muted);
+}
+
+blockquote p:first-child {
+  margin-top: 0;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* --- responsive header reflow (narrow viewports) ------------------------- */
+@media (max-width: 600px) {
+  header .container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  header nav {
+    margin-top: 0.5rem;
+  }
+
+  header nav a {
+    margin-right: 1rem;
+  }
+
+  header nav a + a {
+    margin-left: 0;
+  }
+
+  h1 {
+    font-size: 19px;
+  }
 }

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -16,6 +16,45 @@
   --muted-2: #8a8a8a;
 }
 
+/* System dark mode: applies only when no explicit theme is forced. A user who
+   forces light ([data-theme="light"]) keeps the light palette even on a dark OS. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #0a0a0a;
+    --fg: #f2f2f2;
+    --border: rgba(255, 255, 255, 0.16);
+    --accent: #f2f2f2;
+    --code-bg: rgba(255, 255, 255, 0.06);
+    --admonition-bg: rgba(255, 255, 255, 0.06);
+    --muted: #b8b8b8;
+    --muted-2: #909090;
+  }
+}
+
+/* Forced light — same as base :root, wins over system dark. */
+[data-theme="light"] {
+  --bg: #fff;
+  --fg: #111;
+  --border: rgba(0, 0, 0, 0.12);
+  --accent: #111;
+  --code-bg: rgba(0, 0, 0, 0.04);
+  --admonition-bg: rgba(0, 0, 0, 0.04);
+  --muted: #5a5a5a;
+  --muted-2: #8a8a8a;
+}
+
+/* Forced dark — same as the system dark palette, regardless of OS. */
+[data-theme="dark"] {
+  --bg: #0a0a0a;
+  --fg: #f2f2f2;
+  --border: rgba(255, 255, 255, 0.16);
+  --accent: #f2f2f2;
+  --code-bg: rgba(255, 255, 255, 0.06);
+  --admonition-bg: rgba(255, 255, 255, 0.06);
+  --muted: #b8b8b8;
+  --muted-2: #909090;
+}
+
 /* --- reset ---------------------------------------------------------------- */
 *,
 *::before,

--- a/docs/assets/js/theme-toggle.js
+++ b/docs/assets/js/theme-toggle.js
@@ -42,7 +42,6 @@
       "aria-label",
       "Theme: " + mode + ". Activate to switch to " + upcoming + "."
     );
-    button.setAttribute("aria-pressed", mode === "system" ? "false" : "true");
   }
 
   function init() {
@@ -62,9 +61,14 @@
     });
   }
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
+  // The <script> tag is at the end of <body>, so the toggle button already
+  // exists when this runs — initialize synchronously so the descriptive
+  // aria-label upgrades from the generic server label immediately, with no
+  // stale window for assistive tech. The DOMContentLoaded fallback only
+  // matters if this script is ever moved ahead of the button.
+  if (document.querySelector(".theme-toggle")) {
     init();
+  } else {
+    document.addEventListener("DOMContentLoaded", init);
   }
 })();

--- a/docs/assets/js/theme-toggle.js
+++ b/docs/assets/js/theme-toggle.js
@@ -2,6 +2,7 @@
   "use strict";
 
   var MODES = ["system", "light", "dark"];
+  var GLYPHS = { system: "◑", light: "☀", dark: "☾" };
 
   function readStored() {
     try {
@@ -36,8 +37,9 @@
     return MODES[(i + 1) % MODES.length];
   }
 
-  function updateAria(button, mode) {
+  function updateButton(button, mode) {
     var upcoming = next(mode);
+    button.textContent = GLYPHS[mode];
     button.setAttribute(
       "aria-label",
       "Theme: " + mode + ". Activate to switch to " + upcoming + "."
@@ -51,13 +53,13 @@
     }
 
     var current = readStored();
-    updateAria(button, current);
+    updateButton(button, current);
 
     button.addEventListener("click", function () {
       current = next(current);
       apply(current);
       persist(current);
-      updateAria(button, current);
+      updateButton(button, current);
     });
   }
 

--- a/docs/assets/js/theme-toggle.js
+++ b/docs/assets/js/theme-toggle.js
@@ -1,0 +1,59 @@
+(function () {
+  "use strict";
+
+  var MODES = ["system", "light", "dark"];
+
+  function readStored() {
+    try {
+      var t = localStorage.getItem("theme");
+      if (t === "light" || t === "dark") {
+        return t;
+      }
+    } catch (e) {}
+    return "system";
+  }
+
+  function persist(mode) {
+    try {
+      if (mode === "system") {
+        localStorage.removeItem("theme");
+      } else {
+        localStorage.setItem("theme", mode);
+      }
+    } catch (e) {}
+  }
+
+  function apply(mode) {
+    if (mode === "system") {
+      delete document.documentElement.dataset.theme;
+    } else {
+      document.documentElement.dataset.theme = mode;
+    }
+  }
+
+  function next(mode) {
+    var i = MODES.indexOf(mode);
+    return MODES[(i + 1) % MODES.length];
+  }
+
+  function init() {
+    var button = document.querySelector(".theme-toggle");
+    if (!button) {
+      return;
+    }
+
+    var current = readStored();
+
+    button.addEventListener("click", function () {
+      current = next(current);
+      apply(current);
+      persist(current);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/assets/js/theme-toggle.js
+++ b/docs/assets/js/theme-toggle.js
@@ -36,6 +36,15 @@
     return MODES[(i + 1) % MODES.length];
   }
 
+  function updateAria(button, mode) {
+    var upcoming = next(mode);
+    button.setAttribute(
+      "aria-label",
+      "Theme: " + mode + ". Activate to switch to " + upcoming + "."
+    );
+    button.setAttribute("aria-pressed", mode === "system" ? "false" : "true");
+  }
+
   function init() {
     var button = document.querySelector(".theme-toggle");
     if (!button) {
@@ -43,11 +52,13 @@
     }
 
     var current = readStored();
+    updateAria(button, current);
 
     button.addEventListener("click", function () {
       current = next(current);
       apply(current);
       persist(current);
+      updateAria(button, current);
     });
   }
 

--- a/docs/assets/js/theme-toggle.js
+++ b/docs/assets/js/theme-toggle.js
@@ -61,14 +61,8 @@
     });
   }
 
-  // The <script> tag is at the end of <body>, so the toggle button already
-  // exists when this runs — initialize synchronously so the descriptive
-  // aria-label upgrades from the generic server label immediately, with no
-  // stale window for assistive tech. The DOMContentLoaded fallback only
-  // matters if this script is ever moved ahead of the button.
-  if (document.querySelector(".theme-toggle")) {
-    init();
-  } else {
-    document.addEventListener("DOMContentLoaded", init);
-  }
+  // The script tag uses `defer`, so the browser guarantees the full document
+  // is parsed before this runs — the toggle button always exists, and this
+  // executes before DOMContentLoaded. No readiness guard needed.
+  init();
 })();


### PR DESCRIPTION
## Summary

Restyles the published documentation site (`docs/`, served at `team.bostonaholic.dev`) to a faithful **terminal aesthetic** modeled on [matthewboston.com](https://matthewboston.com): monospace everything, lowercase headings, a light/dark theme toggle, inverted link hover, and a blinking block cursor on the home page. Jekyll's stock `minima` theme is fully removed in favor of a small hand-rolled layout + plain CSS + a tiny theme-toggle script. **Presentation only — no content, pages, or nav targets changed.**

This is a **docs-site-only** change — no runtime plugin paths are touched, so per `docs/versioning.md` it carries **no version bump and no changelog entry** (the version gate is scoped to runtime changes).

## What changed

| File | Change |
|------|--------|
| `docs/_config.yml` | Remove `theme: minima`; add `defaults: layout: default`; maintainer note explaining the hand-rolled setup |
| `docs/_layouts/default.html` | **New** — full HTML doc: no-FOUC head script, header (title + 5 nav links + `◑` toggle), `<main>` 800px column, footer include, deferred toggle script |
| `docs/assets/css/site.css` | **New, plain CSS** — three-mode theme custom properties, monospace base, lowercase headings, inverted hover/selection, sticky footer, tables/code/blockquote admonitions, home-h1 cursor, focus-visible, reduced-motion |
| `docs/assets/js/theme-toggle.js` | **New** — cycles system→light→dark (swapping the ◑/☀/☾ glyph), persists to `localStorage`, updates `aria-label` |
| `docs/_includes/footer.html` | **Rewrite** — plain monospace footer; drops the broken `minima-social-icons.svg` reference |

## Design decisions

- Faithful token port from the reference stylesheet (`ui-monospace` 14px/1.75, light `#fff`/`#111`, dark `#0a0a0a`/`#f2f2f2`, lowercase headings, `border-radius: 0`, inverted `::selection`).
- Three-mode theme (system / light / dark); **system mode = no `data-theme` attribute**, so `prefers-color-scheme` wins. No-FOUC inline `<head>` script applies the saved theme before first paint.
- Blinking block cursor on the **home h1 only**; static under `prefers-reduced-motion`.
- Blockquote admonitions get a left accent border + faint tint.
- Tri-state toggle conveys state via descriptive `aria-label` (no misleading `aria-pressed`); all `localStorage` access is try/catch-guarded so JS-off / private-mode visitors still get a themed site via CSS alone.

## Verification

- `cd docs && bundle exec jekyll build` exits 0.
- Live UX (Playwright): theme toggle cycles ◑→☀→☾ in lockstep with the theme + persistence + no-FOUC; link hover inversion; home cursor present on `/` and absent elsewhere; tables/code/blockquotes legible in both themes; keyboard focus ring; responsive at 375px — all confirmed.

> ⚠️ **Post-merge check:** there is no GitHub Pages CI, so verify the live build at `team.bostonaholic.dev` after merge.

## Test plan

- [ ] CI green (version gate skips this docs-only PR; harness + title-sync pass)
- [ ] Live site at `team.bostonaholic.dev` renders the terminal style after merge
- [ ] Theme toggle cycles the glyph + persists across reloads on the live site
- [ ] (optional, deferred) mobile nav wrap at narrow widths; toggle tap-target size; full Rouge syntax-color palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)
