### PR TITLE
docs: record the code-review direct-dispatch path, and pin it

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -533,6 +533,13 @@ action, "review this diff". The field thus stays unset. The distinction
 is the *primary* surface: a skill earns a slash command when a user would
 plausibly run it directly, even if agents also compose it.
 
+That standalone path behaves differently from an ordinary entry point,
+which simply runs its own procedure. A methodology skill invoked directly
+still owes its own rules: the main session shares conversation history
+with whatever wrote the code, so it is not a valid reviewer. `code-review`
+therefore dispatches the `code-reviewer` agent and relays the verdict
+rather than reviewing inline.
+
 (This is separate from the entry-point skills, which are user-invocable by
 definition. Some of those, e.g. `team-worktree` and `team-pr`, are also
 *referenced by path* from `team/SKILL.md`, but those are procedural

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -648,7 +648,9 @@ context (see [architecture.md](architecture.md#design-guidelines)).
 - **Loaded by:** code-reviewer, security-reviewer, ux-reviewer,
   technical-writer (4).
 - **Key behaviors:** Defines how a reviewer reads with fresh eyes and emits
-  a structured verdict. Findings use the format defined in
+  a structured verdict. Invoked directly, it dispatches the `code-reviewer`
+  agent rather than reviewing inline — the main session holds the
+  conversation history the skill forbids. Findings use the format defined in
   `conventional-comments`. The ux-reviewer is the exception: its
   live-verification report uses its own Working/Broken/Could Improve
   format. The gate-type and severity-tier map lives in

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -299,6 +299,12 @@ describe("user-invocable trigger phrases", () => {
       // one "phrase" and pass with zero real trigger phrases. A quote that
       // opens but never closes on the line is an unsupported style — throw
       // rather than scan text that YAML would parse differently.
+      // The other block indicators are unused here. Returned as-is they
+      // would become the whole "description", so the skill lists as an
+      // offender for the wrong reason. Throw with the real cause instead.
+      if (/^[|>][0-9+-]*$/.test(inline)) {
+        throw new Error(`unsupported description scalar style: ${inline}`);
+      }
       const quote = inline[0];
       if (quote === '"' || quote === "'") {
         if (inline.length < 2 || !inline.endsWith(quote)) {

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -909,3 +909,22 @@ describe("checks and balances", () => {
     expect(/\b5 rounds\b/.test(tiers)).toBe(true);
   });
 });
+
+describe("code-review direct invocation preserves separation", () => {
+  // code-review is the one methodology skill a user can invoke. The main
+  // session holds the history the skill forbids, so the standalone path must
+  // hand off rather than review in place. Without this, the separation that
+  // the frontmatter enforces for the pipeline has no counterpart on the path
+  // a natural-language phrase reaches.
+  const CODE_REVIEW = read(join(REPO_ROOT, "skills", "code-review", "SKILL.md"));
+
+  test("the skill states the direct-invocation path", () => {
+    expect(CODE_REVIEW).toContain("## When Invoked Directly");
+  });
+
+  test("the direct path dispatches instead of reviewing inline", () => {
+    const text = flat(CODE_REVIEW);
+    expect(text).toContain("Do not review inline");
+    expect(/Dispatch the\s+`code-reviewer` agent/.test(text)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

v0.33.0 gave `code-review` natural-language triggers and a standalone path that dispatches the `code-reviewer` agent instead of reviewing inline. Two docs surfaces stopped short of saying so, and nothing held the behavior in place.

Picked up from the non-blocking findings on #189.

## What changes

`docs/skills.md`'s per-skill `code-review` entry now names the dispatch behavior — previously it appeared only in the file's summary section, so a reader who jumped to the entry via anchor link missed it. `docs/architecture.md`'s paragraph explaining why `code-review` stays user-invocable now says what that standalone invocation actually does, which is the one way a directly-invoked methodology skill differs from an ordinary entry point.

`tests/protocol.test.ts` pins the contract, next to the checks-and-balances block it belongs to. The frontmatter enforces generator-evaluator separation for the pipeline; this is its counterpart on the path a natural-language phrase reaches, and it was prose a future edit could drop silently.

`tests/architecture.test.ts`'s `descriptionText` now throws on the unused YAML block indicators (`>`, `|-`, `>-`) rather than returning the indicator as the description text, which listed the skill as an offender for the wrong reason.

## Test plan

- [x] `bun test` — 1061 pass, 0 fail
- [x] Both new tripwires verified to trip: renaming the `## When Invoked Directly` heading fails the suite, and the file was restored clean afterward
- [x] `tsc --noEmit` clean on both changed test files
- [x] `version-bump-required.sh` agrees this is dev-only: `runtime_changed=false bumped=false` — lands with no bump and a plain conventional title

## Not in scope

Three findings from #189 are filed rather than fixed here, because they change distributed runtime files: #190 (`team-fix` can push to the default branch), #191 (`team-fix`'s guard is single-layer), #192 (trigger-test opt-out for hard-disabled skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)