### PR TITLE
fix(ci): append eval runs to the PR results comment instead of overwriting

### DIFF
--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -1,7 +1,8 @@
 # PR evals — diff-selected behavioral evals on pull requests, with a results comment.
 #
 # Run the evals relevant to a PR's diff, then upsert ONE comment summarizing
-# pass/fail and cost. Selection (which evals run)
+# pass/fail and cost. The comment accumulates a run-history table across pushes
+# (with a cumulative cost total) instead of overwriting. Selection (which evals run)
 # is decided by the harness from `git diff <base>...HEAD` against each eval's
 # touchfiles (tests/helpers/touchfiles.ts) — cost scales with the diff, NOT the
 # whole suite. The weekly full periodic run stays in periodic-evals.yml.
@@ -118,14 +119,27 @@ jobs:
           merge-multiple: true
 
       - name: Build and upsert results comment
+        env:
+          EVAL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVAL_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          BODY="$(bun run scripts/eval-report.ts artifacts)"
           # Upsert: find our existing comment by the stable marker prefix and
           # PATCH it; otherwise create a new one. Keeps one comment per PR.
-          ID="$(gh api "repos/$REPO/issues/$PR/comments" \
+          # The existing body is fed back into the formatter so each run is
+          # APPENDED to the comment's run history (with a cumulative cost
+          # total) rather than overwriting the previous runs. --paginate so a
+          # comment pushed past page 1 on a busy PR isn't missed (a miss would
+          # create a duplicate and orphan the history).
+          ID="$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
             --jq '.[] | select(.body | startswith("## PR Evals")) | .id' | tail -1 || true)"
+          PREV_FILE=""
+          if [ -n "${ID:-}" ]; then
+            gh api "repos/$REPO/issues/comments/$ID" --jq .body > previous-body.md
+            PREV_FILE=previous-body.md
+          fi
+          BODY="$(bun run scripts/eval-report.ts artifacts "$PREV_FILE")"
           if [ -n "${ID:-}" ]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$ID" -f body="$BODY" >/dev/null
             echo "Updated comment $ID"

--- a/scripts/eval-report.ts
+++ b/scripts/eval-report.ts
@@ -1,11 +1,17 @@
 #!/usr/bin/env bun
 // scripts/eval-report.ts
 //
-// CLI: `bun run scripts/eval-report.ts <results-dir>`
+// CLI: `bun run scripts/eval-report.ts <results-dir> [previous-body-file]`
 // Formats one or more eval result JSONs (the schema written by
 // tests/helpers/eval-store.ts) into a Markdown body for a PR comment, then
 // prints it to stdout. Used by .github/workflows/pr-evals.yml, which upserts the
 // body as a single `## PR Evals` comment on the PR.
+//
+// The comment is append-only across runs: prior runs are carried forward as a
+// run-history table with a cumulative cost total, so the spend for the whole PR
+// stays visible. The history rides inside the body itself as JSON in a hidden
+// HTML comment (HISTORY_MARKER), parsed back out on the next run — no external
+// state. Run metadata comes from EVAL_HEAD_SHA / EVAL_RUN_URL in the env.
 //
 // The body builder is a pure function (buildReportBody) so it is unit-tested
 // for free in tests/eval-report.test.ts. The CLI wrapper only reads files and
@@ -21,6 +27,38 @@ import type { EvalResult, EvalTestEntry } from "../tests/helpers/eval-store";
 // existing comment or create a new one. MUST stay stable and in sync with the
 // upsert logic in .github/workflows/pr-evals.yml (locked by a tripwire test).
 export const REPORT_MARKER = "## PR Evals";
+
+// Hidden carrier for the machine-readable run history. Must stay an HTML
+// comment (invisible on GitHub) and must not contain `-->` in its payload —
+// the JSON below (hex shas, URLs, numbers) never does.
+const HISTORY_MARKER = "<!-- pr-evals-history:v1 ";
+
+/** One completed eval run on this PR, as carried in the comment's history. */
+export interface RunRecord {
+  sha: string;
+  run_url: string;
+  passed: number;
+  total: number;
+  cost_usd: number;
+}
+
+/** Extract the run history embedded in a previous comment body. Returns []
+ *  for a missing body, an old-format body without the marker, or malformed
+ *  JSON — the history restarts rather than failing the report. */
+export function parseHistory(body: string | undefined): RunRecord[] {
+  if (!body) return [];
+  const start = body.indexOf(HISTORY_MARKER);
+  if (start === -1) return [];
+  const end = body.indexOf("-->", start);
+  if (end === -1) return [];
+  try {
+    const parsed = JSON.parse(body.slice(start + HISTORY_MARKER.length, end));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((r): r is RunRecord => typeof r?.cost_usd === "number");
+  } catch {
+    return [];
+  }
+}
 
 function fmtCost(usd: number): string {
   return `$${usd.toFixed(2)}`;
@@ -38,13 +76,52 @@ function noEvalsBody(): string {
   );
 }
 
