### PR TITLE
fix: verify board status moves instead of trusting the edit's exit code

### DIFF
--- a/.claude/scripts/project-set-status.sh
+++ b/.claude/scripts/project-set-status.sh
@@ -20,8 +20,11 @@
 #   Backlog | Ready | In progress | In review | Done
 #
 # Resolves the project, Status field, and target option IDs at runtime by name,
-# so it survives field/option recreation. Prints a confirmation to stderr;
-# stdout is left empty. Requires: gh (authenticated) and jq.
+# so it survives field/option recreation. After editing, it RE-READS the
+# authoritative project-side status and fails loudly if it does not match the
+# requested column — a successful exit from item-edit is not proof the move took
+# (bug #141). Prints a confirmation to stderr; stdout is left empty. Requires:
+# gh (authenticated) and jq.
 
 set -uo pipefail
 
@@ -59,12 +62,31 @@ EOF
 project_id="$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.id')" \
   || die "failed to resolve project id"
 
-gh project item-edit \
+# Perform the edit. Capture its output instead of suppressing it, so a silent
+# or partial failure surfaces in the error rather than being masked (bug #141).
+edit_out="$(gh project item-edit \
   --project-id "$project_id" \
   --id "$item_id" \
   --field-id "$field_id" \
-  --single-select-option-id "$option_id" \
-  >/dev/null \
-  || die "item-edit failed"
+  --single-select-option-id "$option_id" 2>&1)" \
+  || die "item-edit failed: ${edit_out:-<no output>}"
 
-printf 'set %s -> "%s"\n' "$item_id" "$status" >&2
+# Verify the move actually took. A clean exit from item-edit is NOT proof: a
+# silent/partial write would otherwise pass unnoticed. Re-read the AUTHORITATIVE
+# project-side status and fail loudly if it does not match the requested column
+# (bug #141). LIMIT mirrors project-item-id.sh so a recent item past the default
+# first page is still found.
+LIMIT=10000
+items_json="$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit "$LIMIT")" \
+  || die "failed to re-read project status for verification (is gh authenticated?)"
+actual="$(printf '%s' "$items_json" \
+  | jq -r --arg id "$item_id" '.items[] | select(.id == $id) | .status')"
+[ -n "$actual" ] \
+  || die "verification failed: item $item_id not found on project $PROJECT_NUMBER after edit"
+
+if [ "$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')" \
+     != "$(printf '%s' "$status" | tr '[:upper:]' '[:lower:]')" ]; then
+  die "verification failed: requested \"$status\" but board reports \"$actual\" for $item_id — the move did not take. If the board UI looks stale, hard-refresh it (the value is authoritative here); otherwise the write did not land."
+fi
+
+printf 'set %s -> "%s" (verified)\n' "$item_id" "$status" >&2

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -216,6 +216,23 @@ Both resolve every GitHub node ID at runtime, so they keep working if a field
 or option is recreated. They are dev-only helpers (under `.claude/`), not part
 of the distributed plugin.
 
+> **Moves are verified, not assumed.** `project-set-status.sh` does not trust
+> the edit's exit code. After it fires `gh project item-edit` (without
+> suppressing the command's output), it **re-reads the authoritative
+> project-side status and fails loudly if it does not match the column you
+> asked for** — printing `... (verified)` only when the read-back agrees. So a
+> zero exit from the script means the move genuinely landed, not just that the
+> mutation was accepted. This closes [#141](https://github.com/bostonaholic/team/issues/141),
+> where an edit reported success but the board appeared unchanged.
+>
+> **UI-refresh gotcha.** The GraphQL value is authoritative; an *already-open*
+> board tab is not. The Projects UI does not always live-update an open view, so
+> a move that the script reports as `(verified)` can still look stale in a tab
+> you left open — **hard-refresh the board** (or reopen the view) to see it.
+> Trust the script's verified read-back over a stale tab. (When you edit by
+> hand, never pipe `item-edit` through `tail`/`head`/`… | …` that swallows its
+> output — that masks a silent or partial write; let the script verify instead.)
+
 ## How it ties to the QRSPI pipeline
 
 A Team run (`/team`, or the individual `/team-*` phases) maps onto the board

