### PR TITLE
v0.13.2 fix: route SOFT gate to code-review severity tiers (#68)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.13.1"
+    "version": "0.13.2"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-06-24
+
+### Fixed
+
+- **The QRSPI workflow's SOFT-gate guidance no longer contradicts the review severity model.** [`skills/qrspi-workflow/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/qrspi-workflow/SKILL.md) listed *code review suggestions* and *UX review feedback* as canonical SOFT-gate examples, but the severity model in [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) → "Severity Tiers and the Auto-Fix Boundary" classifies `code-reviewer` REQUEST CHANGES as **Blocking** and `ux-reviewer` REQUEST CHANGES as **Major** — both auto-fixed in the loop and never surfaced to the user. An agent loading both skills saw contradictory guidance, and the consult guard calls a prompt listing a Blocking/Major finding "a defect." The stale example list is removed and the SOFT section now cross-references the severity-tier table as the single source of truth, so future reclassifications touch only one file. Pinned by L2 tripwires in [`tests/protocol.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/protocol.test.ts), including a drift guard that fails the build if the cross-referenced heading is renamed in `code-review/SKILL.md`.
+
 ## [0.13.1] - 2026-06-24
 
 ### Fixed
@@ -169,7 +175,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/bostonaholic/team/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/bostonaholic/team/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/bostonaholic/team/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/bostonaholic/team/compare/v0.11.1...v0.12.0

--- a/docs/plans/68-qrspi-soft-gate-severity-tiers/task.md
+++ b/docs/plans/68-qrspi-soft-gate-severity-tiers/task.md
@@ -1,0 +1,30 @@
+---
+topic: qrspi-soft-gate-severity-tiers
+date: 2026-06-24
+phase: task
+ticketId: "68"
+---
+
+# Bug: qrspi-workflow SOFT gate examples contradict severity tiers
+
+## Description
+
+`skills/qrspi-workflow/SKILL.md` (SOFT gate section) lists *code review
+suggestions* and *UX review feedback* as canonical SOFT-gate examples. Both
+are wrong under the severity model introduced in PR #23:
+
+- `code-reviewer` REQUEST CHANGES is **Blocking** (auto-fix).
+- `ux-reviewer` REQUEST CHANGES is **Major** (auto-fix).
+
+The single source of truth is `skills/code-review/SKILL.md` → "Severity Tiers
+and the Auto-Fix Boundary". An agent loading both skills sees contradictory
+guidance; the consult guard calls a prompt listing a Blocking/Major finding "a
+defect."
+
+## Fix (Option 2, decided in issue #68)
+
+Drop the SOFT example list and cross-reference the severity-tier table in
+`skills/code-review/SKILL.md` — the same pattern `team-implement` and `team`
+already use. Keeps the severity model defined in exactly one place.
+
+GitHub issue: https://github.com/bostonaholic/team/issues/68

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -257,7 +257,11 @@ failures.
 Informational gate. The pipeline presents findings to the user and may proceed
 at the user's judgment. The user is expected to read and acknowledge.
 
-Examples: code review suggestions, UX review feedback.
+Which review findings actually gate — and which auto-fix rather than wait on the
+user — is defined in exactly one place: `skills/code-review/SKILL.md` →
+"Severity Tiers and the Auto-Fix Boundary". Only findings below the auto-fix
+boundary surface to the user as a SOFT acknowledgment; consult that table rather
+than restating it here.
 
 ### ADVISORY
 

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -423,6 +423,44 @@ describe("topic consistency", () => {
   });
 });
 
