### PR TITLE
docs: split the site into user and developer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 Team is a Claude Code plugin that orchestrates specialized agents to implement features end-to-end. The orchestrator (the main Claude Code session) walks a linear phase table, persisting state as artifact files in `docs/plans/<id>/` (per-id directory; with YAML frontmatter carrying phase, approval, and revision metadata) and coordinating live progress via TodoWrite. See [docs/architecture.md](docs/architecture.md) for the full design.
 
-> **North star — read [VISION.md](VISION.md) and [ETHOS.md](ETHOS.md).** Team is a *loop-driven development system*: a human fills the Backlog and reviews finished work; everything in between (groom → start → implement → open PR) runs autonomously. The ethos explains *why* the autonomous middle can be trusted. Every agent should understand this end state — it is the target the whole project moves toward.
+> **North star — read [docs/vision.md](docs/vision.md) and [docs/ethos.md](docs/ethos.md).** Team is a *loop-driven development system*: a human fills the Backlog and reviews finished work; everything in between (groom → start → implement → open PR) runs autonomously. The ethos explains *why* the autonomous middle can be trusted. Every agent should understand this end state — it is the target the whole project moves toward.
 
 ## Runtime vs. Development
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,11 +21,24 @@
       <div class="container">
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title | downcase }}</a>
         <nav>
-          <a href="{{ '/' | relative_url }}">home</a>
-          <a href="{{ '/architecture' | relative_url }}">architecture</a>
-          <a href="{{ '/skills' | relative_url }}">skills</a>
-          <a href="{{ '/versioning' | relative_url }}">versioning</a>
-          <a href="{{ '/project-tracking' | relative_url }}">project-tracking</a>
+          {%- comment -%} Nav is data-driven: each page declares `audience` + `nav_order`.
+          The shared group (audience: user) serves everyone; contributor-only pages
+          live in the "contributing" dropdown. Add a page → set its front matter. {%- endcomment -%}
+          {%- assign shared = site.html_pages | where_exp: "p", "p.audience contains 'user'" | sort: "nav_order" -%}
+          {%- for p in shared -%}
+          <a href="{{ p.url | relative_url }}">{{ p.nav_label | default: p.title | downcase }}</a>
+          {%- endfor -%}
+          {%- assign devpages = site.html_pages | where_exp: "p", "p.audience contains 'developer'" | sort: "nav_order" -%}
+          <details class="nav-dd">
+            <summary>contributing</summary>
+            <div class="nav-dd-menu">
+              {%- for p in devpages -%}
+              {%- unless p.audience contains 'user' -%}
+              <a href="{{ p.url | relative_url }}">{{ p.nav_label | default: p.title | downcase }}</a>
+              {%- endunless -%}
+              {%- endfor -%}
+            </div>
+          </details>
           <button class="theme-toggle" type="button" aria-label="Toggle color theme">◑</button>
         </nav>
       </div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,16 @@
 ---
 title: Architecture
 description: "Team plugin architecture — agents as microservices, the QRSPI pipeline, artifact frontmatter, and phase-inference rules."
+audience: [user, developer]
+nav_order: 4
+nav_label: architecture
 ---
 
-# Team Plugin — Architecture
+# Team Architecture
 
-> **Audience:** Plugin maintainers and contributors. End users only need
-> the README + `/team` slash command.
+> **A deep dive into how Team is built.** Skim it for the mental model, or read
+> it in full to contribute — the high-level pipeline overview lives on the
+> [home page](index.md).
 >
 > **Source of truth:** the artifacts in `docs/plans/<id>/*.md` and the
 > in-session TodoWrite ledger.
@@ -441,7 +445,7 @@ Plugin-developer tooling — not distributed with the plugin. Three tiers:
 `EvalCollector` writes incrementally, finds the previous run on the same
 branch+tier, and prints regressions + budget regressions (≥2× growth in
 tool calls or turns without a verdict change). See
