### PR TITLE
v0.12.0 feat: remove local planning docs during worktree teardown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.11.1"
+    "version": "0.12.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-23
+
 ### Changed
 
 - **Worktree teardown now deletes the feature's local planning docs (`docs/plans/<id>/`) as part of cleanup, alongside removing the branch and worktree.** The QRSPI planning artifacts (`questions`/`research`/`design`/`structure`/`plan`/`task.md`) are untracked scratch that exist only to drive a topic to a merged PR; previously teardown removed the branch and worktree but left the planning dir behind, cluttering `docs/plans/` and blurring which topics were still in flight. The teardown procedure now ends with `rm -rf docs/plans/<id>`, guarded to verify the directory is untracked first and to remove only that feature's `<id>` directory (never sibling dirs for other in-flight work). Documented as the procedure of record in [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md), with policy pointers in [`skills/team-pr/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md) and [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md).
@@ -155,7 +157,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/bostonaholic/team/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/bostonaholic/team/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/bostonaholic/team/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/bostonaholic/team/compare/v0.9.1...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Worktree teardown now deletes the feature's local planning docs (`docs/plans/<id>/`) as part of cleanup, alongside removing the branch and worktree.** The QRSPI planning artifacts (`questions`/`research`/`design`/`structure`/`plan`/`task.md`) are untracked scratch that exist only to drive a topic to a merged PR; previously teardown removed the branch and worktree but left the planning dir behind, cluttering `docs/plans/` and blurring which topics were still in flight. The teardown procedure now ends with `rm -rf docs/plans/<id>`, guarded to verify the directory is untracked first and to remove only that feature's `<id>` directory (never sibling dirs for other in-flight work). Documented as the procedure of record in [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md), with policy pointers in [`skills/team-pr/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md) and [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md).
+
 ## [0.11.1] - 2026-06-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -133,7 +133,10 @@ done
    After removing the worktree, bring the repo's local default branch up
    to date with the merge: `git -C <repo-root> pull --rebase origin
    <base>` (rebase, never a merge commit — the project keeps linear
-   history). Do this for every involved repo in multi-repo mode.
+   history). Do this for every involved repo in multi-repo mode. Finally,
+   delete the feature's local planning docs (`rm -rf docs/plans/<id>`,
+   verified untracked) as part of the same teardown — see
+   `worktree-isolation`.
 
 ## PR Body Template
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -338,7 +338,10 @@ When the aggregate gate passes:
    worktree. After removal, update the repo's local default branch with
    the merge: `git -C <repo-root> pull --rebase origin <base>` (rebase,
    never a merge commit — linear history is the rule). In multi-repo
-   mode, do this for every involved repo.
+   mode, do this for every involved repo. As the last teardown step,
+   delete the feature's local planning docs (`rm -rf docs/plans/<id>`,
+   verified untracked) — the QRSPI scratch dir is removed alongside the
+   branch and worktree, not left behind.
 
 ## Rules
 

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -143,6 +143,13 @@ When teardown is warranted (post-merge or on explicit request):
 4. After the worktree is gone, update the repo's local default branch
    with the merge: `git -C <repo-path> pull --rebase origin <base>`.
    Always rebase — never a merge commit — so history stays linear.
+5. Remove the feature's local planning docs: `rm -rf docs/plans/<id>`.
+   These are untracked QRSPI scratch that only existed to drive the work
+   to a merged PR; deleting them is part of teardown, alongside the
+   branch and worktree. Verify the directory is untracked first
+   (`git ls-files docs/plans/<id>` returns nothing) and remove only that
+   feature's `<id>` directory — never sibling dirs for other in-flight
+   work.
 
 ## Gitignored Files
 


### PR DESCRIPTION
## Summary

- Worktree teardown now deletes the feature's local planning docs (`docs/plans/<id>/`) as part of cleanup, alongside removing the branch and worktree.
- Previously teardown removed the branch and worktree but left the untracked QRSPI scratch dir behind, cluttering `docs/plans/` and obscuring which topics were still in flight.

## Changes

- `skills/worktree-isolation/SKILL.md` — procedure of record: adds `rm -rf docs/plans/<id>` as the final teardown step, guarded to verify the dir is untracked first and to remove only that feature's `<id>` directory (never siblings for other in-flight work).
- `skills/team-pr/SKILL.md` and `skills/team/SKILL.md` — policy pointers: the post-merge cleanup now references the planning-docs removal so it isn't left behind.
- `CHANGELOG.md` — `[Unreleased]` entry under Changed.

## How to verify

- `bun test` (CI runs it). The additive teardown step preserves existing tripwires (`architecture.test.ts` / `protocol.test.ts` still find "Why first", multi-repo topology, and reuse docs); the new `[Unreleased]` links are absolute URLs per `changelog-links.test.ts`.
