### PR TITLE
v0.11.1 docs: correct stale rebase-merge references to squash-merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-19
+
+### Fixed
+
+- **Corrected two stale "rebase-merge" references left over from the v0.11.0 squash-merge change.** The `/team-pr` skill description still told readers to use `/shipit` to "wait for CI, then rebase-merge," and the `tests/shipit-skill.test.ts` header comment still described shipit as rebase-merging — both now say squash-merge, matching shipit's actual behavior since v0.11.0. Documentation/comment text only; no behavior changed.
+
 ## [0.11.0] - 2026-06-18
 
 ### Changed
@@ -145,7 +151,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/bostonaholic/team/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/bostonaholic/team/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/bostonaholic/team/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/bostonaholic/team/compare/v0.9.0...v0.9.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-pr
-description: Open the pull request after verification passes. Updates the changelog, optionally surfaces the tracking ticket, and closes out the topic. Trigger on "open the PR", "open a draft PR", or "/team-pr". To land/merge a reviewed PR (wait for CI, then rebase-merge) use the separate /shipit skill — "ship it", "land the PR", and "land this" trigger /shipit, not this skill.
+description: Open the pull request after verification passes. Updates the changelog, optionally surfaces the tracking ticket, and closes out the topic. Trigger on "open the PR", "open a draft PR", or "/team-pr". To land/merge a reviewed PR (wait for CI, then squash-merge) use the separate /shipit skill — "ship it", "land the PR", and "land this" trigger /shipit, not this skill.
 effort: medium
 argument-hint: "[docs/plans/<id>/]"
 ---

--- a/tests/shipit-skill.test.ts
+++ b/tests/shipit-skill.test.ts
@@ -5,7 +5,8 @@
 // distributed to Team's users (docs/plans/2026-06-15-version-at-land-time).
 // It knows NOTHING about Team's versioning: it discovers the open PR, pushes
 // unpushed commits, waits for CI, handles PR-behind-base and branch-protection,
-// and rebase-merges. Team's own version-bump mechanics are fenced separately by
+// and squash-merges so the PR title lands as the commit subject. Team's own
+// version-bump mechanics are fenced separately by
 // tests/version-bump-skill.test.ts (the dev skill).
 //
 // Every assertion is guarded so a not-yet-existing skill file yields a failed


### PR DESCRIPTION
## What

Follow-up to #106 (the squash-merge change). A full-tree `git grep rebase` sweep surfaced two stale references to shipit's old rebase-merge strategy that survived v0.11.0:

- `tests/shipit-skill.test.ts` — header comment still said shipit "rebase-merges"
- `skills/team-pr/SKILL.md` — the `/team-pr` skill **description** still pointed at `/shipit` as "wait for CI, then rebase-merge"

Both corrected to **squash-merge**. Comment/description text only — no assertion or behavior changed.

## Sweep result (the rest is intentionally left alone)

Every other `rebase` hit is legitimate and was **not** touched:

- `git pull --rebase origin <base>` — local default-branch sync after merge (keeps history linear)
- shipit's **rebase-if-behind-base** logic + `--force-with-lease` (step 5) — still correct
- `rebaseMergeAllowed` in shipit's `gh repo view --json` read-list — we read all three strategies, gate on squash
- **historical** `CHANGELOG.md` entries describing what shipit did at 0.6.0 — immutable history, correctly says rebase-merge for that era
- `CONTRIBUTING.md` "never create merge commits (rebase, don't merge)" — general linear-history rule; squash isn't a merge commit
- `dependabot.yml` rebase-dependabots reference — unrelated

## Test plan

- [x] `bun test` — full free suite green (368 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)