### PR TITLE
v0.31.1 fix(worktree): sweep residue left after teardown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.31.0"
+    "version": "0.31.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Worktree teardown no longer reports success while leaving the directory behind.** `git worktree remove` exits 0 and deletes gitignored files, so teardown treated a successful removal as the end of the story. It is not: a long-lived process still anchored to the old absolute path — an editor language server booting the app per workspace, a hook writing per-session state — re-creates the directory by `mkdir -p` seconds to hours *after* the command returns, holding nothing but regenerable cache. Because recreation lands after the removal, a check inside the same command cannot catch it, and the leftovers accumulate silently under `.claude/worktrees/`. [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md) → "Ship (teardown)" gains a post-removal assertion on the removed path, and a residue sweep as teardown's final action that also catches sibling directories under `.claude/worktrees/` which `git worktree list` no longer knows about. The sweep deletes only pure regenerable residue — no `.git` entry, and no files outside `tmp/`, `.omc/`, and the already-disposable `docs/plans/` — so anything holding real work stays on disk and is reported with the files it holds, and a worktree still listed by git is never a candidate. Teardown now says which directories it swept, or that it found none. [`tests/worktree-teardown-sweep.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/worktree-teardown-sweep.test.ts) pins the behavior at L3 by extracting the documented snippet from the skill and running it against hermetic temp repos, so the documented command and the tested command cannot drift.
+
 ## [0.31.0] - 2026-07-31
 
 ### Added
@@ -18,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`pr-approve-watch` loses its human-only guard on Codex, and the install instructions now say so.** On Claude Code the skill carries `disable-model-invocation`, so only a person can arm it — its approval can transitively merge a pull request that has auto-merge enabled. Codex does not implement that key, and skills bypass its trust gate, so on Codex the model can invoke the skill in any session with no prompt. The skill's own description says it is user-only, but that sentence falls past the point where Codex truncates a long description, so it cannot be relied on. [`README.md`](https://github.com/bostonaholic/team/blob/main/README.md) states the gap at the point of install and gives the command to remove the skill for anyone who wants the guard back.
 
+||||||| Stash base
 ## [0.30.0] - 2026-07-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-07-31
+
 ### Fixed
 
 - **Worktree teardown no longer reports success while leaving the directory behind.** `git worktree remove` exits 0 and deletes gitignored files, so teardown treated a successful removal as the end of the story. It is not: a long-lived process still anchored to the old absolute path — an editor language server booting the app per workspace, a hook writing per-session state — re-creates the directory by `mkdir -p` seconds to hours *after* the command returns, holding nothing but regenerable cache. Because recreation lands after the removal, a check inside the same command cannot catch it, and the leftovers accumulate silently under `.claude/worktrees/`. [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md) → "Ship (teardown)" gains a post-removal assertion on the removed path, and a residue sweep as teardown's final action that also catches sibling directories under `.claude/worktrees/` which `git worktree list` no longer knows about. The sweep deletes only pure regenerable residue — no `.git` entry, and no files outside `tmp/`, `.omc/`, and the already-disposable `docs/plans/` — so anything holding real work stays on disk and is reported with the files it holds, and a worktree still listed by git is never a candidate. Teardown now says which directories it swept, or that it found none. [`tests/worktree-teardown-sweep.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/worktree-teardown-sweep.test.ts) pins the behavior at L3 by extracting the documented snippet from the skill and running it against hermetic temp repos, so the documented command and the tested command cannot drift.
@@ -354,7 +356,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.31.1...HEAD
+[0.31.1]: https://github.com/bostonaholic/team/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/bostonaholic/team/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/bostonaholic/team/compare/v0.29.2...v0.30.0
 [0.29.2]: https://github.com/bostonaholic/team/compare/v0.29.1...v0.29.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -148,16 +148,53 @@ When teardown is warranted (post-merge or on explicit request):
 2. Empty worktrees clean up automatically.
 3. If manual cleanup is needed: `git -C <repo-path> worktree remove
    <worktree-path>` and `git -C <repo-path> branch -D <id>`.
-4. After the worktree is gone, update the repo's local default branch
+4. **Assert the path is actually gone.** `git worktree remove` exits 0 and
+   does delete gitignored files, but a long-lived process still anchored to
+   the old absolute path — an editor language server, a hook writing
+   per-session state — can `mkdir -p` it straight back. Re-check the path,
+   and delete a reappeared one only when it is
+   `<repo-root>/.claude/worktrees/<name>`: never a path still listed by
+   `git worktree list`, and never a primary clone.
+5. After the worktree is gone, update the repo's local default branch
    with the merge: `git -C <repo-path> pull --rebase origin <base>`.
    Always rebase — never a merge commit — so history stays linear.
-5. Remove the feature's local planning docs: `rm -rf docs/plans/<id>`.
+6. Remove the feature's local planning docs: `rm -rf docs/plans/<id>`.
    These are untracked QRSPI scratch that only existed to drive the work
    to a merged PR. Deleting them is part of teardown, alongside the
    branch and worktree. Verify the directory is untracked first
    (`git ls-files docs/plans/<id>` returns nothing) and remove only that
    feature's `<id>` directory — never sibling dirs for other in-flight
    work.
