### PR TITLE
docs: surface the testing guide in the top-level nav

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 ---
 title: Testing
 description: "Team's six-layer test harness for products where a model is part of the system — push every check to the cheapest, most deterministic layer; gate on deterministic checks, run stochastic evals on a schedule."
-audience: [developer]
+audience: [user, developer]
 nav_order: 8
 nav_label: testing
 ---


### PR DESCRIPTION
## Summary

Reclassify `docs/testing.md` from `audience: [developer]` to `[user, developer]`.

The testing guide isn't contributor-only material — it's a framework/vendor-agnostic methodology for testing any product with a non-deterministic (model-in-the-loop) component, and even includes an **"Adopting this in a new project"** section aimed at outside readers. The dual-audience tag is the site's encoding of a *shared, first-class* page (the same tag `architecture.md` and `index.md` carry).

## Effect on the nav

Per the layout (`_layouts/default.html`), the "contributing" dropdown excludes any page tagged `user` (`{%- unless p.audience contains 'user' -%}`), so this change:

- **adds** `testing` to the **top-level nav** (home · vision · ethos · architecture · skills · **testing**), and
- **removes** it from the "contributing" dropdown (now just versioning · project-tracking).

Verified against a rendered Jekyll build of the branch content.

## Changes

- `docs/testing.md` — frontmatter `audience` only. One line.

## How to Verify

- [ ] `bun test` passes — verified locally: 317 pass / 0 fail.
- [ ] Rendered nav: `testing` appears in the top-level nav, not the contributing dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)