### PR TITLE
fix(evals): gate PR-evals jobs and declare environment: evals (#111)

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -27,7 +27,8 @@ jobs:
     name: Diff-selected evals (${{ matrix.suite.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (!startsWith(github.event_name, 'pull_request') || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+    environment: evals
     permissions:
       contents: read
     strategy:
@@ -81,7 +82,7 @@ jobs:
   report:
     name: Post results comment
     needs: run-evals
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (!startsWith(github.event_name, 'pull_request') || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -9,9 +9,17 @@
 # ADVISORY: includes stochastic periodic evals, so this is intentionally NOT a
 # required merge check (TESTING.md: stochastic checks must not gate merges).
 #
-# SECURITY: same-repo PRs only. Fork PRs lack the EVALS_ANTHROPIC_API_KEY secret
-# and a write token, so both jobs are guarded on head.repo (mirrors
-# pr-title-sync.yml). No pull_request_target — avoids the secret-exfil surface.
+# SECURITY: same-repo PRs only, AND trusted authors only. Fork PRs lack the
+# EVALS_ANTHROPIC_API_KEY secret and a write token, so both jobs are guarded on
+# head.repo (mirrors pr-title-sync.yml). Both jobs additionally gate on an
+# author-association allowlist (OWNER/MEMBER/COLLABORATOR — the verbatim
+# TRUST_EXPR), so untrusted same-repo authors (CONTRIBUTOR/FIRST_TIME_CONTRIBUTOR/
+# NONE) are skipped and never spend the key. run-evals declares
+# `environment: evals` so the env-scoped EVALS_ANTHROPIC_API_KEY is reachable on
+# trusted same-repo PRs — this requires the `evals` environment's main-only
+# deployment-branch policy to be removed (out-of-band maintainer step); without
+# that, gated PRs fail at the deploy gate. No pull_request_target — avoids the
+# secret-exfil surface.
 name: PR evals
 
 on:

--- a/.github/workflows/harness-checks.yml
+++ b/.github/workflows/harness-checks.yml
@@ -5,7 +5,7 @@
 # fixture and rubric on disk. No model calls, no EVALS_ANTHROPIC_API_KEY,
 # completes in well under 5 seconds.
 #
-# Live agent runs against the model live in behavioral-evals.yml.
+# Live agent runs against the model live in periodic-evals.yml.
 name: Harness checks
 
 on:
@@ -32,7 +32,7 @@ jobs:
     #   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     # When PR #32's "Run gate-tier evals" step attaches paid execution here,
     # it inherits this gate so untrusted PR authors never spend tokens.
-    # Canonical in-use example: behavioral-evals.yml wires exactly this
+    # Canonical in-use example: periodic-evals.yml wires exactly this
     # allowlist into a live job-level `if:` (wrapped event-aware with
     # startsWith(github.event_name, 'pull_request')) — copy that form when
     # adding the paid step here.

--- a/.github/workflows/periodic-evals.yml
+++ b/.github/workflows/periodic-evals.yml
@@ -1,4 +1,4 @@
-# Behavioral evals — weekly live-agent regression check.
+# Periodic evals — weekly live-agent regression check.
 #
 # This is the actual eval tier: spawns `claude -p` against fixtures under
 # evals/fixtures/<agent>/<case>/, then runs the LLM-judge over the agent's
@@ -9,7 +9,7 @@
 # workflow_dispatch.
 #
 # Runs Monday 06:00 UTC. Offline harness checks live in harness-checks.yml.
-name: Behavioral evals
+name: Periodic evals
 
 # Hard ban (issue #51, design Decision 5): token/secret-consuming jobs
 # MUST NOT trigger on pull_request_target. That event runs in base-repo
@@ -22,11 +22,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: behavioral-evals
+  group: periodic-evals
   cancel-in-progress: true
 
 jobs:
-  behavioral-evals:
+  periodic-evals:
     name: Live agent runs (${{ matrix.suite.name }})
     # Author gate (issue #51): only OWNER/MEMBER/COLLABORATOR may spend tokens
     # via a pull_request. Event-aware so schedule/workflow_dispatch (no PR
@@ -110,6 +110,6 @@ jobs:
           # any shell, so it cannot read a `$VAR` — env indirection is not
           # possible here. Safe regardless: matrix.suite.name is a
           # repo-controlled YAML literal, and GitHub sanitizes artifact names.
-          name: behavioral-evals-${{ matrix.suite.name }}-${{ github.run_id }}
+          name: periodic-evals-${{ matrix.suite.name }}-${{ github.run_id }}
           path: evals/results/
           retention-days: 90

--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -4,7 +4,7 @@
 # pass/fail and cost. Selection (which evals run)
 # is decided by the harness from `git diff <base>...HEAD` against each eval's
 # touchfiles (tests/helpers/touchfiles.ts) — cost scales with the diff, NOT the
-# whole suite. The weekly full periodic run stays in behavioral-evals.yml.
+# whole suite. The weekly full periodic run stays in periodic-evals.yml.
 #
 # ADVISORY: includes stochastic periodic evals, so this is intentionally NOT a
 # required merge check (TESTING.md: stochastic checks must not gate merges).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -514,12 +514,12 @@ env-var knobs, and the rerun-on-base blame protocol.
 
 **CI wiring.** Two GitHub Actions workflows in `.github/workflows/`:
 `harness-checks.yml` runs the offline harness validation on every PR
-(no secrets, ~5s); `behavioral-evals.yml` runs the live-agent regression
+(no secrets, ~5s); `periodic-evals.yml` runs the live-agent regression
 check on a weekly cron (Monday 06:00 UTC) with `EVALS_ANTHROPIC_API_KEY`.
 That key is an **environment secret** scoped to the `evals` GitHub
 Environment — a one-time Settings → Environments setup (create the `evals`
 environment, attach the secret, optionally set required reviewers / a
-main-only branch restriction). If the PR-eval workflow (`evals.yml`) is
+main-only branch restriction). If the PR-eval workflow (`pr-evals.yml`) is
 active, the `evals` environment must **not** restrict deployment branches to
 `main` — PR head/merge refs are not `main`, so a main-only policy blocks the
 secret on PRs and every gated eval fails at the deploy gate. Remove it via

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -519,7 +519,13 @@ check on a weekly cron (Monday 06:00 UTC) with `EVALS_ANTHROPIC_API_KEY`.
 That key is an **environment secret** scoped to the `evals` GitHub
 Environment — a one-time Settings → Environments setup (create the `evals`
 environment, attach the secret, optionally set required reviewers / a
-main-only branch restriction). The job declares `environment: evals` and
+main-only branch restriction). If the PR-eval workflow (`evals.yml`) is
+active, the `evals` environment must **not** restrict deployment branches to
+`main` — PR head/merge refs are not `main`, so a main-only policy blocks the
+secret on PRs and every gated eval fails at the deploy gate. Remove it via
+Settings → Environments → evals → Deployment branches → "No restriction", or
+`gh api -X DELETE repos/bostonaholic/team/environments/evals/deployment-branch-policies/<id>`.
+The job declares `environment: evals` and
 **fails closed** if the environment is absent: the secret simply resolves
 to empty, so no token spend leaks. `pull_request_target` is hard-banned for
 this and any secret-consuming / `claude`-spawning job — it runs in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -251,7 +251,7 @@ Token-consuming CI jobs are additionally restricted to trusted PR authors
 (OWNER/MEMBER/COLLABORATOR); untrusted PRs (forks, Dependabot, first-time
 contributors) skip them — a security control against token-spend griefing,
 not just a cost optimization. This is forward-proofing: the
-`behavioral-evals.yml` gate is dormant until a `pull_request` trigger is added,
+`periodic-evals.yml` gate is dormant until a `pull_request` trigger is added,
 while `harness-checks.yml` carries the trust expression as a documented-only
 contract for the same reason — so the control is already in place the moment a
 paid step attaches.

--- a/evals/README.md
+++ b/evals/README.md
@@ -255,4 +255,9 @@ contains(...)`). The contract comment on the `harness-checks` job in
 `.github/workflows/harness-checks.yml` carries the same expression for
 reference, but the live `if:` is the canonical form to copy.
 
+Both `behavioral-evals.yml` and `evals.yml` now carry live copies of this
+canonical trust `if:` expression. They must stay byte-identical, and the
+`TRUST_EXPR` tripwire in `tests/static-gate.test.ts` enforces that — any drift
+fails the free gate.
+
 Run `bun run eval:list` to see the registered tests and their tiers.

--- a/evals/README.md
+++ b/evals/README.md
@@ -191,7 +191,7 @@ Manually: `bun run eval:compare evals/results/<a>.json evals/results/<b>.json`
 
 Two workflows run the evals:
 
-- **`.github/workflows/evals.yml`** runs on every pull request. It runs the
+- **`.github/workflows/pr-evals.yml`** runs on every pull request. It runs the
   evals the diff selects (`git diff <base>...HEAD` against each eval's
   touchfiles — no `EVALS_ALL`/`EVALS_TIER`, so cost scales with the change) and
   upserts one `## PR Evals` comment on the PR with a per-suite pass/fail table
@@ -201,7 +201,7 @@ Two workflows run the evals:
   [TESTING.md](../TESTING.md)) — and runs on **same-repo PRs only** (fork PRs
   lack the `EVALS_ANTHROPIC_API_KEY` secret and a write token). When the diff
   selects nothing, the comment says so.
-- **`.github/workflows/behavioral-evals.yml`** runs the full periodic tier
+- **`.github/workflows/periodic-evals.yml`** runs the full periodic tier
   weekly (Monday 06:00 UTC) and on manual dispatch, uploading results as
   artifacts.
 
@@ -248,14 +248,14 @@ field throughout.
 Any **new CI step** that consumes `EVALS_ANTHROPIC_API_KEY` or spawns
 `claude` on a `pull_request` event MUST carry the canonical trust `if:` so
 untrusted authors never spend tokens. Copy the expression from the live
-job-level `if:` on the `behavioral-evals` job in
-`.github/workflows/behavioral-evals.yml` — that is the authoritative,
+job-level `if:` on the `periodic-evals` job in
+`.github/workflows/periodic-evals.yml` — that is the authoritative,
 event-aware copy source (`!startsWith(github.event_name, 'pull_request') ||
 contains(...)`). The contract comment on the `harness-checks` job in
 `.github/workflows/harness-checks.yml` carries the same expression for
 reference, but the live `if:` is the canonical form to copy.
 
-Both `behavioral-evals.yml` and `evals.yml` now carry live copies of this
+Both `periodic-evals.yml` and `pr-evals.yml` now carry live copies of this
 canonical trust `if:` expression. They must stay byte-identical, and the
 `TRUST_EXPR` tripwire in `tests/static-gate.test.ts` enforces that — any drift
 fails the free gate.

--- a/scripts/eval-report.ts
+++ b/scripts/eval-report.ts
@@ -4,7 +4,7 @@
 // CLI: `bun run scripts/eval-report.ts <results-dir>`
 // Formats one or more eval result JSONs (the schema written by
 // tests/helpers/eval-store.ts) into a Markdown body for a PR comment, then
-// prints it to stdout. Used by .github/workflows/evals.yml, which upserts the
+// prints it to stdout. Used by .github/workflows/pr-evals.yml, which upserts the
 // body as a single `## PR Evals` comment on the PR.
 //
 // The body builder is a pure function (buildReportBody) so it is unit-tested
@@ -19,7 +19,7 @@ import type { EvalResult, EvalTestEntry } from "../tests/helpers/eval-store";
 
 // The marker prefix the workflow greps for when deciding whether to update an
 // existing comment or create a new one. MUST stay stable and in sync with the
-// upsert logic in .github/workflows/evals.yml (locked by a tripwire test).
+// upsert logic in .github/workflows/pr-evals.yml (locked by a tripwire test).
 export const REPORT_MARKER = "## PR Evals";
 
 function fmtCost(usd: number): string {

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -337,6 +337,12 @@ describe("static gate: PR evals workflow", () => {
     expect(workflow).toContain(TRUST_EXPR);
   });
 
+  test("trust expression gates BOTH jobs (run-evals and report)", () => {
+    // Both the run-evals and report jobs must carry the author gate; if only
+    // one does, an untrusted same-repo author could still trigger the other.
+    expect(workflow.split(TRUST_EXPR).length - 1).toBe(2);
+  });
+
   test("author gate wired as a live if:", () => {
     // The author allowlist must be a live `if:` condition, not a comment, so
     // an untrusted same-repo author cannot spend the production key.

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -15,11 +15,11 @@ const FIXTURE_ROOT = join(process.cwd(), "evals", "fixtures");
 const RUBRIC_ROOT = join(process.cwd(), "evals", "rubrics");
 const TESTS_ROOT = join(process.cwd(), "tests");
 const PACKAGE_JSON = join(process.cwd(), "package.json");
-const EVALS_WORKFLOW = join(
+const PERIODIC_EVALS_WORKFLOW = join(
   process.cwd(),
   ".github",
   "workflows",
-  "behavioral-evals.yml",
+  "periodic-evals.yml",
 );
 const HARNESS_WORKFLOW = join(
   process.cwd(),
@@ -31,7 +31,7 @@ const PR_EVALS_WORKFLOW = join(
   process.cwd(),
   ".github",
   "workflows",
-  "evals.yml",
+  "pr-evals.yml",
 );
 const FIXTURE_SIZE_CAP = 50 * 1024;
 
@@ -98,18 +98,18 @@ describe("static gate: fixtures", () => {
   });
 });
 
-// The behavioral-evals workflow spawns the `claude` CLI live
+// The periodic-evals workflow spawns the `claude` CLI live
 // (tests/helpers/session-runner.ts). A scheduled run is the only place this
 // fires, so a missing CLI install or missing agent credentials surfaces only
 // once a week, in CI, with no PR signal. These guards keep that contract
 // visible in the free gate that runs on every PR.
-describe("static gate: behavioral-evals workflow", () => {
-  const workflow = existsSync(EVALS_WORKFLOW)
-    ? readFileSync(EVALS_WORKFLOW, "utf8")
+describe("static gate: periodic-evals workflow", () => {
+  const workflow = existsSync(PERIODIC_EVALS_WORKFLOW)
+    ? readFileSync(PERIODIC_EVALS_WORKFLOW, "utf8")
     : "";
 
   test("workflow file exists", () => {
-    expect(existsSync(EVALS_WORKFLOW)).toBe(true);
+    expect(existsSync(PERIODIC_EVALS_WORKFLOW)).toBe(true);
   });
 
   test("installs the Claude Code CLI before spawning the agent", () => {
@@ -164,8 +164,8 @@ describe("static gate: author gate", () => {
   const harnessWorkflow = existsSync(HARNESS_WORKFLOW)
     ? readFileSync(HARNESS_WORKFLOW, "utf8")
     : "";
-  const evalsWorkflow = existsSync(EVALS_WORKFLOW)
-    ? readFileSync(EVALS_WORKFLOW, "utf8")
+  const evalsWorkflow = existsSync(PERIODIC_EVALS_WORKFLOW)
+    ? readFileSync(PERIODIC_EVALS_WORKFLOW, "utf8")
     : "";
 
   test("trust expression documented as the contract at the future paid seam in harness-checks.yml", () => {
@@ -205,8 +205,8 @@ describe("static gate: author gate", () => {
     expect(evalsAllowlist).not.toContain("NONE");
   });
 
-  test("canonical trust expression present in behavioral-evals.yml", () => {
-    // behavioral-evals.yml is the only workflow that consumes
+  test("canonical trust expression present in periodic-evals.yml", () => {
+    // periodic-evals.yml is the only workflow that consumes
     // EVALS_ANTHROPIC_API_KEY today; the canonical trust expression must
     // appear verbatim so the gate reads identically across token jobs.
     // Asserts on substring presence, not job/matrix shape, so it tolerates
@@ -214,8 +214,8 @@ describe("static gate: author gate", () => {
     expect(evalsWorkflow).toContain(TRUST_EXPR);
   });
 
-  test("trust expression wired as a live `if:` on behavioral-evals.yml's token job", () => {
-    // Unlike harness-checks.yml's documented-only contract, behavioral-evals'
+  test("trust expression wired as a live `if:` on periodic-evals.yml's token job", () => {
+    // Unlike harness-checks.yml's documented-only contract, periodic-evals'
     // secret-consuming job carries the trust expression as a live `if:`
     // condition (not just a comment), so a future pull_request trigger cannot
     // spend tokens for untrusted authors.
@@ -231,8 +231,8 @@ describe("static gate: evals environment backstop", () => {
   const harnessWorkflow = existsSync(HARNESS_WORKFLOW)
     ? readFileSync(HARNESS_WORKFLOW, "utf8")
     : "";
-  const evalsWorkflow = existsSync(EVALS_WORKFLOW)
-    ? readFileSync(EVALS_WORKFLOW, "utf8")
+  const evalsWorkflow = existsSync(PERIODIC_EVALS_WORKFLOW)
+    ? readFileSync(PERIODIC_EVALS_WORKFLOW, "utf8")
     : "";
 
   test("evals environment declared on the token job", () => {
@@ -260,8 +260,8 @@ describe("static gate: evals environment backstop", () => {
     expect(/^\s*pull_request_target:/m.test(harnessWorkflow)).toBe(false);
   });
 
-  test("behavioral-evals stays off pull_request triggers until the gate is deliberately activated", () => {
-    // The author gate's `if:` is dormant today: behavioral-evals.yml triggers
+  test("periodic-evals stays off pull_request triggers until the gate is deliberately activated", () => {
+    // The author gate's `if:` is dormant today: periodic-evals.yml triggers
     // only on schedule + workflow_dispatch, so no untrusted author can reach
     // the token job. Adding a live `pull_request:` trigger would activate that
     // gate — and its sufficiency (does the allowlist cover every author state
@@ -273,7 +273,7 @@ describe("static gate: evals environment backstop", () => {
   });
 });
 
-// The PR evals workflow (evals.yml) runs diff-selected evals on pull requests
+// The PR evals workflow (pr-evals.yml) runs diff-selected evals on pull requests
 // and upserts a `## PR Evals` comment. These guards lock the contracts that, if
 // broken, would silently stop evals running or stop the comment posting — and
 // would otherwise only surface live in CI on a real PR.

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -323,6 +323,31 @@ describe("static gate: PR evals workflow", () => {
     expect(workflow).toContain('startswith("## PR Evals")');
     expect(reportScript).toContain('"## PR Evals"');
   });
+
+  test("declares environment: evals on the secret-consuming job", () => {
+    // Without `environment: evals` the env-scoped EVALS_ANTHROPIC_API_KEY
+    // resolves empty and the harness fails loud — every diff-selected PR eval
+    // goes red with a credential error instead of a real signal.
+    expect(/^\s*environment:\s*evals\s*$/m.test(workflow)).toBe(true);
+  });
+
+  test("carries the verbatim trust expression", () => {
+    // The author-gate must use the canonical TRUST_EXPR byte-for-byte; a
+    // one-byte drift breaks the cross-workflow contract the gate relies on.
+    expect(workflow).toContain(TRUST_EXPR);
+  });
+
+  test("author gate wired as a live if:", () => {
+    // The author allowlist must be a live `if:` condition, not a comment, so
+    // an untrusted same-repo author cannot spend the production key.
+    expect(/^\s*if:.*author_association/m.test(workflow)).toBe(true);
+  });
+
+  test("retains the same-repo head.repo guard", () => {
+    // The fork exclusion must survive the author-gate edit: forks fail this
+    // guard and never reach the secret.
+    expect(workflow).toContain("head.repo.full_name == github.repository");
+  });
 });
 
 describe("static gate: rubrics", () => {


### PR DESCRIPTION
## What & why

Fixes #111. The diff-selected PR-evals workflow could not obtain `EVALS_ANTHROPIC_API_KEY`, so any PR that diff-selected a paid eval went red with `EVALS_ANTHROPIC_API_KEY is empty; refusing live spawn`. Root cause: the `run-evals` job referenced the secret but did **not** declare `environment: evals`, so it resolved empty; and the `evals` environment's `main`-only deployment-branch policy blocks `pull_request` deploy refs (`refs/pull/N/merge`) even once the environment is declared.

**Chosen resolution (Option 2 — make PR evals actually run):** let diff-selected evals run live on **same-repo, trusted-author** pull requests, hardened with the same author-association allowlist the periodic workflow already uses, without weakening protection on the production key beyond what's intended. Fork PRs and untrusted same-repo authors are excluded.

This PR also **renames the two eval workflows** (a follow-up cleanup): both run *behavioral* evals, so naming one "Behavioral evals" was misleading — the real axis is trigger/scope.

| Before | After | Runs |
|--------|-------|------|
| `evals.yml` ("PR evals") | `pr-evals.yml` ("PR evals") | diff-selected, per-PR |
| `behavioral-evals.yml` ("Behavioral evals") | `periodic-evals.yml` ("Periodic evals") | full suite, weekly cron |

"Periodic" matches the repo's own `EVALS_TIER=periodic` vocabulary (and was the file's original name). The "Behavioral Evals" term for the harness *category* (AGENTS.md §, README title, architecture §8) is intentionally kept.

## Changes

- **`.github/workflows/pr-evals.yml`** (was `evals.yml`)
  - `run-evals` now declares `environment: evals` so the env-scoped key is reachable.
  - Both `run-evals` and `report` gate on the existing same-repo `head.repo` guard **AND** the verbatim `OWNER/MEMBER/COLLABORATOR` author-association allowlist (`TRUST_EXPR`), so `CONTRIBUTOR/FIRST_TIME_CONTRIBUTOR/NONE` are skipped and never spend the key.
  - Refreshed the SECURITY header comment to describe the new two-part guard + env requirement.
- **`.github/workflows/periodic-evals.yml`** (was `behavioral-evals.yml`) — renamed only (display name, job id, concurrency group, artifact prefix); behavior unchanged.
- **`tests/static-gate.test.ts`** — 5 new free-gate tripwires pinning the contract (`environment: evals` present, verbatim `TRUST_EXPR`, the gate is on **both** jobs, the author-gate is a live `if:`, the same-repo fork guard is retained); plus const/reference updates for the rename.
- **Docs** (`docs/architecture.md` §8, `docs/testing.md`, `evals/README.md`, `scripts/eval-report.ts`, `harness-checks.yml`) — document that an active `pr-evals.yml` requires the `evals` environment to **not** restrict deployment branches to `main`, note the two byte-identical live copies of the trust `if:`, and update filename references for the rename.

Diff selection is unchanged: PRs run only diff-impacted evals; the weekly `periodic-evals.yml` run (`EVALS_ALL=1`) still runs the full suite. This check stays **advisory** (not a required merge gate).

## ⚠️ Required manual step before this works (maintainer, out-of-band)

CI YAML cannot reconfigure a GitHub environment. Before/with merge, **remove the `main`-only deployment-branch policy on the `evals` environment** (the environment name is unchanged by the rename), or every gated PR will fail at the deploy gate (`Branch "refs/pull/N/merge" is not allowed to deploy to evals`):

```
gh api -X DELETE repos/bostonaholic/team/environments/evals/deployment-branch-policies/52386523
```

(Equivalent UI: Settings → Environments → evals → Deployment branches → "No restriction".)

## Security posture

- **Fork threat stays closed:** fork PRs fail the same-repo guard, never receive the secret on `pull_request`, and there is no `pull_request_target`. Verified by a fresh-context security review (0 findings) + an adversarial skeptic pass that failed to refute the gate.
- With the branch policy removed, all production-key protection rests on the two job-level `if:` guards (same-repo + author allowlist), both pinned by tripwires.
- **Residual, accepted risk:** a trusted collaborator can spend the key by opening a PR that diff-selects an expensive eval. **Recommended follow-up (not in this PR):** provision a budgeted/spend-capped credential to bound the blast radius.

## Test plan

- [x] `bun test` (free static gate) — 566 pass / 0 fail
- [x] New tripwires fail before the YAML change, pass after (test-first)
- [x] `yq eval` parses both `pr-evals.yml` and `periodic-evals.yml`
- [x] Fresh-context security + code + verifier + docs + ux review (security PASS, code APPROVE, verifier PASS; docs/ux gaps addressed)
- [x] Workflow rename: no dangling `behavioral-evals.yml` / `evals.yml` references; git detected both as renames (history preserved)
- [x] **Maintainer:** run the `gh api -X DELETE …deployment-branch-policies/52386523` step above
- [ ] After merge + the manual step: open a same-repo PR touching an eval-covered file and confirm `run-evals` reaches the key and posts the `## PR Evals` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
