### PR TITLE
v0.33.0 feat(skills): route to team-fix and code-review from natural language

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.32.0"
+    "version": "0.33.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -5,9 +5,9 @@ description: |
   the existing skills already use. Establishes the three decisions every skill must
   make before any prose is written: how it is invoked (entry point vs building block),
   how it acquires its input, and how it manages the context window.
-  Proactively invoke this skill (do NOT hand-write a SKILL.md directly) when the user
-  asks to "create a skill", "add a new skill", "scaffold a skill", "write a SKILL.md",
-  or describes new skill functionality they want to build.
+  Do NOT hand-write a SKILL.md directly. Trigger on "create a skill",
+  "add a new skill", "scaffold a skill", "write a SKILL.md", or a description of
+  new skill functionality the user wants to build.
 ---
 
 # Creating a new Team skill
@@ -70,21 +70,22 @@ surface(s) per §1A / §1B below and set the frontmatter from the table above.
 
 ### §1A — Wire it as an entry point
 
-1. **Write the description as a router.** Lead with WHAT it does, then name the user
-    intents and phrases that should fire it:
+1. **Write the description as a router.** Lead with WHAT it does, then end with the
+    trigger sentence naming the phrases and the slash name that should fire it:
     ```yaml
     description: |
       <one line: what this does>.
-      Proactively invoke this skill (do NOT answer directly) when the user
-      <intent A>, <intent B>, or says "<phrase>", "<phrase>".
+      Trigger on "<phrase>", "<phrase>", or "/<name>".
     ```
     Specific intents + example phrases = reliable triggering. Vague text = mis-routing.
 2. **Add one line to the routing map** in your standing agent instructions — in this
     repo that's the Entry Points table in `AGENTS.md`: `- <user intent> → invoke
     /<skill>`. This is guidance the agent reads, not a code gate, so keep it in sync
     with the description.
-3. **To make it user-explicit-ONLY:** omit the proactive-invoke language and leave it
-    off the routing map. If your host honors a hard opt-out flag (e.g.
+3. **To make it user-explicit-ONLY:** replace the plain `Trigger on` carrier with
+    shipit-style explicit-intent guard wording, and leave the skill off the routing
+    map. The description still carries the quoted phrases and the `/<name>` — the
+    trigger test has no opt-out. If your host honors a hard opt-out flag (e.g.
     `disable-model-invocation`), set it — but on hosts that ignore it, the description is
     the only control. Use this for irreversible skills (deploy, force-push, destructive
     cleanup) so they require an explicit ask.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -85,8 +85,10 @@ surface(s) per §1A / §1B below and set the frontmatter from the table above.
 3. **Side-effecting or irreversible skills MUST guard.** If the skill commits, pushes,
     opens a PR, moves a ticket, merges, deploys, or deletes, replace the plain
     `Trigger on` carrier with shipit-style explicit-intent guard wording ("Invoke ONLY
-    on explicit … intent — … never infer …"), and leave the skill off the routing map.
-    The description still carries the quoted phrases and the `/<name>` — the trigger
+    on explicit … intent — … never infer …"). Word its routing-map line with that same
+    explicit intent, so the map never invites the skill on a plain request — `team-fix`
+    is listed as a command but reached only on stated pipeline intent, never on "fix
+    this bug". The description still carries the quoted phrases and the `/<name>` — the trigger
     test has no opt-out, but it checks phrase presence only: no test checks the guard
     wording, so it is YOUR responsibility, and its absence on a side-effecting skill
     is a review-blocking defect. If your host honors a hard opt-out flag (e.g.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,13 +82,16 @@ surface(s) per §1A / §1B below and set the frontmatter from the table above.
     repo that's the Entry Points table in `AGENTS.md`: `- <user intent> → invoke
     /<skill>`. This is guidance the agent reads, not a code gate, so keep it in sync
     with the description.
-3. **To make it user-explicit-ONLY:** replace the plain `Trigger on` carrier with
-    shipit-style explicit-intent guard wording, and leave the skill off the routing
-    map. The description still carries the quoted phrases and the `/<name>` — the
-    trigger test has no opt-out. If your host honors a hard opt-out flag (e.g.
-    `disable-model-invocation`), set it — but on hosts that ignore it, the description is
-    the only control. Use this for irreversible skills (deploy, force-push, destructive
-    cleanup) so they require an explicit ask.
+3. **Side-effecting or irreversible skills MUST guard.** If the skill commits, pushes,
+    opens a PR, moves a ticket, merges, deploys, or deletes, replace the plain
+    `Trigger on` carrier with shipit-style explicit-intent guard wording ("Invoke ONLY
+    on explicit … intent — … never infer …"), and leave the skill off the routing map.
+    The description still carries the quoted phrases and the `/<name>` — the trigger
+    test has no opt-out, but it checks phrase presence only: no test checks the guard
+    wording, so it is YOUR responsibility, and its absence on a side-effecting skill
+    is a review-blocking defect. If your host honors a hard opt-out flag (e.g.
+    `disable-model-invocation`), set it — but on hosts that ignore it, the description
+    is the only control.
 
 ### §1B — Wire it as a building block
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-03
+
 ### Added
 
 - **Natural-language phrases now route to the two skills that were slash-only.** Saying "run the bug-fix pipeline" or "team-fix this bug" routes to `/team-fix`, and "review this diff", "review these changes", or "code review this" routes to `/code-review` — no need to know the slash command. Because `/team-fix` moves the tracker ticket, commits, pushes, and opens a draft PR, it fires only on explicit pipeline intent — a plain "fix this bug" still means an inline fix, never the pipeline. A direct `/code-review` dispatches the fresh-context `code-reviewer` agent instead of reviewing inline, so the review keeps the clean context the methodology requires. A deterministic test pins the trigger convention across all user-invocable skills, so no future entry point regresses to slash-only. [`skills/team-fix/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md), [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
@@ -367,7 +369,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/bostonaholic/team/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/bostonaholic/team/compare/v0.31.1...v0.32.0
 [0.31.1]: https://github.com/bostonaholic/team/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/bostonaholic/team/compare/v0.30.0...v0.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Natural-language phrases now route to the two skills that were slash-only.** Saying "fix this bug", "squash this bug", or "quick bug fix" routes to `/team-fix`, and "review this diff", "review these changes", or "code review this" routes to `/code-review` — no need to know the slash command. A deterministic test pins the trigger convention across all user-invocable skills, so no future entry point regresses to slash-only. [`skills/team-fix/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md), [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
+- **Natural-language phrases now route to the two skills that were slash-only.** Saying "run the bug-fix pipeline" or "team-fix this bug" routes to `/team-fix`, and "review this diff", "review these changes", or "code review this" routes to `/code-review` — no need to know the slash command. Because `/team-fix` moves the tracker ticket, commits, pushes, and opens a draft PR, it fires only on explicit pipeline intent — a plain "fix this bug" still means an inline fix, never the pipeline. A direct `/code-review` dispatches the fresh-context `code-reviewer` agent instead of reviewing inline, so the review keeps the clean context the methodology requires. A deterministic test pins the trigger convention across all user-invocable skills, so no future entry point regresses to slash-only. [`skills/team-fix/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md), [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
 
 ## [0.32.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Natural-language phrases now route to the two skills that were slash-only.** Saying "fix this bug", "squash this bug", or "quick bug fix" routes to `/team-fix`, and "review this diff", "review these changes", or "code review this" routes to `/code-review` — no need to know the slash command. A deterministic test pins the trigger convention across all user-invocable skills, so no future entry point regresses to slash-only. [`skills/team-fix/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md), [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
+
 ## [0.32.0] - 2026-08-03
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -510,12 +510,18 @@ not on `argument-hint`, which `docs/skills.md` uses to sort skill
 *flavor*. A skill that does not set `user-invocable: false` must state,
 in its description, at least one double-quoted natural-language phrase
 (one that does not start with `/`) plus its own literal `/<name>`,
-normally as a final `Trigger on "…", "…", or "/<name>".` sentence. An
-irreversible action may use shipit-style explicit-intent guard wording
-instead of the plain carrier, but it still carries the quoted phrases
-and the slash name. A deterministic test in `tests/architecture.test.ts`
-enforces the invariant with no opt-out; the slash-name check is
-prefix-safe, so `/team-research` cannot satisfy the `/team` requirement.
+normally as a final `Trigger on "…", "…", or "/<name>".` sentence. A
+**side-effecting or irreversible** entry-point skill — one that commits,
+pushes, opens a PR, moves a ticket, merges, deploys, or deletes — MUST
+replace the plain carrier with shipit-style explicit-intent guard wording
+("Invoke ONLY on explicit … intent — … never infer …"), still carrying
+the quoted phrases and the slash name, and should set
+`disable-model-invocation` where the host honors it. A deterministic test
+in `tests/architecture.test.ts` enforces the phrase invariant with no
+opt-out; the slash-name check is prefix-safe, so `/team-research` cannot
+satisfy the `/team` requirement. The guard wording is NOT
+machine-checked — it is the author's and reviewer's responsibility, and
+its absence on a side-effecting skill is a review-blocking defect.
 
 Among methodology skills, `code-review` is the only one kept
 user-invocable. It is a building block: the `code-reviewer`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -505,6 +505,18 @@ auto-load a methodology skill when relevant, so
 new methodology skill, set `user-invocable: false`. When you add a new
 entry-point skill, leave it unset, so it registers as a slash command.
 
+The trigger-phrase convention keys on the `user-invocable` field —
+not on `argument-hint`, which `docs/skills.md` uses to sort skill
+*flavor*. A skill that does not set `user-invocable: false` must state,
+in its description, at least one double-quoted natural-language phrase
+(one that does not start with `/`) plus its own literal `/<name>`,
+normally as a final `Trigger on "…", "…", or "/<name>".` sentence. An
+irreversible action may use shipit-style explicit-intent guard wording
+instead of the plain carrier, but it still carries the quoted phrases
+and the slash name. A deterministic test in `tests/architecture.test.ts`
+enforces the invariant with no opt-out; the slash-name check is
+prefix-safe, so `/team-research` cannot satisfy the `/team` requirement.
+
 Among methodology skills, `code-review` is the only one kept
 user-invocable. It is a building block: the `code-reviewer`,
 `security-reviewer`, `ux-reviewer`, and `technical-writer` agents load it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -516,7 +516,9 @@ pushes, opens a PR, moves a ticket, merges, deploys, or deletes — MUST
 replace the plain carrier with shipit-style explicit-intent guard wording
 ("Invoke ONLY on explicit … intent — … never infer …"), still carrying
 the quoted phrases and the slash name, and should set
-`disable-model-invocation` where the host honors it. A deterministic test
+`disable-model-invocation` where the host honors it. Such a skill stays
+listed as a command, but its routing-map line in `AGENTS.md` states the
+explicit intent, so the map never invites it on a plain request. A deterministic test
 in `tests/architecture.test.ts` enforces the phrase invariant with no
 opt-out; the slash-name check is prefix-safe, so `/team-research` cannot
 satisfy the `/team` requirement. The guard wording is NOT

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -36,7 +36,10 @@ catalog into two flavors:
   as slash commands (`/team`, `/team-research`, and so on). The
   `argument-hint` documents what to pass as `$ARGUMENTS`.
 - **Methodology skills omit `argument-hint`.** They are never invoked
-  directly. Agents load them through one of two mechanisms: a `skills:`
+  directly — with one exception, `code-review`, which stays user-invocable
+  as a standalone review command (see
+  [Methodology skills](#methodology-skills)). Agents load them through one
+  of two mechanisms: a `skills:`
   YAML list in the agent's frontmatter (e.g., `agents/design-author.md`
   declares `skills: [product-thinking,
   progress-tracking, authoring-designs]`), or an inline prose load
@@ -529,8 +532,15 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 ## Methodology skills
 
-The 35 methodology skills carry no `argument-hint` and are never invoked
-directly. Agents load them through one of two mechanisms. The first is a
+The 35 methodology skills carry no `argument-hint` and, with one
+exception, are never invoked directly. The exception is `code-review`: it
+is a meaningful standalone user action ("review this diff",
+`/code-review`) as well as a building block, so it does not set
+`user-invocable: false` — and when invoked directly it dispatches the
+`code-reviewer` agent rather than reviewing inline, preserving the
+fresh-context separation it mandates (see
+[architecture.md](architecture.md#methodology-skills-loaded-by-agents-not-directly-invoked)).
+Agents load them through one of two mechanisms. The first is a
 `skills:` YAML list in the agent's frontmatter. The second is an inline
 prose load instruction in the agent body. See the "Two flavors of skill"
 section above. The "Loaded by" line for each skill names its consumers from
@@ -988,7 +998,7 @@ entry-point section above rather than repeating them here.
 | `team-worktree` | orchestrator | Worktree |
 | `team-implement` | orchestrator → implementer + reviewers | Implement |
 | `team-pr` | orchestrator | PR |
-| `team-fix` | user (direct invocation) | Compressed bug-fix flow (outside QRSPI) |
+| `team-fix` | user or model (direct invocation, on explicit pipeline intent) | Compressed bug-fix flow (outside QRSPI) |
 | `eng-design-doc-review` | user (direct invocation). Pipeline DESIGN review gate (brief by reference) | Design review-gate brief + standalone audit. Dispatches a read-only Explore subagent |
 | `shipit` | user or model (direct invocation, on explicit ship intent) | Standalone: land a reviewed PR (not a QRSPI phase) |
 | `pr-open-comments` | user or model (direct invocation) | Standalone: triage unresolved PR review feedback (not a QRSPI phase) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Generator-evaluator separation and review methodology — loaded by review agents to enforce fresh-context review discipline and gate verdicts; findings from the code, security, and docs reviewers are formatted per the conventional-comments skill
+description: Generator-evaluator separation and review methodology — loaded by review agents to enforce fresh-context review discipline and gate verdicts; findings from the code, security, and docs reviewers are formatted per the conventional-comments skill. Trigger on "review this diff", "review these changes", "code review this", or "/code-review".
 ---
 
 # Code Review

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -14,6 +14,16 @@ Write the prose your review comments carry at a seventh-grade reading
 level — short sentences, common words, no unexplained jargon. Full
 methodology: `skills/writing-prose/SKILL.md`.
 
+## When Invoked Directly
+
+When a user asks for a review in the main session ("review this diff",
+`/code-review`), the session itself is not a valid reviewer — it holds the
+conversation history this skill forbids. Do not review inline. Dispatch the
+`code-reviewer` agent (or, if unavailable, a fresh read-only subagent
+instructed to follow this skill) against the requested diff, then relay its
+verdict and findings. Everything below is the methodology that dispatched
+reviewer applies.
+
 ## Generator-Evaluator Separation
 
 The cardinal rule: **Do not let the same model grade its own exam.**

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-fix
-description: Compressed bug-fix pipeline — reproduce, write failing test, minimal fix, verify. Skips Question/Research/Design/Structure/Plan phases. Trigger on "/team-fix <bug description>".
+description: Compressed bug-fix pipeline — reproduce, write failing test, minimal fix, verify. Skips Question/Research/Design/Structure/Plan phases. Trigger on "fix this bug", "squash this bug", "quick bug fix", or "/team-fix <bug description>".
 effort: high
 argument-hint: "<ticket id, issue URL, or bug description>"
 ---

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: team-fix
-description: Compressed bug-fix pipeline — reproduce, write failing test, minimal fix, verify. Skips Question/Research/Design/Structure/Plan phases. Trigger on "fix this bug", "squash this bug", "quick bug fix", or "/team-fix <bug description>".
+description: |
+  Compressed bug-fix pipeline — reproduce, write failing test, minimal fix,
+  verify, and open a draft PR. Skips Question/Research/Design/Structure/Plan
+  phases. Invoke ONLY on explicit pipeline intent — the user says "run the
+  bug-fix pipeline", "team-fix this bug", or runs "/team-fix". The pipeline
+  moves the tracker ticket, commits, pushes a branch, and opens a draft PR
+  without stopping to ask: never infer pipeline intent from a plain request
+  to fix a bug — that asks for an inline fix, not this pipeline.
 effort: high
 argument-hint: "<ticket id, issue URL, or bug description>"
 ---

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -292,7 +292,7 @@ describe("user-invocable trigger phrases", () => {
     const lines = fm.split("\n");
     const start = lines.findIndex((line) => line.startsWith("description:"));
     if (start === -1) return "";
-    const inline = lines[start].slice("description:".length).trim();
+    const inline = (lines[start] ?? "").slice("description:".length).trim();
     if (inline !== "" && inline !== "|") {
       // A fully-quoted inline scalar must be unwrapped: returned verbatim,
       // its surrounding quotes would make matchAll treat the whole value as
@@ -313,8 +313,9 @@ describe("user-invocable trigger phrases", () => {
     }
     const block: string[] = [];
     for (let i = start + 1; i < lines.length; i++) {
-      if (!/^\s+\S/.test(lines[i])) break;
-      block.push(lines[i].trim());
+      const line = lines[i];
+      if (line === undefined || !/^\s+\S/.test(line)) break;
+      block.push(line.trim());
     }
     return block.join(" ");
   }
@@ -337,7 +338,9 @@ describe("user-invocable trigger phrases", () => {
     // its quoted phrases and must pass as-is.
     const offenders: string[] = [];
     for (const { file, description } of userInvocableSkills()) {
-      const phrases = [...description.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+      const phrases = [...description.matchAll(/"([^"]+)"/g)].flatMap((m) =>
+        m[1] === undefined ? [] : [m[1]],
+      );
       if (!phrases.some((phrase) => !phrase.startsWith("/"))) offenders.push(file);
     }
     expect(offenders).toEqual([]);

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -70,7 +70,9 @@ describe("skill architecture", () => {
   });
 
   test("code-review row in docs/skills.md names all 4 consumer agents", () => {
-    const row = filterRows(read(SKILLS_MD), "`code-review`", /^#|^>|SKILL\.md|\/\/|event/);
+    // Key on the table-row delimiter so prose mentions of the skill name
+    // elsewhere in the doc cannot crowd the row out of the 5-line window.
+    const row = filterRows(read(SKILLS_MD), "| `code-review` |", /^#|^>|SKILL\.md|\/\/|event/);
     for (const agent of ["code-reviewer", "security-reviewer", "ux-reviewer", "technical-writer"]) {
       expect(row).toContain(agent);
     }
@@ -291,7 +293,24 @@ describe("user-invocable trigger phrases", () => {
     const start = lines.findIndex((line) => line.startsWith("description:"));
     if (start === -1) return "";
     const inline = lines[start].slice("description:".length).trim();
-    if (inline !== "" && inline !== "|") return inline;
+    if (inline !== "" && inline !== "|") {
+      // A fully-quoted inline scalar must be unwrapped: returned verbatim,
+      // its surrounding quotes would make matchAll treat the whole value as
+      // one "phrase" and pass with zero real trigger phrases. A quote that
+      // opens but never closes on the line is an unsupported style — throw
+      // rather than scan text that YAML would parse differently.
+      const quote = inline[0];
+      if (quote === '"' || quote === "'") {
+        if (inline.length < 2 || !inline.endsWith(quote)) {
+          throw new Error(`unsupported description scalar style: ${inline}`);
+        }
+        const body = inline.slice(1, -1);
+        return quote === '"'
+          ? body.replace(/\\"/g, '"')
+          : body.replace(/''/g, "'");
+      }
+      return inline;
+    }
     const block: string[] = [];
     for (let i = start + 1; i < lines.length; i++) {
       if (!/^\s+\S/.test(lines[i])) break;

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -279,6 +279,66 @@ describe("effort tiering", () => {
   });
 });
 
+describe("user-invocable trigger phrases", () => {
+  // Extract the description field's text only from a frontmatter slice,
+  // handling both YAML styles in use: single-line scalar
+  // (`description: <text>`) and block scalar (`description: |` followed by
+  // indented lines until the first non-indented line). Scoping to the
+  // description prevents a false positive on the quoted `argument-hint`
+  // value elsewhere in the frontmatter.
+  function descriptionText(fm: string): string {
+    const lines = fm.split("\n");
+    const start = lines.findIndex((line) => line.startsWith("description:"));
+    if (start === -1) return "";
+    const inline = lines[start].slice("description:".length).trim();
+    if (inline !== "" && inline !== "|") return inline;
+    const block: string[] = [];
+    for (let i = start + 1; i < lines.length; i++) {
+      if (!/^\s+\S/.test(lines[i])) break;
+      block.push(lines[i].trim());
+    }
+    return block.join(" ");
+  }
+
+  // Every skills/*/SKILL.md that does not set `user-invocable: false` is a
+  // user-facing entry point and must carry routing triggers in its
+  // description. Offenders are collected and asserted empty so a single run
+  // names every non-conforming skill.
+  function userInvocableSkills(): Array<{ file: string; description: string }> {
+    return skillFiles()
+      .map((file) => ({ file, fm: frontmatter(read(join(REPO_ROOT, file))) }))
+      .filter(({ fm }) => !/^user-invocable: false$/m.test(fm))
+      .map(({ file, fm }) => ({ file, description: descriptionText(fm) }));
+  }
+
+  test("every user-invocable skill description carries at least one double-quoted natural-language phrase", () => {
+    // A phrase that starts with "/" is a slash trigger, not natural
+    // language — it does not satisfy this check. No "Trigger on" carrier
+    // sentence is required: shipit's explicit-intent guard wording carries
+    // its quoted phrases and must pass as-is.
+    const offenders: string[] = [];
+    for (const { file, description } of userInvocableSkills()) {
+      const phrases = [...description.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+      if (!phrases.some((phrase) => !phrase.startsWith("/"))) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("every user-invocable skill description carries its own literal /<name>, prefix-safe", () => {
+    // Prefix-safe: the occurrence must not be immediately followed by
+    // another name character, so `/team-research` cannot satisfy the
+    // `/team` requirement. Quote-style-agnostic: a backtick-quoted slash
+    // name (eng-design-doc-review) passes.
+    const offenders: string[] = [];
+    for (const { file, description } of userInvocableSkills()) {
+      const name = file.split("/")[1];
+      const slashName = new RegExp(`/${name}(?![a-z0-9-])`);
+      if (!slashName.test(description)) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe("worktree-first pipeline", () => {
   // ---- Slice 4: phase-diagram sweep (6 files) -------------------------------
   // Each file carries a phase-diagram string. After the sweep, every one must

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -148,7 +148,9 @@ describe("engineering-standards methodology", () => {
   });
 
   test("skills.md code-review row unchanged", () => {
-    const row = filterRows(read(SKILLS_MD), "`code-review`", /^#|^>|SKILL\.md|\/\/|event/);
+    // Key on the table-row delimiter so prose mentions of the skill name
+    // elsewhere in the doc cannot crowd the row out of the 5-line window.
+    const row = filterRows(read(SKILLS_MD), "| `code-review` |", /^#|^>|SKILL\.md|\/\/|event/);
     for (const agent of ["code-reviewer", "security-reviewer", "ux-reviewer", "technical-writer"]) {
       expect(row).toContain(agent);
     }


### PR DESCRIPTION
## Why

Two user-invocable skills could only be reached by typing their slash command. `/team-fix`'s description carried no natural-language phrases at all, and `/code-review`'s carried no trigger sentence. A user who did not already know the command name had no way to reach either by saying what they wanted.

The wider problem is that nothing stopped the next entry-point skill from shipping the same way. The convention existed in 17 descriptions and in no test.

## What changes

Saying "run the bug-fix pipeline" or "team-fix this bug" now routes to `/team-fix`. Saying "review this diff", "review these changes", or "code review this" now routes to `/code-review`.

`/team-fix` moves the tracker ticket, commits, pushes a branch, and opens a draft PR without stopping to ask. So its description carries the same explicit-intent guard `/shipit` and `/pr-cleanup` use, and names the near-miss case by hand: a plain "fix this bug" asks for an inline fix, never the pipeline.

`/code-review` is a methodology skill whose own first rule is that a reviewer must have fresh context with no shared history. Invoked directly, the main session cannot honor that. It now dispatches the `code-reviewer` agent instead of reviewing inline.

A deterministic test pins the convention across every user-invocable skill, so no future entry point regresses to slash-only. The rule is written down in `docs/architecture.md` and in the skill-authoring template, including the requirement that a side-effecting skill pair its phrases with guard wording.

## Test plan

- [x] `bun test` — 1059 pass, 0 fail
- [x] Red-first confirmed: pre-edit, the phrase assertion failed for exactly `team-fix` and `code-review`, and the slash-name assertion for `code-review` only
- [x] All pre-existing description tripwires stay green (the six per-utility `Trigger on` regexes, `shipit`'s phrase pins, the `disable-model-invocation` presence/absence pins, effort/argument-hint exclusivity, and the `docs/skills.md` count pins)
- [x] Adversarial design review passed on revision 2; five-reviewer verify passed with no blocking or major findings

`npm run typecheck` cannot run here — `tsc` is not installed in this environment and it fails identically on clean `main`. Unverified locally; CI covers it.

## Review notes

Non-blocking findings from the five-reviewer verify pass. All seven are now dispositioned:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | The `code-review` direct-dispatch contract is prose only — no test pins the "When Invoked Directly" section, so a future edit could drop it silently. | Fixed in #193 (pinned in `tests/protocol.test.ts`) |
| 2 | `tests/architecture.test.ts`'s `descriptionText` returns the indicator character for the unused YAML block styles (`>`, `|-`, `>-`), listing the skill as an offender for the wrong reason. | **Dropped.** Fixed in #193, then reverted in #196 — the branch was unreachable (no skill uses those styles) and untestable (the helper is local), and the finding asked only for a clearer message in a case that does not occur |
| 3 | `docs/skills.md`'s per-skill `code-review` entry does not mention the direct-dispatch behavior; it appears in the file's summary section only. | Fixed in #193 |
| 4 | `docs/architecture.md`'s `code-review` exception paragraph does not say what direct invocation mechanically does. | Fixed in #193 |
| 5 | `team-fix`'s Ship step falls back to committing to the working branch when not on a branch. Unchanged by this PR, but model-invocability is a new path into it. | Fixed in #194 (v0.33.1) — filed as #190 (`bug`, P0), and on inspection worse than reported: `team-fix` created no branch or worktree at all, so a session on the default branch pushed to it. `team-fix` now leads with a WORKTREE phase that refuses the default branch. Follow-up #195 tracks the same hole in `/team-pr` and `/team`'s worktree fallback |
| 6 | `team-fix`'s guard is now its only layer: `/shipit` traded `disable-model-invocation` for three controls and `team-fix` has one. | Filed as #191 (`security`, P1) |
| 7 | The trigger test has no opt-out, which forecloses a slash-only description as a mitigation for skills that hard-disable model invocation. | Filed as #192 (`tests`, P2) |

One further finding was **dropped**: `code-review` the skill and `code-reviewer` the agent advertise overlapping phrase sets that can drift independently. Both converge on the same behavior today and there is no failure mode; the proposed fix was a cross-reference comment, which would itself go stale.

A grammar nitpick — "the methodology that dispatched reviewer applies" in `skills/code-review/SKILL.md` parses two ways — rides along on #191, since that file needs a version bump either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