-[evals/README.md](../evals/README.md) for fixture schema, rubric format,
+[evals/README.md](https://github.com/bostonaholic/team/blob/main/evals/README.md) for fixture schema, rubric format,
 env-var knobs, and the rerun-on-base blame protocol.
 
 **CI wiring.** Two GitHub Actions workflows in `.github/workflows/`:
@@ -477,3 +481,10 @@ the same for new sessions.
 git and survive across sessions, compaction events, and context resets.
 They are the durable communication protocol between agents and the
 source of truth for "did phase N finish?"
+
+## See also
+
+- **[Skills](skills.md)** — the full per-skill reference for all 29 skills.
+- **[Vision](vision.md)** — the loop-driven end state this design builds toward.
+- **[Ethos](ethos.md)** — the principles behind the pipeline.
+- **[Overview](index.md)** — the landing page and pipeline overview.

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -210,6 +210,57 @@ header nav a:hover {
   background: var(--fg);
 }
 
+/* contributor docs live in a "contributing" dropdown, kept out of the user-facing bar */
+header nav details.nav-dd {
+  position: relative;
+  display: inline-block;
+  margin-left: 1.1rem;
+}
+
+header nav details.nav-dd > summary {
+  list-style: none;
+  cursor: pointer;
+  color: var(--muted);
+  text-transform: lowercase;
+}
+
+header nav details.nav-dd > summary::-webkit-details-marker {
+  display: none;
+}
+
+header nav details.nav-dd > summary::after {
+  content: " \25BE";
+  color: var(--muted-2);
+}
+
+header nav details.nav-dd[open] > summary {
+  color: var(--fg);
+}
+
+header nav .nav-dd-menu {
+  position: absolute;
+  right: 0;
+  top: 1.7rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 0.4rem 0;
+  z-index: 20;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+}
+
+header nav .nav-dd-menu a {
+  display: block;
+  margin: 0; /* override the `nav a + a` inline spacing */
+  padding: 0.25rem 0.9rem;
+  white-space: nowrap; /* keep "project-tracking" on one line */
+  color: var(--muted);
+}
+
+header nav .nav-dd-menu a:hover {
+  color: var(--bg);
+  background: var(--fg);
+}
+
 /* --- footer -------------------------------------------------------------- */
 footer {
   margin-top: auto;

--- a/docs/ethos.md
+++ b/docs/ethos.md
@@ -1,12 +1,29 @@
-# Team Builder Ethos
-
-These are the principles that shape how Team thinks, plans, reviews, and ships.
-They are the beliefs behind the pipeline, the agents, and the loop — the reasons
-the system is built the way it is. They reflect what we believe about building
-software when the building itself is done by agents, and the human's scarce
-resource is judgment, not keystrokes.
-
 ---
+title: Ethos
+description: "The principles behind Team — files as the contract, mechanical gates over good intentions, adversarial-by-design review, and deep agents with narrow seams — that make the autonomous middle trustworthy."
+audience: [user, developer]
+nav_order: 3
+nav_label: ethos
+---
+
+# Team Ethos
+
+> **The principles behind the pipeline, the agents, and the loop.** They shape
+> how Team thinks, plans, reviews, and ships — the reasons the system is built
+> the way it is. They reflect what we believe about building software when the
+> building itself is done by agents, and the human's scarce resource is
+> judgment, not keystrokes.
+
+## Contents
+
+- [The Shift](#the-shift)
+- [1. The Human Owns the Ends](#1-the-human-owns-the-ends)
+- [2. Files Are the Contract](#2-files-are-the-contract)
+- [3. Mechanical Gates Over Good Intentions](#3-mechanical-gates-over-good-intentions)
+- [4. Adversarial by Design](#4-adversarial-by-design)
+- [5. Deep Agents, Narrow Seams](#5-deep-agents-narrow-seams)
+- [How They Work Together](#how-they-work-together)
+- [Autonomy Is Earned, Not Assumed](#autonomy-is-earned-not-assumed)
 
 ## The Shift
 
@@ -30,10 +47,8 @@ testing, reviewing, opening the PR — runs itself.
 | | Testing, reviewing, opening the PR |
 
 This only works if the autonomous middle is *trustworthy*. The rest of this
-document is how we earn that trust. See [VISION.md](VISION.md) for the end state
+document is how we earn that trust. See [Vision](vision.md) for the end state
 this drives toward.
-
----
 
 ## 1. The Human Owns the Ends
 
@@ -54,8 +69,6 @@ principle is to make the *ends* the only place a human is needed.
 - The loop merging its own PR. (Shipping is a human decision. Always.)
 - "Ask the user at every step." (Ask at the ends. Be autonomous in the middle.)
 
----
-
 ## 2. Files Are the Contract
 
 The conversation is ephemeral; the artifact on disk is durable. Every phase
@@ -74,8 +87,6 @@ artifact is the value.)*
 - Trusting "the model will remember." It won't — about one time in five.
 - A phase that produces no artifact. If it didn't write a file, it didn't happen.
 
----
-
 ## 3. Mechanical Gates Over Good Intentions
 
 LLMs forget instructions roughly one time in five. So where a rule **must** hold,
@@ -85,15 +96,13 @@ not discipline; it is hope.
 
 The corollary is layering: push every check to the cheapest, most deterministic
 layer that can catch it. A test at the wrong layer is worse than no test — it is
-slow, flaky, or costs money to learn nothing. *(See [TESTING.md](TESTING.md).)*
+slow, flaky, or costs money to learn nothing. *(See [TESTING.md](https://github.com/bostonaholic/team/blob/main/TESTING.md).)*
 Detect errors early, surface them loudly, never mask them silently.
 
 **Anti-patterns:**
 - "The agent's prompt says not to do X." (Add a hook that makes X impossible.)
 - A check that only passes when the model happens to be well-behaved.
 - An expensive LLM judge for something a regex could decide.
-
----
 
 ## 4. Adversarial by Design
 
@@ -112,8 +121,6 @@ but with the verifier structurally unable to collude with the generator.
 - A reviewer that read the conversation where the code was written.
 - Treating model confidence as correctness. Agreement is a signal, not a proof.
 
----
-
 ## 5. Deep Agents, Narrow Seams
 
 Each agent is a **deep module behind a narrow interface**: read one predecessor
@@ -129,8 +136,6 @@ downward. Armstrong: isolate failures so one fault can't take down the system.)*
 - An agent that reaches around its input artifact to peek at others' state.
 - Orchestration logic leaking into a specialist agent.
 - A "utility" agent that quietly does five unrelated things.
-
----
 
 ## How They Work Together
 
@@ -148,8 +153,6 @@ confident mistakes; without clean seams one failure becomes ten. Autonomy is not
 the *absence* of control — it is control moved out of the human's hands and into
 the system's structure.
 
----
-
 ## Autonomy Is Earned, Not Assumed
 
 The loop only gets to run hands-off because every step beneath it is gated,
@@ -162,6 +165,8 @@ where judgment is scarce." Build the system so well that the only things left
 worth a human's attention are the two that were always theirs: **what to build,
 and what to ship.**
 
----
+## See also
 
-*Read next: [VISION.md](VISION.md) — the end state · [docs/architecture.md](docs/architecture.md) — how the pipeline is built · [TESTING.md](TESTING.md) — where checks belong.*
+- **[Vision](vision.md)** — the loop-driven end state Team builds toward.
+- **[Architecture](architecture.md)** — how the pipeline turns these principles into a system.
+- **[TESTING.md](https://github.com/bostonaholic/team/blob/main/TESTING.md)** — where each check belongs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,9 @@
 title: Overview
 description: "Team — a Claude Code plugin that orchestrates specialized agents to autonomously implement features end-to-end via the QRSPI pipeline."
 permalink: /
+audience: [user, developer]
+nav_order: 1
+nav_label: home
 ---
 
 # Team
@@ -51,7 +54,8 @@ For a focused bug fix that skips the QRSPI ceremony:
 
 ## Read next
 
+- **[Vision](vision.md)** — the loop-driven end state Team builds toward.
+- **[Ethos](ethos.md)** — the principles that make the autonomous middle trustworthy.
 - **[Architecture](architecture.md)** — full design, artifact frontmatter, phase-inference rules.
 - **[Skills](skills.md)** — all 29 skills, their arguments, consumers, and behaviors.
-- **[Project Tracking](project-tracking.md)** — how work is tracked on the GitHub Project board.
 - **[GitHub repository](https://github.com/bostonaholic/team)** — source, agents, skills.

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -1,6 +1,9 @@
 ---
 title: Project Tracking
 description: "How work on the Team plugin is tracked — the GitHub Project board is the single source of truth for features, bugs, and chores, moved across a Backlog → Ready → In progress → In review → Done kanban."
+audience: [developer]
+nav_order: 7
+nav_label: project-tracking
 ---
 
 # Project Tracking

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,12 +1,16 @@
 ---
 title: Skills
 description: "The Team plugin's 29 skills — 11 entry-point slash commands and 18 methodology skills loaded by agents, with purpose, arguments, consumers, and behaviors."
+audience: [user, developer]
+nav_order: 5
+nav_label: skills
 ---
 
-# Team Plugin — Skills
+# Team Skills
 
-> **Audience:** Plugin maintainers and contributors. End users only need
-> the README + `/team` slash command.
+> **The features you use.** Every entry-point skill is a slash command you can
+> run (`/team`, `/team-fix`, …); the methodology skills are the internal
+> building blocks the agents load to do their work.
 >
 > **Source of truth:** the skill bodies themselves, `skills/*/SKILL.md`.
 > This page is a hand-maintained reference; when it disagrees with a
@@ -450,8 +454,10 @@ is consistent: the **skill** is the orchestrator or methodology, while the
 
 ## See also
 
-- **[architecture.md](architecture.md)** — the design rationale behind
+- **[Architecture](architecture.md)** — the design rationale behind
   skills (two flavors, three-tier discovery, load limits) in §6.
-- **[index.md](index.md)** — the landing page and pipeline overview.
+- **[Vision](vision.md)** — the loop-driven end state Team builds toward.
+- **[Ethos](ethos.md)** — the principles behind the pipeline.
+- **[Overview](index.md)** — the landing page and pipeline overview.
 - **`skills/team/registry.json`** — the phase-tagged inventory of the 13
   specialist agents, in the source tree.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,9 @@
 ---
 title: Versioning
 description: "Scoped per-PR versioning for the Team plugin — PRs touching runtime paths (agents/, skills/, hooks/, .claude-plugin/) bump the version, roll their own changelog section, and carry the version in their title; dev-only PRs are exempt. CI gates the bump and auto-publishes the release on merge."
+audience: [developer]
+nav_order: 6
+nav_label: versioning
 ---
 
 # Versioning
@@ -20,7 +23,7 @@ tags and publishes automatically.
 
 A bump is required **iff** the PR's diff (vs the base branch) touches a
 runtime path — the runtime half of the runtime-vs-development split in
-[AGENTS.md](../AGENTS.md):
+[AGENTS.md](https://github.com/bostonaholic/team/blob/main/AGENTS.md):
 
 | Paths | Bump |
 |-------|------|
@@ -132,7 +135,7 @@ title correctly yourself; the sync is a backstop, not the mechanism.
 
 ## What CI enforces, and where
 
-Per [TESTING.md](../TESTING.md), every check lives at the cheapest layer that
+Per [TESTING.md](https://github.com/bostonaholic/team/blob/main/TESTING.md), every check lives at the cheapest layer that
 can catch it:
 
 | Check | Layer | Where |
@@ -197,4 +200,4 @@ gh release create "v$V" --title "v$V" --notes-file /tmp/notes.md
 ## Read next
 
 - **[Project Tracking](project-tracking.md)** — the board the PR's issue moves across.
-- **[TESTING.md](../TESTING.md)** — why each check lives at its layer.
+- **[TESTING.md](https://github.com/bostonaholic/team/blob/main/TESTING.md)** — why each check lives at its layer.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,8 +1,24 @@
-# Vision
+---
+title: Vision
+description: "Team's north star — a human keeps the board fed and reviews finished work; everything in between runs itself via a continuously running, board-driven control loop."
+audience: [user, developer]
+nav_order: 2
+nav_label: vision
+---
 
-> **North star for the Team plugin.** This is the end state we are building
+# Team Vision
+
+> **The north star for the Team plugin.** This is the end state we are building
 > toward. It is not a description of how Team works today — it is the target
 > the project moves toward.
+
+## Contents
+
+- [The one-sentence vision](#the-one-sentence-vision)
+- [What the human does](#what-the-human-does)
+- [What the system does](#what-the-system-does)
+- [Why this is the goal](#why-this-is-the-goal)
+- [How we get there](#how-we-get-there)
 
 ## The one-sentence vision
 
@@ -79,5 +95,11 @@ and leaving the mechanical flow to the machine.
 
 The loop is assembled from capabilities the pipeline already has — isolated
 worktrees, adversarial review, durable artifacts — plus a control loop over the
-board. See [ETHOS.md](ETHOS.md) for the principles that make the autonomous
+board. See [Ethos](ethos.md) for the principles that make the autonomous
 middle trustworthy.
+
+## See also
+
+- **[Ethos](ethos.md)** — the principles that make the autonomous middle trustworthy.
+- **[Architecture](architecture.md)** — how the pipeline is built.
+- **[Overview](index.md)** — what Team is and how the pipeline runs.


### PR DESCRIPTION
## What

Reorganizes the docs site (team.bostonaholic.dev) by **audience**, and makes `docs/` the single home for all long-form docs.

- **User vs developer split, data-driven.** Each page declares an `audience:` (`[user, developer]` or `[developer]`) in front matter. The shared/user pages render in the nav bar; the contributor-only pages tuck into a **`contributing ▾` dropdown** — keeping the top bar user-focused (the convention used by Vue's "About ▾", React's "Community", Node's "Contributing"). Adding a page is a front-matter change, not a layout edit.
  - Bar (both audiences): Overview, Vision, Ethos, Architecture, Skills
  - `contributing ▾` dropdown: Versioning, Project tracking
- **Publish vision + ethos, single-source.** `VISION.md` / `ETHOS.md` move from the repo root into `docs/` as the one canonical copy each; root copies deleted; AGENTS.md's north-star links repointed to `docs/`.
- **Consistency pass.** Content pages share one skeleton: `# Team <X>` heading, intro blockquote, `## Contents` jump-list, `## See also` footer. Stale "Audience: maintainers" notes on architecture/skills refreshed.
- **Link fixes.** Cross-repo links that 404'd on the published site (`AGENTS.md`, `TESTING.md`, `evals/README.md`) now point at their GitHub sources.

## Why this shape

Jekyll only publishes `docs/` and GitHub Pages safe mode won't follow a symlink outside it, so the canonical copy lives in `docs/` (no duplication) — matching AGENTS.md's own rule: "put guidance in `docs/` and link from here." The nav pattern follows what popular OSS docs do: primary bar stays user-facing, contributor/release docs go in a "contributing" menu.

## Test plan

- [x] `jekyll build` clean; all 7 pages published (incl. versioning + project-tracking)
- [x] Nav renders shared bar + `contributing ▾` dropdown (versioning, project-tracking); `project-tracking` stays on one line
- [x] Live crawl: every page and every internal link across all 7 pages → 200
- [x] `## Contents` anchors resolve; `AGENTS.md` / `TESTING.md` / `evals/README.md` GitHub links → 200
- [x] Root `VISION.md` / `ETHOS.md` deleted; AGENTS.md north-star links point at existing `docs/` files
- [x] Content pages share the heading / blockquote / Contents / See also skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)