### PR TITLE
fix(dev): correct stale team-plan approval-grep expectation in discovery check

### DIFF
--- a/.claude/scripts/check-discovery-consistency.sh
+++ b/.claude/scripts/check-discovery-consistency.sh
@@ -110,8 +110,7 @@ done
 
 # =============================================================================
 # VERBATIM-IDENTITY (slices 1-4): the load-bearing fragments are byte-identical
-# to canon in every copy. Approval grep present in team-structure + team-plan
-# ONLY.
+# to canon in every copy. Approval grep present in team-structure ONLY.
 # =============================================================================
 i=0
 while [ "$i" -lt "${#A_SKILLS[@]}" ]; do
@@ -129,13 +128,13 @@ while [ "$i" -lt "${#A_SKILLS[@]}" ]; do
   i=$((i + 1))
 done
 
-# Approval grep: present verbatim in team-structure + team-plan, absent elsewhere.
-for skill in team-structure team-plan; do
+# Approval grep: present verbatim in team-structure only, absent elsewhere.
+for skill in team-structure; do
   file="$SKILLS/$skill/SKILL.md"
   [ -f "$file" ] && grep -qF "$CANON_APPROVAL_GREP" "$file" \
     || fail "$skill approval grep" "verbatim approval grep in predecessor filter" "approval grep absent"
 done
-for skill in team-research team-design team-worktree team-implement team-pr eng-design-doc-review; do
+for skill in team-research team-design team-plan team-worktree team-implement team-pr eng-design-doc-review; do
   file="$SKILLS/$skill/SKILL.md"
   if [ -f "$file" ] && grep -qF "$CANON_APPROVAL_GREP" "$file"; then
     fail "$skill approval grep" "no approval grep (non-gated skill)" "approval grep unexpectedly present"


### PR DESCRIPTION
## Summary

`.claude/scripts/check-discovery-consistency.sh` fails on `main` with `FAIL [team-plan approval grep] — approval grep absent`. This is a **pre-existing** failure (reproduces on clean `main`), surfaced while shipping the worktree-first change.

## Root cause

The script asserts an "approval grep" (`grep -qE '^approved:[[:space:]]*true...'` on the predecessor artifact) must appear in a skill's three-tier discovery block. That grep is only correct for skills whose **predecessor artifact is approval-gated** — and the *only* human-gated artifact is `design.md` (design approval is the sole human gate; STRUCTURE auto-advances and `structure.md` carries no approval frontmatter).

- `team-structure` consumes the gated `design.md` → correctly **has** the approval grep.
- `team-plan` consumes `structure.md` (**not** gated) → correctly has **no** approval grep.

The script's expectation that `team-plan` carries an approval grep is **stale** — left over from when STRUCTURE was human-gated. The skill is correct; the check was wrong.

## Fix

Move `team-plan` from the must-HAVE-approval-grep list to the must-NOT-have list in the script (the only file changed). `team-structure` remains actively asserted — the check is not deleted or weakened. No skill files touched, so discovery-block byte-identity across the 8 archetype-A skills is fully intact.

## Test plan

- [x] `bash .claude/scripts/check-discovery-consistency.sh` → `All discovery-consistency assertions passed.` (exit 0); previously the single `team-plan approval grep` assertion failed.
- [x] `team-structure` approval-grep assertion still present and passing (not weakened).
- [x] `bun test` — 326 pass / 0 fail.
- [x] `git diff --name-only main..HEAD` → only `.claude/scripts/check-discovery-consistency.sh` (4 insertions, 5 deletions); zero `skills/` files.
- [x] Diagnosed and adversarially verified by independent agents (correct direction, minimal, no regression).

Draft; no version bump (versioning happens at land time per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)