### PR TITLE
v0.26.1 fix(agents): give reporting agents SendMessage so their findings survive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.26.0"
+    "version": "0.26.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A reporting agent dispatched in the background can now hand its report back.** `code-reviewer`, `security-reviewer`, `technical-writer`, `ux-reviewer` and `verifier` gain `SendMessage` in their `tools:` frontmatter. A reporting agent's entire output is its report, but a background subagent's plain text never reaches the orchestrator — so without a messaging tool the agent finished, went idle, and its findings were unrecoverable. `permissionMode: plan` denies these agents `Write`, so there was no file fallback either, and a review could silently lose a gate while appearing to run. `tests/protocol.test.ts` pins the tool on all five.
+
 ## [0.26.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-07-29
+
 ### Fixed
 
 - **A reporting agent dispatched in the background can now hand its report back.** `code-reviewer`, `security-reviewer`, `technical-writer`, `ux-reviewer` and `verifier` gain `SendMessage` in their `tools:` frontmatter. A reporting agent's entire output is its report, but a background subagent's plain text never reaches the orchestrator — so without a messaging tool the agent finished, went idle, and its findings were unrecoverable. `permissionMode: plan` denies these agents `Write`, so there was no file fallback either, and a review could silently lose a gate while appearing to run. `tests/protocol.test.ts` pins the tool on all five.
@@ -289,7 +291,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/bostonaholic/team/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/bostonaholic/team/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/bostonaholic/team/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/bostonaholic/team/compare/v0.23.0...v0.24.0

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -4,7 +4,7 @@ description: Use when an adversarial code review is needed after implementation.
 color: orange
 model: fable
 effort: high
-tools: Read, Grep, Glob, Bash, TodoWrite, Agent
+tools: Read, Grep, Glob, Bash, TodoWrite, Agent, SendMessage
 permissionMode: plan
 skills:
   - progress-tracking

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -4,7 +4,7 @@ description: Use when a security review is needed after implementation. Applies 
 color: red
 model: opus
 effort: high
-tools: Read, Grep, Glob, Bash, TodoWrite, Agent
+tools: Read, Grep, Glob, Bash, TodoWrite, Agent, SendMessage
 permissionMode: plan
 skills:
   - progress-tracking

--- a/agents/technical-writer.md
+++ b/agents/technical-writer.md
@@ -4,7 +4,7 @@ description: Use after implementation to review whether project documentation ne
 color: cyan
 model: sonnet
 effort: medium
-tools: Read, Grep, Glob, Bash, TodoWrite
+tools: Read, Grep, Glob, Bash, TodoWrite, SendMessage
 permissionMode: plan
 skills:
   - progress-tracking

--- a/agents/ux-reviewer.md
+++ b/agents/ux-reviewer.md
@@ -4,7 +4,7 @@ description: Use when live application verification is needed after implementati
 color: pink
 model: sonnet
 effort: medium
-tools: Read, Grep, Glob, Bash, TodoWrite
+tools: Read, Grep, Glob, Bash, TodoWrite, SendMessage
 permissionMode: plan
 skills:
   - progress-tracking

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -4,7 +4,7 @@ description: Use when comprehensive verification checks need to run before compl
 color: yellow
 model: haiku
 effort: low
-tools: Read, Grep, Glob, Bash, TodoWrite
+tools: Read, Grep, Glob, Bash, TodoWrite, SendMessage
 permissionMode: plan
 skills:
   - progress-tracking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Drive a feature from idea to PR with a team of Claude Code agents.",
   "license": "MIT",
   "type": "module",

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -105,6 +105,27 @@ describe("ask-user-question contract", () => {
   });
 });
 
+describe("reporting agents can reach the orchestrator", () => {
+  // A reporting agent's whole output is its report. Dispatched in the
+  // background, its plain text never reaches the orchestrator, so without
+  // SendMessage the report is unrecoverable — the agent goes idle and the
+  // review silently loses a gate.
+  const REPORTING_AGENTS = [
+    "code-reviewer",
+    "security-reviewer",
+    "technical-writer",
+    "ux-reviewer",
+    "verifier",
+  ];
+
+  for (const agent of REPORTING_AGENTS) {
+    test(`${agent} tools frontmatter includes SendMessage`, () => {
+      const fm = frontmatter(read(join(REPO_ROOT, "agents", `${agent}.md`)));
+      expect(/^tools:.*\bSendMessage\b/m.test(fm)).toBe(true);
+    });
+  }
+});
+
 describe("multi-repo support", () => {
   const QRSPI = join(REPO_ROOT, "skills", "qrspi-workflow", "SKILL.md");
   const WORKTREE_ISO = join(REPO_ROOT, "skills", "worktree-isolation", "SKILL.md");


### PR DESCRIPTION
## Why

A reporting agent's entire output is its report. When one is dispatched in the background, its plain text never reaches the orchestrator — and none of these agents had a messaging tool. The agent would finish its analysis, go idle, and its findings would be unrecoverable.

`permissionMode: plan` also denies them `Write`, so there was no file fallback. The failure is silent and looks like success: a review appears to run every gate while actually losing some of them.

Hit live during a code review where both the code-reviewer and security-reviewer completed their analysis and neither report could be retrieved by any route.

## What changed

`code-reviewer`, `security-reviewer`, `technical-writer`, `ux-reviewer` and `verifier` gain `SendMessage` in their `tools:` frontmatter, so a backgrounded reporting agent can push its report to the orchestrator regardless of how the dispatch resolves.

The eight non-reporting agents are untouched — only the reporting path demonstrably broke.

This does not conflict with the existing assertion that the orchestrator skill carries no `SendMessage` reference; that one guards `skills/team/SKILL.md` against reintroducing a mid-run pause protocol, which is unrelated to an agent's tool set.

## Test plan

- Added a `reporting agents can reach the orchestrator` block to `tests/protocol.test.ts` asserting the tool is present on all five agents.
- Full suite green: 921 pass, 0 fail across 32 files.
- Confirmed the pre-existing orchestrator-skill assertion still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)