### PR TITLE
v0.7.0 feat: make Structure phase autonomous, removing its human gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.6.1"
+    "version": "0.7.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Agents are **decoupled microservices**. Each consumes a predecessor artifact on 
 QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEMENT → PR
 ```
 
-Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-PR). Two human gates: **Design approval** (~200-line alignment doc) and **Structure approval** (~2-page vertical-slice breakdown). Research is **isolated** — the researcher reads only `questions.md`, never `task.md` or the user's framing. The Plan is a tactical artifact for the implementer, not for human review. Implement is a sub-pipeline (test-first → slice execution → 5-reviewer adversarial verify with hard-gate retry loop). Everything outside the two human gates is autonomous with mechanical gates.
+Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-PR). One human gate: **Design approval** (~200-line alignment doc). The Structure (~2-page vertical-slice breakdown) is produced autonomously and advances to Plan with no approval wait. Research is **isolated** — the researcher reads only `questions.md`, never `task.md` or the user's framing. The Plan is a tactical artifact for the implementer, not for human review. Implement is a sub-pipeline (test-first → slice execution → 5-reviewer adversarial verify with hard-gate retry loop). Everything outside the design gate is autonomous with mechanical gates.
 
 ## Entry Points
 
@@ -53,8 +53,8 @@ Team runs **QRSPI** (Question-Research-Design-Structure-Plan-Worktree-Implement-
 | `/team-research` | Isolated codebase research (runs Question if missing) |
 | `/team-design` | Align with user on approach (human gate) |
 | `/eng-design-doc-review` | *(optional)* Adversarial fresh-context audit of `design.md` before the human gate |
-| `/team-structure` | Break design into vertical slices (human gate) |
-| `/team-plan` | Tactical plan from approved structure |
+| `/team-structure` | Break design into vertical slices (autonomous) |
+| `/team-plan` | Tactical plan from the structure |
 | `/team-worktree` | Prepare isolated git worktree |
 | `/team-implement` | Test-first + slice execution + 5-reviewer verify |
 | `/team-pr` | Commit + open PR |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Structure phase is no longer a human approval gate.** The QRSPI pipeline now has a single human gate — **Design approval** — and the Structure phase advances to Plan autonomously: the `structure-planner` writes `structure.md` with plain frontmatter (no `approved`/`approved_at`/`revision` fields) and the orchestrator proceeds to PLAN with no approval wait. The orchestrator skill ([skills/team/SKILL.md](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)), the Structure and Plan phase skills, the phase discipline ([skills/qrspi-workflow/SKILL.md](https://github.com/bostonaholic/team/blob/main/skills/qrspi-workflow/SKILL.md)), the gate registry, the `structure-planner` agent, and the phase-inference logic in the `session-start-recover` and `pre-compact-anchor` hooks all treat Structure as gateless. Documentation across `README.md`, `AGENTS.md`/`CLAUDE.md`, and [docs/architecture.md](https://github.com/bostonaholic/team/blob/main/docs/architecture.md) now describes one human gate instead of two.
+
 ## [0.6.1] - 2026-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-16
+
 ### Changed
 
 - **The Structure phase is no longer a human approval gate.** The QRSPI pipeline now has a single human gate — **Design approval** — and the Structure phase advances to Plan autonomously: the `structure-planner` writes `structure.md` with plain frontmatter (no `approved`/`approved_at`/`revision` fields) and the orchestrator proceeds to PLAN with no approval wait. The orchestrator skill ([skills/team/SKILL.md](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)), the Structure and Plan phase skills, the phase discipline ([skills/qrspi-workflow/SKILL.md](https://github.com/bostonaholic/team/blob/main/skills/qrspi-workflow/SKILL.md)), the gate registry, the `structure-planner` agent, and the phase-inference logic in the `session-start-recover` and `pre-compact-anchor` hooks all treat Structure as gateless. Documentation across `README.md`, `AGENTS.md`/`CLAUDE.md`, and [docs/architecture.md](https://github.com/bostonaholic/team/blob/main/docs/architecture.md) now describes one human gate instead of two.
@@ -107,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/bostonaholic/team/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/bostonaholic/team/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bostonaholic/team/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/bostonaholic/team/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEME
 - **Question** — Decompose intent into a full task record (`task.md`) and neutral research questions (`questions.md`). The questioner is the only agent that ever sees the user's original description.
 - **Research** *(isolated)* — Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task. This structurally prevents opinion-bias in research findings.
 - **Design** *(human gate)* — Design author asks open questions interactively, then drafts a ~200-line alignment doc. Humans review here.
-- **Structure** *(human gate)* — Break the design into vertical slices with verification checkpoints. Humans review the ~2-page structure here.
-- **Plan** — Tactical implementation plan derived from the approved structure. Read by the implementer; not human-gated.
+- **Structure** — Break the design into vertical slices with verification checkpoints. Produced autonomously; advances to Plan with no human gate.
+- **Plan** — Tactical implementation plan derived from the structure. Read by the implementer; not human-gated.
 - **Worktree** — Orchestrator prepares an isolated git worktree.
 - **Implement** — Test-first (test-architect writes failing tests, mechanical gate confirms) → slice execution (implementer commits each vertical slice atomically) → adversarial verification (5 parallel reviewers + typed failure-class retry loop, max 5 rounds).
 - **PR** — Update changelog, commit, open pull request, surface the tracking item.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -26,7 +26,7 @@ The orchestrator dispatches you with the artifact directory
 
 1. **Read the approved plan** at `docs/plans/<id>/plan.md` to understand the
    slice list, file-level steps, and per-slice tests.
-2. **Read the approved structure** at `docs/plans/<id>/structure.md` to
+2. **Read the structure** at `docs/plans/<id>/structure.md` to
    understand the order and verification checkpoints.
 3. **Read `docs/plans/<id>/repos.md` if present.** It defines multi-repo
    mode and lists each repo's slug, absolute path, and worktree path

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,6 +1,6 @@
 ---
 name: planner
-description: Use after the structure is approved to produce the tactical implementation plan. Translates each vertical slice in structure.md into precise file-level steps with acceptance test mappings. The plan is a tactical artifact for the implementer — humans review the structure, not the plan.
+description: Use after the structure is produced to create the tactical implementation plan. Translates each vertical slice in structure.md into precise file-level steps with acceptance test mappings. The plan is a tactical artifact for the implementer — neither the structure nor the plan is human-reviewed (design is the human gate).
 color: purple
 model: opus
 tools: Read, Write, Edit, Grep, Glob, TodoWrite
@@ -11,20 +11,20 @@ skills:
 
 # Planner Agent
 
-You are a senior engineer turning an approved structure into the tactical
+You are a senior engineer turning the structure into the tactical
 plan the implementer will execute step by step. The structure tells you
 **what slices ship and in what order**. You spell out **which files change
 in which way for each slice**.
 
-The human has already approved the structure. They will not review your plan
-in detail — your audience is the implementer.
+The human approved the design. They will not review the structure or your
+plan in detail — your audience is the implementer.
 
 ## Inputs
 
 The orchestrator dispatches you with the artifact directory
 `docs/plans/<id>/`. You read:
 
-- `docs/plans/<id>/structure.md` — the approved vertical-slice breakdown
+- `docs/plans/<id>/structure.md` — the vertical-slice breakdown
 - `docs/plans/<id>/design.md` — context, decisions, patterns
 - `docs/plans/<id>/research.md` — codebase facts
 - `docs/plans/<id>/repos.md` — repo scope (only present when the topic
@@ -125,6 +125,6 @@ context referenced in the body)
 ## What you do NOT do
 
 - Do not re-litigate design decisions. The design is approved.
-- Do not re-slice the work. The structure is approved.
+- Do not re-slice the work. The structure is the agreed slice breakdown.
 - Do not invent slices not present in the structure.
 - Do not write a "Trade-offs" section. Trade-offs were resolved in the design.

--- a/agents/structure-planner.md
+++ b/agents/structure-planner.md
@@ -1,6 +1,6 @@
 ---
 name: structure-planner
-description: Use after the design is approved to break the work into vertical slices with verification checkpoints. Each slice is end-to-end (touches every layer needed to deliver one piece of functionality), independently testable, and atomically committable. Produces a ~2-page document the human reviews before any code is written.
+description: Use after the design is approved to break the work into vertical slices with verification checkpoints. Each slice is end-to-end (touches every layer needed to deliver one piece of functionality), independently testable, and atomically committable. Produces a ~2-page document that the planner and implementer consume; it advances autonomously to PLAN with no human gate.
 color: purple
 model: opus
 tools: Read, Write, Edit, Grep, Glob, TodoWrite
@@ -39,32 +39,29 @@ shows `approved: true`):
 - `docs/plans/<id>/repos.md` — repo scope (only present when the topic
   spans more than one repository)
 
-For revision dispatch (after a human gate rejection):
+For re-dispatch (e.g. the design changed, or implementation surfaced a
+structure flaw and the orchestrator returned to STRUCTURE):
 
 - The previous `docs/plans/<id>/structure.md`
-- The user's verbatim feedback supplied by the orchestrator
+- The reason for the re-run, supplied by the orchestrator
 
 ## Output
 
-Write to `docs/plans/<id>/structure.md` (overwrite on revision).
+Write to `docs/plans/<id>/structure.md` (overwrite on re-dispatch).
 
-The file MUST open with this YAML frontmatter — the `approved` and
-`approved_at` fields are how the human gate is recorded:
+The file MUST open with this YAML frontmatter:
 
 ```yaml
 ---
 topic: <kebab-case-topic>
 date: <YYYY-MM-DD>
 phase: structure
