### PR TITLE
test: pin pre-bash-guard and project-set-status behavior with real tests

### DIFF
--- a/tests/pre-bash-guard.test.ts
+++ b/tests/pre-bash-guard.test.ts
@@ -1,0 +1,97 @@
+// tests/pre-bash-guard.test.ts
+//
+// L3 subprocess tests for the runtime PreToolUse hook hooks/pre-bash-guard.mjs.
+// The hook reads {tool_input:{command}} from stdin and, for a dangerous command,
+// emits a permissionDecision:"ask" payload; otherwise it passes through
+// silently. It always exits 0 (fail-open). Driven as a real subprocess so the
+// guard's actual behavior — not its prose — is pinned. Free, fast, gate-tier.
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const HOOK = join(REPO_ROOT, "hooks", "pre-bash-guard.mjs");
+
+function runHook(input: unknown): { status: number | null; out: string } {
+  const r = spawnSync("node", [HOOK], {
+    input: typeof input === "string" ? input : JSON.stringify(input),
+    encoding: "utf8",
+  });
+  return { status: r.status, out: r.stdout ?? "" };
+}
+
+// True when the hook asks the user to confirm; asserts fail-open exit 0.
+function asksFor(command: string): boolean {
+  const { status, out } = runHook({ tool_name: "Bash", tool_input: { command } });
+  expect(status).toBe(0); // the hook always fails open
+  if (out.trim() === "") return false;
+  const payload = JSON.parse(out);
+  return payload?.hookSpecificOutput?.permissionDecision === "ask";
+}
+
+const DANGEROUS = [
+  "rm -rf /",
+  "rm -rf ~",
+  "rm -fr /etc",
+  "sudo rm -rf / --no-preserve-root",
+  "psql -c 'DROP TABLE users'",
+  "mysql -e 'drop database prod'",
+  "git push --force origin main",
+  "git push -f",
+  "git reset --hard HEAD~3",
+  "chmod 777 /usr/bin",
+  "dd if=/dev/zero of=/dev/sda bs=1M",
+  "mkfs.ext4 /dev/sdb1",
+  ":(){ :|:& };:",
+];
+
+const SAFE = [
+  "ls -la",
+  "rm -rf ./build", // relative path, not / or ~
+  "rm -rf node_modules",
+  "git push origin main",
+  "git commit -m 'wip'",
+  "chmod 644 file.txt",
+  "echo hello",
+];
+
+describe("pre-bash-guard.mjs: dangerous commands prompt for confirmation", () => {
+  for (const cmd of DANGEROUS) {
+    test(`asks: ${cmd}`, () => {
+      expect(asksFor(cmd)).toBe(true);
+    });
+  }
+});
+
+describe("pre-bash-guard.mjs: safe commands pass through", () => {
+  for (const cmd of SAFE) {
+    test(`allows: ${cmd}`, () => {
+      expect(asksFor(cmd)).toBe(false);
+    });
+  }
+});
+
+describe("pre-bash-guard.mjs: payload shape and fail-open edges", () => {
+  test("the ask payload carries the blocking reason in systemMessage", () => {
+    const { out } = runHook({
+      tool_name: "Bash",
+      tool_input: { command: "rm -rf /" },
+    });
+    const payload = JSON.parse(out);
+    expect(payload.hookSpecificOutput.permissionDecision).toBe("ask");
+    expect(payload.systemMessage).toMatch(/recursive forced deletion/i);
+  });
+
+  test("non-Bash input (no command string) passes through silently", () => {
+    const r = runHook({ tool_name: "Read", tool_input: { file_path: "/etc/passwd" } });
+    expect(r.status).toBe(0);
+    expect(r.out.trim()).toBe("");
+  });
+
+  test("malformed stdin fails open (exit 0, no output)", () => {
+    const r = runHook("this is not json {");
+    expect(r.status).toBe(0);
+    expect(r.out.trim()).toBe("");
+  });
+});

