### PR TITLE
v0.17.1 fix: defer ticket in-review until PR is ready

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.17.0"
+    "version": "0.17.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Opening a draft PR no longer moves the tracking ticket to in-review.** The PR phase ([`skills/team-pr/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md), the [`/team`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md) PR gate, and [`/team-fix`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md) Ship) opens every PR as a draft, but then moved the ticket to the tracker's in-review state right away — so a Linear issue (or any tracker) read "In Review" against a PR nobody had been asked to review. The tracker contract now defers the in-review move until the PR is marked ready for review; the ticket stays in-progress while the PR is a draft. The PR↔ticket link (which drives close-on-merge) still happens at open time, and the contract stays tracker-agnostic, best-effort, and never blocking.
+
 ## [0.17.0] - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-21
+
 ### Fixed
 
 - **Opening a draft PR no longer moves the tracking ticket to in-review.** The PR phase ([`skills/team-pr/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md), the [`/team`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md) PR gate, and [`/team-fix`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md) Ship) opens every PR as a draft, but then moved the ticket to the tracker's in-review state right away — so a Linear issue (or any tracker) read "In Review" against a PR nobody had been asked to review. The tracker contract now defers the in-review move until the PR is marked ready for review; the ticket stays in-progress while the PR is a draft. The PR↔ticket link (which drives close-on-merge) still happens at open time, and the contract stays tracker-agnostic, best-effort, and never blocking.
@@ -214,7 +216,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/bostonaholic/team/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/bostonaholic/team/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/bostonaholic/team/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/bostonaholic/team/compare/v0.14.1...v0.15.0

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -173,7 +173,7 @@ of the work.
 | **Bugs** | A **Backlog for `bug`-labeled issues only** — a convenience view so open bugs are easy to spot. Captured, not started, not committed to. Not a separate stage in the flow. | A `bug` issue is captured. Use this instead of **Backlog** so it shows in the bugs view; bugs are pulled **directly into In progress** from here — they are **not** promoted to **Ready**. |
 | **Ready** | Shaped and ready to be picked up. Has enough detail to start. **WIP-limited to 5.** | The work is well-understood and prioritized, and Ready has an open slot (see WIP limit below). |
 | **In progress** | Actively being worked on. | You start work — open a worktree, run `/team`, or begin coding. |
-| **In review** | Implementation complete; a PR is open and under review. | A pull request is opened for the card. |
+| **In review** | Implementation complete; a PR is ready and under review. | The card's pull request is **marked ready for review**. A **draft** PR does not move the card — it stays in **In progress** until the draft is marked ready. |
 | **Done** | Merged and complete. | The PR is merged. |
 
 > **The Bugs column.** `Bugs` is an entry bucket, not a stage — the same
@@ -195,8 +195,10 @@ of the work.
 > may carry their own limits under that model.)
 
 **Move the card as the work moves.** Pull a card into **In progress** when
-you start, not after — from `Ready` (non-bug work) or `Bugs` (bug work). When the
-PR opens, move it to **In review**. When the PR merges, move it to **Done**.
+you start, not after — from `Ready` (non-bug work) or `Bugs` (bug work). When
+the PR is marked ready for review, move the card to **In review** — opening a
+draft PR is not that moment; the card stays in **In progress** while the PR is
+a draft. When the PR merges, move it to **Done**.
 
 Dragging the card on the board UI is the simplest way. From the CLI, two small
 helper scripts in `.claude/scripts/` compose over a pipe — one resolves an
@@ -252,17 +254,22 @@ like this:
   Best-effort: if the card can't be resolved (no board item, free-form
   description), the run continues without it — the move never blocks the
   pipeline. You no longer need to pre-move the card by hand before launching.
-- **Opening the PR** → the card moves to **In review** **automatically**. The PR
-  phase (`/team-pr`, the `/team` PR gate, and `/team-fix` Ship) performs the
-  generic, best-effort "move to in-review" defined in those skills, and links
-  the PR to the issue (`Closes #<N>` in the PR body) so the issue closes on
-  merge. **This repo's concrete binding** is the same board scripts. For an
-  issue number `<N>`:
+- **Opening the PR** → the PR phase (`/team-pr`, the `/team` PR gate, and
+  `/team-fix` Ship) links the PR to the issue (`Closes #<N>` in the PR body)
+  so the issue closes on merge. The pipeline opens the PR as a **draft**, and
+  a draft is not under review, so **the card stays in In progress** — the
+  generic contract in those skills forbids the in-review move while the PR is
+  a draft.
+- **Marking the PR ready for review** → the card moves to **In review**. The
+  human marks the PR ready; the generic, best-effort "move to in-review"
+  defined in the PR-phase skills fires at this moment, never at draft-open.
+  **This repo's concrete binding** is the same board scripts. For an issue
+  number `<N>`:
   ```sh
   .claude/scripts/project-item-id.sh <N> | .claude/scripts/project-set-status.sh "In review"
   ```
   Best-effort: if the card can't be resolved, the run continues — the move never
-  blocks opening the PR.
+  blocks the PR.
 - **Merge** → the card moves to **Done** **automatically**. Because the PR
   carries `Closes #<N>`, merging it closes the issue, and the board's built-in
   "an item is closed → Done" automation moves the card. No manual move and no

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -98,14 +98,18 @@ assertion failure, not a crash. Do not proceed to the fix until confirmed.
 2. **Open a draft PR automatically — do not stop to ask.** If working on
    a branch, push it and open the PR as a **draft** (`gh pr create
    --draft`). If not on a branch, commit to the working branch.
-3. **Ticket → in-review.** If `ticketId` is non-null in `task.md`'s
-   frontmatter: **link the PR to the ticket** so the tracker closes it —
-   and any board automation moves it to its done state — when the PR merges
-   (GitHub: `Closes #<n>` in the PR body); then **move the ticket to the
-   tracker's in-review state**. Best-effort and tracker-agnostic — skip
-   silently if the project defines no tracker-move mechanism; never block.
-   Because the link auto-closes the ticket on merge, the orchestrator never
-   closes tickets by hand. Surface the `ticketId` in the completion report.
+3. **Ticket — link now, in-review when ready.** If `ticketId` is non-null
+   in `task.md`'s frontmatter: **link the PR to the ticket** so the
+   tracker closes it — and any board automation moves it to its done state
+   — when the PR merges (GitHub: `Closes #<n>` in the PR body). **Never
+   move the ticket to in-review while the PR is a draft** — a draft is not
+   under review, and Ship opens a draft PR, so the ticket keeps its
+   in-progress state at open time; move it to the tracker's in-review
+   state **only once the PR is marked ready for review**. Best-effort and
+   tracker-agnostic — skip silently if the project defines no tracker-move
+   mechanism; never block. Because the link auto-closes the ticket on
+   merge, the orchestrator never closes tickets by hand. Surface the
+   `ticketId` in the completion report.
 4. Mark all TodoWrite items complete.
 
 ## Aborting

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -112,15 +112,21 @@ done
 7. In multi-repo mode, push each repo's branch independently and open one
    draft PR per repo. Cross-link the PRs in their bodies (see PR Body
    Template below).
-8. **Tracking ticket → in-review.** If `ticketId` is non-null:
+8. **Tracking ticket — link now, in-review when ready.** If `ticketId` is
+   non-null:
    - **Link the PR to the ticket** so the tracker closes the ticket — and
      any board automation moves it to its done state — when the PR merges.
      For GitHub, put `Closes #<n>` in the PR body; for another tracker use
      its PR↔issue link. This link is what drives the eventual move to done
      on merge, so the orchestrator never closes tickets by hand.
-   - **Move the ticket to the tracker's in-review state.** Best-effort and
-     tracker-agnostic: if the project defines no tracker-move mechanism,
-     skip silently. Never block the pipeline on a tracker update.
+   - **Never move the ticket to in-review while the PR is a draft.** A
+     draft is not under review, and this phase opens the PR as a draft —
+     at open time the ticket keeps its in-progress state. Move the ticket
+     to the tracker's in-review state **only once the PR is marked ready
+     for review** (non-draft — on GitHub, `gh pr view --json isDraft`).
+     Best-effort and tracker-agnostic: if the project defines no
+     tracker-move mechanism, skip silently. Never block the pipeline on a
+     tracker update.
    - Surface the `ticketId` in the completion report.
 9. **Whenever you push to a PR, review and adjust its description.** Any
    push that adds, removes, or changes commits on a PR's branch — the

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -333,14 +333,18 @@ When the aggregate gate passes:
 3. In multi-repo mode this opens **one draft PR per repo with commits
    ahead**, and the PR bodies cross-link to each other so reviewers can
    see the full change set.
-4. **Ticket → in-review.** If `task.md` frontmatter has `ticketId` set:
-   **link the PR to the ticket** so the tracker closes it — and any board
-   automation moves it to its done state — when the PR merges (GitHub:
-   `Closes #<n>` in the PR body); then **move the ticket to the tracker's
-   in-review state**. Best-effort and tracker-agnostic — skip silently if
-   the project defines no tracker-move mechanism; never block the pipeline.
-   Because the link auto-closes the ticket on merge, the orchestrator never
-   closes tickets by hand. Surface the `ticketId` in the completion report.
+4. **Ticket — link now, in-review when ready.** If `task.md` frontmatter
+   has `ticketId` set: **link the PR to the ticket** so the tracker closes
+   it — and any board automation moves it to its done state — when the PR
+   merges (GitHub: `Closes #<n>` in the PR body). **Never move the ticket
+   to in-review while the PR is a draft** — a draft is not under review,
+   and this gate opens draft PRs, so the ticket keeps its in-progress
+   state at open time; move it to the tracker's in-review state **only
+   once the PR is marked ready for review**. Best-effort and
+   tracker-agnostic — skip silently if the project defines no tracker-move
+   mechanism; never block the pipeline. Because the link auto-closes the
+   ticket on merge, the orchestrator never closes tickets by hand. Surface
+   the `ticketId` in the completion report.
 5. Mark all TodoWrite items complete.
 6. **Leave the worktree(s) in place.** Do not remove a worktree when a
    PR is opened — the user may need to iterate on the branch (push

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -606,22 +606,26 @@ describe("ticket pickup → in-progress", () => {
   });
 });
 
-// Regression: when the PR phase opens a pull request, the ticket must move to
-// the tracker's in-review state, and the PR must be linked to the ticket so the
-// tracker closes it (and any board automation moves it to its done state) on
-// merge. The PR phase previously only "surfaced the ticketId so the user can
-// close it" — no in-review move, no link. The fix carries the same generic,
-// best-effort runtime contract through every skill that opens a PR, while the
-// merge skill (shipit) stays board-agnostic. These tripwires pin the contract.
-describe("PR open → in-review → (merge) done", () => {
+// Regression: when the PR phase opens a pull request, the PR must be linked to
+// the ticket so the tracker closes it (and any board automation moves it to its
+// done state) on merge, and the ticket must move to the tracker's in-review
+// state — but only once the PR is marked ready for review. The pipeline opens
+// draft PRs, and a draft is not under review: the skills previously moved the
+// ticket to in-review immediately after the draft opened (observed as a Linear
+// issue reading "In Review" against a draft PR — #159). The fix carries the
+// same generic, best-effort runtime contract through every skill that opens a
+// PR, while the merge skill (shipit) stays board-agnostic. These tripwires pin
+// the contract, including its timing.
+describe("PR open (link) → ready for review (in-review) → (merge) done", () => {
   const TEAM_SKILL = join(REPO_ROOT, "skills", "team", "SKILL.md");
   const TEAM_FIX = join(REPO_ROOT, "skills", "team-fix", "SKILL.md");
   const TEAM_PR = join(REPO_ROOT, "skills", "team-pr", "SKILL.md");
   const SHIPIT = join(REPO_ROOT, "skills", "shipit", "SKILL.md");
   const PROJECT_TRACKING = join(REPO_ROOT, "docs", "project-tracking.md");
 
-  // The generic runtime contract for the PR phase: move the ticket to
-  // in-review, link it so it auto-closes on merge, best-effort, never blocking,
+  // The generic runtime contract for the PR phase: link the PR at open so it
+  // auto-closes on merge, move the ticket to in-review only once the PR is
+  // ready for review (never while it is a draft), best-effort, never blocking,
   // and no board hardcoded into the distributed runtime.
   function assertInReviewContract(path: string) {
     const text = flat(read(path));
@@ -629,6 +633,16 @@ describe("PR open → in-review → (merge) done", () => {
     expect(/in-review/i.test(text)).toBe(true);
     // Links the PR to the ticket so it auto-closes on merge (drives "done").
     expect(/closes #|link the pr/i.test(text)).toBe(true);
+    // The move is gated on the PR being ready for review — a draft PR is not
+    // under review, so the ticket stays in-progress while the PR is a draft.
+    expect(
+      /never\s+move\s+the\s+ticket\s+to\s+in-review\s+while\s+the\s+pr\s+is\s+a\s+draft/i.test(
+        text,
+      ),
+    ).toBe(true);
+    expect(
+      /only\s+once\s+the\s+pr\s+is\s+marked\s+ready\s+for\s+review/i.test(text),
+    ).toBe(true);
     // Stays generic — best-effort and never blocks the pipeline.
     expect(/best-effort/i.test(text)).toBe(true);
     expect(/never block/i.test(text)).toBe(true);
@@ -637,15 +651,15 @@ describe("PR open → in-review → (merge) done", () => {
     expect(text).not.toContain("projects/5");
   }
 
-  test("team-pr: opening the PR moves the ticket to in-review and links it", () => {
+  test("team-pr: links the PR at open; in-review waits for ready-for-review", () => {
     assertInReviewContract(TEAM_PR);
   });
 
-  test("team: PR gate moves the ticket to in-review and links it", () => {
+  test("team: PR gate links the PR; in-review waits for ready-for-review", () => {
     assertInReviewContract(TEAM_SKILL);
   });
 
-  test("team-fix: Ship moves the ticket to in-review and links it", () => {
+  test("team-fix: Ship links the PR; in-review waits for ready-for-review", () => {
     assertInReviewContract(TEAM_FIX);
   });
 
@@ -663,6 +677,9 @@ describe("PR open → in-review → (merge) done", () => {
     const text = flat(read(PROJECT_TRACKING));
     // In-review binding: the board script with the "In review" column.
     expect(/"In review"/i.test(text)).toBe(true);
+    // The binding fires when the PR is marked ready for review, not when the
+    // draft opens — the card stays In progress while the PR is a draft.
+    expect(/marked\s+ready\s+for\s+review/i.test(text)).toBe(true);
     // Done is automated by the board's close-on-merge automation, driven by
     // the PR's Closes-link — not a manual move.
     expect(/closes #/i.test(text)).toBe(true);


### PR DESCRIPTION
## Summary

- The PR phase (`/team-pr`, the `/team` PR gate, and `/team-fix` Ship) opens every PR as a draft, then immediately moved the tracking ticket to the tracker's in-review state — so a Linear issue (or any tracker) read "In Review" against a PR nobody had been asked to review.
- The tracker contract is now split in two: the PR↔ticket link (which drives close-on-merge) still happens at open time, but the in-review move fires only once the PR is marked ready for review. The ticket keeps its in-progress state while the PR is a draft. The contract stays tracker-agnostic, best-effort, and never blocking.

## Design Decisions

- Only the *timing* of the in-review move changed. Linking at open is deliberately kept: it is what lets the tracker close the ticket (and board automation move it to done) on merge, and a link on a draft PR is harmless.
- `docs/project-tracking.md` (this repo's dev-side board binding) gets the same split, so the board doc and the distributed runtime describe one lifecycle: draft open → link, ready for review → In review, merge → Done.
- The existing "PR open → in-review" tripwires pinned the move but not its timing, which is how the regression shipped unnoticed. The contract tests now pin the timing too.

## Changes

- `skills/team-pr/SKILL.md`, `skills/team/SKILL.md`, `skills/team-fix/SKILL.md` — the ticket step becomes "link now, in-review when ready", forbidding the in-review move while the PR is a draft.
- `docs/project-tracking.md` — the In review column, kanban flow, and QRSPI mapping now key on "marked ready for review" instead of "PR opened".
- `tests/protocol.test.ts` — the in-review contract tripwires additionally assert the draft-gating and ready-for-review wording in all three skills and the board doc.
- `CHANGELOG.md` — user-facing bullet, cut into the dated `[0.17.1]` section by the land-time version bump (`chore(version): 0.17.1`, which also bumps the four version strings).

## How to Verify

- The new tripwire assertions fail against the pre-fix skill text (4 assertion failures, verified by running the updated test file against an unfixed checkout) and pass with the fix.
- Full free suite: 625 pass, 0 fail (`bun test`). `tsc --noEmit` clean.

## References

Closes #159
