### PR TITLE
fix: decide PR title version by merge-base, not the base tip

### DIFF
--- a/.github/scripts/pr-title-version.sh
+++ b/.github/scripts/pr-title-version.sh
@@ -44,6 +44,9 @@ grep -qE "$SEMVER_RE" <<<"$HEAD_V" \
 # differ and a stale prefix gets stamped onto a PR that shipped no bump.
 MERGE_BASE=$(git merge-base "$HEAD_SHA" "$BASE_SHA") \
   || die "could not compute merge-base of head and base"
+# Fail loud locally rather than leaning on the downstream semver check: a
+# successful merge-base that printed nothing would otherwise read an empty ref.
+[ -n "$MERGE_BASE" ] || die "merge-base of head and base is empty"
 BASE_V=$(read_version "$MERGE_BASE")
 grep -qE "$SEMVER_RE" <<<"$BASE_V" \
   || die "merge-base plugin.json version is not 3-part semver: '$BASE_V'"

--- a/.github/scripts/pr-title-version.sh
+++ b/.github/scripts/pr-title-version.sh
@@ -37,15 +37,25 @@ HEAD_V=$(read_version "$HEAD_SHA")
 grep -qE "$SEMVER_RE" <<<"$HEAD_V" \
   || die "head plugin.json version is not 3-part semver: '$HEAD_V'"
 
-# The version this PR is measured against. (Current behavior — see #104: this
-# reads the base BRANCH TIP, which disagrees with the checked-out merge ref when
-# the PR is behind a version-bumped base, so a bump-less PR gets re-stamped.)
-BASE_V=$(read_version "$BASE_SHA")
+# Measure the version against the MERGE-BASE (the fork point), not the live base
+# tip — i.e. "did this branch move plugin.json's version relative to where it
+# forked?" (#104). Comparing against the base tip mis-fires for a bump-less PR
+# that is behind a version-bumped main: the tip has advanced, so the versions
+# differ and a stale prefix gets stamped onto a PR that shipped no bump.
+MERGE_BASE=$(git merge-base "$HEAD_SHA" "$BASE_SHA") \
+  || die "could not compute merge-base of head and base"
+BASE_V=$(read_version "$MERGE_BASE")
 grep -qE "$SEMVER_RE" <<<"$BASE_V" \
-  || die "base plugin.json version is not 3-part semver: '$BASE_V'"
+  || die "merge-base plugin.json version is not 3-part semver: '$BASE_V'"
 
-# Stamp on ANY difference vs the base tip.
-if [ "$HEAD_V" = "$BASE_V" ]; then
+# Only stamp on a STRICT FORWARD bump over the fork point. A bump-less PR
+# (HEAD_V == BASE_V) no-ops no matter how far the base has advanced; a branch
+# that lowered the version (revert) no-ops too.
+ver_gt() { # ver_gt A B -> true when A > B by semver order
+  [ "$1" = "$2" ] && return 1
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+}
+if ! ver_gt "$HEAD_V" "$BASE_V"; then
   exit 0
 fi
 