-approved: false
-approved_at: null
-revision: 0
 ---
 ```
 
-Leave `approved: false` on every draft, including revisions. The
-orchestrator flips it to `true` (and stamps `approved_at`) when the user
-approves at the human gate.
+Structure is **not human-gated** — it carries no `approved`/`approved_at`/
+`revision` fields. The orchestrator records the artifact and advances to
+PLAN automatically (design is the pipeline's only human gate).
 
 The `topic` value MUST be copied verbatim from the predecessor
 `design.md`. Never re-derive, re-word, or combine it with the ticket
@@ -160,5 +157,5 @@ does not accidentally include it>
 ## Output to orchestrator
 
 When done, return a short summary to the orchestrator:
-`{structurePath, id, sliceCount: <number>}`. The orchestrator will
-then run the human gate (present the structure, capture approval).
+`{structurePath, id, sliceCount: <number>}`. The orchestrator records
+the structure and advances to PLAN (no human gate).

--- a/agents/test-architect.md
+++ b/agents/test-architect.md
@@ -1,6 +1,6 @@
 ---
 name: test-architect
-description: Use after the worktree is prepared to write all failing acceptance tests from the approved structure. Tests form the immutable scope fence for implementation. Operates inside the implement phase as a sub-step before the implementer runs.
+description: Use after the worktree is prepared to write all failing acceptance tests from the structure. Tests form the immutable scope fence for implementation. Operates inside the implement phase as a sub-step before the implementer runs.
 color: green
 model: inherit
 tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,12 +56,12 @@ seeds and updates a TodoWrite ledger, and runs the human gates.
   *structural* — the orchestrator only passes the `questions.md` path to
   the research agents; *procedural* — the research agents' system prompts
   forbid reading `task.md`.
-- **Two human touchpoints.** Design approval (~200-line alignment doc)
-  and Structure approval (~2-page vertical-slice breakdown). Approval
-  is recorded by flipping `approved: true` (and stamping `approved_at`)
-  in the gated artifact's own YAML frontmatter — the artifact is
-  self-describing. The Plan is not human-gated; humans review the
-  structure, which is the real contract.
+- **One human touchpoint.** Design approval (~200-line alignment doc).
+  Approval is recorded by flipping `approved: true` (and stamping
+  `approved_at`) in the design's own YAML frontmatter — the artifact is
+  self-describing. The Structure (~2-page vertical-slice breakdown) and
+  the Plan are not human-gated; they advance autonomously. Design is the
+  real contract.
 - **Hooks enforce discipline mechanically.** LLMs forget instructions
   ~20% of the time; hooks are deterministic.
 
@@ -92,8 +92,8 @@ Per-phase additions:
 | questions | (none)                                                                  |
 | research  | (none)                                                                  |
 | design    | `approved: false`, `approved_at: null`, `revision: 0`                   |
-| structure | `approved: false`, `approved_at: null`, `revision: 0`                   |
-| plan      | (none — derived mechanically from the approved structure)               |
+| structure | (none — not human-gated; advances to PLAN once it exists)               |
+| plan      | (none — derived mechanically from the structure)                        |
 
 **Approval check** (used by downstream phase entry):
 
@@ -116,8 +116,7 @@ Cap at 5; beyond that, escalate to the user.
 | `research.md`                                          | DESIGN (next up)    |
 | `design.md` (frontmatter `approved: false`)            | DESIGN (human gate) |
 | `design.md` (frontmatter `approved: true`)             | STRUCTURE (next up) |
-| `structure.md` (frontmatter `approved: false`)         | STRUCTURE (gate)    |
-| `structure.md` (frontmatter `approved: true`)          | PLAN (next up)      |
+| `structure.md`                                         | PLAN (next up)      |
 | `plan.md`                                              | WORKTREE (next up)  |
 | worktree exists for the `<id>` branch                  | IMPLEMENT           |
 | topic branch has slice commits + verifier passed       | PR (next up)        |
@@ -170,16 +169,16 @@ rejection the agent re-drafts and increments `revision`.
 **Agent:** `structure-planner`
 **Predecessor:** `design.md` with frontmatter `approved: true`
 **Artifact:** `docs/plans/<id>/structure.md`
-**Gate:** HUMAN — same flip-frontmatter mechanics as Design.
+**Gate:** NONE — autonomous. Once `structure.md` exists the pipeline
+advances to PLAN; design is the only human gate.
 
 ### Phase 5: Plan
 
 **Agent:** `planner`
-**Predecessor:** `structure.md` with frontmatter `approved: true`
+**Predecessor:** `structure.md`
 **Artifact:** `docs/plans/<id>/plan.md`
 
-No human gate. The plan is mechanically derived from the approved
-structure.
+No human gate. The plan is mechanically derived from the structure.
 
 ### Phase 6: Worktree
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The autonomous engineering mesh for Claude Code.
 
 ## What is Team?
 
-Team orchestrates **13 specialized agents** — from isolated researchers to adversarial reviewers — that drive a feature through an 8-phase pipeline (QRSPI) and deliver a verified pull request. Agents are decoupled microservices: each consumes a predecessor artifact on disk, does its work, and writes its own artifact. The orchestrator (the main Claude Code session) walks a linear phase table and runs two human approval gates.
+Team orchestrates **13 specialized agents** — from isolated researchers to adversarial reviewers — that drive a feature through an 8-phase pipeline (QRSPI) and deliver a verified pull request. Agents are decoupled microservices: each consumes a predecessor artifact on disk, does its work, and writes its own artifact. The orchestrator (the main Claude Code session) walks a linear phase table and runs a single human approval gate (design).
 
 ## The Pipeline
 
@@ -26,8 +26,8 @@ QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → WORKTREE → IMPLEME
 | **Question** | Decompose intent into `task.md` + neutral `questions.md`. The questioner is the only agent that ever sees your original description. |
 | **Research** *(isolated)* | Parallel agents (file-finder + researcher) consume only `questions.md`. They never see the task — structurally preventing opinion-bias. |
 | **Design** *(human gate)* | The design author runs an interactive interview, then drafts a ~200-line alignment doc. You review here. |
-| **Structure** *(human gate)* | Break the design into vertical slices with verification checkpoints. ~2-page doc. You review here. |
-| **Plan** | Tactical implementation plan derived from the approved structure. Read by the implementer; not human-gated. |
+| **Structure** | Break the design into vertical slices with verification checkpoints. ~2-page doc. Produced autonomously — advances to Plan with no human gate. |
+| **Plan** | Tactical implementation plan derived from the structure. Read by the implementer; not human-gated. |
 | **Worktree** | Orchestrator prepares an isolated git worktree. |
 | **Implement** | Test-first → slice execution → 5 parallel reviewers + typed retry loop. |
 | **PR** | Update changelog, commit, open pull request. |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -97,7 +97,7 @@ argument shape.
   Plan → Worktree → Implement → PR).
 - **Key behaviors:** Walks a linear Phase Loop, dispatching the specialist
   agent(s) for each phase per its phase table, then running that phase's
-  gate before advancing. Enforces the two human gates (Design, Structure)
+  gate before advancing. Enforces the single human gate (Design)
   and the aggregate five-reviewer review gate during Implement — that
   aggregate gate sorts every finding into Blocking / Major / Minor-and-below
   tiers and auto-loops on any Blocking or Major (the consult guard: the
@@ -132,7 +132,7 @@ argument shape.
   shared three-tier chain above.
 - **Phase:** Design (human gate).
 - **Key behaviors:** Runs an interactive interview, then writes a ~200-line
-  `design.md`. This is the first of the two human approval gates.
+  `design.md`. This is the pipeline's only human approval gate.
 
 ### team-structure
 
@@ -140,13 +140,13 @@ argument shape.
   per-slice verification checkpoints.
 - **`$ARGUMENTS`:** `[docs/plans/<id>/]` — optional; resolves via the
   shared three-tier chain above.
-- **Phase:** Structure (human gate).
-- **Key behaviors:** Produces the ~2-page `structure.md`. This is the
-  second human approval gate.
+- **Phase:** Structure (autonomous — no human gate).
+- **Key behaviors:** Produces the ~2-page `structure.md`, then advances
+  to PLAN automatically. Design is the pipeline's only human gate.
 
 ### team-plan
 
-- **Purpose:** Turn the approved structure into a tactical, file-level
+- **Purpose:** Turn the structure into a tactical, file-level
   implementation plan.
 - **`$ARGUMENTS`:** `[docs/plans/<id>/]` — optional; resolves via the
   shared three-tier chain above.
@@ -434,7 +434,7 @@ entry-point section above rather than repeating them here.
 | `team-question` | orchestrator | Question |
 | `team-research` | orchestrator → researcher, file-finder | Research |
 | `team-design` | orchestrator → design-author | Design (human gate) |
-| `team-structure` | orchestrator → structure-planner | Structure (human gate) |
+| `team-structure` | orchestrator → structure-planner | Structure (autonomous) |
 | `team-plan` | orchestrator → planner | Plan |
 | `team-worktree` | orchestrator | Worktree |
 | `team-implement` | orchestrator → implementer + reviewers | Implement |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -66,9 +66,9 @@ In strict priority order (right to left):
 1. **In Progress → In Review — finish first.** If a pipeline run is complete,
    open its PR and move the card to In Review: get finished work in front of the
    human and free the In Progress slot. The pipeline runs end to end *without*
-   the two mid-pipeline human gates (design and structure approvals become
-   autonomous, self-approved after adversarial agent review); the single human
-   checkpoint moves to the **end** — the PR review.
+   the mid-pipeline human gate (structure already advances autonomously, and the
+   design approval will become autonomous too — self-approved after adversarial
+   agent review); the single human checkpoint moves to the **end** — the PR review.
 2. **Ready → In Progress — start only when nothing's waiting to finish.** When In
    Progress is below its WIP limit *and* no in-flight work can be pushed further
    right, pull the highest-priority Ready item and launch the Team pipeline for

--- a/hooks/pre-compact-anchor.mjs
+++ b/hooks/pre-compact-anchor.mjs
@@ -67,9 +67,7 @@ async function inferPhase(dir) {
   const p = (kind) => join(dir, `${kind}.md`);
   const has = async (path) => { try { await stat(path); return true; } catch { return false; } };
   if (await has(p("plan"))) return "WORKTREE";
-  if (await has(p("structure"))) {
-    return isTrue((await readFrontmatter(p("structure"))).approved) ? "PLAN" : "STRUCTURE";
-  }
+  if (await has(p("structure"))) return "PLAN";   // structure is not gated; advances to PLAN
   if (await has(p("design"))) {
     return isTrue((await readFrontmatter(p("design"))).approved) ? "STRUCTURE" : "DESIGN";
   }

--- a/hooks/session-start-recover.mjs
+++ b/hooks/session-start-recover.mjs
@@ -70,9 +70,7 @@ async function inferPhase(dir) {
   const p = (kind) => join(dir, `${kind}.md`);
   const has = async (path) => { try { await stat(path); return true; } catch { return false; } };
   if (await has(p("plan"))) return "WORKTREE";
-  if (await has(p("structure"))) {
-    return isTrue((await readFrontmatter(p("structure"))).approved) ? "PLAN" : "STRUCTURE";
-  }
+  if (await has(p("structure"))) return "PLAN";   // structure is not gated; advances to PLAN
   if (await has(p("design"))) {
     return isTrue((await readFrontmatter(p("design"))).approved) ? "STRUCTURE" : "DESIGN";
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -50,19 +50,20 @@ a ~200-line markdown artifact the human reviews carefully.
 
 Break the approved design into vertical slices with verification checkpoints.
 Each slice is end-to-end and independently testable. The result is a ~2-page
-markdown artifact the human reviews.
+markdown artifact, produced autonomously.
 
 - **Artifact:** `docs/plans/<id>/structure.md`
-- **Gate:** HARD — user must explicitly approve the structure
+- **Gate:** NONE — autonomous; once `structure.md` exists the pipeline
+  advances to PLAN. Design is the only human gate.
 
 ### PLAN
 
 Tactical implementation details for the agent. Read by the implementer.
 No human approval gate — the plan is mechanically derived from the
-approved structure.
+structure.
 
 - **Artifact:** `docs/plans/<id>/plan.md`
-- **Gate:** SOFT — no human approval; the structure is the contract
+- **Gate:** SOFT — no human approval; design is the human contract
 
 ### WORKTREE
 
@@ -243,8 +244,8 @@ This enforces incremental verifiability over big-bang integration.
 Blocks phase transition. The pipeline cannot proceed until the gate condition
 is satisfied. No override allowed except by explicit user command.
 
-Examples: design approval, structure approval, security review with critical
-findings, test failures.
+Examples: design approval, security review with critical findings, test
+failures.
 
 ### SOFT
 
@@ -287,8 +288,8 @@ Per-phase additions:
 | questions | (none)                                                                             |
 | research  | (none)                                                                             |
 | design    | `approved: false`, `approved_at: null`, `revision: 0`                              |
-| structure | `approved: false`, `approved_at: null`, `revision: 0`                              |
-| plan      | (none — derived mechanically from the approved structure)                          |
+| structure | (none — not human-gated; advances to PLAN once it exists)                          |
+| plan      | (none — derived mechanically from the structure)                                   |
 
 **Approval check** (used by downstream phase entry):
 
@@ -314,8 +315,7 @@ The orchestrator infers the current phase by scanning what exists in
 | `research.md`                                          | DESIGN (next up)    |
 | `design.md` (frontmatter `approved: false`)            | DESIGN (human gate) |
 | `design.md` (frontmatter `approved: true`)             | STRUCTURE (next up) |
-| `structure.md` (frontmatter `approved: false`)         | STRUCTURE (gate)    |
-| `structure.md` (frontmatter `approved: true`)          | PLAN (next up)      |
+| `structure.md`                                         | PLAN (next up)      |
 | `plan.md`                                              | WORKTREE (next up)  |
 | worktree exists for `<id>` branch in every involved repo | IMPLEMENT         |
 | topic branch has commits ahead and verifier passed     | PR (next up)        |
@@ -372,8 +372,9 @@ critical defect.
 
 The plan is a tactical artifact for the agent. Reviewing it duplicates
 effort: a 1000-line plan begets ~1000 lines of code, and surprises during
-implementation invalidate the review. Review the design (~200 lines) and
-the structure (~2 pages) instead — those are where leverage lives.
+implementation invalidate the review. Review the design (~200 lines)
+instead — that is where leverage lives. The structure and plan are
+autonomous artifacts.
 
 ### Horizontal Layering
 
@@ -381,16 +382,19 @@ Plans that build the entire database, then the entire API, then the entire
 UI defer integration risk to the very end. The structure phase exists to
 force vertical slicing — reject any structure that flattens into layers.
 
-### Implementing Without Structure Approval
+### Implementing Without a Structure
 
-The structure is the human contract. Bypassing its gate removes the user's
-ability to course-correct before code is written. Wait for explicit approval.
+The structure is the scope fence for implementation. Jumping from design
+straight to code skips the vertical-slice breakdown the planner and
+implementer rely on. Always produce the structure — even though it now
+advances autonomously, design remains the human contract behind it.
 
 ### Gold-Plating
 
 Adding features, tests, or abstractions beyond what the structure specifies.
 The structure defines the scope fence. If scope needs to expand, update the
-structure and get re-approval — do not silently add work.
+structure (and, for a material change, return to the DESIGN gate) — do not
+silently add work.
 
 ### Backward Skipping
 

--- a/skills/team-design/SKILL.md
+++ b/skills/team-design/SKILL.md
@@ -6,8 +6,8 @@ argument-hint: "[docs/plans/<id>/]"
 
 # Team Design — Where Are We Going?
 
-Run the DESIGN phase. This is the first human gate — get alignment here
-before investing in detailed planning.
+Run the DESIGN phase. This is the pipeline's only human gate — get
+alignment here before investing in detailed planning.
 
 ## Input
 

--- a/skills/team-plan/SKILL.md
+++ b/skills/team-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: team-plan
-description: Produce the tactical implementation plan from the approved structure. The plan is for the implementer — humans review the structure, not the plan. No human approval gate at this phase. Trigger on "plan the implementation", "spell out the steps", or "/team-plan".
+description: Produce the tactical implementation plan from the structure. The plan is an autonomous artifact for the implementer — no human approval gate at this phase (design is the pipeline's only human gate). Trigger on "plan the implementation", "spell out the steps", or "/team-plan".
 argument-hint: "[docs/plans/<id>/]"
 ---
 
 # Team Plan — Tactical Implementation Plan
 
-Run the PLAN phase. There is no human gate here; humans reviewed the
-structure already, and the plan is a tactical artifact for the implementer.
+Run the PLAN phase. There is no human gate here; the plan is a tactical
+artifact for the implementer, mechanically derived from the structure.
 
 ## Input
 
@@ -16,13 +16,13 @@ discovery block below resolves it.
 
 The `planner` reads:
 
-- `$ARGUMENTS/structure.md` (must carry `approved: true` in its frontmatter)
+- `$ARGUMENTS/structure.md`
 - `$ARGUMENTS/design.md`
 - `$ARGUMENTS/research.md`
 
 Resolve the artifact directory by running this self-contained block (one bash
 call — agent threads reset cwd between calls). The predecessor filter requires
-an **approved** `structure.md`, so unapproved candidates are skipped:
+a `structure.md` (structure is not human-gated, so no approval check):
 
 ```sh
 # Three-tier artifact-directory discovery (archetype A).
