### PR TITLE
chore(golden-master): freeze canonical benchmark prompt (Save/Bookmark)

### DIFF
--- a/golden-master/README.md
+++ b/golden-master/README.md
@@ -3,8 +3,19 @@
 This directory holds the **frozen input** for the Team pipeline Golden Master — an
 out-of-band characterization run. We feed the *same* feature prompt to the full
 `/team` pipeline against a *frozen* external app and compare each run's output
-(effectiveness + efficiency metrics) against history, so we can see how changes to
-skills and agents move the result. See the epic: #132.
+(effectiveness + efficiency metrics) against history. See the epic: #132.
+
+The same frozen input serves **two** benchmarks:
+
+1. **Pipeline drift over time** — replay as our skills/agents change; attribute
+   differences to *our* changes.
+2. **Model / provider comparison** — replay on a new underlying model (a new
+   Claude, or GPT / Gemini / etc.) to benchmark *the model itself* through a
+   realistic full-pipeline task (#139).
+
+That is why the prompt is deliberately **provider-neutral** (it names no model and
+no vendor) and the seed app is vanilla — the exact same input is portable across
+any backend.
 
 > **Out of band, by design.** This is **not** part of the build, `bun test`, or
 > CI — running `/team` from inside this repo would let Team's own context poison

--- a/golden-master/README.md
+++ b/golden-master/README.md
@@ -1,0 +1,41 @@
+# Golden Master benchmark
+
+This directory holds the **frozen input** for the Team pipeline Golden Master — an
+out-of-band characterization run. We feed the *same* feature prompt to the full
+`/team` pipeline against a *frozen* external app and compare each run's output
+(effectiveness + efficiency metrics) against history, so we can see how changes to
+skills and agents move the result. See the epic: #132.
+
+> **Out of band, by design.** This is **not** part of the build, `bun test`, or
+> CI — running `/team` from inside this repo would let Team's own context poison
+> what is meant to be a real-world test. The seed app (Linkboard) lives in a
+> **separate, isolated repository**; only the prompt, the per-run results, and the
+> runbook live here.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `prompt.md` | The frozen canonical feature prompt (Save/Bookmark). **DO NOT EDIT.** |
+| `results/` | Per-run metric vectors — added by #136. |
+| `RUNBOOK.md` | Operator procedure for a run — added by #137. |
+
+## Freeze contract
+
+`prompt.md` is immutable: it is replayed verbatim across runs, so editing it
+invalidates every historical comparison. Its SHA-256 is pinned here as a
+tamper check:
+
+```
+f6c46a2388dbfbda56b51c97e7a625e518186b8083ee2bc4afbde41fbbb165fe  golden-master/prompt.md
+```
+
+Verify from the repo root before a run:
+
+```sh
+echo "f6c46a2388dbfbda56b51c97e7a625e518186b8083ee2bc4afbde41fbbb165fe  golden-master/prompt.md" | shasum -a 256 -c
+```
+
+If this fails, the prompt was changed and the benchmark history is no longer
+comparable. This check is run **manually as part of the runbook (#137)** — it is
+deliberately *not* wired into CI, consistent with the out-of-band design above.

--- a/golden-master/README.md
+++ b/golden-master/README.md
@@ -33,18 +33,22 @@ any backend.
 
 ## Freeze contract
 
+A Golden Master run has **two frozen halves**: this `prompt.md` and the Linkboard
+baseline tag **`golden-master-baseline`** (commit `2cfee1a`) that every run branches
+from. The input is **the prompt × that baseline** — keep both pinned.
+
 `prompt.md` is immutable: it is replayed verbatim across runs, so editing it
 invalidates every historical comparison. Its SHA-256 is pinned here as a
 tamper check:
 
 ```
-f6c46a2388dbfbda56b51c97e7a625e518186b8083ee2bc4afbde41fbbb165fe  golden-master/prompt.md
+8c5bb38e357103f783d2ad80dcc8fa551891a586356ab49b3dcebf378580fa4f  golden-master/prompt.md
 ```
 
 Verify from the repo root before a run:
 
 ```sh
-echo "f6c46a2388dbfbda56b51c97e7a625e518186b8083ee2bc4afbde41fbbb165fe  golden-master/prompt.md" | shasum -a 256 -c
+echo "8c5bb38e357103f783d2ad80dcc8fa551891a586356ab49b3dcebf378580fa4f  golden-master/prompt.md" | shasum -a 256 -c
 ```
 
 If this fails, the prompt was changed and the benchmark history is no longer

--- a/golden-master/prompt.md
+++ b/golden-master/prompt.md
@@ -2,7 +2,8 @@
 status: frozen
 feature: save-bookmark-posts
 target_app: linkboard
-frozen_on: 2026-06-26
+target_baseline: golden-master-baseline   # Linkboard commit 2cfee1a
+frozen_on: 2026-06-27
 issue: 134
 epic: 132
 ---
@@ -16,11 +17,15 @@ epic: 132
 > recorded as a *new* file — never an edit to this one. See the epic (#132) and
 > the freeze contract in [`README.md`](./README.md).
 
-**Target app:** Linkboard — a Reddit-style link aggregator (Rails 8 · Inertia ·
-React · Tailwind/Catalyst) with users/auth, boards, link/text posts, **flat**
-comments, and up/down post votes. It deliberately does **not** have
-saved/bookmarked posts — that is exactly the capability this prompt asks the
-pipeline to add, so the app is a clean "before" state.
+**Target app:** Linkboard — a full-featured Reddit-style link aggregator (Rails 8 ·
+Inertia · React · Tailwind/Catalyst): users/auth, boards, link/text posts, **flat**
+comments, up/down votes and ranked feeds, plus the supporting machinery a real app
+accrues (such as notifications, transactional email, background jobs, and real-time
+updates). The one capability it deliberately **lacks** is saved/bookmarked posts —
+exactly what this prompt asks the pipeline to add, so it is a clean "before" state.
+Every run branches from the frozen Linkboard baseline tag **`golden-master-baseline`**
+(commit `2cfee1a`); that tag, replayed with the prompt below, is the complete Golden
+Master input.
 
 **How it is used:** the operator opens a Claude Code session *in the Linkboard
 repository* (never in this repo) and runs `/team` with exactly the text in the

--- a/golden-master/prompt.md
+++ b/golden-master/prompt.md
@@ -1,0 +1,41 @@
+---
+status: frozen
+feature: save-bookmark-posts
+target_app: linkboard
+frozen_on: 2026-06-26
+issue: 134
+epic: 132
+---
+
+# Golden Master — Canonical Feature Prompt (FROZEN)
+
+> ⛔ **DO NOT EDIT.** This is the frozen input for the Team pipeline Golden Master
+> benchmark. The prompt below is replayed **verbatim** across runs to measure
+> pipeline drift; **changing a single character invalidates every historical
+> comparison.** If the feature ever needs to change, that is a *new* benchmark,
+> recorded as a *new* file — never an edit to this one. See the epic (#132) and
+> the freeze contract in [`README.md`](./README.md).
+
+**Target app:** Linkboard — a Reddit-style link aggregator (Rails 8 · Inertia ·
+React · Tailwind/Catalyst) with users/auth, boards, link/text posts, **flat**
+comments, and up/down post votes. It deliberately does **not** have
+saved/bookmarked posts — that is exactly the capability this prompt asks the
+pipeline to add, so the app is a clean "before" state.
+
+**How it is used:** the operator opens a Claude Code session *in the Linkboard
+repository* (never in this repo) and runs `/team` with exactly the text in the
+block below. The full procedure lives in the runbook (#137).
+
+## The prompt (verbatim — copy the block below)
+
+```text
+I want signed-in users to be able to save posts for later. On any post — in a
+board listing or on the post's own page — there should be a "Save" control that
+toggles to "Saved" when clicked, so people can save and unsave without leaving
+the page they're on. Add a /saved page that lists everything the current user
+has saved, newest first, and show a small count somewhere sensible so I can see
+how many I've saved. Saving is private — only I can see my own saved posts, and
+signed-out visitors shouldn't see the control at all. Please cover the
+migration, the model and associations, routes and controller, the views, and
+tests. Keep an eye on N+1 queries on the listings and on the saved page.
+```


### PR DESCRIPTION
Adds the frozen input for the Team pipeline **Golden Master** characterization run (epic #132): the one canonical feature prompt that will be replayed verbatim against the isolated Linkboard seed app so we can measure how skill/agent changes move the pipeline's output over time.

## What's in this PR

- `golden-master/prompt.md` — the **frozen** canonical prompt. Selected **Candidate 1 (Save/Bookmark posts)** from the three drafted candidates, on a signal-to-noise argument: its requirements are near closed-form, so two correct runs look alike and a *divergence* is real evidence of pipeline drift rather than the implementer picking a different-but-valid design — while still driving a full vertical slice (migration → model → routes/controller → views → tests → authz/N+1). Carries a `DO NOT EDIT` contract + `status: frozen` frontmatter.
- `golden-master/README.md` — the directory's purpose, the **out-of-band** design note (this is *not* part of the build/`bun test`/CI — running `/team` from inside this repo would poison a real-world test), and a **SHA-256 freeze contract** pinning `prompt.md` (verified manually in the runbook, not in CI).

## Why dev-only (no version bump)

`golden-master/` lives entirely outside the distributed plugin — no `agents/`, `skills/`, `hooks/`, or `.claude-plugin/` change — so per the Runtime-vs-Development split this lands with **no version bump and no changelog cut**, on a plain conventional title. The deterministic `version-bump-required.sh` gate should pass on that basis.

## Scope / what's intentionally NOT here

- The **seed app** (Linkboard) is a *separate isolated repo* (#133), not part of this PR.
- **Metrics capture** (#136), **baseline/compare** (#135), and the **operator runbook + `results/`** (#137) are follow-ups; `README.md` references them as forthcoming.

## Test plan

- [x] `prompt.md` SHA-256 matches the value pinned in `README.md`:
      `f6c46a2388dbfbda56b51c97e7a625e518186b8083ee2bc4afbde41fbbb165fe`
- [x] Change is markdown-only under a new `golden-master/` directory; touches no runtime plugin files.
- [ ] Reviewer: confirm Candidate 1 is the prompt we want frozen (it is trivially swappable before merge if not).

Part of #132.

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