+7. **Sweep residue as the final action.** Recreation lands *after* the
+   removal command returns — seconds to hours later — so a check inside
+   that same command cannot catch it, and the sweep is not redundant with
+   step 4. It re-checks the removed path plus every sibling under
+   `.claude/worktrees/` that `git worktree list` no longer knows about. A
+   directory is deleted only when it is pure regenerable residue: no
+   `.git` entry, and no files outside `tmp/`, `.omc/`, and `docs/plans/`.
+
+   ```sh
+   root="$(git -C <repo-path> rev-parse --show-toplevel)"
+   live="$(git -C "$root" worktree list --porcelain | sed -n 's/^worktree //p')"
+   for dir in "$root"/.claude/worktrees/*; do
+     [ -d "$dir" ] || continue
+     printf '%s\n' "$live" | grep -qxF "$dir" && continue
+     if [ -e "$dir/.git" ]; then
+       echo "kept (still a checkout): $dir"; continue
+     fi
+     extra="$(find "$dir" -type f \
+       -not -path "$dir/tmp/*" -not -path "$dir/.omc/*" -not -path "$dir/docs/plans/*")"
+     if [ -n "$extra" ]; then
+       printf 'kept (holds unexpected files): %s\n%s\n' "$dir" "$extra"
+     else
+       rm -rf "$dir" && echo "swept: $dir"
+     fi
+   done
+   ```
+
+   Report the outcome either way: name each swept directory, or say no
+   residue was found. A kept directory is surfaced to the user with the
+   files it holds — never deleted silently, never left unreported.
 
 ## Gitignored Files
 