--- a/tests/project-set-status.test.ts
+++ b/tests/project-set-status.test.ts
@@ -1,0 +1,133 @@
+// tests/project-set-status.test.ts
+//
+// Regression + contract tests for the dev board status setter,
+// `.claude/scripts/project-set-status.sh`. The script must set a card's Status
+// column AND verify the move took — it re-reads the authoritative project-side
+// status after the edit and fails loudly if it does not match the target.
+//
+// Regression: this pins bug #141 — the setter fired `gh project item-edit` with
+// its output suppressed (`>/dev/null`) and trusted the exit code, never reading
+// back the result. A silent or partial write (or a UI/consistency discrepancy)
+// was therefore reported as success. The fix makes the move verifiable:
+// read the authoritative status back and fail loudly on mismatch. These tests
+// drive the script against a stateful fake `gh` and assert that a masked write
+// (read-back never reflects the edit) fails loudly, while an honest write
+// confirms.
+//
+// Hermetic: a fake `gh` is placed first on PATH, so the script never touches the
+// network. Free, fast, gate-tier (L3 per docs/testing.md).
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SCRIPT = join(REPO_ROOT, ".claude", "scripts", "project-set-status.sh");
+
+// A stateful fake `gh` covering the four project subcommands the setter uses:
+//   field-list  → the Status field + its column options
+//   view        → the project node id (script reads it via --jq '.id')
+//   item-edit   → records the option id it was asked to set into $GH_FAKE_STATE
+//   item-list   → reports each item's status. In honest mode it reflects the
+//                 last item-edit; in masked mode ($GH_FAKE_MASK=1) it always
+//                 reports a STALE "Backlog", simulating a silent/partial write
+//                 or a board that never converges on the new value.
+const FAKE_GH = `#!/usr/bin/env bash
+sub="$2"
+opt=""; prev=""
+for a in "$@"; do
+  case "$prev" in --single-select-option-id) opt="$a" ;; esac
+  prev="$a"
+done
+case "$sub" in
+  field-list)
+    jq -n '{fields:[{id:"FIELD_STATUS", name:"Status", options:[
+      {id:"OPT_BACKLOG", name:"Backlog"},
+      {id:"OPT_READY", name:"Ready"},
+      {id:"OPT_INPROG", name:"In progress"},
+      {id:"OPT_INREVIEW", name:"In review"},
+      {id:"OPT_DONE", name:"Done"}
+    ]}]}'
+    ;;
+  view)
+    printf '%s\\n' "PVT_TEST"
+    ;;
+  item-edit)
+    printf '%s' "$opt" > "$GH_FAKE_STATE"
+    ;;
+  item-list)
+    if [ "\${GH_FAKE_MASK:-0}" = "1" ]; then
+      status="Backlog"
+    else
+      optid="$(cat "$GH_FAKE_STATE" 2>/dev/null)"
+      case "$optid" in
+        OPT_BACKLOG) status="Backlog" ;;
+        OPT_READY) status="Ready" ;;
+        OPT_INPROG) status="In progress" ;;
+        OPT_INREVIEW) status="In review" ;;
+        OPT_DONE) status="Done" ;;
+        *) status="Backlog" ;;
+      esac
+    fi
+    jq -n --arg s "$status" '{items:[{id:"PVTI_TEST", status:$s, content:{number:42}}], totalCount:1}'
+    ;;
+esac
+`;
+
+const binDir = mkdtempSync(join(tmpdir(), "project-set-status-"));
+writeFileSync(join(binDir, "gh"), FAKE_GH);
+chmodSync(join(binDir, "gh"), 0o755);
+const stateFile = join(binDir, "state");
+
+afterAll(() => rmSync(binDir, { recursive: true, force: true }));
+
+// Run the setter with the fake `gh` first on PATH (real `jq` still resolves).
+// `mask` flips the fake into masked-write mode.
+function run(status: string, itemId: string, mask = false) {
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    GH_FAKE_STATE: stateFile,
+    GH_FAKE_MASK: mask ? "1" : "0",
+  };
+  const r = spawnSync("bash", [SCRIPT, status, itemId], { encoding: "utf8", env });
+  return { status: r.status, out: (r.stdout ?? "").trim(), err: r.stderr ?? "" };
+}
+
+describe("project-set-status.sh: verifies the move (#141)", () => {
+  test("regression: fails loudly when the read-back does not match the target", () => {
+    const r = run("In review", "PVTI_TEST", /* mask */ true);
+    expect(r.status).not.toBe(0);
+    expect(r.err).toMatch(/in review/i); // names the requested target
+    expect(r.err).toMatch(/backlog/i); // names the actual (stale) status
+  });
+
+  test("confirms the move when the read-back matches the target", () => {
+    const r = run("In review", "PVTI_TEST");
+    expect(r.status).toBe(0);
+    expect(r.err).toMatch(/in review/i);
+  });
+
+  test("still rejects an unknown status before touching the board", () => {
+    const r = run("Nonsense", "PVTI_TEST");
+    expect(r.status).not.toBe(0);
+    expect(r.err).toMatch(/unknown status/i);
+  });
+});
+
+describe("project-set-status.sh: source contract", () => {
+  // Lock the fix in: the setter must NOT suppress item-edit's result and MUST
+  // re-read the authoritative status to verify the move (#141).
+  test("does not suppress the item-edit command's output with >/dev/null", () => {
+    // Anchor on the actual invocation, not any prose mention of "item-edit".
+    expect(read(SCRIPT)).not.toMatch(/gh project item-edit[\s\S]*?>\s*\/dev\/null/);
+  });
+
+  test("re-reads the authoritative status with item-list", () => {
+    expect(read(SCRIPT)).toContain("item-list");
+  });
+});


