### PR TITLE
v0.25.0 feat: make the /shipit land skill model-invocable

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.24.0"
+    "version": "0.25.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/shipit` is now model-invocable — saying "ship it" lands the PR without you typing the slash command.** [`skills/shipit/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md) drops `disable-model-invocation: true`, so the skill no longer shows as user-only in `/skills` and Claude can reach it directly. The merge is still irreversible, so three guards replace the flag: the skill fires **only on explicit ship intent** ("ship it", "land the PR", "land this", `/shipit`) and never on a PR merely being approved, green, or finished; the interactive pre-merge confirmation stands, and the model never supplies `--yes` on its own initiative (that flag belongs to a caller already carrying your authorization to merge); and the bounded CI-green wait still gates the merge mechanically, so a red or timed-out check stops the land before `gh pr merge` runs. [`/pr-watch`](https://github.com/bostonaholic/team/blob/main/skills/pr-watch/SKILL.md) is unchanged — on approval it still hands off with `Next: run /shipit` and never auto-runs it, so an unattended watch loop cannot merge on your behalf.
+
 ## [0.24.0] - 2026-07-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-29
+
 ### Changed
 
 - **`/shipit` is now model-invocable — saying "ship it" lands the PR without you typing the slash command.** [`skills/shipit/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md) drops `disable-model-invocation: true`, so the skill no longer shows as user-only in `/skills` and Claude can reach it directly. The merge is still irreversible, so three guards replace the flag: the skill fires **only on explicit ship intent** ("ship it", "land the PR", "land this", `/shipit`) and never on a PR merely being approved, green, or finished; the interactive pre-merge confirmation stands, and the model never supplies `--yes` on its own initiative (that flag belongs to a caller already carrying your authorization to merge); and the bounded CI-green wait still gates the merge mechanically, so a red or timed-out check stops the land before `gh pr merge` runs. [`/pr-watch`](https://github.com/bostonaholic/team/blob/main/skills/pr-watch/SKILL.md) is unchanged — on approval it still hands off with `Next: run /shipit` and never auto-runs it, so an unattended watch loop cannot merge on your behalf.
@@ -277,7 +279,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/bostonaholic/team/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/bostonaholic/team/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/bostonaholic/team/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/bostonaholic/team/compare/v0.21.0...v0.22.0

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -264,7 +264,11 @@ QRSPI phase — a self-contained action a user runs on demand.
   **Project-agnostic** — it does no versioning,
   changelog editing, or release work; those, if a project needs them, run in a
   separate step before `/shipit` (in this repo, the dev `version-bump` skill).
-  `disable-model-invocation: true` — irreversible, so user-invoked only.
+  Model-invocable — but the merge is irreversible, so three guards replace the
+  former hard flag: it fires only on explicit ship intent ("ship it", "land the
+  PR", `/shipit`) and never on a PR merely being approved or green; the
+  pre-merge confirmation stands unless the caller already carries the user's
+  authorization (`--yes`); and the CI-green wait gates the merge mechanically.
 
 ### pr-open-comments
 
@@ -755,7 +759,7 @@ entry-point section above rather than repeating them here.
 | `team-pr` | orchestrator | PR |
 | `team-fix` | user (direct invocation) | Compressed bug-fix flow (outside QRSPI) |
 | `eng-design-doc-review` | user (direct invocation); pipeline DESIGN review gate (brief by reference) | Design review-gate brief + standalone audit; dispatches a read-only Explore subagent |
-| `shipit` | user (direct invocation) | Standalone — land a reviewed PR (not a QRSPI phase) |
+| `shipit` | user or model (direct invocation, on explicit ship intent) | Standalone — land a reviewed PR (not a QRSPI phase) |
 | `pr-open-comments` | user or model (direct invocation) | Standalone — triage unresolved PR review feedback (not a QRSPI phase) |
 | `pr-watch` | user or model (direct invocation) | Standalone — bounded PR review watch loop (not a QRSPI phase) |
 | `qrspi-workflow` | orchestrator skills | All phases |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/skills/shipit/SKILL.md
+++ b/skills/shipit/SKILL.md
@@ -6,11 +6,11 @@ description: |
   the PR title (which may carry a version) lands as the commit subject.
   Handles a PR that has fallen behind its base (rebase + force-with-lease) and
   surfaces branch-protection rejections verbatim. Project-agnostic — it knows
-  nothing about how any project versions itself. Use ONLY when the user
-  explicitly says "ship it", "land the PR", "land this", or runs "/shipit";
-  never auto-fire it — it merges, which is irreversible.
+  nothing about how any project versions itself. Invoke ONLY on explicit ship
+  intent — the user says "ship it", "land the PR", "land this", or runs
+  "/shipit". Landing merges, which is irreversible: never infer ship intent
+  from a PR merely being approved, green, or finished.
 effort: medium
-disable-model-invocation: true
 argument-hint: "[<pr-number>] [--yes]"
 ---
 
@@ -30,9 +30,17 @@ version at land time, that happens in a separate project-specific step *before*
 [docs/versioning.md](../../docs/versioning.md)); `shipit` only cares that the
 branch is ready to land.
 
-`gh pr merge` is irreversible, so this skill is **user-invocable only**
-(`disable-model-invocation: true`): a human runs it deliberately; the model
-never auto-fires it.
+`gh pr merge` is irreversible, so three things guard it — none of them a
+frontmatter flag:
+
+1. **Explicit ship intent.** The skill fires only on a direct "ship it" / "land
+   the PR" / `/shipit`. An approved, green, or finished-looking PR is *not*
+   ship intent — the user decides when to land.
+2. **The pre-merge confirmation** (step 4), which the model never skips on its
+   own initiative: `--yes` belongs to a caller that already carries the user's
+   authorization to merge.
+3. **CI green** (step 3), which gates the merge mechanically — a red or timed
+   out check stops the land before `gh pr merge` ever runs.
 
 ## Input acquisition
 

--- a/skills/shipit/SKILL.md
+++ b/skills/shipit/SKILL.md
@@ -137,10 +137,12 @@ again, and merges. It is safe to re-run.
 
 ### 4. Pre-merge confirmation
 
-`gh pr merge` is irreversible. For a human operator, **ask for an explicit
-confirmation** before merging — "about to merge PR #N into `<base>` — proceed?" —
-and only merge on a yes. A non-interactive caller passes `--yes` to skip this
-prompt; the prompt wraps the scriptable core, it does not live inside it.
+`gh pr merge` is irreversible. **Ask for an explicit confirmation** before
+merging — "about to merge PR #N into `<base>` — proceed?" — and only merge on a
+yes. `--yes` skips this prompt, but it is **the caller's to pass, never yours to
+add**: it means the invoker already authorized the merge. Running as an agent
+does not make you a non-interactive caller — when `--yes` is absent, ask.
+The prompt wraps the scriptable core, it does not live inside it.
 
 ### 5. Rebase if behind the base, then merge
 

--- a/tests/shipit-skill.test.ts
+++ b/tests/shipit-skill.test.ts
@@ -44,10 +44,14 @@ describe("shipit skill: it is a runtime skill, project-agnostic", () => {
     expect(/^name:\s*shipit\s*$/m.test(fm())).toBe(true);
   });
 
-  test("frontmatter carries disable-model-invocation: true (never auto-merge)", () => {
-    // shipit is irreversible (it merges) → user-invocable only, so the model
-    // can never auto-trigger a merge.
-    expect(/^disable-model-invocation:\s*true\s*$/m.test(fm())).toBe(true);
+  test("frontmatter does NOT set disable-model-invocation (model-invocable by design)", () => {
+    // shipit is irreversible (it merges), but the guard is explicit ship
+    // intent + the pre-merge confirmation + CI-green gating, not a hard flag —
+    // so the model can reach it when the user asks it to land the PR.
+    const f = fm();
+    // Guard: an empty frontmatter must fail, not vacuously pass the absence check.
+    expect(f.length).toBeGreaterThan(0);
+    expect(/^disable-model-invocation:/m.test(f)).toBe(false);
   });
 
   test("carries NO Team-version-specific logic (it is generic)", () => {

--- a/tests/shipit-skill.test.ts
+++ b/tests/shipit-skill.test.ts
@@ -67,6 +67,39 @@ describe("shipit skill: it is a runtime skill, project-agnostic", () => {
   });
 });
 
+// The merge is irreversible and NO frontmatter flag fences it any more, so the
+// three prose guards that replaced `disable-model-invocation: true` are now
+// load-bearing. Each gets its own tripwire — a guard nothing asserts is a guard
+// the next edit silently deletes.
+describe("shipit skill: model-invocable, scoped to explicit ship intent", () => {
+  test("description scopes invocation to explicit ship intent + names the trigger phrases", () => {
+    const f = flat(fm());
+    expect(f.length).toBeGreaterThan(0);
+    // \s+ throughout: flat() turns the folded YAML description's line breaks
+    // into runs of whitespace, so single-space literals do not match.
+    expect(/(invoke|use|fire)[^.]{0,40}only[^.]{0,60}explicit\s+ship\s+intent/i.test(f)).toBe(true);
+    expect(/"ship it"/i.test(f)).toBe(true);
+    expect(/"land the PR"/i.test(f)).toBe(true);
+    expect(f).toContain("/shipit");
+  });
+
+  test("pins the prohibition: an approved / green PR is NOT ship intent", () => {
+    // The failure mode the removed flag used to make impossible: the model
+    // reads "approved and green" as permission to land.
+    const t = flat(body());
+    expect(/never infer ship intent[^.]{0,80}approved/i.test(t)).toBe(true);
+    expect(/(approved|green)[^.]{0,80}(is\s*\*?not\*?|never)[^.]{0,40}ship intent/i.test(t)).toBe(true);
+  });
+
+  test("pins the prohibition: --yes is the caller's to pass, never self-supplied", () => {
+    // Without this, a model could self-classify as a "non-interactive caller",
+    // pass --yes, and skip the only human checkpoint on an irreversible merge.
+    const t = flat(body());
+    expect(/--yes[^.]{0,120}(never yours to add|caller'?s to pass)/i.test(t)).toBe(true);
+    expect(/running as an agent does not make you a non-interactive caller/i.test(t)).toBe(true);
+  });
+});
+
 describe("shipit skill: PR discovery + refuse branches", () => {
   test("discovers the open PR via gh pr view with a base-branch fallback", () => {
     const t = flat(body());


### PR DESCRIPTION
## Summary

- `/shipit` carried `disable-model-invocation: true`, so it rendered as "user-only / locked by author" in `/skills` and the model could not reach it — even when the user explicitly asked to land the PR. This drops the flag.
- The merge is still irreversible. Three guards replace the flag rather than leaving the act unguarded: **explicit ship intent**, the **pre-merge confirmation**, and the **CI-green wait**. Each is pinned by its own L2 tripwire.
- The user-only decision was asserted by a test and restated as prose in two docs. All touchpoints move together so the repo does not contradict itself.

## Design Decisions

**What replaces the flag.** The flag was a hard surface lock; the guards are scoped behavior:

1. **Explicit ship intent only** — "ship it", "land the PR", "land this", `/shipit`. The description says outright: *never infer ship intent from a PR merely being approved, green, or finished.* That closes the main new failure mode, a model reading a finished-looking PR as permission to land.
2. **The pre-merge confirmation stands**, and `--yes` is the caller's to pass, never the agent's to add. Step 4 states that running as an agent does not make you a non-interactive caller.
3. **CI green gates mechanically** (step 3) — a red or timed-out check stops the land before `gh pr merge` runs.

**`/pr-watch`'s "never auto-run `/shipit`" rule is deliberately kept.** The two rules are complementary, not contradictory. Reachability means *the model can run it when you ask, this turn*. pr-watch auto-chaining would mean *a merge fires hours later inside an unattended 24-hour poll loop with no fresh human intent* — exactly what guard 1 rules out. It is also the highest-risk path and the only one with an explicit rule; removing it would delete that. Pinned by three tests in `tests/pr-watch-skill.test.ts`.

**`CHANGELOG.md:194` (the released 0.6.0 entry) is left as written.** Keep a Changelog treats released sections as historical record; the new `[Unreleased]` entry supersedes it.

## Changes

**Runtime (`skills/`)**
- `skills/shipit/SKILL.md` — removed `disable-model-invocation: true`; rewrote the description to scope on explicit ship intent; replaced the "user-invocable only" paragraph with the three numbered guards; rewrote step 4 so `--yes` cannot be self-supplied.

**Tests**
- `tests/shipit-skill.test.ts` — inverted the flag assertion to require the flag's *absence* (mirrors `tests/pr-watch-skill.test.ts:71-76`, including its empty-frontmatter guard so the absence check cannot pass vacuously), and added three tripwires for the replacement guards: the description's ship-intent scoping, the approved/green carve-out, and `--yes` ownership.

**Docs**
- `docs/skills.md` — rewrote the `### shipit` key-behaviors line; consumers table now reads `user or model (direct invocation, on explicit ship intent)`.
- `CHANGELOG.md` — `### Changed` bullet under `[Unreleased]`, including the pr-watch interaction so the two rules read as complementary.

`docs/architecture.md:468-486` needed no change — that passage is entirely about *methodology* skills and `user-invocable: false`, and never cited shipit. `docs/versioning.md` describes shipit only as project-agnostic, never as user-only. Nothing under `docs/_site/` was touched.

## Self-review (second commit)

Reviewing the first commit turned up two holes, both fixed in `9745c7e`:

1. **`--yes` could be self-supplied.** Step 4 still read *"For a human operator… A non-interactive caller passes `--yes` to skip this prompt"*. A model can self-classify as a non-interactive caller, pass `--yes`, and skip the only human checkpoint on an irreversible merge — precisely the hole the removed flag used to make impossible. The intro guard said the right thing, but step 4 is where the model acts.
2. **The replacement guards had no tripwire.** The flag they replaced *was* asserted by a test; the prose that replaced it was not. CONTRIBUTING is explicit — *"a constraint that matters gets a tripwire"* — and a PR whose whole thesis is "the prose guards are enough" is the worst place to leave them unpinned.

## How to Verify

- [x] `bun test` — **899 pass, 0 fail** (896 before; +3 new tripwires).
- [x] `grep -rn "disable-model-invocation" skills/ docs/skills.md` → no hits.
- [x] Full audit of every `shipit` mention outside `docs/_site/` — no stale user-only claim remains anywhere except the historical CHANGELOG entries, which are deliberate.
- [x] **Mutation-tested all three new tripwires** — each goes red when its guard is removed, so none is a vacuous pass:
  - re-adding `disable-model-invocation: true` → flag tripwire red
  - weakening the approved/green carve-out → carve-out tripwire red
  - restoring the "non-interactive caller passes `--yes`" wording → `--yes` tripwire red
- [x] `tests/pr-watch-skill.test.ts` passes unchanged — pr-watch still hands off with `Next: run /shipit` and never auto-runs it.
- [ ] **Not mechanically verifiable:** that the model *obeys* the ship-intent scoping. shipit is deliberately excluded from L5 evals (`tests/skill-eval-coverage.test.ts:463-475` — heavy external state: a live PR, CI, the GitHub API), so no harness layer can test the behavior. The tripwires assert the guards *exist* in the source, which is what every comparable prose contract in this repo does. Worth knowing the limit rather than implying coverage.
- [ ] **Requires a fresh session to confirm:** `/skills` no longer showing shipit as user-only. Claude Code reads plugin definitions at session start, so this cannot be verified in-session. Corroborating evidence: in the session that produced this PR, `team:shipit` is *absent* from the available-skills list while `team:pr-watch` and `team:pr-open-comments` are present — the exact symptom this PR fixes.

## Known follow-up (not in this PR)

`.claude/skills/create-team-skill/SKILL.md` states a normative rule for *all future* skills — test #1 at lines 56-57: *"Is it irreversible or side-effecting (deploys, pushes, deletes, sends)? → **User-invocable only**. Never let the model auto-trigger it."* — plus the line-51 table and the line-254 checklist. shipit is the archetype that rule describes and now diverges from it. Nothing breaks (the guide never names shipit, and no test binds them), but a future skill author would be told to do what this PR undoes. Relaxing that rule is a broader policy call than this change, so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfHAiCk4HZFQqRMUxHTQFu
