### PR TITLE
v0.18.0 feat: pin the ticket closing line as the PR body footer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.17.1"
+    "version": "0.18.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-22
+
 ### Added
 
 - **Every PR opened for a ticketed topic now ends with a `Closes` line in one fixed spot — the final line of the PR body.** Before, the three PR-opening skills said to put `Closes #<n>` "in the PR body" without saying where, so the link landed in a different place on every run. Now the PR Body Template in [`skills/team-pr/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md) ends with the closing line, a placement rationale sits next to the template (narrative first; the footer mirrors the commit-trailer convention; GitHub parses closing keywords anywhere, so the footer costs nothing), and the [`/team`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md) PR gate and [`/team-fix`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md) Ship step state the same rule. The skills also spell out how `ticketId` renders — a bare number becomes `Closes #<n>`; a recognized qualified reference or issue URL substitutes in; a null, empty, or whitespace-only ticket omits the line entirely, no placeholder; a non-GitHub shape (like `ENG-1234`) is a legible reference that closes nothing, so the tracker-move step is what advances that ticket — and every refresh of the body re-emits exactly one closing line, never duplicated, never dropped. PR bodies are passed to `gh` via `--body-file` or a quoted heredoc, never interpolated into a shell string. Pinned by static tripwires in `tests/protocol.test.ts`.
@@ -224,7 +226,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/bostonaholic/team/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/bostonaholic/team/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/bostonaholic/team/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/bostonaholic/team/compare/v0.15.0...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every PR opened for a ticketed topic now ends with a `Closes` line in one fixed spot — the final line of the PR body.** Before, the three PR-opening skills said to put `Closes #<n>` "in the PR body" without saying where, so the link landed in a different place on every run. Now the PR Body Template in [`skills/team-pr/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md) ends with the closing line, a placement rationale sits next to the template (narrative first; the footer mirrors the commit-trailer convention; GitHub parses closing keywords anywhere, so the footer costs nothing), and the [`/team`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md) PR gate and [`/team-fix`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md) Ship step state the same rule. The skills also spell out how `ticketId` renders — a bare number becomes `Closes #<n>`; a recognized qualified reference or issue URL substitutes in; a null, empty, or whitespace-only ticket omits the line entirely, no placeholder; a non-GitHub shape (like `ENG-1234`) is a legible reference that closes nothing, so the tracker-move step is what advances that ticket — and every refresh of the body re-emits exactly one closing line, never duplicated, never dropped. PR bodies are passed to `gh` via `--body-file` or a quoted heredoc, never interpolated into a shell string. Pinned by static tripwires in `tests/protocol.test.ts`.
+
+### Changed
+
+- **In multi-repo runs, only the home repo's PR closes the ticket.** A bare `#<n>` is repo-scoped — in a companion repo it names a different issue — and even a correctly-qualified closing reference would close the ticket when the first companion PR merged, before the whole change set landed. Companion PRs now carry a non-closing reference (`Part of owner/repo#<n>` or the issue URL) in the same footer spot; close-on-merge fires from the home repo's PR only.
+
 ## [0.17.1] - 2026-07-21
 
 ### Fixed

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -255,11 +255,13 @@ like this:
   description), the run continues without it — the move never blocks the
   pipeline. You no longer need to pre-move the card by hand before launching.
 - **Opening the PR** → the PR phase (`/team-pr`, the `/team` PR gate, and
-  `/team-fix` Ship) links the PR to the issue (`Closes #<N>` in the PR body)
-  so the issue closes on merge. The pipeline opens the PR as a **draft**, and
-  a draft is not under review, so **the card stays in In progress** — the
-  generic contract in those skills forbids the in-review move while the PR is
-  a draft.
+  `/team-fix` Ship) links the PR to the issue (`Closes #<N>` as the final
+  line of the PR body) so the issue closes on merge. In a multi-repo run,
+  only the home repo's PR carries the closing keyword — companion PRs carry
+  a non-closing qualified reference (`owner/repo#<N>` or the issue URL). The
+  pipeline opens the PR as a **draft**, and a draft is not under review, so
+  **the card stays in In progress** — the generic contract in those skills
+  forbids the in-review move while the PR is a draft.
 - **Marking the PR ready for review** → the card moves to **In review**. The
   human marks the PR ready; the generic, best-effort "move to in-review"
   defined in the PR-phase skills fires at this moment, never at draft-open.
