### PR TITLE
fix(ci): filter PR evals to gate-tier fixtures

### DIFF
--- a/.github/workflows/pr-evals.yml
+++ b/.github/workflows/pr-evals.yml
@@ -7,8 +7,9 @@
 # touchfiles (tests/helpers/touchfiles.ts) — cost scales with the diff, NOT the
 # whole suite. The weekly full periodic run stays in periodic-evals.yml.
 #
-# ADVISORY: includes stochastic periodic evals, so this is intentionally NOT a
-# required merge check (TESTING.md: stochastic checks must not gate merges).
+# ADVISORY: runs gate-tier fixtures only (EVALS_TIER: gate) — stochastic
+# periodic evals never run here, only in the weekly periodic-evals.yml. Still
+# intentionally NOT a required merge check: zero gate-tier fixtures exist today.
 #
 # SECURITY: same-repo PRs only, AND trusted authors only. Fork PRs lack the
 # EVALS_ANTHROPIC_API_KEY secret and a write token, so both jobs are guarded on
@@ -73,8 +74,9 @@ jobs:
           EVALS_ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_API_KEY }}
           EVALS: "1"
-          # NOT EVALS_ALL and NOT EVALS_TIER: let the diff drive selection across
-          # all tiers, so cost scales with the change.
+          # Diff drives selection (no EVALS_ALL — cost scales with the change),
+          # then the gate-tier filter drops periodic (stochastic) fixtures.
+          EVALS_TIER: gate
           EVALS_BASE: origin/${{ github.event.pull_request.base.ref }}
           SUITE_FILE: ${{ matrix.suite.file }}
         run: bun test "$SUITE_FILE"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -234,6 +234,10 @@ trains everyone to ignore red. Gate on what's stable, monitor what's fuzzy.
 | **Cheap**     | gate, every PR              | periodic (or band-gated) |
 | **Expensive** | gate if rare; else periodic | periodic, scheduled      |
 
+> **Where Team stands today:** every eval fixture drives a live model, so all
+> are tiered periodic and none can gate. `pr-evals.yml` stays advisory until
+> someone authors the first offline deterministic fixture and tiers it `gate`.
+
 ---
 
 ## 5. Free vs. paid: the line that organizes everything

--- a/evals/README.md
+++ b/evals/README.md
@@ -199,14 +199,15 @@ Two workflows run the evals:
 
 - **`.github/workflows/pr-evals.yml`** runs on every pull request. It runs the
   evals the diff selects (`git diff <base>...HEAD` against each eval's
-  touchfiles — no `EVALS_ALL`/`EVALS_TIER`, so cost scales with the change) and
-  upserts one `## PR Evals` comment on the PR with a per-suite pass/fail table
-  and cost. The comment body is produced by `scripts/eval-report.ts` (pure +
-  unit-tested in `tests/eval-report.test.ts`). It is **advisory** — it includes
-  stochastic periodic evals, which must not gate merges (see
-  [TESTING.md](../TESTING.md)) — and runs on **same-repo PRs only** (fork PRs
-  lack the `EVALS_ANTHROPIC_API_KEY` secret and a write token). When the diff
-  selects nothing, the comment says so.
+  touchfiles — no `EVALS_ALL`, so cost scales with the change), filtered to the
+  **gate tier** (`EVALS_TIER: gate`) — periodic evals run only in the weekly
+  `periodic-evals.yml`. It upserts one `## PR Evals` comment on the PR with a
+  per-suite pass/fail table and cost. The comment body is produced by
+  `scripts/eval-report.ts` (pure + unit-tested in `tests/eval-report.test.ts`).
+  It is **advisory** (not a required merge check) while zero gate-tier fixtures
+  exist, and runs on **same-repo PRs only** (fork PRs lack the
+  `EVALS_ANTHROPIC_API_KEY` secret and a write token). When the diff selects
+  nothing — today's steady state — the comment says so.
 - **`.github/workflows/periodic-evals.yml`** runs the full periodic tier
   weekly (Monday 06:00 UTC) and on manual dispatch, uploading results as
   artifacts.

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -312,12 +312,15 @@ describe("static gate: PR evals workflow", () => {
     expect(/^\s*ANTHROPIC_API_KEY:/m.test(workflow)).toBe(true);
   });
 