--- a/.github/scripts/pr-title-version.sh
+++ b/.github/scripts/pr-title-version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# pr-title-version.sh — decide the version-prefixed PR title for pr-title-sync.yml.
+#
+# Prints the desired PR title to stdout when the title should be rewritten, and
+# NOTHING (exit 0) when the workflow should leave the title alone. The caller
+# (`.github/workflows/pr-title-sync.yml`) runs `gh pr edit --title` only when this
+# script prints a non-empty line.
+#
+# Inputs (env):
+#   HEAD_SHA       — the PR head commit (github.event.pull_request.head.sha)
+#   BASE_SHA       — the base branch commit (github.event.pull_request.base.sha)
+#   CURRENT_TITLE  — the PR's current title (attacker-influenced; env-only)
+#
+# Reads `.claude-plugin/plugin.json`'s version at the relevant commits via
+# `git show`, so the repository must be checked out with enough history to
+# resolve both SHAs.
+#
+# Requires: git, jq.
+
+set -uo pipefail
+
+SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+PLUGIN_JSON='.claude-plugin/plugin.json'
+
+die() { printf '::error::%s\n' "$1" >&2; exit 1; }
+
+: "${HEAD_SHA:?HEAD_SHA required}"
+: "${BASE_SHA:?BASE_SHA required}"
+CURRENT_TITLE="${CURRENT_TITLE:-}"
+
+read_version() { # read_version <ref> -> version on stdout
+  git show "$1:$PLUGIN_JSON" 2>/dev/null | jq -r '.version' 2>/dev/null
+}
+
+HEAD_V=$(read_version "$HEAD_SHA")
+grep -qE "$SEMVER_RE" <<<"$HEAD_V" \
+  || die "head plugin.json version is not 3-part semver: '$HEAD_V'"
+
+# The version this PR is measured against. (Current behavior — see #104: this
+# reads the base BRANCH TIP, which disagrees with the checked-out merge ref when
+# the PR is behind a version-bumped base, so a bump-less PR gets re-stamped.)
+BASE_V=$(read_version "$BASE_SHA")
+grep -qE "$SEMVER_RE" <<<"$BASE_V" \
+  || die "base plugin.json version is not 3-part semver: '$BASE_V'"
+
+# Stamp on ANY difference vs the base tip.
+if [ "$HEAD_V" = "$BASE_V" ]; then
+  exit 0
+fi
+
+STRIPPED=$(sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+[[:space:]:]+//' <<<"$CURRENT_TITLE")
+WANT="v${HEAD_V} ${STRIPPED}"
+if [ "$WANT" = "$CURRENT_TITLE" ]; then
+  exit 0
+fi
+printf '%s\n' "$WANT"

--- a/.github/workflows/pr-title-sync.yml
+++ b/.github/workflows/pr-title-sync.yml
@@ -2,13 +2,18 @@
 #
 # A thin backstop for land-time versioning (docs/versioning.md): version is
 # assigned by `version-bump` at land time, so a drafted PR carries no version
-# until it lands. This workflow reads the version from the PR's
-# .claude-plugin/plugin.json and rewrites the title to match — but only when
-# that version differs from the base branch's; when the version is unchanged
-# (the normal pre-land state) it does nothing (it never adds or strips a
-# prefix). It is a backstop — `version-bump` sets the title when it bumps.
-# Accepted residue: a bump that is later reverted in-branch leaves its
-# now-wrong prefix in place (cosmetic only).
+# until it lands. This workflow decides the version this PR ships from what the
+# BRANCH changed — it reads .claude-plugin/plugin.json at the PR head and
+# compares it against the version at the MERGE-BASE (the fork point), rewriting
+# the title only on a strict forward bump. When the branch did not bump the
+# version (the normal pre-land state) it does nothing (it never adds or strips a
+# prefix), no matter how far the base has advanced since the fork (#104). It is a
+# backstop — `version-bump` sets the title when it bumps. Accepted residue: a
+# bump that is later reverted in-branch leaves its now-wrong prefix in place
+# (cosmetic only).
+#
+# The decision logic lives in .github/scripts/pr-title-version.sh and is pinned
+# by tests/pr-title-version.test.ts (free, deterministic git-fixture tests).
 #
 # WHY plain `pull_request` (not pull_request_target): all PRs here come from
 # same-repo branches, where the default GITHUB_TOKEN honors
@@ -19,9 +24,11 @@
 # SECURITY: the PR title is attacker-influenced content — it enters only via
 # `env:` and is referenced as a quoted "$VAR", never inlined as a `${{ }}`
 # expression in `run:`. It is also never echoed (Actions parses
-# ::workflow-commands:: from stdout). The version is regex-validated before
-# use. Loop safety: the rewrite fires an `edited` event, which re-enters this
-# job, computes an identical title, and exits at the no-op check.
+# ::workflow-commands:: from stdout); the computed title is captured via command
+# substitution and passed to `gh pr edit --title`, never printed. The version is
+# regex-validated before use. Loop safety: the rewrite fires an `edited` event,
+# which re-enters this job, computes an identical title, and exits at the
+# already-correct no-op check.
 name: PR title sync
 
 on:
@@ -47,32 +54,28 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
       # Attacker-influenced — env-only, never inlined in run:, never echoed.
       CURRENT_TITLE: ${{ github.event.pull_request.title }}
     steps:
+      # fetch-depth: 0 so `git merge-base` can resolve the fork point of the
+      # head and base commits.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Rewrite title to match plugin.json version
         run: |
           set -euo pipefail
-          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
-          V=$(jq -r .version .claude-plugin/plugin.json)
-          grep -qE "$SEMVER_RE" <<<"$V" \
-            || { echo "::error::plugin.json version is not 3-part semver"; exit 1; }
-          git fetch origin "$BASE_REF" --depth=1 --quiet
-          BASE_V=$(git show FETCH_HEAD:.claude-plugin/plugin.json | jq -r .version)
-          grep -qE "$SEMVER_RE" <<<"$BASE_V" \
-            || { echo "::error::base plugin.json version is not 3-part semver"; exit 1; }
-          if [ "$V" = "$BASE_V" ]; then
-            echo "Version unchanged vs base ($V); leaving the title alone."
+          WANT=$(.github/scripts/pr-title-version.sh)
+          if [ -z "$WANT" ]; then
+            echo "No forward version bump vs the fork point; leaving the title alone."
             exit 0
           fi
-          STRIPPED=$(sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+[[:space:]:]+//' <<<"$CURRENT_TITLE")
-          WANT="v${V} ${STRIPPED}"
           if [ "$WANT" = "$CURRENT_TITLE" ]; then
             echo "Title already correct; no change."
             exit 0
           fi
           gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --title "$WANT"
-          echo "Synced PR #$PR_NUMBER title to v$V."
+          echo "Synced PR #$PR_NUMBER title to the shipped version."

--- a/docs/plans/104-pr-title-sync-stale-base/task.md
+++ b/docs/plans/104-pr-title-sync-stale-base/task.md
@@ -1,0 +1,41 @@
+---
+topic: pr-title-sync-stale-base
+date: 2026-06-24
+phase: task
+ticketId: "104"
+---
+
+# Bug: pr-title-sync re-stamps a stale base version onto PRs behind a bumped main
+
+GitHub issue: https://github.com/bostonaholic/team/issues/104
+
+## Summary
+
+`.github/workflows/pr-title-sync.yml` (job *Sync PR title to version*) rewrites a
+PR's title to `v<stale-version>` when the PR branch is behind a `main` that has had
+version bumps since the branch forked. It keeps re-stamping even after a maintainer
+strips the prefix, so a bump-less PR cannot hold a version-free title until it is
+rebased to parity with `main`.
+
+## Root cause
+
+The no-op guard compares two inconsistent snapshots of the base:
+
+- `V` is read from the checked-out tree, which on a `pull_request` event is the
+  **merge ref** (`branch ⊕ base`). GitHub recomputes the merge ref lazily, so when
+  `main` is bumping rapidly and the PR is behind, the cached merge-ref base **lags**
+  the live base.
+- `BASE_V` is read from a **fresh** fetch of the live base tip.
+
+For a bump-less PR these should cancel out, but the lag makes them disagree, the
+`V == BASE_V` guard misses, and the workflow stamps a version unrelated to the PR.
+
+## Fix (per issue)
+
+Decide "the version this PR ships" from what the branch itself changed:
+
+- Read the candidate version from the **PR head** (`head.sha`), not the merge ref.
+- Compare it against the **merge-base** (fork point) version, not the live base tip.
+- Only rewrite the title on a **strict forward bump** over the merge-base; else no-op.
+
+Preserve loop-safety (the `edited` re-entry no-ops) and the same-repo-only `if:` guard.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -153,9 +153,11 @@ vX.Y.Z <type>: <subject>
 ```
 
 e.g. `v0.6.0 feat: add the shipit land skill`. The `PR title sync` workflow
-rewrites a drifted title only when the PR's version differs from the base
-branch's (i.e. after `version-bump` has bumped); while the version is unchanged
-it does nothing. It is a backstop, not the mechanism.
+rewrites a drifted title only when the branch bumped the version forward of its
+fork point — it reads the version at the PR head and compares it against the
+merge-base, not the live base tip, so a bump-less PR no-ops no matter how far
+`main` has advanced since the branch forked (#104). It is a backstop, not the
+mechanism.
 
 ## What CI enforces, and where
 
@@ -166,7 +168,7 @@ can catch it:
 |-------|-------|-------|
 | Four version strings agree; strict semver (holds on every commit, drafted or landed) | L2 tripwire (free, every `bun test`) | `tests/version-consistency.test.ts` |
 | Released-section + footer-compare-link invariants hold for the assigned version — run after the changelog cut, before the commit | Land-time assertion (`version-bump`) | `.claude/skills/version-bump/SKILL.md` |
-| Title prefix matches the version — only when the PR's version differs from base (after `version-bump` bumps); no-op otherwise | CI (needs PR context) | `.github/workflows/pr-title-sync.yml` |
+| Title prefix matches the version — only when the branch bumped the version forward of its merge-base/fork point (after `version-bump` bumps); no-op otherwise | CI (needs PR context) | `.github/workflows/pr-title-sync.yml` |
 | Tag + GitHub release on merge | CI (needs write perms) | `.github/workflows/release-on-merge.yml` |
 
 The land-time assertion row is the in-tree replacement for the per-PR CI gate

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -52,11 +52,44 @@ describe("ci workflows: pr-title-sync slimmed to a backstop, loop-safe (Slice 3)
     expect(text).toContain("github.actor != 'github-actions[bot]'");
   });
 
-  test("retains the version-unchanged-vs-base no-op early exit (loop safety)", () => {
-    // Slimmed, but the `version == base → no-op` early exit must survive so
-    // the workflow no-ops for bump-less PRs and never loops on its own edit.
-    const hasNoopExit = /if \[ "\$V" = "\$BASE_V" \]/.test(text);
-    expect(hasNoopExit).toBe(true);
+  test("delegates the version decision to pr-title-version.sh (#104)", () => {
+    // The branch-relative decision (head vs merge-base, strict forward bump)
+    // lives in the script so it can be pinned by deterministic git-fixture
+    // tests; the workflow only acts on its output.
+    expect(text).toContain(".github/scripts/pr-title-version.sh");
+  });
+
+  test("only edits the title when the script prints a non-empty result", () => {
+    // The empty-output → no-op early exit keeps the workflow from touching a
+    // bump-less PR's title (and from looping on its own `edited` event).
+    expect(/if \[ -z "\$WANT" \]/.test(text)).toBe(true);
+  });
+
+  test("retains the already-correct no-op early exit (loop safety)", () => {
+    // The rewrite fires an `edited` event that re-enters the job; with the
+    // title already correct it must exit without editing, so it cannot loop.
+    expect(/if \[ "\$WANT" = "\$CURRENT_TITLE" \]/.test(text)).toBe(true);
+  });
+
+  test("computes the candidate from the head SHA, not a base-tip fetch (#104)", () => {
+    // Regression fence: the misfire was reading the base BRANCH TIP. The fix
+    // measures the head against the merge-base, so the title is passed by
+    // head.sha and the old `git fetch origin "$BASE_REF"` base-tip read is gone.
+    expect(text).toContain("github.event.pull_request.head.sha");
+    expect(/git fetch origin "\$BASE_REF"/.test(text)).toBe(false);
+  });
+});
+
+describe("ci workflows: pr-title-version.sh decides by merge-base, not base tip (#104)", () => {
+  const SCRIPT = join(REPO_ROOT, ".github", "scripts", "pr-title-version.sh");
+  const src = readIf(SCRIPT);
+
+  test("pr-title-version.sh exists", () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+  });
+
+  test("measures against the merge-base (fork point), not the base tip", () => {
+    expect(/git merge-base/.test(src)).toBe(true);
   });
 });
 

--- a/tests/pr-title-version.test.ts
+++ b/tests/pr-title-version.test.ts
@@ -1,0 +1,214 @@
+// tests/pr-title-version.test.ts
+//
+// Deterministic behavioral tests for the PR-title version decision,
+// `.github/scripts/pr-title-version.sh`. The script prints the desired PR title
+// when the title should be rewritten, and NOTHING when the workflow should leave
+// it alone — a function of (head version, fork-point version, current title).
+//
+// L3/L4 per docs/testing.md (real git, no model/network — free, gate-tier). The
+// git merge-base computation IS the subject, so each case stands up a real git
+// fixture rather than asserting on the YAML source.
+//
+// Regression for #104: pr-title-sync re-stamped a stale base version onto a PR
+// whose branch was behind a version-bumped `main`. The fix decides the version
+// from what the BRANCH changed — head version vs the MERGE-BASE (fork point),
+// stamping only on a strict forward bump — so a bump-less PR no-ops no matter how
+// far `main` has advanced.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SCRIPT = join(REPO_ROOT, ".github", "scripts", "pr-title-version.sh");
+
+const HAS_JQ = spawnSync("jq", ["--version"]).status === 0;
+
+// Hermetic temp repo keyed by pid+timestamp (docs/testing.md), cleaned up after.
+const fixtures: string[] = [];
+afterAll(() => {
+  for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]) {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  }
+  return (r.stdout ?? "").trim();
+}
+
+// Write plugin.json at `version` and commit it; return the new commit SHA.
+function commitVersion(cwd: string, version: string, message: string) {
+  mkdirSync(join(cwd, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(cwd, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name: "team", version }, null, 2) + "\n",
+  );
+  git(cwd, "add", "-A");
+  git(cwd, "commit", "-q", "-m", message);
+  return git(cwd, "rev-parse", "HEAD");
+}
+
+function newRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), `pr-title-${process.pid}-`));
+  fixtures.push(dir);
+  git(dir, "init", "-q", "-b", "main");
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "Test");
+  return dir;
+}
+
+// Build: fork point at `fork`, then advance main to each of `mainBumps`, and lay
+// the branch's own commits (`branchVersions`) on top of the fork point.
+function scenario(opts: {
+  fork: string;
+  mainBumps: string[];
+  branchVersions: string[];
+}) {
+  const dir = newRepo();
+  commitVersion(dir, opts.fork, `chore: fork at ${opts.fork}`);
+  const forkSha = git(dir, "rev-parse", "HEAD");
+  git(dir, "branch", "feature", forkSha);
+
+  // main advances past the fork (the version-bumped base from #104).
+  for (const v of opts.mainBumps) commitVersion(dir, v, `chore(version): ${v}`);
+  const baseSha = git(dir, "rev-parse", "main");
+
+  // the PR branch's own work.
+  git(dir, "checkout", "-q", "feature");
+  for (const v of opts.branchVersions) commitVersion(dir, v, `work: ${v}`);
+  const headSha = git(dir, "rev-parse", "HEAD");
+
+  return { dir, headSha, baseSha };
+}
+
+function run(
+  cwd: string,
+  env: { HEAD_SHA: string; BASE_SHA: string; CURRENT_TITLE?: string },
+) {
+  const r = spawnSync("bash", [SCRIPT], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HEAD_SHA: env.HEAD_SHA,
+      BASE_SHA: env.BASE_SHA,
+      CURRENT_TITLE: env.CURRENT_TITLE ?? "",
+    },
+  });
+  return { status: r.status, out: (r.stdout ?? "").trim(), err: r.stderr ?? "" };
+}
+
+describe.if(HAS_JQ)("pr-title-version.sh: branch-relative version decision", () => {
+  // The #104 repro: branch forked at 0.8.0, never bumped; main advanced to
+  // 0.9.1 since the fork. The title must NOT be stamped — the PR ships no bump.
+  test("regression #104: bump-less PR behind a bumped main → no-op", () => {
+    const { dir, headSha, baseSha } = scenario({
+      fork: "0.8.0",
+      mainBumps: ["0.9.0", "0.9.1"],
+      branchVersions: [],
+    });
+    const r = run(dir, {
+      HEAD_SHA: headSha,
+      BASE_SHA: baseSha,
+      CURRENT_TITLE: "Fix the thing",
+    });
+    expect(r.status).toBe(0);
+    expect(r.out).toBe("");
+  });
+
+  // Even when a maintainer's manual strip left a clean title, a bump-less PR
+  // behind a bumped main must still no-op so the strip holds.
+  test("regression #104: bump-less PR, plain title stays plain", () => {
+    const { dir, headSha, baseSha } = scenario({
+      fork: "0.8.0",
+      mainBumps: ["0.9.1"],
+      branchVersions: [],
+    });
+    const r = run(dir, {
+      HEAD_SHA: headSha,
+      BASE_SHA: baseSha,
+      CURRENT_TITLE: "Park the CI author-gate PR",
+    });
+    expect(r.out).toBe("");
+  });
+
+  // A branch that lowers the version below its fork point (revert) is not a
+  // forward bump → no-op, regardless of where the base tip sits.
+  test("branch version below the fork point → no-op", () => {
+    const { dir, headSha, baseSha } = scenario({
+      fork: "0.8.0",
+      mainBumps: ["0.9.1"],
+      branchVersions: ["0.7.0"],
+    });
+    const r = run(dir, { HEAD_SHA: headSha, BASE_SHA: baseSha });
+    expect(r.out).toBe("");
+  });
+
+  // A genuine bump (branch moves the version strictly forward of its fork
+  // point) is still stamped — the happy path the workflow exists for.
+  test("genuine forward bump → stamps v<new>", () => {
+    const { dir, headSha, baseSha } = scenario({
+      fork: "0.8.0",
+      mainBumps: ["0.9.1"],
+      branchVersions: ["0.9.0"],
+    });
+    const r = run(dir, {
+      HEAD_SHA: headSha,
+      BASE_SHA: baseSha,
+      CURRENT_TITLE: "Some PR title",
+    });
+    expect(r.out).toBe("v0.9.0 Some PR title");
+  });
+
+  // The rewrite fires an `edited` event that re-enters the workflow; with the
+  // title already correct the script must no-op so it cannot loop.
+  test("loop safety: already-correct title on a real bump → no-op", () => {
+    const { dir, headSha, baseSha } = scenario({
+      fork: "0.8.0",
+      mainBumps: ["0.9.1"],
+      branchVersions: ["0.9.0"],
+    });
+    const r = run(dir, {
+      HEAD_SHA: headSha,
+      BASE_SHA: baseSha,
+      CURRENT_TITLE: "v0.9.0 Some PR title",
+    });
+    expect(r.out).toBe("");
+  });
+
+  // A real bump replaces a stale prefix rather than doubling it.
+  test("real bump restamps a stale prefix in place", () => {
+    const { dir, headSha, baseSha } = scenario({
+      fork: "0.8.0",
+      mainBumps: ["0.9.1"],
+      branchVersions: ["0.9.0"],
+    });
+    const r = run(dir, {
+      HEAD_SHA: headSha,
+      BASE_SHA: baseSha,
+      CURRENT_TITLE: "v0.8.5 Some PR title",
+    });
+    expect(r.out).toBe("v0.9.0 Some PR title");
+  });
+});
+
+describe.if(HAS_JQ)("pr-title-version.sh: input validation", () => {
+  test("rejects a non-semver head version", () => {
+    const dir = newRepo();
+    mkdirSync(join(dir, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(dir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "team", version: "1.2" }) + "\n",
+    );
+    git(dir, "add", "-A");
+    git(dir, "commit", "-q", "-m", "bad version");
+    const sha = git(dir, "rev-parse", "HEAD");
+    const r = run(dir, { HEAD_SHA: sha, BASE_SHA: sha });
+    expect(r.status).not.toBe(0);
+    expect(r.err).toMatch(/not 3-part semver/);
+  });
+});

--- a/tests/pr-title-version.test.ts
+++ b/tests/pr-title-version.test.ts
@@ -89,7 +89,11 @@ function run(
   cwd: string,
   env: { HEAD_SHA: string; BASE_SHA: string; CURRENT_TITLE?: string },
 ) {
-  const r = spawnSync("bash", [SCRIPT], {
+  // Invoke the script directly (not via `bash SCRIPT`) so the test exercises
+  // the exact production path: the committed executable bit + shebang. A dropped
+  // mode or broken shebang — which would break the workflow on the runner —
+  // fails the test here instead of silently passing.
+  const r = spawnSync(SCRIPT, [], {
     cwd,
     encoding: "utf8",
     env: {


### PR DESCRIPTION
## Problem

`pr-title-sync.yml` re-stamps a stale `v<version>` prefix onto PRs whose branch is **behind a version-bumped `main`**, and keeps re-stamping even after a maintainer strips it — so a bump-less PR can't hold a version-free title until it's rebased to base parity.

Closes #104

## Root cause

The no-op guard compared two inconsistent snapshots of the base: the version from the checked-out **merge ref** vs. a **fresh fetch of the live base tip**. When `main` bumps faster than GitHub recomputes the lazily-cached merge ref, the two disagree, the `V == BASE_V` guard misses, and the workflow stamps a version unrelated to the PR.

## Fix

Decide the version the PR ships from **what the branch itself changed**:

- Read the candidate version from the **PR head** (`head.sha`), not the merge ref.
- Compare it against the **merge-base** (fork point), not the live base tip.
- Rewrite the title only on a **strict forward bump**; otherwise no-op.

The decision logic is extracted into `.github/scripts/pr-title-version.sh` (mirroring the `next-version.sh` precedent) so it can be pinned by deterministic git-fixture tests. The workflow checks out with `fetch-depth: 0` (for `git merge-base`) and passes the head/base SHAs to the script. Loop-safety (fork-PR `if:` guard, bot-actor guard, already-correct no-op) is preserved.

## Test plan

- [x] **RED**: new git-fixture test reproduces #104 — a bump-less PR behind a bumped `main` stamps a stale prefix under the old logic (3 assertion failures).
- [x] **GREEN**: after the fix, the bump-less PR no-ops; a genuine forward bump still stamps `v<new>`; a reverted (backward) version no-ops.
- [x] **Mutation check**: reverting merge-base → base-tip re-reds the regression tests.
- [x] Loop-safety: an already-correct title no-ops (no `edited` loop).
- [x] Updated `ci-workflows.test.ts` tripwires for the extracted script.
- [x] Full free suite: `bun test` → 591 pass, 0 fail.
- [x] `shellcheck` clean on the new script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)