-/** Build the Markdown PR-comment body from the collected eval result files.
+/** Render the accumulated runs as a Markdown table with a cumulative total. */
+function historySection(runs: RunRecord[]): string {
+  const total = runs.reduce((sum, r) => sum + r.cost_usd, 0);
+  const rows = runs.map((r, i) => {
+    const commit = r.sha ? r.sha.slice(0, 7) : "—";
+    const label = r.run_url ? `[${commit}](${r.run_url})` : commit;
+    const icon = r.passed === r.total ? "✅" : "❌";
+    return `| ${i + 1} | ${label} | ${icon} ${r.passed}/${r.total} | ${fmtCost(r.cost_usd)} |`;
+  });
+  return (
+    `### Run history — **${fmtCost(total)}** total across ${runs.length} run${runs.length === 1 ? "" : "s"}\n\n` +
+    "| Run | Commit | Result | Cost |\n" +
+    "|-----|--------|--------|------|\n" +
+    rows.join("\n")
+  );
+}
+
+export interface ReportOptions {
+  /** Body of the existing `## PR Evals` comment, when one exists — its
+   *  embedded history is carried forward instead of overwritten. */
+  previousBody?: string;
+  /** Head commit sha of the run being reported. */
+  sha?: string;
+  /** Workflow-run URL, used to link each history row. */
+  runUrl?: string;
+}
+
+/** Build the Markdown PR-comment body from the collected eval result files,
+ *  appending this run to the history carried in the previous comment body.
  *  Pure: no I/O, no process state. */
