### PR TITLE
fix: disallow the Skill tool on live eval spawns

### DIFF
--- a/tests/helpers/session-runner.test.ts
+++ b/tests/helpers/session-runner.test.ts
@@ -4,7 +4,7 @@
 // under `bun test` with no env vars and no subprocess; they cost $0.
 
 import { test, expect, describe } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -288,6 +288,51 @@ describe("runAgentTest live-path API-key guard", () => {
       if (savedMock === undefined) delete process.env.EVALS_MOCK_AGENT;
       else process.env.EVALS_MOCK_AGENT = savedMock;
       if (savedKey !== undefined) process.env.EVALS_ANTHROPIC_API_KEY = savedKey;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// Environment skills (the CLI's built-in /review, …) can hijack the agent
+// under test away from the fixture, so live spawns must disallow the Skill
+// tool.
+describe("runAgentTest live-spawn tool restrictions", () => {
+  test("disallows the Skill tool so environment skills cannot hijack the run", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "session-runner-test-"));
+    // Hermetic fake `claude` on PATH that records its argv; drains stdin so
+    // the prompt write can't EPIPE.
+    const fakeBin = join(tmp, "bin");
+    mkdirSync(fakeBin);
+    const argvFile = join(tmp, "argv.txt");
+    writeFileSync(
+      join(fakeBin, "claude"),
+      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argvFile}"\ncat > /dev/null\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const savedPath = process.env.PATH;
+    const savedMock = process.env.EVALS_MOCK_AGENT;
+    const savedKey = process.env.EVALS_ANTHROPIC_API_KEY;
+    process.env.PATH = `${fakeBin}:${savedPath ?? ""}`;
+    delete process.env.EVALS_MOCK_AGENT;
+    process.env.EVALS_ANTHROPIC_API_KEY = "test-key";
+    try {
+      await runAgentTest({
+        prompt: "Review x.ts.",
+        workingDirectory: tmp,
+        testName: "live-disallow-skill",
+        timeout: 5_000,
+      });
+      const argv = readFileSync(argvFile, "utf8").split("\n");
+      const flagIndex = argv.indexOf("--disallowed-tools");
+      expect(flagIndex).toBeGreaterThan(-1);
+      expect(argv[flagIndex + 1]).toBe("Skill");
+    } finally {
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
+      if (savedMock !== undefined) process.env.EVALS_MOCK_AGENT = savedMock;
+      if (savedKey === undefined) delete process.env.EVALS_ANTHROPIC_API_KEY;
+      else process.env.EVALS_ANTHROPIC_API_KEY = savedKey;
       rmSync(tmp, { recursive: true, force: true });
     }
   });

--- a/tests/helpers/session-runner.ts
+++ b/tests/helpers/session-runner.ts
@@ -283,6 +283,8 @@ export async function runAgentTest(
     if (options.allowedTools && options.allowedTools.length > 0) {
       args.push("--allowed-tools", ...options.allowedTools);
     }
+    // Environment skills (built-in /review, …) can hijack the run.
+    args.push("--disallowed-tools", "Skill");
 
     const child = spawn("claude", args, {
       cwd: options.workingDirectory,


### PR DESCRIPTION
## Problem

The 2026-07-20 [periodic evals run](https://github.com/bostonaholic/team/actions/runs/29723884855/job/88292499969) failed `planted-time-bomb` (`tests/code-reviewer.evals.ts`) with `detection_rate: 0`. The run artifact's transcript shows the agent under test never reviewed the inline fixture: the prompt "You are reviewing a code change…" triggered the CLI's **built-in `/review` skill** via the `Skill` tool — a GitHub-PR-review procedure — so the agent ran `gh pr list`, was denied (non-interactive `-p` session), and ended the run asking the user for a PR number.

This is a test-harness defect, not an agent regression: `planted-null-deref` passed in the same run, and the hijack path is stochastic.

## Fix

`runAgentTest` (`tests/helpers/session-runner.ts`) now passes `--disallowed-tools Skill` on every live spawn. Evals run in an empty temp dir where Team's skills are never installed, so the `Skill` tool is never legitimate for the agent under test — only environment skills (built-in `/review`, `/code-review`, …) can leak in. Fixing at the runner closes the hijack path for all 10 eval suites at the single point of CLI drift.

Pinned by a deterministic, free (L3) subprocess test using the existing fake-`claude` sentinel pattern: the stub records its argv and the test asserts `--disallowed-tools Skill` is present. Red before the fix, green after.

Dev-only change (`tests/`) — no version bump per the runtime-vs-development split.

## Test plan

- [x] `bun test` green (625 pass locally, includes the new reproduction test)
- [x] Live verification: ran the full code-reviewer suite ad-hoc with the CI env shape (`EVALS=1 EVALS_ALL=1 EVALS_TIER=periodic`) on this branch — both evals pass; `planted-time-bomb` scored `detection_rate: 1`, `reason_substance: 5` (was 0 / 1), and the session init event confirms `Skill` is absent from the spawned toolset

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dvNmwZ7Uh4xm2ncaxYmPr