--- a/tests/worktree-teardown-sweep.test.ts
+++ b/tests/worktree-teardown-sweep.test.ts
@@ -1,0 +1,158 @@
+// L3 subprocess-snapshot tests (see docs/testing.md §2) for the residue sweep
+// documented in skills/worktree-isolation/SKILL.md → "Ship (teardown)". The
+// snippet under test is EXTRACTED from the SKILL.md code block — the docs are
+// the single source of truth, so the documented command and the tested command
+// cannot drift. Real `git` runs against hermetic temp repos; free and
+// deterministic.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+const ISOLATION = join(REPO_ROOT, "skills", "worktree-isolation", "SKILL.md");
+
+// Pull the sweep snippet out of the teardown section's sh code block (the one
+// iterating .claude/worktrees/ against `git worktree list`).
+function sweepSnippet(): string {
+  const blocks = [...read(ISOLATION).matchAll(/```sh\n([\s\S]*?)```/g)].map((m) => m[1]!);
+  const matches = blocks.filter(
+    (b) => b.includes(".claude/worktrees/*") && b.includes("worktree list --porcelain"),
+  );
+  expect(matches.length).toBe(1); // guard: exactly one documented sweep block
+  return matches[0]!;
+}
+
+function runSweep(repoPath: string): string {
+  const script = sweepSnippet().replaceAll("<repo-path>", repoPath);
+  return spawnSync("bash", ["-c", script], { encoding: "utf8" }).stdout.trim();
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const res = spawnSync(
+    "git",
+    ["-c", "user.email=test@test", "-c", "user.name=test", ...args],
+    { cwd, encoding: "utf8" },
+  );
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  }
+  return res.stdout.trim();
+}
+
+function writeFileAt(path: string, body: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body);
+}
+
+// Re-create a removed worktree path the way a long-lived writer does: absolute
+// path + mkdir -p, after `git worktree remove` has already returned 0.
+function plantResidue(worktreePath: string): void {
+  writeFileAt(join(worktreePath, "tmp", "cache", "bootsnap", "load-path-cache"), "cache\n");
+  writeFileAt(join(worktreePath, ".omc", "state", "sessions", "abc123", "state.json"), "{}\n");
+}
+
+let root: string;
+let repo: string;
+let staleWt: string; // removed from git, then re-created by a late writer
+let liveWt: string; // still listed by `git worktree list`
+
+beforeEach(() => {
+  // realpath: git reports worktree paths physically, so the fixture must too
+  // or every path assertion below compares /var against /private/var on macOS.
+  root = realpathSync(mkdtempSync(join(tmpdir(), `worktree-sweep-${process.pid}-`)));
+  repo = join(root, "repo");
+  mkdirSync(repo);
+  git(repo, "init", "-b", "main");
+  writeFileSync(join(repo, ".gitignore"), "tmp/\n.omc/\ndocs/plans/\n");
+  git(repo, "add", ".gitignore");
+  git(repo, "commit", "-m", "init");
+
+  staleWt = join(repo, ".claude", "worktrees", "feat-stale");
+  git(repo, "worktree", "add", staleWt, "-b", "feat-stale");
+  plantResidue(staleWt);
+
+  liveWt = join(repo, ".claude", "worktrees", "feat-live");
+  git(repo, "worktree", "add", liveWt, "-b", "feat-live");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("residue sweep (snippet from worktree-isolation SKILL.md)", () => {
+  test("`git worktree remove` deletes gitignored files and exits 0 — git is not the culprit", () => {
+    git(repo, "worktree", "remove", staleWt);
+    expect(existsSync(staleWt)).toBe(false);
+  });
+
+  test("sweeps a path a late writer re-created after removal returned", () => {
+    git(repo, "worktree", "remove", staleWt);
+    plantResidue(staleWt); // the failure mode: recreation lands AFTER the command returns
+
+    const output = runSweep(repo);
+
+    expect(output).toContain(`swept: ${staleWt}`);
+    expect(existsSync(staleWt)).toBe(false);
+  });
+
+  test("refuses residue holding a file outside tmp/, .omc/, and docs/plans/, and surfaces it", () => {
+    git(repo, "worktree", "remove", staleWt);
+    plantResidue(staleWt);
+    writeFileAt(join(staleWt, "app", "foo.rb"), "class Foo; end\n");
+
+    const output = runSweep(repo);
+
+    expect(output).toContain(`kept (holds unexpected files): ${staleWt}`);
+    expect(output).toContain(join(staleWt, "app", "foo.rb")); // surfaced with what it holds
+    expect(output).not.toContain(`swept: ${staleWt}`);
+    expect(existsSync(join(staleWt, "app", "foo.rb"))).toBe(true);
+  });
+
+  test("planning scratch stays disposable — docs/plans/ alone does not block the sweep", () => {
+    git(repo, "worktree", "remove", staleWt);
+    writeFileAt(join(staleWt, "docs", "plans", "feat-stale", "plan.md"), "# plan\n");
+
+    expect(runSweep(repo)).toContain(`swept: ${staleWt}`);
+    expect(existsSync(staleWt)).toBe(false);
+  });
+
+  test("never targets a worktree still listed in `git worktree list`, even holding the same junk", () => {
+    plantResidue(liveWt);
+
+    const output = runSweep(repo);
+
+    expect(output).not.toContain(liveWt);
+    expect(existsSync(liveWt)).toBe(true);
+    expect(git(repo, "worktree", "list")).toContain(liveWt);
+  });
+
+  test("a stale directory that still carries a .git entry is kept, not deleted", () => {
+    // Simulates a checkout git no longer tracks (pruned metadata, moved path):
+    // it is not regenerable residue, so it must survive and be reported.
+    git(repo, "worktree", "remove", staleWt);
+    writeFileAt(join(staleWt, ".git"), "gitdir: /nonexistent\n");
+
+    const output = runSweep(repo);
+
+    expect(output).toContain(`kept (still a checkout): ${staleWt}`);
+    expect(existsSync(staleWt)).toBe(true);
+  });
+
+  test("reports nothing and deletes nothing when no residue exists", () => {
+    git(repo, "worktree", "remove", staleWt);
+
+    expect(runSweep(repo)).toBe("");
+    expect(existsSync(liveWt)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Worktree teardown reported success while leaving the directory on disk. Eight such leftovers accumulated under one repo's `.claude/worktrees/` over two weeks, each holding 1–3 gitignored files and nothing else.

`git worktree remove` is not at fault — it exits 0 and does delete gitignored files. The directory comes back *after* the command returns, re-created by a long-lived process still anchored to the old absolute path via `mkdir -p`: an editor language server booting the app per workspace, or a hook writing per-session state. Observed lag ranged from 12 seconds to over two hours. Because recreation lands after the removal, a check inside the same command cannot catch it, which is why teardown never noticed.

Teardown now asserts the path is actually gone after removal, and runs a residue sweep as its final action. The sweep re-checks the removed path and also catches sibling directories under `.claude/worktrees/` that `git worktree list` no longer knows about. It deletes only pure regenerable residue — no `.git` entry, and no files outside `tmp/`, `.omc/`, and the already-disposable `docs/plans/`. Anything holding real work stays on disk and is reported with the files it holds, and a worktree still listed by git is never a candidate. Teardown says which directories it swept, or that it found none.

The fix lives in `skills/worktree-isolation/SKILL.md` → "Ship (teardown)", the one file that owns the procedure. `skills/team-pr/SKILL.md` and `skills/team/SKILL.md` already delegate to it by name, so nothing was duplicated.

## Test plan

`tests/worktree-teardown-sweep.test.ts` extracts the documented snippet from the skill and runs it against hermetic temp repos, so the documented command and the tested command cannot drift. Verified at L3 (free, deterministic, gates on every PR) per `docs/testing.md`:

- `git worktree remove` deletes gitignored files and exits 0 — the diagnosis that git is not the culprit
- A path a late writer re-created after removal returned is swept
- Residue holding a file outside `tmp/`, `.omc/`, `docs/plans/` is refused and surfaced with what it holds
- Planning scratch alone does not block the sweep, keeping `docs/plans/` disposable as teardown already treats it
- A worktree still listed by `git worktree list` is never targeted, even holding identical junk
- A stale directory that still carries a `.git` entry is kept, not deleted
- Nothing is reported and nothing deleted when no residue exists

Also proven by hand in a scratch repo outside any real checkout: the positive sweep, the negative refusal with a real source file present, and the live-worktree exclusion.

`bun test`: 929 pass, 0 fail across 36 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)