-export function buildReportBody(results: EvalResult[]): string {
+export function buildReportBody(results: EvalResult[], opts: ReportOptions = {}): string {
+  const history = parseHistory(opts.previousBody);
+
   // Only results that actually ran a test carry signal; a skipped run still
   // writes a total_tests: 0 file (eval-store finalize()), which we ignore.
+  // A no-evals run adds no history row (nothing ran, nothing spent) — prior
+  // runs and the cost total still render so they are never lost.
   const ran = results.filter((r) => r.total_tests > 0);
-  if (ran.length === 0) return noEvalsBody();
+  if (ran.length === 0) {
+    let body = noEvalsBody();
+    if (history.length > 0) {
+      body += `\n\n${historySection(history)}`;
+      body += `\n\n${HISTORY_MARKER}${JSON.stringify(history)} -->`;
+    }
+    return body;
+  }
 
   const tests: EvalTestEntry[] = ran.flatMap((r) => r.tests);
   const total = tests.length;
@@ -66,7 +143,7 @@ export function buildReportBody(results: EvalResult[]): string {
 
   let body =
     `${REPORT_MARKER}: ${status}\n\n` +
-    `**${passed}/${total}** tests passed | **${fmtCost(cost)}** total cost\n\n` +
+    `**${passed}/${total}** tests passed | **${fmtCost(cost)}** this run\n\n` +
     "| Suite | Result | Status | Cost |\n" +
     "|-------|--------|--------|------|\n" +
     rows.join("\n");
@@ -78,6 +155,19 @@ export function buildReportBody(results: EvalResult[]): string {
       .join("\n");
     body += `\n\n### Failures\n${failLines}`;
   }
+
+  const runs: RunRecord[] = [
+    ...history,
+    {
+      sha: opts.sha ?? "",
+      run_url: opts.runUrl ?? "",
+      passed,
+      total,
+      cost_usd: cost,
+    },
+  ];
+  body += `\n\n${historySection(runs)}`;
+  body += `\n\n${HISTORY_MARKER}${JSON.stringify(runs)} -->`;
 
   return body;
 }
@@ -108,6 +198,17 @@ export function readResultsDir(dir: string): EvalResult[] {
 
 if (import.meta.main) {
   const dir = process.argv[2] ?? "artifacts";
-  process.stdout.write(buildReportBody(readResultsDir(dir)) + "\n");
+  const previousBodyFile = process.argv[3];
+  const previousBody =
+    previousBodyFile && existsSync(previousBodyFile)
+      ? readFileSync(previousBodyFile, "utf8")
+      : undefined;
+  process.stdout.write(
+    buildReportBody(readResultsDir(dir), {
+      previousBody,
+      sha: process.env.EVAL_HEAD_SHA,
+      runUrl: process.env.EVAL_RUN_URL,
+    }) + "\n",
+  );
   process.exit(0);
 }

--- a/tests/eval-report.test.ts
+++ b/tests/eval-report.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { buildReportBody, REPORT_MARKER } from "../scripts/eval-report";
+import { buildReportBody, parseHistory, REPORT_MARKER } from "../scripts/eval-report";
 import type { EvalResult, EvalTestEntry } from "./helpers/eval-store";
 
 function entry(over: Partial<EvalTestEntry> = {}): EvalTestEntry {
@@ -97,5 +97,71 @@ describe("buildReportBody", () => {
     ]) {
       expect(body.startsWith(REPORT_MARKER)).toBe(true);
     }
+  });
+});
+
+describe("buildReportBody run history (append across runs)", () => {
+  const meta = { sha: "abc1234def5678", runUrl: "https://github.com/o/r/actions/runs/1" };
+
+  test("first run: history table with one linked row and the run's cost as total", () => {
+    const body = buildReportBody([result()], meta);
+    expect(body).toContain("### Run history — **$0.02** total across 1 run");
+    expect(body).toContain("| 1 | [abc1234](https://github.com/o/r/actions/runs/1) | ✅ 1/1 | $0.02 |");
+  });
+
+  test("second run appends a row and sums the cumulative cost", () => {
+    const first = buildReportBody([result()], meta);
+    const second = buildReportBody(
+      [result({ tests: [entry({ name: "b", passed: false, exit_reason: "timeout", cost_usd: 0.03 })] })],
+      { previousBody: first, sha: "9876543fedcba", runUrl: "https://github.com/o/r/actions/runs/2" },
+    );
+    expect(second).toContain("### Run history — **$0.05** total across 2 runs");
+    expect(second).toContain("| 1 | [abc1234](https://github.com/o/r/actions/runs/1) | ✅ 1/1 | $0.02 |");
+    expect(second).toContain("| 2 | [9876543](https://github.com/o/r/actions/runs/2) | ❌ 0/1 | $0.03 |");
+    // Latest-run detail reflects only the new run, not the accumulated history.
+    expect(second).toContain(`${REPORT_MARKER}: ❌ FAIL`);
+    expect(second).toContain("**0/1** tests passed");
+  });
+
+  test("history round-trips through parseHistory", () => {
+    const first = buildReportBody([result()], meta);
+    const runs = parseHistory(first);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ sha: meta.sha, passed: 1, total: 1, cost_usd: 0.02 });
+  });
+
+  test("old-format previous body (no history marker) starts a fresh history", () => {
+    const body = buildReportBody([result()], {
+      previousBody: `${REPORT_MARKER}: ✅ PASS\n\nold overwrite-style comment`,
+      ...meta,
+    });
+    expect(body).toContain("total across 1 run");
+  });
+
+  test("malformed embedded history is discarded, not fatal", () => {
+    const body = buildReportBody([result()], {
+      previousBody: "## PR Evals: ✅ PASS\n\n<!-- pr-evals-history:v1 {not json -->",
+      ...meta,
+    });
+    expect(body).toContain("total across 1 run");
+  });
+
+  test("no-evals run keeps prior history and total without adding a row", () => {
+    const first = buildReportBody([result()], meta);
+    const body = buildReportBody([], { previousBody: first, sha: "9876543", runUrl: "" });
+    expect(body).toContain(`${REPORT_MARKER}: ⚠️ No evals selected`);
+    expect(body).toContain("### Run history — **$0.02** total across 1 run");
+    expect(parseHistory(body)).toHaveLength(1);
+  });
+
+  test("no-evals run with no prior history renders no history section", () => {
+    const body = buildReportBody([], meta);
+    expect(body).not.toContain("### Run history");
+    expect(body).not.toContain("pr-evals-history");
+  });
+
+  test("missing sha/runUrl renders a plain placeholder row", () => {
+    const body = buildReportBody([result()]);
+    expect(body).toContain("| 1 | — | ✅ 1/1 | $0.02 |");
   });
 });


### PR DESCRIPTION
## Why

The PR evals comment was overwritten on every push with only the latest run, so earlier runs — and the cumulative eval spend for the PR — were invisible. Reviewing a PR gave no way to see how much the evals had cost across its lifetime or how results evolved.

## What

The `## PR Evals` comment is now append-only across runs. Each report run carries the prior history forward and renders a **Run history** table — one row per run with a linked commit, pass/fail result, and cost — headed by a cumulative total (e.g. `$2.50 total across 2 runs`). The latest run's detail (suite table, failures) still leads the comment.

The history travels inside the comment body itself as JSON in a hidden HTML comment, so no external state is needed. Details:

- A "no evals selected" push adds no history row (nothing ran, nothing spent) but still renders the prior history, so it is never lost.
- An old-format or malformed body restarts the history rather than failing the report — the formatter keeps its never-fail contract.
- The comment lookup now paginates, so the upsert cannot miss the comment (and duplicate it, orphaning the history) once a PR passes 30 comments.

Dev-only change (workflow + scripts + tests) — no version bump.

## Test plan

- Unit tests cover first-run history, appending with cost summing, parse round-trip, old-format/malformed fallback, and the no-evals cases.
- Simulated two consecutive workflow invocations of the CLI locally: the second comment shows both runs and the correct combined total.
- Full free suite passes (641 tests), including the marker-sync tripwires in `static-gate.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)