@@ -272,7 +274,9 @@ like this:
   blocks the PR.
 - **Merge** → the card moves to **Done** **automatically**. Because the PR
   carries `Closes #<N>`, merging it closes the issue, and the board's built-in
-  "an item is closed → Done" automation moves the card. No manual move and no
+  "an item is closed → Done" automation moves the card. In a multi-repo run,
+  close-on-merge fires from the home repo PR's merge specifically — companion
+  PRs carry no closing keyword. No manual move and no
   `/shipit` board logic is involved — `/shipit` stays tracker-agnostic. (A PR
   added to the board as its own item is likewise moved to **Done** by the
   built-in "pull request merged → Done" automation.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -101,12 +101,12 @@ assertion failure, not a crash. Do not proceed to the fix until confirmed.
 3. **Ticket — link now, in-review when ready.** If `ticketId` is non-null
    in `task.md`'s frontmatter: **link the PR to the ticket** so the
    tracker closes it — and any board automation moves it to its done state
-   — when the PR merges. On GitHub, render the link as `Closes #<n>`
-   as the final line of the PR body. **Never move the ticket to
-   in-review while the PR is a draft** — a draft is not under review,
-   and Ship opens a draft PR, so the ticket keeps its in-progress state
-   at open time; move it to the tracker's in-review state **only once
-   the PR is marked ready for review**.
+   — when the PR merges. On GitHub, render the link as a `Closes #<n>`
+   footer, emitted as the final line of the PR body. **Never move the
+   ticket to in-review while the PR is a draft** — a draft is not under
+   review, and Ship opens a draft PR, so the ticket keeps its
+   in-progress state at open time; move it to the tracker's in-review
+   state **only once the PR is marked ready for review**.
    Best-effort and tracker-agnostic — skip silently if the project defines
    no tracker-move mechanism; never block. Because the link auto-closes the
    ticket on merge, the orchestrator never closes tickets by hand. Surface

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -101,15 +101,15 @@ assertion failure, not a crash. Do not proceed to the fix until confirmed.
 3. **Ticket — link now, in-review when ready.** If `ticketId` is non-null
    in `task.md`'s frontmatter: **link the PR to the ticket** so the
    tracker closes it — and any board automation moves it to its done state
-   — when the PR merges (GitHub: `Closes #<n>` in the PR body). **Never
-   move the ticket to in-review while the PR is a draft** — a draft is not
-   under review, and Ship opens a draft PR, so the ticket keeps its
-   in-progress state at open time; move it to the tracker's in-review
-   state **only once the PR is marked ready for review**. Best-effort and
-   tracker-agnostic — skip silently if the project defines no tracker-move
-   mechanism; never block. Because the link auto-closes the ticket on
-   merge, the orchestrator never closes tickets by hand. Surface the
-   `ticketId` in the completion report.
+   — when the PR merges (GitHub: `Closes #<n>` as the final line of the PR
+   body). **Never move the ticket to in-review while the PR is a draft** —
+   a draft is not under review, and Ship opens a draft PR, so the ticket
+   keeps its in-progress state at open time; move it to the tracker's
+   in-review state **only once the PR is marked ready for review**.
+   Best-effort and tracker-agnostic — skip silently if the project defines
+   no tracker-move mechanism; never block. Because the link auto-closes the
+   ticket on merge, the orchestrator never closes tickets by hand. Surface
+   the `ticketId` in the completion report.
 4. Mark all TodoWrite items complete.
 
 ## Aborting

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -101,11 +101,12 @@ assertion failure, not a crash. Do not proceed to the fix until confirmed.
 3. **Ticket — link now, in-review when ready.** If `ticketId` is non-null
    in `task.md`'s frontmatter: **link the PR to the ticket** so the
    tracker closes it — and any board automation moves it to its done state
-   — when the PR merges (GitHub: `Closes #<n>` as the final line of the PR
-   body). **Never move the ticket to in-review while the PR is a draft** —
-   a draft is not under review, and Ship opens a draft PR, so the ticket
-   keeps its in-progress state at open time; move it to the tracker's
-   in-review state **only once the PR is marked ready for review**.
+   — when the PR merges. On GitHub, render the link as `Closes #<n>`
+   as the final line of the PR body. **Never move the ticket to
+   in-review while the PR is a draft** — a draft is not under review,
+   and Ship opens a draft PR, so the ticket keeps its in-progress state
+   at open time; move it to the tracker's in-review state **only once
+   the PR is marked ready for review**.
    Best-effort and tracker-agnostic — skip silently if the project defines
    no tracker-move mechanism; never block. Because the link auto-closes the
    ticket on merge, the orchestrator never closes tickets by hand. Surface

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -105,7 +105,9 @@ done
    entries belonging to that repo's commits.
 6. **Open a draft PR automatically — do not stop to ask.** The PR phase
    is not a human gate; opening the PR requires no approval. Push the
-   branch and open the PR as a **draft** (`gh pr create --draft`). Any
+   branch and open the PR as a **draft** (`gh pr create --draft`). Pass
+   the body to `gh pr create`/`gh pr edit` via `--body-file` or a quoted
+   heredoc — never interpolated into a double-quoted shell argument. Any
    uncommitted final changes (typically `CHANGELOG.md`) land as a single
    trailing ship commit before the push. In multi-repo mode this opens
    **one draft PR per repo with commits** and cross-links them.
@@ -123,9 +125,15 @@ done
      the PR Body Template. Interpret `ticketId` here, where it is
      consumed:
      - A bare number → `Closes #<n>` (a GitHub issue in the origin repo).
-     - Any other non-null value → `Closes <ticketId or issue-url>`. An
-       unrecognized shape is emitted verbatim and noted in the completion
-       report — never block on it.
+     - A qualified reference (`owner/repo#<n>`) or an issue URL →
+       `Closes` followed by that value substituted in — e.g.
+       `Closes https://github.com/owner/repo/issues/42`.
+     - Any other non-null shape still goes in verbatim as the footer
+       text (`Closes` plus the value), but note the unrecognized shape
+       in the completion report — never block on it. On GitHub such a
+       value (e.g. `Closes ENG-1234`) auto-closes nothing — the footer
+       is then a legible reference only, and the tracker-move step below
+       is what advances the ticket.
      - Null, absent, empty, or whitespace-only → omit the closing line
        entirely; no placeholder.
      This link is what drives the eventual move to done on merge, so the
@@ -143,16 +151,18 @@ done
    push that adds, removes, or changes commits on a PR's branch — the
    initial open *and* every follow-up push (review feedback, fixups,
    rebases) — must be followed by re-reading the current PR body against
-   the now-pushed commits and updating it (`gh pr edit --body`) so the
-   Summary, Changes, and How-to-Verify sections still match what the
-   branch actually does. The footer survives every refresh too: when the
+   the now-pushed commits and updating it (`gh pr edit --body-file`, or
+   a quoted heredoc per step 6) so the Summary, Changes, and
+   How-to-Verify sections still match what the branch actually does.
+   The footer survives every refresh too: when the
    body carries a closing line (the home repo's PR of a ticketed topic),
    each refresh re-emits **exactly one** closing line in footer position
    — never duplicated, never dropped. A companion PR re-emits its
    non-closing reference the same way, and a PR with no ticket has no
-   closing line to re-emit. Never leave a stale description after a
-   push. In multi-repo mode, do this for each repo's PR whose branch you
-   pushed.
+   closing line to re-emit; the post-open `## Companion PRs` section is
+   likewise preserved on every refresh. Never leave a stale description
+   after a push. In multi-repo mode, do this for each repo's PR whose
+   branch you pushed.
 10. **Leave the worktree(s) in place.** Do not remove a worktree after
    opening a PR — the user may need to iterate on the branch (push
    follow-up commits, address review feedback). Clean up only after the
@@ -193,8 +203,10 @@ Closes #<n>
 
 The `Closes` line is a standalone footer — no heading — rendered as the
 final line of the PR body. It is conditional on `ticketId`: when
-`ticketId` is null, absent, or empty, omit the line entirely — no
-placeholder, no empty footer.
+`ticketId` is null, absent, empty, or whitespace-only, omit the line
+entirely — no placeholder, no empty footer — and drop its preceding
+blank line with it, so the body ends at the last `## References` bullet
+with no trailing blank line.
 
 **Placement rationale:** reviewers open a PR to read `## Summary`; the
 closing line is machine-facing metadata, so the narrative comes first
@@ -207,10 +219,15 @@ In multi-repo mode, only the **home** repo's PR carries the closing
 keyword (`Closes #<n>`) — so the ticket closes exactly once, when the
 home PR merges. Companion PRs carry a **non-closing** reference to the
 issue in the same footer position, using the unambiguous qualified form
-(`owner/repo#<n>` or the issue URL). A bare `#<n>` is repo-scoped — in
-a companion repo it names a *different* issue — and even a qualified
-*closing* form would close the ticket on the first companion merge,
-before the full change set lands.
+(`owner/repo#<n>` or the issue URL) — for example:
+
+```
+Part of owner/repo#<n>
+```
+
+A bare `#<n>` is repo-scoped — in a companion repo it names a
+*different* issue — and even a qualified *closing* form would close the
+ticket on the first companion merge, before the full change set lands.
 
 In multi-repo mode, append a `## Companion PRs` section to each PR
 listing the URLs of every other PR opened for the same topic, so a

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -116,9 +116,18 @@ done
    non-null:
    - **Link the PR to the ticket** so the tracker closes the ticket — and
      any board automation moves it to its done state — when the PR merges.
-     For GitHub, put `Closes #<n>` in the PR body; for another tracker use
-     its PR↔issue link. This link is what drives the eventual move to done
-     on merge, so the orchestrator never closes tickets by hand.
+     Render the link as the closing line the PR Body Template ends with
+     (GitHub: `Closes #<n>` as the final line of the PR body); for another
+     tracker use its PR↔issue link. Interpret `ticketId` here, where it is
+     consumed:
+     - A bare number → `Closes #<n>` (a GitHub issue in the origin repo).
+     - Any other non-null value → `Closes <ticketId or issue-url>`. An
+       unrecognized shape is emitted verbatim and noted in the completion
+       report — never block on it.
+     - Null, absent, empty, or whitespace-only → omit the closing line
+       entirely; no placeholder.
+     This link is what drives the eventual move to done on merge, so the
+     orchestrator never closes tickets by hand.
    - **Never move the ticket to in-review while the PR is a draft.** A
      draft is not under review, and this phase opens the PR as a draft —
      at open time the ticket keeps its in-progress state. Move the ticket
@@ -134,8 +143,11 @@ done
    rebases) — must be followed by re-reading the current PR body against
    the now-pushed commits and updating it (`gh pr edit --body`) so the
    Summary, Changes, and How-to-Verify sections still match what the
-   branch actually does. Never leave a stale description after a push. In
-   multi-repo mode, do this for each repo's PR whose branch you pushed.
+   branch actually does. The closing line survives every refresh too:
+   each refresh re-emits **exactly one** closing line in footer position
+   — never duplicated, never dropped. Never leave a stale description
+   after a push. In multi-repo mode, do this for each repo's PR whose
+   branch you pushed.
 10. **Leave the worktree(s) in place.** Do not remove a worktree after
    opening a PR — the user may need to iterate on the branch (push
    follow-up commits, address review feedback). Clean up only after the
@@ -170,7 +182,21 @@ done
 ## References
 - Design: $ARGUMENTS/design.md
 - Plan:   $ARGUMENTS/plan.md
+
+Closes #<n>
 ```
+
+The `Closes` line is a standalone footer — no heading — rendered as the
+final line of the PR body. It is conditional on `ticketId`: when
+`ticketId` is null, absent, or empty, omit the line entirely — no
+placeholder, no empty footer.
+
+**Placement rationale:** reviewers open a PR to read `## Summary`; the
+closing line is machine-facing metadata, so the narrative comes first
+and the footer comes last, mirroring the commit-footer convention in
+`skills/git-commit/SKILL.md`. GitHub parses closing keywords anywhere in
+the body, so the footer position costs nothing — and "last authored
+line" is deterministic to emit and trivial to verify.
 
 In multi-repo mode, append a `## Companion PRs` section to each PR
 listing the URLs of every other PR opened for the same topic, so a

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -198,6 +198,15 @@ and the footer comes last, mirroring the commit-footer convention in
 the body, so the footer position costs nothing — and "last authored
 line" is deterministic to emit and trivial to verify.
 
+In multi-repo mode, only the **home** repo's PR carries the closing
+keyword (`Closes #<n>`) — so the ticket closes exactly once, when the
+home PR merges. Companion PRs carry a **non-closing** reference to the
+issue in the same footer position, using the unambiguous qualified form
+(`owner/repo#<n>` or the issue URL). A bare `#<n>` is repo-scoped — in
+a companion repo it names a *different* issue — and even a qualified
+*closing* form would close the ticket on the first companion merge,
+before the full change set lands.
+
 In multi-repo mode, append a `## Companion PRs` section to each PR
 listing the URLs of every other PR opened for the same topic, so a
 reviewer can navigate the full change set:
@@ -210,7 +219,10 @@ This change spans multiple repos. The companion PRs are:
 ```
 
 Open the PRs first to obtain URLs, then edit each PR's body to add the
-section once all URLs are known.
+section once all URLs are known. This post-open edit appends the
+section *after* the closing line — "final line of the PR body" refers
+to creation-time authoring, so the appended `## Companion PRs` section
+following it is expected, not a violation.
 
 ## Changelog Update
 

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -118,7 +118,9 @@ done
      any board automation moves it to its done state — when the PR merges.
      Render the link as the closing line the PR Body Template ends with
      (GitHub: `Closes #<n>` as the final line of the PR body); for another
-     tracker use its PR↔issue link. Interpret `ticketId` here, where it is
+     tracker use its PR↔issue link. In multi-repo mode this closing line
+     goes on the **home** repo's PR only — see the multi-repo rule below
+     the PR Body Template. Interpret `ticketId` here, where it is
      consumed:
      - A bare number → `Closes #<n>` (a GitHub issue in the origin repo).
      - Any other non-null value → `Closes <ticketId or issue-url>`. An
@@ -143,11 +145,14 @@ done
    rebases) — must be followed by re-reading the current PR body against
    the now-pushed commits and updating it (`gh pr edit --body`) so the
    Summary, Changes, and How-to-Verify sections still match what the
