### PR TITLE
docs(project-tracking): require every bug to be P0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,4 +108,6 @@ Behavioral regression harness for pipeline agents — TypeScript + Bun. Harness 
 
 All work — features, bugs, chores — is tracked on the [GitHub Project board](https://github.com/users/bostonaholic/projects/5/views/1). It is the single source of truth: if work is not on the board, it is not tracked. Create a GitHub issue in `bostonaholic/team`, add it to the project, and move its card across the kanban (**Backlog → Ready → In progress → In review → Done**) as the work progresses. See [docs/project-tracking.md](docs/project-tracking.md) for the full workflow.
 
+**Every `bug` is filed as `P0`** — bugs take precedence over features and enhancements; see [docs/project-tracking.md](docs/project-tracking.md#creating-work).
+
 > The GitHub Project replaces the previous **bd (beads)** tracker. The `.beads/` directory remains for historical reference but is no longer the front door for new work.

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -33,7 +33,7 @@ carry a few fields beyond title:
 | Field | Purpose |
 |-------|---------|
 | **Status** | Which kanban column the card is in (see below). |
-| **Priority** | `P0` (drop everything) … `P2` (eventually). |
+| **Priority** | `P0` (drop everything) … `P2` (eventually). **Every `bug` is `P0`** — see [Creating work](#creating-work). |
 | **Size** | Rough effort estimate. |
 | **Labels** | What kind of work this is and how it should be handled — see [Labels](#labels). |
 | **Linked pull requests** | The PR(s) that implement the card. |
@@ -62,6 +62,11 @@ or chore.
    *draft item* directly on the board (the "+ Add item" row). Convert it to a
    real issue before anyone starts work on it.
 
+> **Rule — every `bug` is `P0`.** When you file or triage a bug, set its
+> **Priority** to `P0`. Bugs take precedence over features and enhancements —
+> there is no lower-priority bug. (A defect that genuinely isn't worth dropping
+> other work for is usually an `enhancement`, not a `bug`.)
+
 ## Labels
 
 Labels classify *what a card is* and *how it should be handled* — the kanban
@@ -82,7 +87,7 @@ the board. If none of the three fits, the item is almost certainly a
 
 | Label | Definition | Assign when |
 |-------|------------|-------------|
-| `bug` | Something isn't working | Existing behavior is broken, incorrect, or crashes — a defect in shipped functionality. Reproduction steps belong in the issue. |
+| `bug` | Something isn't working | Existing behavior is broken, incorrect, or crashes — a defect in shipped functionality. Reproduction steps belong in the issue. **Always set Priority `P0`** (see [Creating work](#creating-work)). |
 | `enhancement` | New feature or request | New capability, or an improvement to existing behavior that works but should do more or do it better. **This is the "feature" label — there is no separate `feature` label.** |
 | `documentation` | Improvements or additions to documentation | The change is to docs only (`README`, `docs/`, `AGENTS.md`, code comments) with no behavior change. If code *and* docs change, use the code label (`bug`/`enhancement`), not this. |
 


### PR DESCRIPTION
Codifies the rule that **every `bug` is `P0`** — bugs take precedence over features and enhancements; there is no lower-priority bug.

## Where it's documented
- **`docs/project-tracking.md`** — the board **Priority** row, a **rule callout** under *Creating work*, and the **`bug`** label row.
- **`AGENTS.md`** (project router) → *Work Tracking* section, so agents see it every session.

First application: bug #141 was filed at Priority **P0** under this rule.

Dev/docs-only change → no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B718yPv3Zo52R5wxYYD1tM