@@ -43,7 +43,6 @@ for dir in docs/plans/*/; do
   name="$(basename "$dir")"
   printf '%s' "$name" | grep -qE "$ID_RE" || continue   # ID_RE filter
   [ -f "$dir$PRED" ] || continue                        # predecessor filter
-  grep -qE '^approved:[[:space:]]*true[[:space:]]*$' "$dir$PRED" || continue
   m=-1
   for p in $PHASE_FILES; do
     f="$dir$p.md"
@@ -58,15 +57,15 @@ done
 ```
 
 - **If the block printed a path**, use it as `$ARGUMENTS` for the rest of this
-  skill (tier 1 explicit arg, or tier 2 discovery of an approved predecessor).
+  skill (tier 1 explicit arg, or tier 2 discovery of the predecessor).
   When the path came from tier 2 (no explicit arg), announce the resolved
   directory to the user before proceeding, so an auto-picked topic is never
   silent.
-- **If the block printed nothing** (tier 3 — no directory holds an approved
+- **If the block printed nothing** (tier 3 — no directory holds a
   `structure.md`), do not hard-error. Fire `AskUserQuestion` with a `Setup`
   header and labeled options:
-  - **Run the producer** — run `/team-structure docs/plans/<id>/` to produce or
-    approve `structure.md`.
+  - **Run the producer** — run `/team-structure docs/plans/<id>/` to produce
+    `structure.md`.
   - **Provide a path** — the user supplies the `docs/plans/<id>/` directory
     directly (run `ls docs/plans/` to find your topic directory).
 
@@ -74,8 +73,8 @@ done
 
 > Follow `skills/progress-tracking/SKILL.md`: when this procedure has two or more steps, seed one todo item per step before starting and mark each complete as you go.
 
-1. Use the directory resolved in `## Input` (the approval grep there already
-   confirmed `structure.md` carries `approved: true`).
+1. Use the directory resolved in `## Input` (the discovery there already
+   confirmed `structure.md` exists).
 2. Dispatch `planner`, which writes `$ARGUMENTS/plan.md` with file-level
    steps and per-slice acceptance test mappings.
 3. **Stop once `$ARGUMENTS/plan.md` exists.**

--- a/skills/team-structure/SKILL.md
+++ b/skills/team-structure/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: team-structure
-description: Break the approved design into vertical slices with verification checkpoints. The structure document is the human's last review point before code is written. Trigger on "slice this up", "break the design into steps", or "/team-structure".
+description: Break the approved design into vertical slices with verification checkpoints. Runs autonomously and advances to PLAN — no human gate (design is the pipeline's only human gate). Trigger on "slice this up", "break the design into steps", or "/team-structure".
 argument-hint: "[docs/plans/<id>/]"
 ---
 
 # Team Structure — How Do We Get There?
 
-Run the STRUCTURE phase. This is the second (and final) human gate.
+Run the STRUCTURE phase. It runs autonomously and advances to PLAN — there
+is **no human gate** here. Design is the pipeline's only human gate.
 
 ## Input
 
@@ -76,24 +77,17 @@ done
 1. Use the directory resolved in `## Input` (the approval grep there already
    confirmed `design.md` carries `approved: true`).
 2. Dispatch `structure-planner`, which writes `$ARGUMENTS/structure.md`
-   with vertical slices and frontmatter `approved: false`,
-   `approved_at: null`, `revision: 0`.
-3. **Human gate.** Present the structure **in full**, then use
-   `AskUserQuestion` to capture the verdict. Use a single question with a
-   `Decision` header and these options:
-   - **Approve** — structure is ready; advance to PLAN.
-   - **Request changes** — describe what to revise; re-dispatch
-     `structure-planner` with the user's feedback verbatim.
-   - **Reject** — abandon this structure and revisit DESIGN.
-
-   - On Approve → edit `$ARGUMENTS/structure.md` frontmatter to set
-     `approved: true` and `approved_at: <ISO-8601>`.
-   - On Request changes → re-dispatch `structure-planner` with feedback
-     verbatim. New draft increments `revision: <n+1>`. Cap at
-     `revision: 5`.
-4. **Stop once `$ARGUMENTS/structure.md` carries `approved: true`.**
+   with vertical slices. The artifact carries plain frontmatter
+   (`topic`, `date`, `phase: structure`) — no approval fields, because
+   structure is not human-gated.
+3. **No human gate.** Do not present the structure for approval — design is
+   the only human gate. Within a full `/team` run the orchestrator advances
+   to PLAN automatically; run standalone, this skill stops after writing the
+   structure and reports the next command.
+4. **Stop once `$ARGUMENTS/structure.md` exists.**
 
 ## Completion
 
-Report structure path and tell the user:
+Report the structure path. When run standalone, tell the user:
 **"Next: run `/team-plan docs/plans/<id>/`"**
+(Within a full `/team` run the orchestrator advances to PLAN automatically.)

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -113,7 +113,7 @@ loop:
      with the YAML frontmatter the agent specifies (see the agent file
      and skills/qrspi-workflow/SKILL.md).
   7. Run the gate for this phase:
-     - HUMAN (design, structure): present the artifact, wait for verdict.
+     - HUMAN (design): present the artifact, wait for verdict.
        On approve, edit the artifact's frontmatter to set
        `approved: true` and `approved_at: <ISO-8601>`. On reject,
        increment `revision: <n+1>` on the new draft and re-dispatch.
@@ -136,8 +136,8 @@ loop:
 | QUESTION   | `questioner`                                            | (none — description in `$ARGUMENTS`)                            | RESEARCH           |
 | RESEARCH   | `file-finder`, `researcher` (parallel, isolated)        | `docs/plans/<id>/questions.md`                                  | DESIGN             |
 | DESIGN     | `design-author` (→ human gate)                          | `docs/plans/<id>/research.md`                                   | STRUCTURE          |
-| STRUCTURE  | `structure-planner` (→ human gate)                      | `docs/plans/<id>/design.md` (frontmatter `approved: true`)      | PLAN               |
-| PLAN       | `planner`                                               | `docs/plans/<id>/structure.md` (frontmatter `approved: true`)   | WORKTREE           |
+| STRUCTURE  | `structure-planner`                                     | `docs/plans/<id>/design.md` (frontmatter `approved: true`)      | PLAN               |
+| PLAN       | `planner`                                               | `docs/plans/<id>/structure.md`                                  | WORKTREE           |
 | WORKTREE   | (orchestrator-emit)                                     | `docs/plans/<id>/plan.md`                                       | IMPLEMENT          |
 | IMPLEMENT  | `test-architect`, `implementer`, 5 reviewers (parallel) | worktree prepared                                               | PR                 |
 | PR         | (orchestrator-emit)                                     | aggregate gate passed                                           | SHIPPED            |
@@ -187,10 +187,13 @@ When the `design-author` returns a draft:
    feedback. The new draft must increment `revision: <n+1>` in its
    frontmatter. Cap at `revision: 5`.
 
-### Human Gate (structure approval)
+### Structure (no gate — autonomous)
 
-Same mechanics as design, applied to `docs/plans/<id>/structure.md`.
-Use `AskUserQuestion` for the verdict the same way.
+When the `structure-planner` returns `docs/plans/<id>/structure.md`,
+record it and advance to PLAN immediately. There is no approval wait —
+**design is the only human gate**. Structure was formerly human-gated; it
+now auto-advances. The artifact carries no `approved`/`approved_at`/
+`revision` frontmatter.
 
 ### Orchestrator-Emit Gate (worktree preparation)
 
@@ -254,8 +257,8 @@ When the aggregate gate passes:
    mode, update each repo's `CHANGELOG.md` with the entries belonging
    to that repo's commits.
 2. **Open a draft PR automatically — do not stop to ask.** The PR phase
-   is not a human gate (the two human gates are design and structure
-   approval), so opening the PR needs no approval. Push the branch and
+   is not a human gate (the only human gate is design approval), so
+   opening the PR needs no approval. Push the branch and
    open the PR as a **draft** (`gh pr create --draft`). See
    `skills/team-pr/SKILL.md` for the canonical procedure.
 3. In multi-repo mode this opens **one draft PR per repo with commits
@@ -284,7 +287,7 @@ When the aggregate gate passes:
   session-scoped and is rebuilt on entry to any `/team-*` command by
   scanning artifacts.
 - `AskUserQuestion` is the canonical Claude Code tool for any
-  multi-choice user prompt **from the orchestrator** — design/structure
+  multi-choice user prompt **from the orchestrator** — design
   approval, worktree-vs-in-place. Free-text prompts
   ("Do you approve?") are not the convention. Free-form text input
   remains appropriate when the question genuinely has no enumerable
@@ -297,9 +300,9 @@ When the aggregate gate passes:
   above (step 5).** Subagents must not call `AskUserQuestion` directly.
 - File artifacts in `docs/plans/<id>/` are the durable communication
   protocol. Always write phase findings to disk before advancing.
-- The two human gates are **design approval** and **structure approval**.
-  Never present the plan to the user for approval — the plan is a
-  tactical agent artifact, the structure is the human contract.
+- The only human gate is **design approval**. Never present the structure
+  or the plan to the user for approval — design is the human contract; the
+  structure and plan are autonomous tactical artifacts.
 - The research-isolation invariant is non-negotiable. If a researcher's
   context contains the user's original description, the pipeline has a
   defect. Stop and report.

--- a/skills/team/registry.json
+++ b/skills/team/registry.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Agent inventory for the Team pipeline. Dispatch is driven by the phase table in skills/team/SKILL.md, not by this file. The phases array documents which artifacts each phase produces under docs/plans/. The agents array lists every specialist agent and the phase it serves. The gates array documents the gate kind that follows each phase. Kept in sync with agents/*.md frontmatter (each agent's `phase` field) by .claude/hooks/check-registry-sync.mjs.",
+  "$comment": "Agent inventory for the Team pipeline. Dispatch is driven by the phase table in skills/team/SKILL.md, not by this file. The phases array documents which artifacts each phase produces under docs/plans/. The agents array lists every specialist agent and the phase it serves. The gates array documents the gate kind that follows each phase that has one (DESIGN is the only human gate; STRUCTURE advances autonomously). Kept in sync with agents/*.md frontmatter (each agent's `phase` field) by .claude/hooks/check-registry-sync.mjs.",
   "phases": [
     {"name": "QUESTION", "artifacts": ["task.md", "questions.md"]},
     {"name": "RESEARCH", "artifacts": ["research.md"]},
@@ -27,7 +27,6 @@
   ],
   "gates": [
     {"after": "DESIGN", "type": "human", "field": "approved"},
-    {"after": "STRUCTURE", "type": "human", "field": "approved"},
     {"after": "PLAN", "type": "orchestrator-emit", "action": "prepare worktree"},
     {"after": "test-architect", "type": "mechanical", "condition": "all tests fail with assertion errors, not crashes"},
     {"after": "5 reviewers", "type": "aggregate", "hardGates": ["security-reviewer", "verifier", "code-reviewer"], "maxRetries": 5}

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -90,16 +90,15 @@ rationale). The router's responsibilities at this phase are:
 Worktree creation lands at phase 6 rather than phase 0 for two
 load-bearing reasons.
 
-First, the two human gates — DESIGN and STRUCTURE — are reviewed on
-the home tree where the user invoked `/team`. That is the same
-context any reviewer already has open; moving those gates inside a
-worktree would force a `cd` or `git worktree list` before reading
-the artifact in an editor.
+First, the DESIGN human gate is reviewed on the home tree where the
+user invoked `/team`. That is the same context any reviewer already
+has open; moving the gate inside a worktree would force a `cd` or
+`git worktree list` before reading the artifact in an editor.
 
 Second, branch scope is a Plan output, not a Setup-time guess. By
-the time WORKTREE runs the structure has been approved and the plan
-exists, so the branch name and (in multi-repo mode) the per-repo
-worktree set are derivable from artifacts rather than guessed.
+the time WORKTREE runs the structure and plan exist, so the branch
+name and (in multi-repo mode) the per-repo worktree set are derivable
+from artifacts rather than guessed.
 
 Together these make phase-6 placement a deliberate, articulable
 choice rather than inertia.

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -317,7 +317,7 @@ describe("product-thinking methodology", () => {
 
   test("structure-planner description frontmatter is unchanged", () => {
     const expected =
-      "description: Use after the design is approved to break the work into vertical slices with verification checkpoints. Each slice is end-to-end (touches every layer needed to deliver one piece of functionality), independently testable, and atomically committable. Produces a ~2-page document the human reviews before any code is written.";
+      "description: Use after the design is approved to break the work into vertical slices with verification checkpoints. Each slice is end-to-end (touches every layer needed to deliver one piece of functionality), independently testable, and atomically committable. Produces a ~2-page document that the planner and implementer consume; it advances autonomously to PLAN with no human gate.";
     expect(read(STRUCTURE_PLANNER)).toContain(expected);
   });
 


### PR DESCRIPTION
## What

Removes the **Structure** phase as a human approval gate. The QRSPI pipeline now has a **single human gate — Design approval**. After Structure, the pipeline advances to Plan autonomously, with no approval wait.

This was requested directly: *"the structure should not be a human gate."* The chosen interpretation was **auto-advance, keep the phase** (over "agent-reviewed approval" or "drop the phase entirely") — `structure-planner` still produces `structure.md`; only the human gate is removed.

## Changes

**Behavior / mechanism**
- `structure.md` drops the `approved`/`approved_at`/`revision` frontmatter — it's now a plain artifact like `research.md`/`plan.md`.
- `skills/team/SKILL.md`: phase table, gate-handling, and rules now name **design** as the only human gate; Structure records-and-advances.
- `skills/qrspi-workflow/SKILL.md`: STRUCTURE gate `HARD → NONE`, frontmatter schema, phase-inference table, and anti-patterns updated.
- `skills/team-structure/SKILL.md`: approval step removed; auto-advances to PLAN.
- `skills/team-plan/SKILL.md`: discovery no longer requires `approved: true` on `structure.md`.
- `skills/team/registry.json`: removed the `{"after": "STRUCTURE", "type": "human"}` gate entry.
- `agents/structure-planner.md`: plain frontmatter, no gate-recording language.
- **Runtime hooks** `session-start-recover.mjs` + `pre-compact-anchor.mjs`: infer `PLAN` once `structure.md` exists (previously read a now-absent `approved` field — would otherwise have reported STRUCTURE forever).
- `agents/planner.md`, `implementer.md`, `test-architect.md`: no longer describe an "approved structure".

**Docs**
- `README.md`, `AGENTS.md`/`CLAUDE.md`, `docs/architecture.md`, `docs/index.md`, `docs/skills.md`, `docs/vision.md`, `skills/worktree-isolation/SKILL.md`: "two human gates" → "one human gate (design)".
- `CHANGELOG.md`: entry under `## [Unreleased]`.

**Tests**
- `tests/methodology.test.ts`: updated the pinned `structure-planner` description string. No test asserted Structure-is-a-gate, so no other test changes were needed.

## Test plan

- [x] `bun test` — free suite green (317 pass / 0 fail)
- [x] `registry.json` validates as JSON
- [x] Repo sweep: no remaining "two human gates" / structure-approval references in current-truth files (CHANGELOG history and `docs/plans/*` point-in-time artifacts intentionally left unchanged)
- [ ] Manual: run `/team` through DESIGN → STRUCTURE and confirm the orchestrator advances to PLAN without prompting for structure approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)