-   branch actually does. The closing line survives every refresh too:
+   branch actually does. The footer survives every refresh too: when the
+   body carries a closing line (the home repo's PR of a ticketed topic),
    each refresh re-emits **exactly one** closing line in footer position
-   — never duplicated, never dropped. Never leave a stale description
-   after a push. In multi-repo mode, do this for each repo's PR whose
-   branch you pushed.
+   — never duplicated, never dropped. A companion PR re-emits its
+   non-closing reference the same way, and a PR with no ticket has no
+   closing line to re-emit. Never leave a stale description after a
+   push. In multi-repo mode, do this for each repo's PR whose branch you
+   pushed.
 10. **Leave the worktree(s) in place.** Do not remove a worktree after
    opening a PR — the user may need to iterate on the branch (push
    follow-up commits, address review feedback). Clean up only after the

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -342,9 +342,13 @@ When the aggregate gate passes:
    keeps its in-progress state at open time; move it to the tracker's
    in-review state **only once the PR is marked ready for review**.
    Best-effort and tracker-agnostic — skip silently if the project defines
-   no tracker-move mechanism; never block the pipeline. Because the link
-   auto-closes the ticket on merge, the orchestrator never closes tickets
-   by hand. Surface the `ticketId` in the completion report.
+   no tracker-move mechanism; never block the pipeline.
+   In multi-repo mode, only the **home** repo's PR carries the closing
+   keyword; companion PRs carry a non-closing qualified reference
+   (`owner/repo#<n>` or the issue URL) instead — see the multi-repo rule
+   in `skills/team-pr/SKILL.md`.
+   Because the link auto-closes the ticket on merge, the orchestrator never
+   closes tickets by hand. Surface the `ticketId` in the completion report.
 5. Mark all TodoWrite items complete.
 6. **Leave the worktree(s) in place.** Do not remove a worktree when a
    PR is opened — the user may need to iterate on the branch (push

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -336,15 +336,15 @@ When the aggregate gate passes:
 4. **Ticket — link now, in-review when ready.** If `task.md` frontmatter
    has `ticketId` set: **link the PR to the ticket** so the tracker closes
    it — and any board automation moves it to its done state — when the PR
-   merges (GitHub: `Closes #<n>` in the PR body). **Never move the ticket
-   to in-review while the PR is a draft** — a draft is not under review,
-   and this gate opens draft PRs, so the ticket keeps its in-progress
-   state at open time; move it to the tracker's in-review state **only
-   once the PR is marked ready for review**. Best-effort and
-   tracker-agnostic — skip silently if the project defines no tracker-move
-   mechanism; never block the pipeline. Because the link auto-closes the
-   ticket on merge, the orchestrator never closes tickets by hand. Surface
-   the `ticketId` in the completion report.
+   merges (GitHub: `Closes #<n>` as the final line of the PR body).
+   **Never move the ticket to in-review while the PR is a draft** — a
+   draft is not under review, and this gate opens draft PRs, so the ticket
+   keeps its in-progress state at open time; move it to the tracker's
+   in-review state **only once the PR is marked ready for review**.
+   Best-effort and tracker-agnostic — skip silently if the project defines
+   no tracker-move mechanism; never block the pipeline. Because the link
+   auto-closes the ticket on merge, the orchestrator never closes tickets
+   by hand. Surface the `ticketId` in the completion report.
 5. Mark all TodoWrite items complete.
 6. **Leave the worktree(s) in place.** Do not remove a worktree when a
    PR is opened — the user may need to iterate on the branch (push

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -344,9 +344,9 @@ When the aggregate gate passes:
    Best-effort and tracker-agnostic — skip silently if the project defines
    no tracker-move mechanism; never block the pipeline.
    In multi-repo mode, only the **home** repo's PR carries the closing
-   keyword; companion PRs carry a non-closing qualified reference
-   (`owner/repo#<n>` or the issue URL) instead — see the multi-repo rule
-   in `skills/team-pr/SKILL.md`.
+   keyword (`Closes #<n>`); companion PRs carry a non-closing qualified
+   reference (`owner/repo#<n>` or the issue URL) instead — see the
+   multi-repo rule in `skills/team-pr/SKILL.md`.
    Because the link auto-closes the ticket on merge, the orchestrator never
    closes tickets by hand. Surface the `ticketId` in the completion report.
 5. Mark all TodoWrite items complete.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -337,16 +337,16 @@ When the aggregate gate passes:
    has `ticketId` set: **link the PR to the ticket** so the tracker closes
    it — and any board automation moves it to its done state — when the PR
    merges (GitHub: `Closes #<n>` as the final line of the PR body).
+   In multi-repo mode, only the **home** repo's PR carries the closing
+   keyword (`Closes #<n>`); companion PRs carry a non-closing qualified
+   reference (`owner/repo#<n>` or the issue URL) instead — see the
+   multi-repo rule in `skills/team-pr/SKILL.md`.
    **Never move the ticket to in-review while the PR is a draft** — a
    draft is not under review, and this gate opens draft PRs, so the ticket
    keeps its in-progress state at open time; move it to the tracker's
    in-review state **only once the PR is marked ready for review**.
    Best-effort and tracker-agnostic — skip silently if the project defines
    no tracker-move mechanism; never block the pipeline.
-   In multi-repo mode, only the **home** repo's PR carries the closing
-   keyword (`Closes #<n>`); companion PRs carry a non-closing qualified
-   reference (`owner/repo#<n>` or the issue URL) instead — see the
-   multi-repo rule in `skills/team-pr/SKILL.md`.
    Because the link auto-closes the ticket on merge, the orchestrator never
    closes tickets by hand. Surface the `ticketId` in the completion report.
 5. Mark all TodoWrite items complete.

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -686,4 +686,90 @@ describe("PR open (link) → ready for review (in-review) → (merge) done", () 
     expect(/\bDone\b/.test(text)).toBe(true);
     expect(/automatic/i.test(text)).toBe(true);
   });
+
+  // Issue #158: the ticket closing line must land in a deterministic position
+  // — the final line of the authored PR body — across all three PR-opening
+  // skills, with ticketId interpretation codified at the consumption site and
+  // multi-repo runs closing the ticket exactly once (home PR only). These
+  // tripwires pin the closing-footer contract on the skill source.
+
+  // The PR Body Template: the first fenced code block after the
+  // "## PR Body Template" heading in team-pr.
+  function prBodyTemplate(text: string): string {
+    const afterHeading = text.split("## PR Body Template")[1] ?? "";
+    return afterHeading.match(/```\n([\s\S]*?)```/)?.[1] ?? "";
+  }
+
+  // Canonical placement phrase — deliberately duplicated prose across the
+  // three PR-opening skills. One helper applied per file pins every copy
+  // against drift.
+  function assertClosingFooterPlacement(path: string) {
+    const text = flat(read(path));
+    expect(/as the final line of the PR body/i.test(text)).toBe(true);
+  }
+
+  test("team-pr: PR Body Template ends with the ticketId-conditional Closes footer", () => {
+    const template = prBodyTemplate(read(TEAM_PR));
+    // Fail loud if the template block vanished, so the position assertions
+    // below can't pass vacuously against an empty string.
+    expect(template.length).toBeGreaterThan(0);
+    // The closing line sits after the ## References bullets — the footer of
+    // the authored body.
+    expect(template).toContain("Closes");
+    expect(template.indexOf("Closes")).toBeGreaterThan(
+      template.indexOf("## References"),
+    );
+    // Conditional on ticketId: omitted entirely when null/absent/empty —
+    // no placeholder is ever rendered.
+    const text = flat(read(TEAM_PR));
+    expect(
+      /omit[^.]{0,200}(null|absent|empty)|(null|absent|empty)[^.]{0,200}omit/i.test(
+        text,
+      ),
+    ).toBe(true);
+    expect(/no placeholder/i.test(text)).toBe(true);
+  });
+
+  test("team-pr: placement rationale is documented alongside the template", () => {
+    expect(/placement rationale/i.test(flat(read(TEAM_PR)))).toBe(true);
+  });
+
+  test("team-pr: body refresh re-emits exactly one closing line", () => {
+    const text = flat(read(TEAM_PR));
+    // Step 9 lists the closing line among the refresh-surviving sections:
+    // every `gh pr edit --body` re-emits exactly one, never duplicated,
+    // never dropped.
+    expect(
+      /exactly one[^.]{0,200}closing line|closing line[^.]{0,200}exactly one/i.test(
+        text,
+      ),
+    ).toBe(true);
+    expect(/never duplicated/i.test(text)).toBe(true);
+    expect(/never dropped/i.test(text)).toBe(true);
+  });
+
+  test("team-pr: states the Closes footer placement (final line of the PR body)", () => {
+    assertClosingFooterPlacement(TEAM_PR);
+  });
+
+  test("team: PR gate states the Closes footer placement (final line of the PR body)", () => {
+    assertClosingFooterPlacement(TEAM_SKILL);
+  });
+
+  test("team-fix: Ship states the Closes footer placement (final line of the PR body)", () => {
+    assertClosingFooterPlacement(TEAM_FIX);
+  });
+
+  test("team-pr: multi-repo — only the home PR carries a closing keyword; companions use a non-closing qualified reference", () => {
+    const text = flat(read(TEAM_PR));
+    // (a) the home repo's PR alone closes the ticket.
+    expect(/home[^.]{0,250}closes #|closes #[^.]{0,250}home/i.test(text)).toBe(
+      true,
+    );
+    // (b) companion PRs reference the issue without a closing keyword, in the
+    // unambiguous qualified form (a bare #<n> is repo-scoped and would name a
+    // different issue in a companion repo).
+    expect(/non-closing/i.test(text)).toBe(true);
+    expect(text).toContain("owner/repo#");
+  });
 });

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -716,6 +716,9 @@ describe("PR open (link) → ready for review (in-review) → (merge) done", () 
     // The closing line sits after the ## References bullets — the footer of
     // the authored body.
     expect(template).toContain("Closes");
+    // Guard the ordering comparison: without this, removing ## References
+    // would make indexOf return -1 and the check below pass vacuously.
+    expect(template).toContain("## References");
     expect(template.indexOf("Closes")).toBeGreaterThan(
       template.indexOf("## References"),
     );

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -719,6 +719,10 @@ describe("PR open (link) → ready for review (in-review) → (merge) done", () 
     expect(template.indexOf("Closes")).toBeGreaterThan(
       template.indexOf("## References"),
     );
+    // And it is the FINAL line of the template — nothing may follow it.
+    // Without this, appending a section after the closing line would still
+    // pass the ordering check above.
+    expect(template.trimEnd().endsWith("Closes #<n>")).toBe(true);
     // Conditional on ticketId: omitted entirely when null/absent/empty —
     // no placeholder is ever rendered.
     const text = flat(read(TEAM_PR));

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -767,8 +767,10 @@ describe("PR open (link) → ready for review (in-review) → (merge) done", () 
     assertClosingFooterPlacement(TEAM_FIX);
   });
 
-  test("team-pr: multi-repo — only the home PR carries a closing keyword; companions use a non-closing qualified reference", () => {
-    const text = flat(read(TEAM_PR));
+  // Multi-repo home-only closing rule — deliberately duplicated prose in
+  // team-pr and team, independently tripwired so neither copy can drift.
+  function assertHomeOnlyClosingRule(path: string) {
+    const text = flat(read(path));
     // (a) the home repo's PR alone closes the ticket.
     expect(/home[^.]{0,250}closes #|closes #[^.]{0,250}home/i.test(text)).toBe(
       true,
@@ -778,5 +780,13 @@ describe("PR open (link) → ready for review (in-review) → (merge) done", () 
     // different issue in a companion repo).
     expect(/non-closing/i.test(text)).toBe(true);
     expect(text).toContain("owner/repo#");
+  }
+
+  test("team-pr: multi-repo — only the home PR carries a closing keyword; companions use a non-closing qualified reference", () => {
+    assertHomeOnlyClosingRule(TEAM_PR);
+  });
+
+  test("team: PR gate carries the multi-repo home-only closing rule", () => {
+    assertHomeOnlyClosingRule(TEAM_SKILL);
   });
 });


### PR DESCRIPTION
## Summary

Every PR the pipeline opens for a ticketed topic now links its issue with a closing keyword in one fixed spot: a `Closes` line as the final line of the PR body. Before, the three PR-opening skills (`team-pr`, the `/team` PR gate, `/team-fix` Ship) said to put the link "in the PR body" without saying where, so it landed in a different place on every run — and in multi-repo runs a companion PR could close the ticket prematurely or reference the wrong issue entirely.

## Design Decisions

- **Placement: footer.** The closing line is the last line of the authored body, after `## References`, with no heading. Reviewers open a PR to read the narrative; the closing line is machine-facing metadata, so it goes last — mirroring the commit-trailer convention. GitHub parses closing keywords anywhere in a body, so the footer position costs nothing, and "last authored line" is deterministic to emit and trivial to tripwire. The rationale is documented next to the template so the decision doesn't rot.
- **Keyword: `Closes` everywhere.** One canonical keyword across all three skills instead of a bugs-vs-features split or author's choice.
- **`ticketId` interpreted where it's consumed.** A bare number renders `Closes #<n>`; a recognized qualified reference or issue URL substitutes in; null/empty/whitespace omits the line entirely (no placeholder); a non-GitHub shape (e.g. `ENG-1234`) is a legible reference that auto-closes nothing, so the tracker-move step advances that ticket.
- **Multi-repo: only the home repo's PR closes the ticket.** A bare `#<n>` is repo-scoped, and even a qualified closing reference would fire on the first companion merge — before the full change set lands. Companion PRs carry a non-closing reference (`Part of owner/repo#<n>` or the issue URL) in the same footer position.
- **Enforcement at the free static layer.** The contract is pinned by deterministic tripwires in `tests/protocol.test.ts`; no paid evals.

## Changes

- `skills/team-pr/SKILL.md` — the PR Body Template ends with the ticket-conditional closing line; placement rationale documented; step 8 codifies `ticketId` interpretation and the multi-repo home-only rule; step 9 guarantees each body refresh re-emits exactly one closing line; bodies are passed to `gh` via `--body-file` or a quoted heredoc, never shell-interpolated.
- `skills/team/SKILL.md` and `skills/team-fix/SKILL.md` — the ticket-linking steps state the position-complete contract ("as the final line of the PR body") and, in the `/team` PR gate, the home-only multi-repo rule.
- `docs/project-tracking.md` — the board-automation narrative reflects the footer position and that close-on-merge fires from the home repo's PR.
- `tests/protocol.test.ts` — new tripwires pin the template footer (including that nothing follows it), the placement phrase in all three skills, the omission rule, the refresh guarantee, and the home-only rule in both skills that carry it.

The branch is rebased onto v0.17.1; the "link now, in-review when ready" contract from #160 is preserved verbatim alongside the new placement rules.

## How to Verify

- [x] `bun test` — full free suite green (633 tests), including the new closing-footer tripwires and the pre-existing #160 draft-gating tripwires
- [x] Read `skills/team-pr/SKILL.md` → PR Body Template ends with `Closes #<n>`, with the placement rationale directly below
- [x] This PR's own body ends with its closing line — the contract applied to itself

## References

- Design: `docs/plans/158-pr-closing-keywords/design.md` (local pipeline artifact)
- Reviewed by the 5-reviewer aggregate gate over 4 rounds plus a post-rebase coherence pass

Closes #158

