### PR TITLE
v0.6.1 fix: require absolute URLs in changelog entries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -101,7 +101,9 @@ entry style per `skills/changelog/SKILL.md`):
   - Add `[X.Y.Z]: https://github.com/bostonaholic/team/compare/v<prev>...vX.Y.Z`
 
 This section becomes the GitHub release notes verbatim — write it for a reader
-deciding whether to upgrade.
+deciding whether to upgrade. Any links must be **absolute URLs**: relative paths
+(e.g. `docs/versioning.md`) render as dead links on the release page (see
+`skills/changelog/SKILL.md`).
 
 **Empty-`[Unreleased]` edge case.** If the `[Unreleased]` body is empty,
 **derive at least one bullet from the PR's commits** (`feat:`/`fix:`/`perf:`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-16
+
 ### Changed
 
 - **Changelog entries now use absolute URLs for links.** A released changelog section is reused verbatim as the GitHub release notes, where repository-relative links (e.g. a bare `docs/versioning.md` target) render as dead links. The changelog convention (`skills/changelog/SKILL.md`) and the `version-bump` land-time changelog step now require full `https://…` URLs, and a new `tests/changelog-links.test.ts` tripwire fails the build if the `[Unreleased]` section contains a repository-relative link.
@@ -101,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/bostonaholic/team/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bostonaholic/team/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/bostonaholic/team/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/bostonaholic/team/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Changelog entries now use absolute URLs for links.** A released changelog section is reused verbatim as the GitHub release notes, where repository-relative links (e.g. a bare `docs/versioning.md` target) render as dead links. The changelog convention (`skills/changelog/SKILL.md`) and the `version-bump` land-time changelog step now require full `https://…` URLs, and a new `tests/changelog-links.test.ts` tripwire fails the build if the `[Unreleased]` section contains a repository-relative link.
+
 ## [0.6.0] - 2026-06-16
 
 ### Added
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The Team plugin now versions itself at land time, retiring the per-PR version gate.** Drafted PRs carry **no version** — no bump commit, no `vX.Y.Z` title, no released changelog section — and simply accumulate user-facing bullets under `## [Unreleased]`. Landing a Team PR is two steps: the dev-internal `version-bump` skill (`.claude/skills/version-bump/SKILL.md`) assigns the next version against current `main`, bumps the four version strings, cuts the `[Unreleased]` body into a dated `## [X.Y.Z]` section, runs a land-time consistency assertion, and commits `chore(version)`; then the generic `/shipit` skill above pushes, waits for CI, and rebase-merges. Because landing is serialized — one PR versioned against the latest `main` at a time — two PRs can no longer claim the same number, so the per-PR CI gate is gone: `.github/workflows/version-gate.yml` is **deleted**, `.github/workflows/pr-title-sync.yml` is slimmed to a thin backstop that no-ops for bump-less PRs, and `tests/version-consistency.test.ts` is narrowed to the invariants that always hold on a feature branch (strict 3-part semver + four-string agreement), with the released-section/footer-link checks moved into `version-bump`'s land-time assertion. `release-on-merge.yml` is unchanged — it still tags and publishes from the landed `plugin.json`. [docs/versioning.md](docs/versioning.md) and the `AGENTS.md`/`CLAUDE.md` versioning invariant document the model.
+- **The Team plugin now versions itself at land time, retiring the per-PR version gate.** Drafted PRs carry **no version** — no bump commit, no `vX.Y.Z` title, no released changelog section — and simply accumulate user-facing bullets under `## [Unreleased]`. Landing a Team PR is two steps: the dev-internal `version-bump` skill (`.claude/skills/version-bump/SKILL.md`) assigns the next version against current `main`, bumps the four version strings, cuts the `[Unreleased]` body into a dated `## [X.Y.Z]` section, runs a land-time consistency assertion, and commits `chore(version)`; then the generic `/shipit` skill above pushes, waits for CI, and rebase-merges. Because landing is serialized — one PR versioned against the latest `main` at a time — two PRs can no longer claim the same number, so the per-PR CI gate is gone: `.github/workflows/version-gate.yml` is **deleted**, `.github/workflows/pr-title-sync.yml` is slimmed to a thin backstop that no-ops for bump-less PRs, and `tests/version-consistency.test.ts` is narrowed to the invariants that always hold on a feature branch (strict 3-part semver + four-string agreement), with the released-section/footer-link checks moved into `version-bump`'s land-time assertion. `release-on-merge.yml` is unchanged — it still tags and publishes from the landed `plugin.json`. [docs/versioning.md](https://github.com/bostonaholic/team/blob/main/docs/versioning.md) and the `AGENTS.md`/`CLAUDE.md` versioning invariant document the model.
 
 ## [0.5.1] - 2026-06-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -171,6 +171,14 @@ commits are rewritten in user-facing language.
 - **Write in past tense.** "Added X" not "Add X". The changelog records what
   happened.
 - **Keep entries short.** One to two sentences maximum. Link to documentation