### PR DESCRIPTION
## What

`project-set-status.sh` fired `gh project item-edit` with its stdout suppressed (`>/dev/null`) and inferred success from the exit code alone. A silent/partial write — or a board that never converged on the new value — was therefore reported as success. That is the root cause of #141: an edit that "succeeded" while the board looked unchanged was indistinguishable from a UI lag.

## Fix

The setter is now **move-and-verify**:

1. Captures `item-edit`'s output instead of suppressing it, so a partial failure surfaces in the error.
2. Re-reads the **authoritative** project-side status with `gh project item-list` and **fails loudly** if it doesn't match the requested column — printing `... (verified)` only on a match.

`docs/project-tracking.md` documents the verification behavior and the Projects **UI-refresh gotcha** (an already-open board tab can look stale even after a verified move — hard-refresh it; the read-back is authoritative).

## Root cause (5 Whys)

The move operation was **not verifiable**: it violated fail-fast/fail-loud — no read-back-and-compare, so a real failure and a UI-consistency lag passed identically and silently. The most likely cause of the *observed* symptom (Projects UI eventual consistency / stale tab) is not a code defect — it's now a documented gotcha. The fixable defect was the unverifiable move.

## Test plan

- [x] New hermetic L3 test (`tests/project-set-status.test.ts`) drives the script against a stateful fake `gh`.
  - [x] Masked-write mode (read-back never reflects the edit) → script **fails loudly**, naming both requested and actual status. (Red on unfixed code, green after.)
  - [x] Honest mode → exits 0 and confirms `(verified)`.
  - [x] Source contract: no `>/dev/null` on the `item-edit` command; re-reads via `item-list`.
- [x] Full free suite green (`bun test`: 615 pass, 0 fail).
- [x] Live read-back verified against the real board (`… (verified)`, exit 0).

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)