### PR TITLE
v0.16.0 feat: code reviewer blocks flaky-test red flags on first occurrence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.15.0"
+    "version": "0.16.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-15
+
 ### Added
 
 - **The code reviewer now blocks flaky-test red flags on first occurrence — including "time-bomb" tests that pass today and deterministically fail on a future date.** [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) gains a **Flaky-test red flags (always blocking)** checklist: ten root-cause categories sourced from the flaky-test literature (Luo et al. FSE 2014; Fowler's *Eradicating Non-Determinism in Tests*; Google/Uber/GitHub engineering practice) — time/date dependence incl. time-bombs, fixed-sleep waits, concurrency interleaving, test-order dependence and shared state, unseeded randomness, real network calls, resource leaks and hard-coded ports, unordered-collection assumptions, exact float equality, and platform/environment assumptions — each with diff-visible signatures a reviewer can grep for, plus a fenced bad/good time-bomb example. Unlike the style flags' escalate-on-repetition rule, any test whose *outcome depends on* a nondeterministic input is an `issue (blocking)` on **first** occurrence — time-bombs are invisible to rerun-based flaky detection, so the diff is the only place to catch them. The [`agents/code-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/code-reviewer.md) mirror names both severity regimes, and a new `planted-time-bomb` eval fixture (`tier: periodic`) behaviorally proves the reviewer detects the planted bug *and* labels it blocking. Pinned by L2 tripwires in [`tests/methodology.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/methodology.test.ts), including a byte-identical drift pin on the shared example pair.
@@ -202,7 +204,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/bostonaholic/team/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/bostonaholic/team/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/bostonaholic/team/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/bostonaholic/team/compare/v0.13.2...v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The code reviewer now blocks flaky-test red flags on first occurrence — including "time-bomb" tests that pass today and deterministically fail on a future date.** [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) gains a **Flaky-test red flags (always blocking)** checklist: ten root-cause categories sourced from the flaky-test literature (Luo et al. FSE 2014; Fowler's *Eradicating Non-Determinism in Tests*; Google/Uber/GitHub engineering practice) — time/date dependence incl. time-bombs, fixed-sleep waits, concurrency interleaving, test-order dependence and shared state, unseeded randomness, real network calls, resource leaks and hard-coded ports, unordered-collection assumptions, exact float equality, and platform/environment assumptions — each with diff-visible signatures a reviewer can grep for, plus a fenced bad/good time-bomb example. Unlike the style flags' escalate-on-repetition rule, any test whose *outcome depends on* a nondeterministic input is an `issue (blocking)` on **first** occurrence — time-bombs are invisible to rerun-based flaky detection, so the diff is the only place to catch them. The [`agents/code-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/code-reviewer.md) mirror names both severity regimes, and a new `planted-time-bomb` eval fixture (`tier: periodic`) behaviorally proves the reviewer detects the planted bug *and* labels it blocking. Pinned by L2 tripwires in [`tests/methodology.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/methodology.test.ts), including a byte-identical drift pin on the shared example pair.
+- **Test authors get the prevention side of the same contract.** [`skills/test-first-development/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md) "Test Style Rules" gains six deterministic-input subsections — *Control the clock*, *Seed all randomness*, *Tests own their state — any order, any host*, *Assert outcomes, not interleavings*, *Impose order before asserting it*, and *Hermetic boundaries* — with bad/good examples, so every reviewer-blocking category has matching author-side guidance before the test is ever written. [`agents/test-architect.md`](https://github.com/bostonaholic/team/blob/main/agents/test-architect.md)'s audit table gains a **Deterministic inputs** row.
+
+### Changed
+
+- **A single `sleep()` used for synchronization is now a blocking finding, not a suggestion.** Async wait is the most common flaky-test root cause (~45% in Luo et al.), so the flag relocated from the escalating style-flag list into the always-blocking flaky checklist in [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) — a diff previously approved with a non-blocking suggestion will now loop the implementer until the sleep is replaced with a wait-for-condition primitive.
+
 ## [0.15.0] - 2026-07-13
 
 ### Changed

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -49,13 +49,17 @@ show. This isolation is intentional: it prevents self-evaluation bias.
      - ISP: does this interface force clients to depend on unused methods?
      - DIP: does business logic instantiate its own infrastructure dependencies?
    - **Test files** — Walk every changed `*test*` / `*spec*` /
-     `__tests__/*` file against the test-quality flags in
+     `__tests__/*` file against both severity regimes in
      `skills/code-review/SKILL.md` (Code Reviewer verdict section) and the
-     style rules in `skills/test-first-development/SKILL.md`. Flag
-     change-detector patterns, mock chains, full-equality assertions on
-     complex objects, `sleep()` for synchronization, logic in tests, and
-     method-named tests. A single occurrence is a `suggestion:`; multiple
-     occurrences across the diff become `issue:`.
+     style rules in `skills/test-first-development/SKILL.md`. Style flags
+     (change-detector patterns, mock chains, full-equality assertions on
+     complex objects, logic in tests, method-named tests) escalate: a
+     single occurrence is a `suggestion:`; multiple occurrences across the
+     diff become `issue:`. Flaky-test red flags (time/date dependence,
+     unseeded randomness, race-ordered assertions, `sleep()` for
+     synchronization, and the rest of the checklist in
+     `skills/code-review/SKILL.md`) are blocking `issue:` findings on
+     **first** occurrence.
 
 5. **Run tests.** Execute the project's test suite to verify tests pass. Report
    the command used and the result.

--- a/agents/test-architect.md
+++ b/agents/test-architect.md
@@ -82,6 +82,7 @@ the bar below is the audit checklist.
 | Narrow assertion | The assertion targets the specific field/effect under test. No full-equality on complex objects unless that IS the contract. |
 | Actionable failure | If the test fails, the failure message names the failing condition. `EXPECT_OK(...)` not `EXPECT_TRUE(...ok())`. |
 | No sleeps | No `sleep()` for synchronization. Use wait-for-condition primitives. |
+| Deterministic inputs | No wall-clock reads, unseeded randomness, order-dependent or shared-state assumptions, real network, hard-coded ports, or exact float equality feeding an assertion. Clock frozen/injected; RNG seeded. |
 | No test logic | No `if`, no loops, no string-building inside the test body. |
 | One scenario per test | The test verifies one behavior and runs independently in any order. |
 | DAMP setup | Setup the reader needs to understand the test lives in the test (or a helper that takes the asserted value as a parameter). |

--- a/agents/test-architect.md
+++ b/agents/test-architect.md
@@ -82,7 +82,7 @@ the bar below is the audit checklist.
 | Narrow assertion | The assertion targets the specific field/effect under test. No full-equality on complex objects unless that IS the contract. |
 | Actionable failure | If the test fails, the failure message names the failing condition. `EXPECT_OK(...)` not `EXPECT_TRUE(...ok())`. |
 | No sleeps | No `sleep()` for synchronization. Use wait-for-condition primitives. |
-| Deterministic inputs | No wall-clock reads, unseeded randomness, order-dependent or shared-state assumptions, real network, hard-coded ports, or exact float equality feeding an assertion. Clock frozen/injected; RNG seeded. |
+| Deterministic inputs | No wall-clock reads, unseeded randomness, order-dependent or shared-state assumptions, race-interleaving assumptions, positional asserts on unordered collections, real network, hard-coded ports, or exact float equality feeding an assertion. Clock frozen/injected; RNG seeded. |
 | No test logic | No `if`, no loops, no string-building inside the test body. |
 | One scenario per test | The test verifies one behavior and runs independently in any order. |
 | DAMP setup | Setup the reader needs to understand the test lives in the test (or a helper that takes the asserted value as a parameter). |

--- a/evals/README.md
+++ b/evals/README.md
@@ -165,6 +165,12 @@ junk prose is not enough to pass. The skill evals mirror this: each runs
 generic `judgeQuality`) behind the deterministic check. Both scores are
 recorded in `judge_scores` on the result entry.
 
+A fixture case may also carry an additional deterministic gate beyond the two
+rubric criteria. Such a gate lives in the eval file's per-fixture options, not
+in `evals/rubrics/<agent>.md` — e.g. the planted-time-bomb case's
+blocking-label assertion (`requireBlockingLabel` in
+`tests/code-reviewer.evals.ts`).
+
 ## Run history & comparison
 
 Every run writes `<version>-<branch>-<tier>-<timestamp>.json` to
@@ -259,5 +265,11 @@ Both `periodic-evals.yml` and `pr-evals.yml` now carry live copies of this
 canonical trust `if:` expression. They must stay byte-identical, and the
 `TRUST_EXPR` tripwire in `tests/static-gate.test.ts` enforces that — any drift
 fails the free gate.
+
+**Adding a second fixture to an existing agent:** a single `<name>.evals.ts`
+can register multiple fixture cases through a shared parameterized helper —
+`registerPlantedBugEval` in `tests/code-reviewer.evals.ts` is the reference.
+Each case is independently diff-selected by fixture name, with its own
+`E2E_TOUCHFILES` and `E2E_TIERS` entries.
 
 Run `bun run eval:list` to see the registered tests and their tiers.

--- a/evals/fixtures/code-reviewer/planted-time-bomb/ground-truth.json
+++ b/evals/fixtures/code-reviewer/planted-time-bomb/ground-truth.json
@@ -1,0 +1,13 @@
+{
+  "bugs": [
+    {
+      "id": "b1",
+      "category": "flaky-test-time-bomb",
+      "severity": "blocking",
+      "description": "The 'accepts a session that has not expired' test reads the real wall clock (new Date()) feeding the assertion and pins a hard-coded future expiry (2030-01-01); it is green today and turns permanently red once the clock crosses the literal. The clock must be frozen/injected and the expiry derived from it.",
+      "detection_hint": "time.?bomb|wall.?clock|real clock|system clock|current (?:time|date)|future (?:date|expiry|expiration|timestamp)|2030-01-01|flak(?:y|iness)|non.?deterministic|date\\.now|new date\\(\\).{0,120}assert"
+    }
+  ],
+  "minimum_detection": 1.0,
+  "max_false_positives": 1
+}

--- a/evals/fixtures/code-reviewer/planted-time-bomb/ground-truth.json
+++ b/evals/fixtures/code-reviewer/planted-time-bomb/ground-truth.json
@@ -5,7 +5,7 @@
       "category": "flaky-test-time-bomb",
       "severity": "blocking",
       "description": "The 'accepts a session that has not expired' test reads the real wall clock (new Date()) feeding the assertion and pins a hard-coded future expiry (2030-01-01); it is green today and turns permanently red once the clock crosses the literal. The clock must be frozen/injected and the expiry derived from it.",
-      "detection_hint": "time.?bomb|wall.?clock|real clock|system clock|current (?:time|date)|future (?:date|expiry|expiration|timestamp)|2030-01-01|flak(?:y|iness)|non.?deterministic|date\\.now|new date\\(\\).{0,120}assert"
+      "detection_hint": "time.?bomb|wall.?clock|real clock|system clock|future (?:date|expiry|expiration|timestamp)|2030-01-01|non.?deterministic|date\\.now|new date\\(\\).{0,120}assert"
     }
   ],
   "minimum_detection": 1.0,

--- a/evals/fixtures/code-reviewer/planted-time-bomb/input.md
+++ b/evals/fixtures/code-reviewer/planted-time-bomb/input.md
@@ -1,0 +1,38 @@
+---
+agent: code-reviewer
+tier: periodic
+deps:
+  - agents/code-reviewer.md
+  - skills/code-review/SKILL.md
+---
+
+# Synthetic implementer artifact: session-token expiry check
+
+The implementer added a small helper that decides whether a session token
+is still valid, plus its tests. The code below is the slice's only
+material change.
+
+```js
+// src/auth/session.js
+export function isSessionValid(session, at) {
+  return new Date(session.expiresAt).getTime() > at.getTime();
+}
+```
+
+```js
+// test/auth/session.test.js
+import { isSessionValid } from "../../src/auth/session.js";
+
+test("accepts a session that has not expired", () => {
+  const session = { expiresAt: "2030-01-01T00:00:00Z" };
+  expect(isSessionValid(session, new Date())).toBe(true);
+});
+
+test("rejects a session that expired before the check", () => {
+  const checkedAt = new Date("2024-06-15T12:00:00Z");
+  const session = { expiresAt: "2024-06-14T12:00:00Z" };
+  expect(isSessionValid(session, checkedAt)).toBe(false);
+});
+```
+
+The implementer notes: "Both tests pass locally and in CI."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -171,11 +171,16 @@ depends on them, even when the offending test's own result is deterministic.
   or CI-parallelism assumptions.
 
 **Time-bomb example** (a rerun never exposes it — only the diff does):
+
+**Bad:**
 ```js
 // Bad — wall-clock read feeds the assertion; hard-coded future expiry.
+// Green today, permanently red once the clock crosses the literal.
 const token = { expiresAt: "2030-01-01" };
 expect(isValid(token, new Date())).toBe(true);
 ```
+
+**Good:**
 ```js
 // Good — frozen/injected clock; expiry derived from it.
 const now = new Date("2024-06-15T12:00:00Z");

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -145,7 +145,8 @@ depends on them, even when the offending test's own result is deterministic.
   construction. Past/fixed date literals with an explicit TZ do not flag.
 - **Fixed-sleep / timed waits** — `sleep()` for synchronization:
   `Thread.sleep(ms)`, `setTimeout`-as-wait, `cy.wait(3000)`,
-  `page.waitForTimeout(...)`; a bounded wait whose success is asserted.
+  `page.waitForTimeout(...)`; a bounded wait whose success is asserted
+  (`assertTrue(latch.await(100, MS))` — a capped wait still flags).
   Tests legitimately about time require a frozen/fake clock — a real
   sleep to observe a delay still flags.
 - **Concurrency / race interleaving** — assertions assuming a completion

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -134,6 +134,9 @@ Blocking tier and auto-loops the implementer. A single time-bomb ships a
 guaranteed future CI failure; flakiness erodes the "green means safe"
 signal. The rule keys to outcome-dependence, not token presence: a
 `Date.now()` in a log line does not flag; one feeding an assertion does.
+Outcome-dependence covers the whole suite, not only the offending test:
+state or resources left behind flag because a *later* test's outcome
+depends on them, even when the offending test's own result is deterministic.
 
 - **Time/date dependence, incl. time-bombs** — `new Date()`, `Date.now()`,
   `datetime.now()` feeding an assertion; a future date literal in a fixture
@@ -172,7 +175,8 @@ signal. The rule keys to outcome-dependence, not token presence: a
 // Bad — wall-clock read feeds the assertion; hard-coded future expiry.
 const token = { expiresAt: "2030-01-01" };
 expect(isValid(token, new Date())).toBe(true);
-
+```
+```js
 // Good — frozen/injected clock; expiry derived from it.
 const now = new Date("2024-06-15T12:00:00Z");
 const token = issueToken({ now, ttlDays: 30 });

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -121,12 +121,63 @@ they appear across multiple tests:
   real or fake equivalent
 - Full-equality assertions on complex objects when one field carries the
   contract
-- `sleep()` for synchronization
 - Logic in tests (`if`, loops, string-building) that can carry the same
   bug as the code
 - Tests named after methods (`testProcessOrder_2`) rather than behaviors
   (`refundsCardOnPartialFailure`)
 - DRY helpers that hide the asserted value
+
+**Flaky-test red flags (always blocking).** Distinct from the style flags
+above: any test in the diff whose *outcome depends on* a nondeterministic
+input is `issue (blocking)` on **first** occurrence — it routes to the
+Blocking tier and auto-loops the implementer. A single time-bomb ships a
+guaranteed future CI failure; flakiness erodes the "green means safe"
+signal. The rule keys to outcome-dependence, not token presence: a
+`Date.now()` in a log line does not flag; one feeding an assertion does.
+
+- **Time/date dependence, incl. time-bombs** — `new Date()`, `Date.now()`,
+  `datetime.now()` feeding an assertion; a future date literal in a fixture
+  (`expiresAt: "2030-01-01"`, cert `notAfter`); naive calendar arithmetic
+  on "now" (`addMonths`, month-end/DST/leap assumptions); TZ-naive date
+  construction. Past/fixed date literals with an explicit TZ do not flag.
+- **Fixed-sleep / timed waits** — `sleep()` for synchronization:
+  `Thread.sleep(ms)`, `setTimeout`-as-wait, `cy.wait(3000)`,
+  `page.waitForTimeout(...)`; a bounded wait whose success is asserted.
+  Tests legitimately about time require a frozen/fake clock — a real
+  sleep to observe a delay still flags.
+- **Concurrency / race interleaving** — assertions assuming a completion
+  order across threads, `Promise.all`, or executors; shared state mutated
+  without synchronization; missing `join()`/`await` before asserting.
+  Order-independent assertions (`Set` comparison, sorted) do not flag.
+- **Test-order dependence & shared mutable state** — static/module-level
+  mutable state written by a test; state (DB row, file, env var) created
+  with no teardown; a test reading state another test produced.
+- **Unseeded randomness** — `Math.random()`, `uuid.v4()`, `faker.*` without
+  `faker.seed(n)` feeding an assertion. Seeded randomness does not flag.
+- **Real network / external services** — live URLs or SDK clients in a test
+  with no stub/interceptor at the boundary.
+- **Resource leaks & hard-coded ports** — a fixed port for an embedded
+  server/DB (collides under parallel CI); an opened connection, file, or
+  socket with no guaranteed teardown.
+- **Unordered-collection order assumptions** — positional assertions on
+  hash map/set iteration or on a query with no `ORDER BY`.
+- **Exact float equality** — `expect(0.1 + 0.2).toBe(0.3)`; require a
+  tolerance/epsilon comparison.
+- **Platform/environment dependence** — hard-coded path separators or line
+  endings; locale/TZ formatting asserted against a fixed string; CPU-count
+  or CI-parallelism assumptions.
+
+**Time-bomb example** (a rerun never exposes it — only the diff does):
+```js
+// Bad — wall-clock read feeds the assertion; hard-coded future expiry.
+const token = { expiresAt: "2030-01-01" };
+expect(isValid(token, new Date())).toBe(true);
+
+// Good — frozen/injected clock; expiry derived from it.
+const now = new Date("2024-06-15T12:00:00Z");
+const token = issueToken({ now, ttlDays: 30 });
+expect(isValid(token, now)).toBe(true);
+```
 
 ### UX Reviewer
 

--- a/skills/test-first-development/SKILL.md
+++ b/skills/test-first-development/SKILL.md
@@ -261,6 +261,9 @@ The test must not depend on anything outside the process it controls.
 - No hard-coded ports for embedded servers/DBs — dynamic allocation
   (port `0`, TestContainers) plus guaranteed teardown; fixed ports collide
   under parallel CI.
+- Guarantee teardown of every opened connection, file, or socket
+  (`try/finally`, `using`, `defer`, or the framework's fixture teardown) —
+  a leaked handle can fail a later test.
 - No locale/platform-format assertions without pinning — pass the locale
   explicitly, use `path.join()` / `os.EOL`, set `TZ`/`LANG` in the harness.
 - No exact float equality — `toBeCloseTo(0.3)`, not `toBe(0.1 + 0.2)`;

--- a/skills/test-first-development/SKILL.md
+++ b/skills/test-first-development/SKILL.md
@@ -166,6 +166,20 @@ Replace every fixed `sleep(N)` with a wait-for-condition primitive (exist,
 not-exist, wait-to-exist with timeout + interval). A fixed sleep both masks
 race-condition bugs and pads runtime when the system is fast.
 
+### Assert outcomes, not interleavings
+
+A test whose result depends on thread or promise scheduling passes only
+when the scheduler cooperates. Accept every valid interleaving, or make
+the interleaving deterministic.
+
+- `join()`/`await` every concurrent task before asserting — never assert
+  mid-flight.
+- Assert order-independent properties on concurrently produced results —
+  set membership or a sorted comparison, not `results[0] === "A"`.
+- Where ordering genuinely matters, impose it with latches/barriers
+  (`CountDownLatch`, chained promises) instead of relying on scheduler
+  luck.
+
 ### Control the clock
 
 Never read the real wall clock in a test — inject or freeze it
@@ -186,12 +200,15 @@ permanently red on some future date.
 Past or fixed date literals with an explicit timezone are the sanctioned
 form.
 
+**Bad:**
 ```js
 // Bad — wall-clock read feeds the assertion; hard-coded future expiry.
 // Green today, permanently red once the clock crosses the literal.
 const token = { expiresAt: "2030-01-01" };
 expect(isValid(token, new Date())).toBe(true);
 ```
+
+**Good:**
 ```js
 // Good — frozen/injected clock; expiry derived from it.
 const now = new Date("2024-06-15T12:00:00Z");
@@ -222,6 +239,18 @@ is order-dependent — a leading flakiness cause.
   teardown (prefer transaction rollback).
 - Never assert on state a different test produced. The suite must pass in
   any order and on any host.
+
+### Impose order before asserting it
+
+Hash map/set iteration, `os.listdir`, and queries without `ORDER BY` have
+no defined order — a positional assertion on them is platform-dependent
+luck.
+
+- Add an explicit `ORDER BY` / `.order_by()` / sort before any positional
+  assertion (`results[0]`).
+- Or assert order-independently: set membership, unordered-elements
+  matchers.
+- Never compare an ordered structure against a set-backed result.
 
 ### Hermetic boundaries
 

--- a/skills/test-first-development/SKILL.md
+++ b/skills/test-first-development/SKILL.md
@@ -191,7 +191,8 @@ form.
 // Green today, permanently red once the clock crosses the literal.
 const token = { expiresAt: "2030-01-01" };
 expect(isValid(token, new Date())).toBe(true);
-
+```
+```js
 // Good — frozen/injected clock; expiry derived from it.
 const now = new Date("2024-06-15T12:00:00Z");
 const token = issueToken({ now, ttlDays: 30 });

--- a/skills/test-first-development/SKILL.md
+++ b/skills/test-first-development/SKILL.md
@@ -166,6 +166,76 @@ Replace every fixed `sleep(N)` with a wait-for-condition primitive (exist,
 not-exist, wait-to-exist with timeout + interval). A fixed sleep both masks
 race-condition bugs and pads runtime when the system is fast.
 
+### Control the clock
+
+Never read the real wall clock in a test — inject or freeze it
+(`vi.setSystemTime`, fake timers, `Clock.fixed`, `freezegun`). Each
+sub-pattern below ships a time-bomb: a test that is green today and
+permanently red on some future date.
+
+- No assertion against "now": `new Date()`, `Date.now()`, `datetime.now()`
+  feeding an assertion.
+- No hard-coded future expiry: `expiresAt: "2030-01-01"`, cert `notAfter` —
+  generate expiring artifacts at setup, relative to the frozen clock.
+- No naive calendar arithmetic on "now": `addMonths` / `+1 day` assumes
+  month lengths, 24-hour days, and no DST; it fails on month-end, leap
+  day, and DST-transition days.
+- No TZ-naive date construction: `new Date("2023-08-31")` parses as UTC
+  midnight and shifts a day in negative-offset zones.
+
+Past or fixed date literals with an explicit timezone are the sanctioned
+form.
+
+```js
+// Bad — wall-clock read feeds the assertion; hard-coded future expiry.
+// Green today, permanently red once the clock crosses the literal.
+const token = { expiresAt: "2030-01-01" };
+expect(isValid(token, new Date())).toBe(true);
+
+// Good — frozen/injected clock; expiry derived from it.
+const now = new Date("2024-06-15T12:00:00Z");
+const token = issueToken({ now, ttlDays: 30 });
+expect(isValid(token, now)).toBe(true);
+```
+
+### Seed all randomness
+
+An unseeded RNG feeding an assertion is a defect, not a convenience —
+generated data can collide with the asserted value.
+
+- Seed every generator the test touches: `faker.seed(12345)`, a seeded
+  `Random(seed)` — never bare `Math.random()` or `uuid.v4()` in asserted
+  data.
+- Better: explicit fixed inputs. `createUser({ name: "Bob" })` cannot
+  collide; `createUser({ name: faker.person.firstName() })` can.
+
+### Tests own their state — any order, any host
+
+A test builds its own preconditions and tears down what it creates. A test
+that passes only in a specific order, or only after another test has run,
+is order-dependent — a leading flakiness cause.
+
+- No static or module-level mutable state shared across tests; reset
+  singletons and caches in `beforeEach`/`afterEach`.
+- Every DB row, file, cache entry, or env var a test creates gets a
+  teardown (prefer transaction rollback).
+- Never assert on state a different test produced. The suite must pass in
+  any order and on any host.
+
+### Hermetic boundaries
+
+The test must not depend on anything outside the process it controls.
+
+- No real network or external services — stub the boundary (`nock`,
+  `WireMock`, `msw`) and inject the client.
+- No hard-coded ports for embedded servers/DBs — dynamic allocation
+  (port `0`, TestContainers) plus guaranteed teardown; fixed ports collide
+  under parallel CI.
+- No locale/platform-format assertions without pinning — pass the locale
+  explicitly, use `path.join()` / `os.EOL`, set `TZ`/`LANG` in the harness.
+- No exact float equality — `toBeCloseTo(0.3)`, not `toBe(0.1 + 0.2)`;
+  compare with a tolerance.
+
 ### Fidelity ladder: real > fake > mock
 
 When a test needs a collaborator, prefer in this order:

--- a/tests/code-reviewer.evals.ts
+++ b/tests/code-reviewer.evals.ts
@@ -39,143 +39,120 @@ const collector = new EvalCollector("e2e");
 // "mentioned the hint but the review is junk" failure mode.
 const MIN_REASON_SUBSTANCE = 3;
 
-testIfSelected(
-  "planted-null-deref",
-  async () => {
-    const fixture = loadFixture("code-reviewer", "planted-null-deref");
-    const workDir = mkdtempSync(join(tmpdir(), "code-reviewer-e2e-"));
+// Deterministic blocking-severity check: the Conventional Comments
+// `issue (blocking):` label, tolerating markdown bold markers and spacing
+// variance (`**issue (blocking):**`, `**issue (blocking)**:`,
+// `issue(blocking):`). Linear-time — every pair of adjacent quantifiers
+// matches disjoint characters (whitespace vs. literal `*`), so there is no
+// backtracking blowup on adversarial input.
+const BLOCKING_LABEL = /\bissue\s*\**\s*\(blocking\)\s*\**\s*:/i;
 
-    try {
-      const prompt =
-        "You are reviewing a code change. Use Conventional Comments " +
-        "(`issue (blocking):`, `suggestion (non-blocking):`, `nitpick`). " +
-        "Surface every correctness defect you can find with the specific " +
-        "line and a one-line fix proposal.\n\n" +
-        fixture.body;
+// Registers one planted-bug E2E eval. Every fixture runs the identical
+// pipeline — prompt scaffold, agent run, deterministic outcome judge, LLM
+// review judge, collector record, assertions — varying only in:
+//   fixtureName          the evals/fixtures/code-reviewer/<name>/ dir, also
+//                        the testIfSelected selection-map key
+//   defectClause         the defect-scope phrase spliced into the prompt
+//   requireBlockingLabel when the fixture's design promises the reviewer
+//                        flags the bug *as blocking*, additionally require
+//                        an `issue (blocking):` label in the output
+//                        (deterministic, no extra judge cost)
+function registerPlantedBugEval(options: {
+  fixtureName: string;
+  defectClause: string;
+  requireBlockingLabel?: boolean;
+}): void {
+  const { fixtureName, defectClause, requireBlockingLabel = false } = options;
 
-      const result = await runAgentTest({
-        prompt,
-        workingDirectory: workDir,
-        maxTurns: 6,
-        timeout: 180_000,
-        testName: "planted-null-deref",
-      });
+  testIfSelected(
+    fixtureName,
+    async () => {
+      const fixture = loadFixture("code-reviewer", fixtureName);
+      const workDir = mkdtempSync(join(tmpdir(), "code-reviewer-e2e-"));
 
-      // Tier 1 — outcome judge (deterministic): did the agent surface the
-      // planted bug? Computed from ground-truth.json, no model call.
-      const outcome = outcomeJudge(fixture.groundTruth, result.output);
+      try {
+        const prompt =
+          "You are reviewing a code change. Use Conventional Comments " +
+          "(`issue (blocking):`, `suggestion (non-blocking):`, `nitpick`). " +
+          `Surface every ${defectClause} defect you ` +
+          "can find with the specific line and a one-line fix proposal.\n\n" +
+          fixture.body;
 
-      // Tier 2 — LLM judge: is the review actually good (concrete line,
-      // named failure mode, root-cause fix)? Deterministic-first inside
-      // judgeReviewerOutput gates the model call on a Conventional Comment
-      // label being present.
-      const review = await judgeReviewerOutput(result.output);
+        const result = await runAgentTest({
+          prompt,
+          workingDirectory: workDir,
+          maxTurns: 6,
+          timeout: 180_000,
+          testName: fixtureName,
+        });
 
-      const passed =
-        result.exitReason === "success" &&
-        outcome.passes_minimum &&
-        review.reason_substance >= MIN_REASON_SUBSTANCE;
+        // Tier 1 — outcome judge (deterministic): did the agent surface the
+        // planted bug? Computed from ground-truth.json, no model call.
+        const outcome = outcomeJudge(fixture.groundTruth, result.output);
 
-      collector.addTest({
-        name: "planted-null-deref",
-        suite: "code-reviewer-e2e",
-        tier: "e2e",
-        passed,
-        duration_ms: result.duration,
-        cost_usd: result.costEstimate.estimatedCost,
-        transcript: result.transcript,
-        judge_scores: {
-          detection_rate: outcome.detection_rate,
-          reason_substance: review.reason_substance,
-        },
-        exit_reason: result.exitReason,
-        model: result.model,
-        first_response_ms: result.firstResponseMs,
-        max_inter_turn_ms: result.maxInterTurnMs,
-      });
+        // Tier 2 — LLM judge: is the review actually good (concrete line,
+        // named failure mode, root-cause fix)? Deterministic-first inside
+        // judgeReviewerOutput gates the model call on a Conventional Comment
+        // label being present.
+        const review = await judgeReviewerOutput(result.output);
 
-      expect(result.exitReason).toBe("success");
-      expect(outcome.detection_rate).toBeGreaterThanOrEqual(
-        fixture.groundTruth.minimum_detection,
-      );
-      expect(review.reason_substance).toBeGreaterThanOrEqual(
-        MIN_REASON_SUBSTANCE,
-      );
-    } finally {
-      rmSync(workDir, { recursive: true, force: true });
-    }
-  },
-  240_000,
-);
+        const blockingLabelOk =
+          !requireBlockingLabel || BLOCKING_LABEL.test(result.output);
 
-testIfSelected(
-  "planted-time-bomb",
-  async () => {
-    const fixture = loadFixture("code-reviewer", "planted-time-bomb");
-    const workDir = mkdtempSync(join(tmpdir(), "code-reviewer-e2e-"));
+        const passed =
+          result.exitReason === "success" &&
+          outcome.passes_minimum &&
+          blockingLabelOk &&
+          review.reason_substance >= MIN_REASON_SUBSTANCE;
 
-    try {
-      const prompt =
-        "You are reviewing a code change. Use Conventional Comments " +
-        "(`issue (blocking):`, `suggestion (non-blocking):`, `nitpick`). " +
-        "Surface every correctness AND test-quality/flakiness defect you " +
-        "can find with the specific line and a one-line fix proposal.\n\n" +
-        fixture.body;
+        collector.addTest({
+          name: fixtureName,
+          suite: "code-reviewer-e2e",
+          tier: "e2e",
+          passed,
+          duration_ms: result.duration,
+          cost_usd: result.costEstimate.estimatedCost,
+          transcript: result.transcript,
+          judge_scores: {
+            detection_rate: outcome.detection_rate,
+            reason_substance: review.reason_substance,
+          },
+          exit_reason: result.exitReason,
+          model: result.model,
+          first_response_ms: result.firstResponseMs,
+          max_inter_turn_ms: result.maxInterTurnMs,
+        });
 
-      const result = await runAgentTest({
-        prompt,
-        workingDirectory: workDir,
-        maxTurns: 6,
-        timeout: 180_000,
-        testName: "planted-time-bomb",
-      });
+        expect(result.exitReason).toBe("success");
+        expect(outcome.detection_rate).toBeGreaterThanOrEqual(
+          fixture.groundTruth.minimum_detection,
+        );
+        if (requireBlockingLabel) {
+          // Detection passed (asserted above); the design additionally
+          // promises the finding carries a blocking severity label.
+          expect(result.output).toMatch(BLOCKING_LABEL);
+        }
+        expect(review.reason_substance).toBeGreaterThanOrEqual(
+          MIN_REASON_SUBSTANCE,
+        );
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    },
+    240_000,
+  );
+}
 
-      // Tier 1 — outcome judge (deterministic): did the agent surface the
-      // planted time-bomb? Computed from ground-truth.json, no model call.
-      const outcome = outcomeJudge(fixture.groundTruth, result.output);
+registerPlantedBugEval({
+  fixtureName: "planted-null-deref",
+  defectClause: "correctness",
+});
 
-      // Tier 2 — LLM judge: is the review actually good (concrete line,
-      // named failure mode, root-cause fix)? Deterministic-first inside
-      // judgeReviewerOutput gates the model call on a Conventional Comment
-      // label being present.
-      const review = await judgeReviewerOutput(result.output);
-
-      const passed =
-        result.exitReason === "success" &&
-        outcome.passes_minimum &&
-        review.reason_substance >= MIN_REASON_SUBSTANCE;
-
-      collector.addTest({
-        name: "planted-time-bomb",
-        suite: "code-reviewer-e2e",
-        tier: "e2e",
-        passed,
-        duration_ms: result.duration,
-        cost_usd: result.costEstimate.estimatedCost,
-        transcript: result.transcript,
-        judge_scores: {
-          detection_rate: outcome.detection_rate,
-          reason_substance: review.reason_substance,
-        },
-        exit_reason: result.exitReason,
-        model: result.model,
-        first_response_ms: result.firstResponseMs,
-        max_inter_turn_ms: result.maxInterTurnMs,
-      });
-
-      expect(result.exitReason).toBe("success");
-      expect(outcome.detection_rate).toBeGreaterThanOrEqual(
-        fixture.groundTruth.minimum_detection,
-      );
-      expect(review.reason_substance).toBeGreaterThanOrEqual(
-        MIN_REASON_SUBSTANCE,
-      );
-    } finally {
-      rmSync(workDir, { recursive: true, force: true });
-    }
-  },
-  240_000,
-);
+registerPlantedBugEval({
+  fixtureName: "planted-time-bomb",
+  defectClause: "correctness AND test-quality/flakiness",
+  requireBlockingLabel: true,
+});
 
 afterAll(async () => {
   await collector.finalize();

--- a/tests/code-reviewer.evals.ts
+++ b/tests/code-reviewer.evals.ts
@@ -108,6 +108,75 @@ testIfSelected(
   240_000,
 );
 
+testIfSelected(
+  "planted-time-bomb",
+  async () => {
+    const fixture = loadFixture("code-reviewer", "planted-time-bomb");
+    const workDir = mkdtempSync(join(tmpdir(), "code-reviewer-e2e-"));
+
+    try {
+      const prompt =
+        "You are reviewing a code change. Use Conventional Comments " +
+        "(`issue (blocking):`, `suggestion (non-blocking):`, `nitpick`). " +
+        "Surface every correctness AND test-quality/flakiness defect you " +
+        "can find with the specific line and a one-line fix proposal.\n\n" +
+        fixture.body;
+
+      const result = await runAgentTest({
+        prompt,
+        workingDirectory: workDir,
+        maxTurns: 6,
+        timeout: 180_000,
+        testName: "planted-time-bomb",
+      });
+
+      // Tier 1 — outcome judge (deterministic): did the agent surface the
+      // planted time-bomb? Computed from ground-truth.json, no model call.
+      const outcome = outcomeJudge(fixture.groundTruth, result.output);
+
+      // Tier 2 — LLM judge: is the review actually good (concrete line,
+      // named failure mode, root-cause fix)? Deterministic-first inside
+      // judgeReviewerOutput gates the model call on a Conventional Comment
+      // label being present.
+      const review = await judgeReviewerOutput(result.output);
+
+      const passed =
+        result.exitReason === "success" &&
+        outcome.passes_minimum &&
+        review.reason_substance >= MIN_REASON_SUBSTANCE;
+
+      collector.addTest({
+        name: "planted-time-bomb",
+        suite: "code-reviewer-e2e",
+        tier: "e2e",
+        passed,
+        duration_ms: result.duration,
+        cost_usd: result.costEstimate.estimatedCost,
+        transcript: result.transcript,
+        judge_scores: {
+          detection_rate: outcome.detection_rate,
+          reason_substance: review.reason_substance,
+        },
+        exit_reason: result.exitReason,
+        model: result.model,
+        first_response_ms: result.firstResponseMs,
+        max_inter_turn_ms: result.maxInterTurnMs,
+      });
+
+      expect(result.exitReason).toBe("success");
+      expect(outcome.detection_rate).toBeGreaterThanOrEqual(
+        fixture.groundTruth.minimum_detection,
+      );
+      expect(review.reason_substance).toBeGreaterThanOrEqual(
+        MIN_REASON_SUBSTANCE,
+      );
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  },
+  240_000,
+);
+
 afterAll(async () => {
   await collector.finalize();
   // A passing-but-3×-more-expensive run is a regression. Fail the run

--- a/tests/code-reviewer.evals.ts
+++ b/tests/code-reviewer.evals.ts
@@ -42,10 +42,10 @@ const MIN_REASON_SUBSTANCE = 3;
 // Deterministic blocking-severity check: the Conventional Comments
 // `issue (blocking):` label, tolerating markdown bold markers and spacing
 // variance (`**issue (blocking):**`, `**issue (blocking)**:`,
-// `issue(blocking):`). Linear-time — every pair of adjacent quantifiers
-// matches disjoint characters (whitespace vs. literal `*`), so there is no
-// backtracking blowup on adversarial input.
-const BLOCKING_LABEL = /\bissue\s*\**\s*\(blocking\)\s*\**\s*:/i;
+// `issue(blocking):`). Linear-time — each decoration gap is a single
+// character class (`[\s*]*`), so no adjacent quantifiers compete over the
+// same characters and there is no backtracking blowup on adversarial input.
+const BLOCKING_LABEL = /\bissue[\s*]*\(blocking\)[\s*]*:/i;
 
 // Registers one planted-bug E2E eval. Every fixture runs the identical
 // pipeline — prompt scaffold, agent run, deterministic outcome judge, LLM

--- a/tests/helpers/touchfiles.ts
+++ b/tests/helpers/touchfiles.ts
@@ -14,6 +14,13 @@ export const E2E_TOUCHFILES: Record<string, string[]> = {
     "evals/fixtures/code-reviewer/planted-null-deref/**",
     "evals/rubrics/code-reviewer.md",
   ],
+  "planted-time-bomb": [
+    "agents/code-reviewer.md",
+    "skills/code-review/**",
+    "tests/code-reviewer.evals.ts",
+    "evals/fixtures/code-reviewer/planted-time-bomb/**",
+    "evals/rubrics/code-reviewer.md",
+  ],
   "git-commit-conventional-subject": [
     "skills/git-commit/**",
     "tests/git-commit.evals.ts",
@@ -99,6 +106,7 @@ export const E2E_TIERS: Record<string, "gate" | "periodic"> = {
   // Note: gate-tier E2E tests would do offline assertions (e.g. against a
   // recorded transcript). Live-model fixtures are periodic.
   "planted-null-deref": "periodic",
+  "planted-time-bomb": "periodic",
   "git-commit-conventional-subject": "periodic",
   "changelog-keep-a-changelog-filter": "periodic",
   "team-question-neutral-questions": "periodic",

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -463,12 +463,14 @@ describe("test-first-development lens (L2 content tripwire)", () => {
     expect(text).toContain("Confirm Tests Fail Correctly");
   });
 
-  test("Test Style Rules contains the four deterministic-input subsections", () => {
+  test("Test Style Rules contains the six deterministic-input subsections", () => {
     const text = read(SKILL_FILE);
     expect(/^### Control the clock$/m.test(text)).toBe(true);
     expect(/^### Seed all randomness$/m.test(text)).toBe(true);
     expect(/^### Tests own their state — any order, any host$/m.test(text)).toBe(true);
     expect(/^### Hermetic boundaries$/m.test(text)).toBe(true);
+    expect(/^### Assert outcomes, not interleavings$/m.test(text)).toBe(true);
+    expect(/^### Impose order before asserting it$/m.test(text)).toBe(true);
   });
 
   test("test-architect audit table has a Deterministic inputs row", () => {

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -463,3 +463,72 @@ describe("test-first-development lens (L2 content tripwire)", () => {
     expect(text).toContain("Confirm Tests Fail Correctly");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Flaky-test red flags — free L2 content tripwires (docs/testing.md §2).
+// The code-review skill carries an always-blocking checklist for tests whose
+// outcome depends on a nondeterministic input (time, randomness, ordering,
+// network...). Two severity regimes coexist in the skill: style flags escalate
+// suggestion→issue across multiple tests; flaky red flags are blocking on
+// FIRST occurrence. These tripwires pin that contract and the skill↔agent
+// mirror agreement (design decision 8,
+// docs/plans/2026-07-15-flaky-test-red-flags/design.md).
+// ---------------------------------------------------------------------------
+
+describe("code-review flaky-test red flags (L2 content tripwire)", () => {
+  const SKILL_FILE = join(REPO_ROOT, "skills", "code-review", "SKILL.md");
+  const CODE_REVIEWER = join(REPO_ROOT, "agents", "code-reviewer.md");
+
+  // Text between two markers; "" when either marker is missing. Callers guard
+  // the slice as non-empty so a missing section fails loud, never vacuously
+  // (pattern: tests/protocol.test.ts softSection guard).
+  function between(text: string, startMarker: string, endMarker: string): string {
+    const start = text.indexOf(startMarker);
+    if (start === -1) return "";
+    const end = text.indexOf(endMarker, start);
+    if (end === -1) return "";
+    return text.slice(start, end);
+  }
+
+  test("code-review skill contains the always-blocking flaky-test red-flag checklist keyed to outcome-dependence", () => {
+    const text = read(SKILL_FILE);
+    expect(text).toContain("**Flaky-test red flags (always blocking).**");
+    // Scope severity assertions to the checklist region so the `issue
+    // (blocking)` occurrences in Comment Types / the severity-tier table
+    // cannot satisfy them.
+    const flaky = between(text, "Flaky-test red flags", "### UX Reviewer");
+    expect(flaky.length).toBeGreaterThan(0);
+    expect(flaky).toContain("issue (blocking)");
+    // First-occurrence wording; tolerate bold (`**first** occurrence`).
+    expect(/first\*{0,2} occurrence/i.test(flaky)).toBe(true);
+    // Severity rule keyed to outcome-dependence — pin the phrase, not just
+    // the heading (design decision 2).
+    expect(/outcome depends on/i.test(flaky)).toBe(true);
+  });
+
+  test("sleep()-for-synchronization is relocated, not duplicated", () => {
+    const text = read(SKILL_FILE);
+    const styleFlags = between(text, "Test-quality flags.", "Flaky-test red flags");
+    const flaky = between(text, "Flaky-test red flags", "### UX Reviewer");
+    // Guard both slices non-empty so the absence assertion below can't pass
+    // vacuously against an empty string.
+    expect(styleFlags.length).toBeGreaterThan(0);
+    expect(flaky.length).toBeGreaterThan(0);
+    // Relocated out of the six-flag style list (design decision 3)...
+    expect(styleFlags).not.toContain("sleep()");
+    // ...into the always-blocking flaky list.
+    expect(flaky).toContain("sleep()");
+  });
+
+  test("code-reviewer agent mirrors the first-occurrence always-blocking rule", () => {
+    // The abbreviated mirror must state both severity regimes and defer the
+    // checklist body to the skill. It must do so WITHOUT the decorated
+    // `issue (blocking)` literal (forbidden in the agent by
+    // tests/architecture.test.ts), so this pins plain wording only.
+    const bullet = between(read(CODE_REVIEWER), "**Test files**", "5. **Run tests");
+    expect(bullet.length).toBeGreaterThan(0);
+    expect(/first\*{0,2} occurrence/i.test(bullet)).toBe(true);
+    expect(/blocking/i.test(bullet)).toBe(true);
+    expect(bullet).toContain("skills/code-review/SKILL.md");
+  });
+});

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -545,3 +545,35 @@ describe("code-review flaky-test red flags (L2 content tripwire)", () => {
     expect(bullet).toContain("skills/code-review/SKILL.md");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Time-bomb example pair — free L2 drift tripwire (docs/testing.md §2,
+// collision/drift form). The fenced bad/good time-bomb example lives in two
+// skills (code-review carries a copy of test-first-development's canonical
+// pair, design decision 5). The copies are maintained by hand; this pin fails
+// the build the moment they drift.
+// ---------------------------------------------------------------------------
+
+describe("time-bomb example pair (L2 drift tripwire)", () => {
+  const CODE_REVIEW_SKILL = join(REPO_ROOT, "skills", "code-review", "SKILL.md");
+  const TFD_SKILL = join(REPO_ROOT, "skills", "test-first-development", "SKILL.md");
+
+  // All ```js fences belonging to the time-bomb example: the bad block
+  // carries the future-expiry literal, the good block the issueToken call.
+  function timeBombFences(text: string): string[] {
+    const fences = text.match(/```js\n[\s\S]*?```/g) ?? [];
+    return fences.filter(
+      (fence) => fence.includes('expiresAt: "2030-01-01"') || fence.includes("issueToken"),
+    );
+  }
+
+  test("fenced bad/good pair is byte-identical across the two skills", () => {
+    const codeReviewPair = timeBombFences(read(CODE_REVIEW_SKILL));
+    const tfdPair = timeBombFences(read(TFD_SKILL));
+    // Fail-loud: extraction must find exactly the bad + good fence in each
+    // file — an empty or partial slice must never pass vacuously.
+    expect(codeReviewPair.length).toBe(2);
+    expect(tfdPair.length).toBe(2);
+    expect(codeReviewPair).toEqual(tfdPair);
+  });
+});

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -462,6 +462,19 @@ describe("test-first-development lens (L2 content tripwire)", () => {
     expect(text).toContain("BEFORE any implementation code");
     expect(text).toContain("Confirm Tests Fail Correctly");
   });
+
+  test("Test Style Rules contains the four deterministic-input subsections", () => {
+    const text = read(SKILL_FILE);
+    expect(/^### Control the clock$/m.test(text)).toBe(true);
+    expect(/^### Seed all randomness$/m.test(text)).toBe(true);
+    expect(/^### Tests own their state — any order, any host$/m.test(text)).toBe(true);
+    expect(/^### Hermetic boundaries$/m.test(text)).toBe(true);
+  });
+
+  test("test-architect audit table has a Deterministic inputs row", () => {
+    const TEST_ARCHITECT = join(REPO_ROOT, "agents", "test-architect.md");
+    expect(read(TEST_ARCHITECT)).toContain("| Deterministic inputs |");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadFixture } from "./helpers/fixtures";
-import { E2E_TOUCHFILES } from "./helpers/touchfiles";
+import { E2E_TIERS, E2E_TOUCHFILES } from "./helpers/touchfiles";
 
 const FIXTURE_ROOT = join(process.cwd(), "evals", "fixtures");
 const RUBRIC_ROOT = join(process.cwd(), "evals", "rubrics");
@@ -95,6 +95,16 @@ describe("static gate: fixtures", () => {
       expect(globs).toContain(`evals/rubrics/${agent}.md`);
       expect(globs).toContain(`tests/${agent}.evals.ts`);
     }
+  });
+
+  test("planted-time-bomb is registered in the selection map with tier periodic", () => {
+    // Live-model fixture → periodic tier (docs/testing.md §4: it can be red
+    // for a non-bug reason, so it never gates). The enumeration tests above
+    // cover its schema/size/touchfile-glob listing once the fixture lands;
+    // this pins the tier, which skill-eval-coverage does not (it audits L5
+    // skills only, not the code-reviewer agent).
+    expect(Object.keys(E2E_TOUCHFILES)).toContain("planted-time-bomb");
+    expect(E2E_TIERS["planted-time-bomb"]).toBe("periodic");
   });
 });
 


### PR DESCRIPTION
## Summary

The code reviewer now treats flaky-test red flags as **always blocking** — `issue (blocking)` on **first** occurrence, distinct from the style flags' escalate-on-repetition regime. The flagship case is the "time-bomb" test: a wall-clock read or hard-coded future date that passes today and deterministically fails later, invisible to rerun-based flaky detection — the diff is the only place to catch it.

Backed by deep web research (Luo et al. FSE 2014, Fowler's *Eradicating Non-Determinism in Tests*, Google/Uber/GitHub/Spotify/Datadog engineering practice; full sourced taxonomy in the run's research artifact):

- **`skills/code-review/SKILL.md`** — new *Flaky-test red flags (always blocking)* checklist: 10 categories (time/date incl. time-bombs, fixed-sleep waits, concurrency interleaving, order-dependence/shared state, unseeded randomness, real network, resource leaks/hard-coded ports, unordered collections, float equality, platform/environment), each with grep-able diff-visible signatures and non-flagging carve-outs keyed to *outcome-dependence*, plus a captioned bad/good time-bomb example. `sleep()`-for-sync **relocated here from the style flags — severity upgrade** (async wait ≈45% of flakes per Luo et al.).
- **`agents/code-reviewer.md`** — mirror names both severity regimes; sync pinned by tripwire.
- **`skills/test-first-development/SKILL.md`** — six new author-side Test Style Rules (*Control the clock; Seed all randomness; Tests own their state; Assert outcomes, not interleavings; Impose order before asserting it; Hermetic boundaries*) so all 10 reviewer categories have prevention-side guidance. `agents/test-architect.md` audit table gains a *Deterministic inputs* row.
- **`evals/fixtures/code-reviewer/planted-time-bomb/`** — periodic-tier eval fixture (planted wall-clock + future-expiry bug, frozen-clock negative control); registered via a new shared `registerPlantedBugEval` helper with a deterministic blocking-label assertion.
- **Free-tier tripwires** — six-subsection pin, relocation (not duplication) pin, mirror-agreement pin, byte-identical drift pin on the duplicated example pair.

## Review record

Full QRSPI run: design human-approved; 5 adversarial review rounds (code, security, docs, ux, verifier — fresh context each round). Final round: all clean (APPROVE/PASS), zero Blocking/Major findings.

## Known follow-ups (pre-existing / accepted by design)

- `max_false_positives` exists in the fixture schema but no scorer enforces it (inherited from `planted-null-deref`).
- The eval's blocking-label assertion is not proximity-scoped to the detection match (accepted deterministic-only design; periodic tier).
- The paid eval runs bare `claude -p` without loading the plugin skill text (pre-existing harness architecture, shared with the existing fixture).
- `docs/architecture.md`'s "~143 lines average per skill" stat was already stale on main.

## Test plan

- [x] `bun test` — 624 pass, 0 fail (6 new/extended tripwires + fixture schema validation)
- [x] `bun run typecheck` — clean
- [x] `hooks/post-write-validate.mjs` structural validation on all changed agent/skill files
- [x] Offline mock-seam eval run: compliant transcript passes; detect-but-mislabel transcript fails exactly on the blocking-label assertion
- [ ] Paid periodic eval (`bun run test:evals`) picks up `planted-time-bomb` on its next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJmkCNnnARGW3wuLriQtMR