### PR TITLE
docs(project-tracking): require a priority on every issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,6 @@ Behavioral regression harness for pipeline agents — TypeScript + Bun. Harness 
 
 All work — features, bugs, chores — is tracked on the [GitHub Project board](https://github.com/users/bostonaholic/projects/5/views/1). It is the single source of truth: if work is not on the board, it is not tracked. Create a GitHub issue in `bostonaholic/team`, add it to the project, and move its card across the kanban (**Backlog → Ready → In progress → In review → Done**) as the work progresses. See [docs/project-tracking.md](docs/project-tracking.md) for the full workflow.
 
-**Every `bug` is filed as `P0`** — bugs take precedence over features and enhancements; see [docs/project-tracking.md](docs/project-tracking.md#creating-work).
+**Every issue carries a `Priority`** (`P0`/`P1`/`P2`), set when it's created — an unprioritized issue is untriaged. **Every `bug` is `P0`** — bugs take precedence over features and enhancements. See [docs/project-tracking.md](docs/project-tracking.md#creating-work).
 
 > The GitHub Project replaces the previous **bd (beads)** tracker. The `.beads/` directory remains for historical reference but is no longer the front door for new work.

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -33,7 +33,7 @@ carry a few fields beyond title:
 | Field | Purpose |
 |-------|---------|
 | **Status** | Which kanban column the card is in (see below). |
-| **Priority** | `P0` (drop everything) … `P2` (eventually). **Every `bug` is `P0`** — see [Creating work](#creating-work). |
+| **Priority** | `P0` (drop everything) … `P2` (eventually). **Required on every card**; every `bug` is `P0` — see [Creating work](#creating-work). |
 | **Size** | Rough effort estimate. |
 | **Labels** | What kind of work this is and how it should be handled — see [Labels](#labels). |
 | **Linked pull requests** | The PR(s) that implement the card. |
@@ -56,11 +56,15 @@ or chore.
    gh issue edit <number> --repo bostonaholic/team \
      --add-project "🤖 Team"
    ```
-   Then set **Status**, **Priority**, **Size**, and its **type label** (see
-   [Labels](#labels)) from the board or the issue sidebar.
+   Then set **Status**, **Priority** (**required** — see below), **Size**, and its
+   **type label** (see [Labels](#labels)) from the board or the issue sidebar.
 3. **Quick capture** — for an idea you have not fully shaped yet, add a
    *draft item* directly on the board (the "+ Add item" row). Convert it to a
    real issue before anyone starts work on it.
+
+> **Rule — every issue carries a `Priority`.** A card is not fully created until it
+> has a `P0`/`P1`/`P2` set — an issue with no priority is untriaged. Set it when you
+> file the issue (or the moment you add it to the board); don't leave it blank.
 
 > **Rule — every `bug` is `P0`.** When you file or triage a bug, set its
 > **Priority** to `P0`. Bugs take precedence over features and enhancements —


### PR DESCRIPTION
Codifies the rule that **every issue must carry a `Priority`** (`P0`/`P1`/`P2`) when created — an unprioritized issue is untriaged. Complements the existing bugs-are-P0 rule.

## Where it's documented
- **`docs/project-tracking.md`** — the board **Priority** row (now "required on every card"), the *Creating work* step (Priority marked **required**), and a **rule callout**.
- **`AGENTS.md`** (project router) → *Work Tracking* section.

Dev/docs-only change → no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B718yPv3Zo52R5wxYYD1tM