-  for details if needed.
+  for details if needed — with an **absolute URL** (see next rule).
+- **Use absolute URLs for links.** A released changelog section is reused
+  *verbatim* as the GitHub release notes, and the release page is not served
+  from the repository root — so repository-relative links (e.g.
+  `[versioning](docs/versioning.md)`) become dead links there. Always write full
+  `https://…` URLs — the file's GitHub blob URL
+  (`https://github.com/<owner>/<repo>/blob/<default-branch>/<path>`) or your
+  published docs site — never relative paths. Bare `#anchors` and `mailto:`
+  targets are fine.
 - **Always update `[Unreleased]`.** Never create a versioned section without
   the user explicitly asking for a release.

--- a/tests/changelog-links.test.ts
+++ b/tests/changelog-links.test.ts
@@ -1,0 +1,61 @@
+// tests/changelog-links.test.ts
+//
+// L2 tripwire (free, deterministic): links in the changelog's `[Unreleased]`
+// section must be ABSOLUTE URLs. A release cuts that section verbatim into the
+// GitHub release notes, and the release page is not served from the repo root,
+// so repository-relative links (e.g. `](docs/versioning.md)`) render as dead
+// links there. Enforcing it on `[Unreleased]` catches bad links while entries
+// accumulate — before they are ever cut into a published release.
+//
+// Convention: skills/changelog/SKILL.md ("Use absolute URLs for links").
+// Historical released sections are not rewritten; the rule applies going forward.
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { read } from "./helpers/text";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const CHANGELOG = join(REPO_ROOT, "CHANGELOG.md");
+
+// Body of a top-level `## [..]` section, up to the next `## [` (or EOF).
+function section(md: string, header: string): string {
+  const lines = md.split("\n");
+  const start = lines.findIndex((l) => l.trimEnd() === header);
+  if (start === -1) return "";
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^## \[/.test(l));
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n");
+}
+
+// Markdown link/image targets — the X in `](X)`.
+function linkTargets(md: string): string[] {
+  const targets: string[] = [];
+  const re = /\]\(([^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(md)) !== null) targets.push(m[1].trim());
+  return targets;
+}
+
+// Absolute = a real scheme (http/https/mailto) or a same-page anchor.
+const ABSOLUTE = /^(https?:\/\/|mailto:|#)/;
+
+describe("changelog: [Unreleased] links are absolute (release-notes-safe)", () => {
+  const changelog = read(CHANGELOG);
+  const unreleased = section(changelog, "## [Unreleased]");
+
+  test("no repository-relative links in the [Unreleased] section", () => {
+    const relative = linkTargets(unreleased).filter((t) => !ABSOLUTE.test(t));
+    // Surfaces the offending targets in the failure message.
+    expect(relative).toEqual([]);
+  });
+
+  // Guards the guard: prove the matcher actually rejects a relative target,
+  // so a future refactor can't silently turn this tripwire into a no-op.
+  test("the absolute-URL matcher rejects a relative path", () => {
+    expect(ABSOLUTE.test("docs/versioning.md")).toBe(false);
+    expect(ABSOLUTE.test("./guide.md")).toBe(false);
+    expect(ABSOLUTE.test("../x.md")).toBe(false);
+    expect(ABSOLUTE.test("https://github.com/o/r/blob/main/docs/x.md")).toBe(true);
+    expect(ABSOLUTE.test("#section")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

A released changelog section is reused **verbatim** as the GitHub release notes, and the release page isn't served from the repo root — so repository-relative links (e.g. `[versioning](docs/versioning.md)`) render as **dead links** there. The just-published v0.6.0 notes had exactly one such link. This makes absolute URLs the changelog convention and enforces it.

## Changes

- **`skills/changelog/SKILL.md`** — new rule: links must be absolute `https://…` URLs (GitHub blob URL or published docs site); `#anchors` and `mailto:` are fine.
- **`.claude/skills/version-bump/SKILL.md`** — the land-time changelog-cut step now points at the rule.
- **`tests/changelog-links.test.ts`** — L2 tripwire: fails if the `[Unreleased]` section contains a repository-relative link (caught while entries accumulate, before a release cuts the section). Includes a guard-the-guard case so the matcher can't silently become a no-op.
- **`CHANGELOG.md`** — fixed the dead `docs/versioning.md` link in the `[0.6.0]` entry; recorded this change under `[Unreleased]`.

## Scope note

Enforcement targets the `[Unreleased]` section only — historical released sections are not rewritten; the convention applies going forward. The live v0.6.0 release notes are being corrected separately (the release already exists, so `release-on-merge` won't re-publish it).

## How to Verify

- [x] `bun test` — 317 pass / 0 fail
- [x] Negative check: injecting `](docs/y.md)` into `[Unreleased]` makes the tripwire flag it

🤖 Generated with [Claude Code](https://claude.com/claude-code)