### PR TITLE
fix: stabilize flaky paid evals via --retry + final-outcome dedup

### DIFF
--- a/docs/plans/54-reduce-eval-flakiness/task.md
+++ b/docs/plans/54-reduce-eval-flakiness/task.md
@@ -1,0 +1,33 @@
+---
+topic: reduce-eval-flakiness
+date: 2026-06-24
+phase: task
+ticketId: "54"
+---
+
+# Reduce flakiness in behavioral evals (planted-null-deref flaps pass/fail)
+
+The paid behavioral eval `tests/code-reviewer.evals.ts` (`planted-null-deref`)
+flaps pass/fail across back-to-back runs with no code change — inherent LLM
+sampling variance scored against a hard 100%-detection threshold.
+
+## Decision (from issue #54)
+
+Option 1 (retry) + reporter fix:
+
+1. Add `--retry=2` to the `test:evals` (and `test:evals:all`) scripts so a
+   usually-passing eval gets retried before failing the suite. Cost grows only
+   on flaps.
+2. Make the eval reporter (`tests/helpers/eval-store.ts`) record only the
+   **final post-retry outcome** per test. Today `addTest` appends one entry
+   per attempt, so a retried flap leaves a stale intermediate failure beside
+   the recovered pass — inflating `total_tests`/`failed` and corrupting the
+   regression comparison. Fix: `addTest` upserts by name.
+
+## Affected files
+
+- `package.json` — `test:evals`, `test:evals:all` (add `--retry=2`)
+- `tests/helpers/eval-store.ts` — `addTest` upsert-by-name
+- `tests/helpers/eval-store.test.ts` — failing test pinning the dedup behavior
+
+Closes #54.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "test:evals": "EVALS=1 bun test --concurrent --max-concurrency 15 ./tests/*.evals.ts",
-    "test:evals:all": "EVALS=1 EVALS_ALL=1 bun test --concurrent --max-concurrency 15 ./tests/*.evals.ts",
+    "test:evals": "EVALS=1 bun test --retry=2 --concurrent --max-concurrency 15 ./tests/*.evals.ts",
+    "test:evals:all": "EVALS=1 EVALS_ALL=1 bun test --retry=2 --concurrent --max-concurrency 15 ./tests/*.evals.ts",
     "eval:select": "bun run scripts/eval-select.ts",
     "eval:list": "bun run scripts/eval-list.ts",
     "eval:compare": "bun run scripts/eval-compare.ts"

--- a/tests/helpers/eval-store.test.ts
+++ b/tests/helpers/eval-store.test.ts
@@ -119,6 +119,23 @@ describe("EvalCollector", () => {
     expect(mid.passed).toBe(1);
   });
 
+  test("collapses retried attempts to the final post-retry outcome", async () => {
+    // Bun's `--retry` re-runs the test body, so addTest fires once per
+    // attempt. A flap that recovers on retry must record only the final
+    // outcome — not a stale intermediate failure beside the recovered pass.
+    const c = new EvalCollector("e2e", scratchDir);
+    c.addTest(entry("flaky", { passed: false })); // attempt 1: missed the bug
+    c.addTest(entry("flaky", { passed: true })); // retry: caught it
+    const path = await c.finalize();
+
+    const result = JSON.parse(readFileSync(path, "utf8")) as EvalResult;
+    expect(result.tests.filter((t) => t.name === "flaky").length).toBe(1);
+    expect(result.total_tests).toBe(1);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.tests[0]?.passed).toBe(true);
+  });
+
   test("finalize populates budgetRegressions vs the previous run", async () => {
     process.env.EVALS_BRANCH = "budget-branch";
     // Seed a previous run with a low tool-call count.

--- a/tests/helpers/eval-store.ts
+++ b/tests/helpers/eval-store.ts
@@ -181,7 +181,17 @@ export class EvalCollector {
     if (this.finalized) {
       throw new Error("EvalCollector: cannot addTest after finalize()");
     }
-    this.result.tests.push(entry);
+    // `--retry` re-runs the test body, so a flaky test calls addTest once per
+    // attempt. Upsert by name so only the final post-retry outcome is recorded
+    // — keeping the counts honest and the regression comparison free of stale
+    // intermediate failures. Cost/duration still accumulate below: retries
+    // really did spend money.
+    const existing = this.result.tests.findIndex((t) => t.name === entry.name);
+    if (existing >= 0) {
+      this.result.tests[existing] = entry;
+    } else {
+      this.result.tests.push(entry);
+    }
     this.result.total_tests = this.result.tests.length;
     this.result.passed = this.result.tests.filter((t) => t.passed).length;
     this.result.failed = this.result.total_tests - this.result.passed;


### PR DESCRIPTION
## What

Fixes #54 — the paid behavioral eval `planted-null-deref` flaps pass/fail across back-to-back runs with no code change (inherent LLM sampling variance scored against a hard 100%-detection threshold).

Implements the issue's decision (Option 1 — retry + reporter fix):

1. **`--retry=2` on the eval suites** (`test:evals`, `test:evals:all`) — Bun re-runs a failed test up to twice, so a usually-passing eval is no longer failed by a single unlucky sample. Extra spend occurs only on flaps.
2. **`EvalCollector.addTest` upserts by name** — `--retry` re-runs the test body, firing `addTest` once per attempt. Previously each attempt appended a separate entry, so a flap that recovered left a stale intermediate *failure* beside the recovered *pass*, inflating `total_tests`/`failed` and corrupting the regression comparison. Now only the final post-retry outcome is recorded. Cost/duration still accumulate, since retries really did spend money.

## Why this layer

The retry behavior is paid + stochastic, but the dedup logic is a pure data transform — pinned with a free, deterministic L1 unit test in `eval-store.test.ts` (per `docs/testing.md`: push every check as far down and as deterministic as it goes).

## Test plan

- [x] New unit test `collapses retried attempts to the final post-retry outcome` fails before the fix (asserts 1 entry, got 2) and passes after.
- [x] Mutation check: reverting the upsert to a plain `push` turns the test red again.
- [x] Full free suite green (`bun test` — 610 pass).
- [x] `tsc --noEmit` clean.
- [x] `bun test --retry=2` parses on Bun 1.3.14.
- [x] _Paid, requires `EVALS_ANTHROPIC_API_KEY`:_ run `bun run test:evals` twice back-to-back; both pass, and a recovered flap reports no regression.

Dev-only change (`tests/`, `package.json` eval scripts, `docs/plans/`) — no runtime plugin files touched, so no version bump or changelog entry at land time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)