### PR TITLE
v0.21.0 feat: require ASD-STE100 Simplified Technical English in doc-authoring skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.20.0"
+    "version": "0.21.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-23
+
 ### Changed
 
 - **Documentation-authoring skills now require ASD-STE100 Simplified Technical English.** [`skills/writing-prose/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md) gains a distilled STE rule set sourced from the Issue 9 specification, with a before/after example for each rule: sentence-length limits (20 words procedural, 25 descriptive), one instruction per sentence, imperative instructions, condition before command, simple tenses only, one meaning per word, three-word noun clusters, no omitted words or semicolons, and warnings before the step they protect. It also gains a word-substitution table tuned for software documentation (utilize→use, ensure/verify→make sure, perform/implement→do, however→but, should→must) and the restricted-meaning traps writers commonly hit (*check*, *follow*, *select* vs *set*, *since*, *or*, *monitor*). The doc-authoring skills — [`technical-design-doc`](https://github.com/bostonaholic/team/blob/main/skills/technical-design-doc/SKILL.md), [`documenting-decisions`](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md), [`product-requirements-doc`](https://github.com/bostonaholic/team/blob/main/skills/product-requirements-doc/SKILL.md), and [`authoring-designs`](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md) — require STE in their prose pointers, and the documentation-quality rubric now gates on STE conformance.
@@ -249,7 +251,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/bostonaholic/team/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/bostonaholic/team/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/bostonaholic/team/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/bostonaholic/team/compare/v0.17.1...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation-authoring skills now require ASD-STE100 Simplified Technical English.** [`skills/writing-prose/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md) gains a distilled STE rule set sourced from the Issue 9 specification, with a before/after example for each rule: sentence-length limits (20 words procedural, 25 descriptive), one instruction per sentence, imperative instructions, condition before command, simple tenses only, one meaning per word, three-word noun clusters, no omitted words or semicolons, and warnings before the step they protect. It also gains a word-substitution table tuned for software documentation (utilize→use, ensure/verify→make sure, perform/implement→do, however→but, should→must) and the restricted-meaning traps writers commonly hit (*check*, *follow*, *select* vs *set*, *since*, *or*, *monitor*). The doc-authoring skills — [`technical-design-doc`](https://github.com/bostonaholic/team/blob/main/skills/technical-design-doc/SKILL.md), [`documenting-decisions`](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md), [`product-requirements-doc`](https://github.com/bostonaholic/team/blob/main/skills/product-requirements-doc/SKILL.md), and [`authoring-designs`](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md) — require STE in their prose pointers, and the documentation-quality rubric now gates on STE conformance.
+
 ## [0.20.0] - 2026-07-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/authoring-designs/SKILL.md
+++ b/skills/authoring-designs/SKILL.md
@@ -9,6 +9,10 @@ user-invocable: false
 The design-author's procedure: confirm repo scope, present open questions
 to the user before drafting, and write `design.md` from the template below.
 
+Write the prose in `design.md` in ASD-STE100 Simplified Technical
+English — short sentences, common words, one instruction per sentence,
+one meaning per word. Full methodology: `skills/writing-prose/SKILL.md`.
+
 If `task.md` references a `prd.md`, read it first and treat its scope
 boundaries and acceptance criteria per the "Consuming a PRD downstream"
 section of `skills/product-requirements-doc/SKILL.md`.

--- a/skills/documenting-decisions/SKILL.md
+++ b/skills/documenting-decisions/SKILL.md
@@ -10,9 +10,10 @@ Architecture Decision Records (ADRs) capture significant technical decisions
 with their context, rationale, and consequences. They are the institutional
 memory that explains WHY the codebase looks the way it does.
 
-Write the prose this skill governs at a seventh-grade reading
-level — short sentences, common words, no unexplained jargon. Full
-methodology: `skills/writing-prose/SKILL.md`.
+Write the prose this skill governs at a seventh-grade reading level
+and in ASD-STE100 Simplified Technical English — short sentences,
+common words, one instruction per sentence, no unexplained jargon.
+Full methodology: `skills/writing-prose/SKILL.md`.
 
 ## ADR Format
 

--- a/skills/product-requirements-doc/SKILL.md
+++ b/skills/product-requirements-doc/SKILL.md
@@ -15,9 +15,10 @@ The goal is precision, not exhaustive documentation: clear scope, unambiguous
 acceptance criteria, and explicit boundaries that prevent scope creep when
 the design-author later turns the task into an approach.
 
-Write the prose this skill governs at a seventh-grade reading
-level — short sentences, common words, no unexplained jargon. Full
-methodology: `skills/writing-prose/SKILL.md`.
+Write the prose this skill governs at a seventh-grade reading level
+and in ASD-STE100 Simplified Technical English — short sentences,
+common words, one instruction per sentence, no unexplained jargon.
+Full methodology: `skills/writing-prose/SKILL.md`.
 
 ## When to Write a PRD
 

--- a/skills/technical-design-doc/SKILL.md
+++ b/skills/technical-design-doc/SKILL.md
@@ -12,9 +12,10 @@ feature needs a full TDD — apply this methodology when a feature is complex
 enough that undocumented architectural decisions would slow or block
 implementation.
 
-Write the prose this skill governs at a seventh-grade reading
-level — short sentences, common words, no unexplained jargon. Full
-methodology: `skills/writing-prose/SKILL.md`.
+Write the prose this skill governs at a seventh-grade reading level
+and in ASD-STE100 Simplified Technical English — short sentences,
+common words, one instruction per sentence, no unexplained jargon.
+Full methodology: `skills/writing-prose/SKILL.md`.
 
 ## When to Write a TDD
 

--- a/skills/writing-prose/SKILL.md
+++ b/skills/writing-prose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-prose
-description: Clear documentation and readable explanation methodology — loaded by technical-writer agent to write prose and to assess documentation quality, grounded in plain language and readability principles
+description: Clear documentation and readable explanation methodology — loaded by technical-writer agent to write prose and to assess documentation quality, grounded in plain language, readability principles, and ASD-STE100 Simplified Technical English
 user-invocable: false
 ---
 
@@ -29,6 +29,133 @@ Write for the reader's comprehension, not the author's expertise.
   knows what you know.
 - **Avoid nominalizations.** "Make a decision" → "decide". "Provide an
   explanation" → "explain". Nominalizations hide the actor and the action.
+
+### Simplified Technical English (ASD-STE100)
+
+Technical documentation must follow ASD-STE100 Simplified Technical English
+(STE). STE removes ambiguity for every reader, including readers whose first
+language is not English. The plain-language principles above are the
+foundation; STE adds mechanical rules. Each rule below shows the rejected
+form (Non-STE) and the fix (STE).
+
+- **Keep sentences short.** No more than 20 words in an instruction, no more
+  than 25 words in a description. A number, an abbreviation, quoted text, or
+  a hyphenated group counts as one word. Split a long sentence rather than
+  compress it.
+- **Write one instruction per sentence.** Combine actions in one sentence
+  only when the reader must do them at the same time.
+  - Non-STE: *Set the TEST switch to the middle position and release the
+    SHORT-CIRCUIT TEST switch.* (two separate actions)
+  - STE: *1. Set the TEST switch to the middle position. 2. Release the
+    SHORT-CIRCUIT TEST switch.*
+  - STE (simultaneous, so one sentence is correct): *Hold the panel in its
+    open position and install the fastener.*
+- **Use the imperative for instructions.**
+  - Non-STE: *The test can be continued.* → STE: *Continue the test.*
+  - Non-STE: *Oil and grease are to be removed with a degreasing agent.* →
+    STE: *Remove oil and grease with a degreasing agent.*
+- **Put the condition before the command, divided by a comma.**
+  - Non-STE: *Set the switch to NORMAL when the light comes on.*
+  - STE: *When the light comes on, set the switch to NORMAL.*
+- **Use simple verb tenses only** — simple present, simple past, simple
+  future, imperative, infinitive, and past participle as an adjective. No
+  perfect or progressive tenses. Use an "-ing" form only inside a technical
+  noun ("error handling", "logging").
+  - Non-STE: *The operator has adjusted the linkage.* → STE: *The operator
+    adjusted the linkage.*
+  - Non-STE: *When you are doing this procedure, obey the safety
+    precautions.* → STE: *When you do this procedure, obey the safety
+    precautions.*
+- **Use the active voice** (see Active Voice below). In description, passive
+  is permitted only when the agent is unknown. Convert a passive by naming
+  the agent as the subject, switching to the imperative, or using "you".
+  - Non-STE: *These values are used by the computer to calculate the energy
+    consumption.* → STE: *The computer calculates the energy consumption
+    from these values.*
+  - Non-STE: *The volume control can be adjusted.* → STE: *Adjust the volume
+    control.* (procedure) or *You can adjust the volume control.*
+    (description)
+- **Give each word one meaning, and each thing one name.** Do not use
+  synonyms for variety, and do not reuse a word outside its one meaning.
+  - Non-STE: *Make sure that the servo control unit is open. Do the test of
+    the actuator. Disconnect the control unit.* (three names, one component)
+  - STE: pick *actuator* and use it in all three sentences.
+- **Limit noun clusters to three words.** Break longer clusters apart with
+  prepositions, or hyphenate the words that form one unit.
+  - Non-STE: *Runway light connection resistance calibration*
+  - STE: *Calibration of the resistance of the runway light connection*
+- **Do not omit words to shorten a sentence.** Keep subjects, verbs, and
+  articles. No contractions ("do not", never "don't").
+  - Non-STE: *If installed, remove the shims.* → STE: *If shims are
+    installed, remove them.*
+  - Non-STE: *Rotary switch to INPUT.* → STE: *Set the rotary switch to
+    INPUT.*
+- **Use a vertical list for complex text.** End the lead-in with a colon and
+  put one item per line. Never use a semicolon — write two sentences instead.
+- **Keep paragraphs short.** No more than six sentences, one topic per
+  paragraph, topic sentence first.
+- **Put warnings and cautions before the step they protect.** Start with a
+  command or condition, then state the risk.
+  - STE: *WARNING: Disconnect the power before you open the panel. The
+    terminals carry line voltage and can cause injury.*
+
+#### STE word substitutions
+
+STE approves about 900 general words, each with one meaning. These
+substitutions cover the non-approved words that appear most often in
+software documentation:
+
+| Instead of | Write |
+|------------|-------|
+| utilize | use |
+| ensure, verify, confirm | make sure that |
+| perform, execute, carry out, implement | do |
+| initiate | start |
+| terminate | stop |
+| prior to | before |
+| via | through |
+| however | but |
+| therefore | thus, as a result |
+| should, shall | must |
+| may | can |
+| enable X to | let X |
+| appropriate, suitable | applicable, correct |
+| required | necessary |
+| provide | give, supply |
+| additional | more |
+| the following steps | these steps, the steps that follow |
+| whether | if |
+| various | different |
+| significant | important |
+| maintain (a state) | keep, hold |
+| trigger | cause, start |
+| persist (of an error) | continue |
+| modify | change |
+| obtain | get |
+
+Examples from the STE dictionary itself:
+
+- Non-STE: *The software utilizes caching techniques to decrease data
+  retrieval times.* → STE: *The software uses caching techniques to decrease
+  data retrieval times.*
+- Non-STE: *Functionally test the software.* → STE: *Do a functional test of
+  the software.*
+- Non-STE: *The database is already synchronizing.* → STE: *The database
+  synchronization is in progress.*
+
+Restricted meanings that writers commonly get wrong:
+
+- *check* is approved only as a noun: "do a check of the logs", never
+  "check the logs".
+- *follow* means only "come after": "obey the instructions", not "follow
+  the instructions".
+- *select* means choose from alternatives ("select a language from the
+  menu"); *set* means put a control in a state ("set the flag to TEST").
+- *since* is approved for time only; for causation write *because*.
+- *or* never means "otherwise". Write a separate sentence: "Make sure that
+  the seal stays bonded. If it does not, a leak can occur."
+- *monitor* means to check something over a period of time for change — not
+  a generic "watch" or "track".
 
 ### Active Voice
 
@@ -115,6 +242,11 @@ Can a typical reader understand this in one pass?
   bar that governs authoring: short sentences, common words, no unexplained
   jargon. Long sentences, rare words, and deep nesting all increase cognitive
   load.
+- **STE conformance.** Check prose against the ASD-STE100 rules above:
+  sentence-length limits, one instruction per sentence, imperative
+  instructions, simple tenses, one meaning per word, noun clusters of three
+  words or fewer, and the word substitutions in the STE table (utilize,
+  ensure, perform, however, should).
 - **Consistent terminology.** If the same concept is called "user", "account",
   and "principal" in different parts of the documentation, readers will not
   know if these are synonyms. Pick one term and use it consistently.


### PR DESCRIPTION
## Why

Documentation produced by the pipeline should be unambiguous for every reader, including readers whose first language is not English. ASD-STE100 Simplified Technical English is the industry standard for that — but a bare "follow STE" instruction is unenforceable without the rules and examples in front of the agent. This distills the Issue 9 specification (all 53 writing rules, the general recommendations, and the dictionary) into the prose skills so the writers and the reviewer share one concrete bar.

## What

- `writing-prose` (the canonical prose skill) gains a Simplified Technical English section with a before/after example for each rule: sentence-length limits (20 words procedural, 25 descriptive), one instruction per sentence, imperative instructions, condition before command, simple tenses only, one meaning per word, three-word noun clusters, no omitted words or semicolons, vertical lists, six-sentence paragraphs, and warnings that lead with the command then state the risk.
- A word-substitution table tuned for software documentation (utilize→use, ensure/verify→make sure, perform/implement→do, however→but, should→must, …), three software examples taken verbatim from the STE dictionary, and the restricted-meaning traps writers commonly hit (`check`, `follow`, `select` vs `set`, `since`, `or`, `monitor`).
- The documentation-quality rubric gates on STE conformance, so the reviewing side checks the same rules the authoring side writes to.
- The doc-authoring skills — `technical-design-doc`, `documenting-decisions`, `product-requirements-doc`, and `authoring-designs` — require STE in their prose pointer paragraphs (authoring-designs previously had no prose pointer and gains one).

## Test plan

- Verified the substitution pairs and example sentences against the ASD-STE100 Issue 9 specification (writing rules part 1 and the dictionary, including its recurring-errors list).
- Confirmed the spoke skills keep single-source pointers to `writing-prose` rather than duplicating the rule set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)