-  test("lets the diff drive selection: no EVALS_ALL, no EVALS_TIER", () => {
-    // Setting either as an env key would override diff selection (run
-    // everything / filter to one tier), defeating cost-scales-with-the-diff.
-    // Match assignments only, so the explanatory comment doesn't trip this.
+  test("filters the PR run to the gate tier; selection stays diff-driven", () => {
+    // EVALS_TIER: gate drops every periodic (live-model, stochastic) fixture
+    // from the PR run, so a borderline grading can never redden the check.
+    // EVALS_ALL stays absent so the diff keeps driving selection within the
+    // gate tier — cost still scales with the change. Match assignments only
+    // (bare key at line start), so the explanatory comment doesn't trip this;
+    // the exact-value match also catches typos like `gates`.
+    expect(/^\s*EVALS_TIER:\s*gate\s*$/m.test(workflow)).toBe(true);
     expect(/^\s*EVALS_ALL:/m.test(workflow)).toBe(false);
-    expect(/^\s*EVALS_TIER:/m.test(workflow)).toBe(false);
   });
 
   test("report job can post PR comments (issues + pull-requests write)", () => {

--- a/tests/static-gate.test.ts
+++ b/tests/static-gate.test.ts
@@ -496,3 +496,90 @@ describe("static gate: planted-comment-violations fixture", () => {
     expect(evalsSource).toContain("non_violations");
   });
 });
+
+// Tier truth lives in two unsynchronized places — fixture frontmatter and the
+// E2E_TIERS map — and tier now decides whether a fixture can run on the PR
+// gate (pr-evals.yml sets EVALS_TIER: gate). These drift guards make any
+// mislabeling, desync, or orphaning fail `bun test` deterministically instead
+// of silently putting a stochastic probe back on the PR gate.
+describe("static gate: tier drift guards", () => {
+  test("every fixture's frontmatter tier matches its E2E_TIERS entry", () => {
+    const cases = enumerate();
+    expect(cases.length).toBeGreaterThan(0);
+
+    // Resolve each fixture's map key as `<agent>-<case>`, falling back to
+    // bare `<case>` (the code-reviewer convention). Collect all problems
+    // with labels so a failure names the offending fixture and key.
+    const unresolved: string[] = [];
+    const resolutions = new Map<string, string[]>();
+    const mismatches: {
+      fixture: string;
+      key: string;
+      frontmatterTier: string;
+      mapTier: string | undefined;
+    }[] = [];
+
+    for (const { agent, caseName } of cases) {
+      const fixtureId = `${agent}/${caseName}`;
+      const combined = `${agent}-${caseName}`;
+      const key =
+        combined in E2E_TIERS
+          ? combined
+          : caseName in E2E_TIERS
+            ? caseName
+            : null;
+      if (key === null) {
+        unresolved.push(fixtureId);
+        continue;
+      }
+      resolutions.set(key, [...(resolutions.get(key) ?? []), fixtureId]);
+      const fixture = loadFixture(agent, caseName, FIXTURE_ROOT);
+      if (fixture.frontmatter.tier !== E2E_TIERS[key]) {
+        mismatches.push({
+          fixture: fixtureId,
+          key,
+          frontmatterTier: fixture.frontmatter.tier,
+          mapTier: E2E_TIERS[key],
+        });
+      }
+    }
+
+    // Every fixture must resolve to exactly one key. Ambiguity (two fixtures
+    // resolving to the same key) fails here, before the tier comparison can
+    // compare the wrong fixture/entry pair.
+    expect(unresolved).toEqual([]);
+    const collisions = [...resolutions.entries()].filter(
+      ([, fixtures]) => fixtures.length > 1,
+    );
+    expect(collisions).toEqual([]);
+    expect(mismatches).toEqual([]);
+    // And the reverse direction: every E2E_TIERS entry must be claimed by a
+    // fixture, or its tier is constrained by no frontmatter at all.
+    expect([...resolutions.keys()].sort()).toEqual(
+      Object.keys(E2E_TIERS).sort(),
+    );
+  });
+
+  test("E2E_TOUCHFILES and E2E_TIERS hold exactly the same keys", () => {
+    // filterByTier silently drops a selected name absent from the tiers map
+    // (touchfiles.ts), which would make a gate fixture silently never run on
+    // PR. Sorted-keyset equality closes that hole in both directions.
+    const touchfileKeys = Object.keys(E2E_TOUCHFILES).sort();
+    const tierKeys = Object.keys(E2E_TIERS).sort();
+    expect(tierKeys).toEqual(touchfileKeys);
+  });
+
+  test("every E2E_TIERS entry is periodic until an offline gate runner exists", () => {
+    // docs/testing.md §4 — a test that can be red for a legitimate
+    // non-bug reason is periodic and never gates. Every current fixture
+    // drives a live model, so none qualifies as gate. Whoever lands the
+    // first offline (recorded-transcript) gate fixture updates this test
+    // deliberately, in the same reviewed edit that flips the fixture's tier
+    // in frontmatter and E2E_TIERS — the first `gate` label must not be a
+    // two-word frontmatter slip.
+    const nonPeriodic = Object.entries(E2E_TIERS).filter(
+      ([, tier]) => tier !== "periodic",
+    );
+    expect(nonPeriodic).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

The PR eval workflow ran the **entire** code-reviewer suite as a gate, including
fixtures tiered `periodic`. Periodic-tier fixtures are stochastic judgment
probes, so a single borderline grading sample turned an unrelated PR red.

On PR #166, `planted-comment-violations` failed 3/3 runs. The reviewer found all
three planted violations but inverted two severities. The assertion failed for
the right reason — the wrong part is that a drift probe gated a PR whose diff
never touched Comment Discipline.

`docs/testing.md` §4 already draws this line: a test that can be red for a
legitimate non-bug reason is periodic and must never gate.

## What changed

**One functional line.** `.github/workflows/pr-evals.yml` gains `EVALS_TIER: gate`
in its existing **step-level** `env:` block. Selection stays diff-driven
(`EVALS_ALL` stays absent), so cost still scales with the change; the tier
filter then drops every periodic fixture from the PR run.

**The PR job selects zero fixtures today, and that is the intended end state.**
Every one of the 12 fixtures drives a live model, so none qualifies as `gate`
under the `docs/testing.md` rule. The workflow becomes a wired-but-empty slot
that activates the day the first offline recorded-transcript fixture lands, with
no further workflow change. `periodic-evals.yml` is untouched, so the weekly run
still catches the severity-inversion signal.

**Four free static tests** pin the new contract in `tests/static-gate.test.ts`:

1. The existing pin is **inverted, not deleted** — `EVALS_TIER: gate` must be
   present, `EVALS_ALL:` must stay absent.
2. Every fixture's frontmatter `tier` must agree with its `E2E_TIERS` entry
   (keys resolve as `<agent>-<case>` with a bare-`<case>` fallback, plus
   collision and reverse-coverage assertions).
3. `E2E_TOUCHFILES` and `E2E_TIERS` must hold the same keys — closing a hole
   where `filterByTier` silently drops a name missing from the tiers map.
4. A tripwire asserting every `E2E_TIERS` entry stays `periodic`. Whoever lands
   the first offline gate fixture updates this deliberately.

Test 4 matters: without it, one word in a fixture's frontmatter plus one in
`E2E_TIERS` would put a stochastic probe back on the PR gate with every other
test green.

All four were mutation-tested — flipping a tier, deleting the workflow env line,
and dropping a map entry each turn the expected assertion red.

## Review notes

Two decisions were made without user review and are flagged for this checkpoint:

- **Accepting zero gate-tier fixtures** rather than promoting `planted-null-deref`
  and `planted-time-bomb`. Three passing runs is not determinism, and promoting
  them re-creates the #166 failure mode on the next borderline grade.
- **Adding the tripwire (test 4)** — more than the issue asked for. It closes a
  re-entry path an adversarial design review identified.

Known trade-off: **per-PR live code-reviewer signal drops to zero** until an
offline fixture exists. Drift detection moves entirely to the weekly cadence.
The per-PR signal was untrustworthy — that was the bug.

Also noted, not fixed: the eval step still resolves `EVALS_ANTHROPIC_API_KEY`
for a run that now makes zero model calls. Exposure is unchanged from `main`
and PR key spend drops to zero, so this is a net reduction; worth revisiting
when the first gate fixture lands.

## Verification

- [x] `bun test` — 893 pass, 0 fail
- [x] `bun run typecheck` (`tsc --noEmit`) — clean
- [x] `.github/scripts/version-bump-required.sh` — `OK: runtime_changed=false bumped=false`
- [x] `EVALS_TIER: gate` confirmed at **step level** inside the run step's `env:` block
- [x] Trust gates byte-identical to `main` (SHA-256 compared): `TRUST_EXPR` on both jobs, same-repo guard, `environment: evals`, `pull_request` trigger
- [x] `periodic-evals.yml` — zero diff
- [x] All 12 fixtures still `tier: periodic`
- [x] Linear history, no merge commits; plain conventional titles (dev-only, no bump)

## Follow-up

The empty gate slot needs an owner: someone must author the first offline
recorded-transcript code-reviewer fixture. A separate issue will track it.

Closes #169