+// Regression guard for issue #68: qrspi-workflow's SOFT-gate examples must not
+// contradict the severity model in code-review/SKILL.md. PR #23 made
+// code-reviewer REQUEST CHANGES Blocking (auto-fix) and ux-reviewer REQUEST
+// CHANGES Major (auto-fix), so neither can be a SOFT example. The severity
+// model lives in exactly one place — qrspi-workflow must cross-reference it,
+// never restate it.
+describe("qrspi-workflow SOFT gate aligns with severity tiers (issue #68)", () => {
+  const QRSPI = join(REPO_ROOT, "skills", "qrspi-workflow", "SKILL.md");
+
+  // The SOFT subsection: from "### SOFT" up to the next "### " heading.
+  function softSection(text: string): string {
+    const lines = text.split("\n");
+    const start = lines.findIndex((l) => /^### SOFT\b/.test(l));
+    if (start === -1) return "";
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (/^### /.test(lines[i] ?? "")) {
+        end = i;
+        break;
+      }
+    }
+    return lines.slice(start, end).join("\n");
+  }
+
+  test("no longer lists code-review or ux-reviewer feedback as SOFT examples", () => {
+    const text = read(QRSPI);
+    expect(/code review suggestions/i.test(text)).toBe(false);
+    expect(/UX review feedback/i.test(text)).toBe(false);
+  });
+
+  test("SOFT section cross-references the code-review severity-tier table", () => {
+    const soft = softSection(read(QRSPI));
+    expect(soft.length).toBeGreaterThan(0);
+    expect(soft).toContain("code-review/SKILL.md");
+    expect(soft).toContain("Severity Tiers and the Auto-Fix Boundary");
+  });
+});
+
 // L2-demoted (heavy prior state): team, team-worktree, team-pr, team-implement
 //
 // These four pipeline skills have no cheap self-contained behavioral property

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -448,9 +448,12 @@ describe("qrspi-workflow SOFT gate aligns with severity tiers (issue #68)", () =
   }
 
   test("no longer lists code-review or ux-reviewer feedback as SOFT examples", () => {
-    const text = read(QRSPI);
-    expect(/code review suggestions/i.test(text)).toBe(false);
-    expect(/UX review feedback/i.test(text)).toBe(false);
+    const soft = softSection(read(QRSPI));
+    // Fail loud if the SOFT subsection vanished, so the absence assertions
+    // below can't pass vacuously against an empty string.
+    expect(soft.length).toBeGreaterThan(0);
+    expect(/code review suggestions/i.test(soft)).toBe(false);
+    expect(/UX review feedback/i.test(soft)).toBe(false);
   });
 
   test("SOFT section cross-references the code-review severity-tier table", () => {
@@ -458,6 +461,18 @@ describe("qrspi-workflow SOFT gate aligns with severity tiers (issue #68)", () =
     expect(soft.length).toBeGreaterThan(0);
     expect(soft).toContain("code-review/SKILL.md");
     expect(soft).toContain("Severity Tiers and the Auto-Fix Boundary");
+  });
+
+  // Drift guard: the SOFT section points at a heading by name. If that heading
+  // is renamed in code-review/SKILL.md, the cross-reference silently rots —
+  // fail the build here so the rename and the reference stay in sync.
+  test("the cross-referenced heading still exists in code-review/SKILL.md", () => {
+    const codeReview = read(
+      join(REPO_ROOT, "skills", "code-review", "SKILL.md"),
+    );
+    expect(
+      /^#{1,4} Severity Tiers and the Auto-Fix Boundary$/m.test(codeReview),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

`skills/qrspi-workflow/SKILL.md` listed *code review suggestions* and *UX review feedback* as canonical SOFT-gate examples. PR #23 reclassified those: `code-reviewer` REQUEST CHANGES is **Blocking** (auto-fix) and `ux-reviewer` REQUEST CHANGES is **Major** (auto-fix) per `skills/code-review/SKILL.md` → "Severity Tiers and the Auto-Fix Boundary". An agent loading both skills saw contradictory guidance, and the consult guard calls a prompt listing a Blocking/Major finding "a defect."

## Fix

Option 2 from the issue: drop the SOFT example list and cross-reference the severity-tier table as the single source of truth — the same pattern `team-implement` and `team` already use. Future reclassifications now require editing only `skills/code-review/SKILL.md`.

## Test plan

- [x] New static tripwire in `tests/protocol.test.ts` (describe "qrspi-workflow SOFT gate aligns with severity tiers (issue #68)") — RED before fix, GREEN after.
- [x] `grep -n "UX review feedback\|code review suggestions" skills/qrspi-workflow/SKILL.md` returns no matches.
- [x] SOFT section cross-references `code-review/SKILL.md` → "Severity Tiers and the Auto-Fix Boundary".
- [x] Full `bun test` passes (581 tests).
- [x] Mutation check: reverting the fix turns the new test red.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVFrbT31psCcXDSCbz923S