--- a/tests/project-set-status.test.ts
+++ b/tests/project-set-status.test.ts
@@ -1,0 +1,153 @@
+// tests/project-set-status.test.ts
+//
+// Hermetic L3 tests for the dev board-status setter
+// `.claude/scripts/project-set-status.sh`. A fake `gh` first on PATH serves the
+// Status field/option ids and records the `item-edit` call, so the script's
+// name->option resolution, stdin item-id sourcing, and error paths are pinned
+// without touching the network. Real `jq` still resolves. Free, fast.
+
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SCRIPT = join(REPO_ROOT, ".claude", "scripts", "project-set-status.sh");
+
+// Fake `gh`: serves the Status field + options for `project field-list`, a
+// scalar id for `project view --jq .id`, and records `project item-edit` args
+// to $EDIT_LOG. Any other subcommand is a hard failure (catches drift).
+const FAKE_GH = `#!/usr/bin/env bash
+case "$1 $2" in
+"project field-list")
+  cat <<'JSON'
+{"fields":[{"name":"Status","id":"FIELD_STATUS","options":[
+  {"name":"Backlog","id":"OPT_BACKLOG"},
+  {"name":"Ready","id":"OPT_READY"},
+  {"name":"In progress","id":"OPT_INPROG"},
+  {"name":"In review","id":"OPT_INREVIEW"},
+  {"name":"Done","id":"OPT_DONE"}
+]}]}
+JSON
+  ;;
+"project view")
+  echo "PROJ_123"
+  ;;
+"project item-edit")
+  printf '%s\\n' "$*" >> "$EDIT_LOG"
+  ;;
+*)
+  echo "fake gh: unhandled: $*" >&2; exit 1 ;;
+esac
+`;
+
+const binDir = mkdtempSync(join(tmpdir(), "project-set-status-bin-"));
+writeFileSync(join(binDir, "gh"), FAKE_GH);
+chmodSync(join(binDir, "gh"), 0o755);
+afterAll(() => rmSync(binDir, { recursive: true, force: true }));
+
+let editLog: string;
+beforeEach(() => {
+  editLog = join(mkdtempSync(join(tmpdir(), "project-set-status-log-")), "edits");
+});
+
+function run(args: string[], stdin = ""): {
+  status: number | null;
+  out: string;
+  err: string;
+} {
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    EDIT_LOG: editLog,
+  };
+  const r = spawnSync("bash", [SCRIPT, ...args], {
+    encoding: "utf8",
+    env,
+    input: stdin,
+  });
+  return { status: r.status, out: r.stdout ?? "", err: r.stderr ?? "" };
+}
+
+function editCall(): string {
+  try {
+    return readFileSync(editLog, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+describe("project-set-status.sh: resolves status name -> option id", () => {
+  test("happy path edits the item with the resolved field + option ids", () => {
+    const r = run(["In review", "PVTI_42"]);
+    expect(r.status).toBe(0);
+    const call = editCall();
+    expect(call).toContain("--id PVTI_42");
+    expect(call).toContain("--field-id FIELD_STATUS");
+    expect(call).toContain("--single-select-option-id OPT_INREVIEW");
+    expect(call).toContain("--project-id PROJ_123");
+  });
+
+  test("status match is case-insensitive", () => {
+    const r = run(["in review", "PVTI_7"]);
+    expect(r.status).toBe(0);
+    expect(editCall()).toContain("--single-select-option-id OPT_INREVIEW");
+  });
+
+  test("confirmation goes to stderr; stdout stays empty (pipe-clean)", () => {
+    const r = run(["Done", "PVTI_9"]);
+    expect(r.status).toBe(0);
+    expect(r.out).toBe("");
+    expect(r.err).toMatch(/set PVTI_9 -> "Done"/);
+  });
+});
+
+describe("project-set-status.sh: item id from stdin", () => {
+  test("reads the item id from stdin when omitted (pipe sink)", () => {
+    const r = run(["In progress"], "PVTI_55\n");
+    expect(r.status).toBe(0);
+    const call = editCall();
+    expect(call).toContain("--id PVTI_55");
+    expect(call).toContain("--single-select-option-id OPT_INPROG");
+  });
+
+  test("reads the item id from stdin when the arg is '-'", () => {
+    const r = run(["Done", "-"], "PVTI_56\n");
+    expect(r.status).toBe(0);
+    expect(editCall()).toContain("--id PVTI_56");
+  });
+});
+
+describe("project-set-status.sh: error paths", () => {
+  test("unknown status name dies without editing", () => {
+    const r = run(["Nonsense", "PVTI_1"]);
+    expect(r.status).not.toBe(0);
+    expect(r.err).toMatch(/unknown status/i);
+    expect(editCall()).toBe("");
+  });
+
+  test("missing args prints usage", () => {
+    const r = run([]);
+    expect(r.status).not.toBe(0);
+    expect(r.err).toMatch(/usage/i);
+  });
+
+  test("no item id (none piped, none passed) dies", () => {
+    const r = run(["Done"], "");
+    expect(r.status).not.toBe(0);
+    expect(r.err).toMatch(/no item id/i);
+  });
+});


### PR DESCRIPTION
## Context

Two deterministic pieces of the plugin were already extracted into code but
carried **no `*.test.ts` coverage** — their behavior was unpinned. This is part
of **Workstream B** (the positive half of the deterministic-skill-test thesis):
test the *real behavior* by driving the code, rather than asserting on prose.

## What changed (tests only)

- **`tests/pre-bash-guard.test.ts`** — drives the runtime `PreToolUse` hook
  `hooks/pre-bash-guard.mjs` as a subprocess over stdin JSON. Asserts every
  dangerous pattern (`rm -rf //~`, SQL `DROP`, `git push --force/-f`,
  `git reset --hard`, `chmod 777`, `dd` to a block device, `mkfs`, fork bomb)
  yields `permissionDecision:"ask"`; that safe commands (incl. `rm -rf ./build`)
  pass through; and that malformed / non-Bash input fails open with exit 0.
- **`tests/project-set-status.test.ts`** — hermetic L3 with a fake `gh` first on
  PATH (real `jq`). Pins the case-insensitive Status-name → option-id resolution,
  the field/option/item ids handed to `gh project item-edit`, the stdin item-id
  pipe sink (and the `-` sentinel), the stderr-only confirmation, and the
  unknown-status / usage / no-item-id error paths.

## Scope / versioning

**Dev-only** (only `tests/` added; no runtime file changed) — no version bump,
no changelog cut, plain conventional title.

## Test plan

- [x] `bun test` — 641 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] New tests: 31 pass / 0 fail in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
