### PR TITLE
fix: gate tsc --noEmit in CI (13 uncaught type errors in the harness)

### DIFF
--- a/.github/workflows/harness-checks.yml
+++ b/.github/workflows/harness-checks.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Type-check harness
+        # `bun test` transpiles without type-checking, so type errors pass it
+        # silently. `tsc --noEmit` is the cheapest deterministic gate (static,
+        # free) and blocks the PR on any type error — see docs/testing.md.
+        run: bun run typecheck
+
       - name: Run harness checks
         # Paid agent-behavior files are named *.evals.ts — outside Bun's
         # auto-discovery pattern (*.test.{ts,js,...}) — so `bun test`

--- a/dev.yml
+++ b/dev.yml
@@ -13,6 +13,7 @@ up:
 
 check:
   plugin: "claude plugin validate ."
+  typecheck: "bun run typecheck"
 
 test:
   run: "bun test"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "bun test",
+    "typecheck": "tsc --noEmit",
     "test:evals": "EVALS=1 bun test --concurrent --max-concurrency 15 ./tests/*.evals.ts",
     "test:evals:all": "EVALS=1 EVALS_ALL=1 bun test --concurrent --max-concurrency 15 ./tests/*.evals.ts",
     "eval:select": "bun run scripts/eval-select.ts",

--- a/skills/nested-agents/supports-nesting.d.mts
+++ b/skills/nested-agents/supports-nesting.d.mts
@@ -1,0 +1,12 @@
+// Type declarations for supports-nesting.mjs — the .mjs is the source of
+// truth; this stub only describes its exports for `tsc --noEmit`. Consumed
+// by TypeScript tooling, never at runtime.
+
+/** The Claude Code release that introduced nested sub-agents. */
+export const MIN_VERSION: string;
+
+/** Numeric [major, minor, patch], or null when no triple is present. */
+export function parseVersion(raw: unknown): [number, number, number] | null;
+
+/** True only when `raw` parses to a version >= `min`. Fail-closed. */
+export function meetsMinimum(raw: unknown, min?: string): boolean;

--- a/tests/changelog-links.test.ts
+++ b/tests/changelog-links.test.ts
@@ -32,7 +32,7 @@ function linkTargets(md: string): string[] {
   const targets: string[] = [];
   const re = /\]\(([^)]+)\)/g;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(md)) !== null) targets.push(m[1].trim());
+  while ((m = re.exec(md)) !== null) targets.push(m[1]!.trim());
   return targets;
 }
 

--- a/tests/skill-eval-coverage.test.ts
+++ b/tests/skill-eval-coverage.test.ts
@@ -119,7 +119,7 @@ describe("L5 skill coverage: git-commit", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -149,7 +149,7 @@ describe("L5 skill coverage: changelog", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -179,7 +179,7 @@ describe("L5 skill coverage: team-question", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -209,7 +209,7 @@ describe("L5 skill coverage: eng-design-doc-review", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -239,7 +239,7 @@ describe("L5 skill coverage: team-fix", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -269,7 +269,7 @@ describe("L5 skill coverage: team-research", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -299,7 +299,7 @@ describe("L5 skill coverage: team-design", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -329,7 +329,7 @@ describe("L5 skill coverage: team-structure", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });
@@ -359,7 +359,7 @@ describe("L5 skill coverage: team-plan", () => {
     );
     expect(keys.length).toBeGreaterThan(0);
     for (const key of keys) {
-      expect(["gate", "periodic"]).toContain(E2E_TIERS[key]);
+      expect(["gate", "periodic"]).toContain(E2E_TIERS[key] ?? "");
     }
   });
 });

--- a/tests/worktree-detection.test.ts
+++ b/tests/worktree-detection.test.ts
@@ -18,10 +18,10 @@ const TEAM_WT = join(REPO_ROOT, "skills", "team-worktree", "SKILL.md");
 // section's sh code block (the one comparing --git-dir to --git-common-dir).
 function detectionSnippet(): string {
   const text = read(TEAM_WT);
-  const blocks = [...text.matchAll(/```sh\n([\s\S]*?)```/g)].map((m) => m[1]);
+  const blocks = [...text.matchAll(/```sh\n([\s\S]*?)```/g)].map((m) => m[1]!);
   const matches = blocks.filter((b) => b.includes("--git-common-dir"));
   expect(matches.length).toBe(1); // guard: exactly one documented detection block
-  return matches[0];
+  return matches[0]!;
 }
 
 // Run the documented snippet against a repo path. Detection prints


### PR DESCRIPTION
## What

Makes `tsc --noEmit` a blocking gate — in **CI** and in the local **`dev check`** — and fixes the 13 pre-existing type errors that `bun test` was silently transpiling past.

`bun test` strips types and runs, so type-correctness had no gate at any layer. A future change could introduce a type error and still merge green. This adds the cheapest deterministic layer (static, free) alongside `bun test`.

## Changes

- **`package.json`** — new `typecheck` script (`tsc --noEmit`).
- **`.github/workflows/harness-checks.yml`** — new "Type-check harness" step running `bun run typecheck`; blocks the PR on any type error.
- **`dev.yml`** — new `typecheck` entry under `check:`, so `dev check` runs it locally alongside plugin validation.
- **13 type-error fixes** (all from `noUncheckedIndexedAccess` `T | undefined` narrowing, plus one untyped `.mjs` import):
  - `tests/changelog-links.test.ts`, `tests/worktree-detection.test.ts` — assert regex capture groups / length-guarded match.
  - `tests/skill-eval-coverage.test.ts` (×9) — coerce a possibly-missing `E2E_TIERS` lookup to `""` so an unmapped key still fails.
  - `skills/nested-agents/supports-nesting.d.mts` — colocated type stub for the plain-JS `.mjs` (the `.mjs` stays the source of truth).

## Verification

- [x] `bun run typecheck` exits 0 locally.
- [x] `dev check typecheck` passes locally.
- [x] Gate **fails red** when a type error is introduced (verified by injecting a scratch type error → exit 2, then removing it → exit 0).
- [x] `bun test` still 594/594.

No CHANGELOG entry — this is dev/harness tooling, not distributed runtime (per the versioning policy).

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)