### PR TITLE
v0.33.1 fix(skills): gate team-fix behind a feature branch before the first commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.33.0"
+    "version": "0.33.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-08-03
+
 ### Fixed
 
 - **`/team-fix` no longer commits and pushes a fix to your default branch.** The bug-fix pipeline had no branch or worktree step at all, and its Ship step authorized pushing from whatever branch you happened to be on — so running it from a clone sitting on `main` (the state Team's own conventions produce) committed the `test:` and `fix:` commits to `main` and pushed them, opening no PR at all. `/team-fix` now leads with a WORKTREE phase, mirroring `/team`: a documented shell block resolves the default branch and refuses it, a non-default branch is reused in place, and otherwise the run isolates into a `<id>` worktree. Isolation stays best-effort — a worktree that cannot be created (shallow clone, restrictive CI) degrades to a plain `<id>` branch — but the branch itself is not optional, and a run that cannot get off the default branch aborts before it writes anything. Ship re-asserts the gate before it pushes, so the commits stay local and recoverable rather than landing on a branch you cannot rewrite. Pinned by a tripwire that extracts the documented gate block and runs it against real repos, so the documented command and the tested command cannot drift. [`skills/team-fix/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md)
@@ -373,7 +375,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.33.1...HEAD
+[0.33.1]: https://github.com/bostonaholic/team/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/bostonaholic/team/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/bostonaholic/team/compare/v0.31.1...v0.32.0
 [0.31.1]: https://github.com/bostonaholic/team/compare/v0.31.0...v0.31.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/team-fix` no longer commits and pushes a fix to your default branch.** The bug-fix pipeline had no branch or worktree step at all, and its Ship step authorized pushing from whatever branch you happened to be on — so running it from a clone sitting on `main` (the state Team's own conventions produce) committed the `test:` and `fix:` commits to `main` and pushed them, opening no PR at all. `/team-fix` now leads with a WORKTREE phase, mirroring `/team`: a documented shell block resolves the default branch and refuses it, a non-default branch is reused in place, and otherwise the run isolates into a `<id>` worktree. Isolation stays best-effort — a worktree that cannot be created (shallow clone, restrictive CI) degrades to a plain `<id>` branch — but the branch itself is not optional, and a run that cannot get off the default branch aborts before it writes anything. Ship re-asserts the gate before it pushes, so the commits stay local and recoverable rather than landing on a branch you cannot rewrite. Pinned by a tripwire that extracts the documented gate block and runs it against real repos, so the documented command and the tested command cannot drift. [`skills/team-fix/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md)
+
 ## [0.33.0] - 2026-08-03
 
 ### Added

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -228,10 +228,15 @@ argument shape.
   ceremony.
 - **`$ARGUMENTS`:** `<ticket id, issue URL, or bug description>`.
 - **Phase:** Standalone fix flow (not a QRSPI phase). Runs the compressed
-  pipeline `REPRODUCE → RED → GREEN → VERIFY → SHIP`.
+  pipeline `WORKTREE → REPRODUCE → RED → GREEN → VERIFY → SHIP`.
 - **Key behaviors:** Loads `test-driven-bug-fix` for reproduce-first,
   red-green discipline: a failing test that reproduces the bug, then the
-  fix that turns it green.
+  fix that turns it green. The leading WORKTREE phase is the pipeline's one
+  hard gate: a documented branch-gate block resolves the default branch and
+  the fix never commits to it. A non-default branch is reused in place;
+  otherwise the run isolates into a `<id>` worktree, and a worktree that
+  cannot be created degrades to a plain `<id>` branch rather than to the
+  default branch. Ship re-asserts the gate before it pushes.
 
 ### eng-design-doc-review
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -50,7 +50,7 @@ Use `/team` (full QRSPI pipeline) when:
 ## Pipeline
 
 ```
-REPRODUCE → RED (failing test) → GREEN (minimal fix) → VERIFY → SHIP
+WORKTREE → REPRODUCE → RED (failing test) → GREEN (minimal fix) → VERIFY → SHIP
 ```
 
 No Question. No Research. No Design. No Structure. No Plan. No approval gate.
@@ -68,18 +68,90 @@ No Question. No Research. No Design. No Structure. No Plan. No approval gate.
    skip silently when no tracker mechanism exists. Never block the pipeline
    on a tracker update.
 3. **Derive `<id>`** the same way `/team` does (ticket-prefixed or
-   date-prefixed kebab slug). Create `docs/plans/<id>/`.
-4. Write a minimal `docs/plans/<id>/task.md` with the standard frontmatter
+   date-prefixed kebab slug).
+4. **Run the WORKTREE phase** (`## Worktree` below) before anything else
+   touches the working tree. It settles which branch the fix commits to, so
+   it must finish before the artifact directory is authored.
+5. **Create `docs/plans/<id>/`** inside the resolved worktree, and write a
+   minimal `docs/plans/<id>/task.md` with the standard frontmatter
    (`topic`, `date`, `phase: task`, `ticketId`) plus a brief description
    of the bug. The `topic` value is the kebab portion of `<id>` — i.e.
    `<id>` minus the `<TICKET>-` or `<YYYY-MM-DD>-` prefix. Never use the
    ticket id, the date, or a re-worded description as the topic.
    `ticketId` lives only on `task.md`. This is the single durable record
    for the fix and lets any `/team-*` command pick it up if interrupted.
-5. **Seed the TodoWrite ledger** with the bug-fix phases:
-   `Reproduce → Red (failing test) → Green (minimal fix) → Verify → Ship`.
-   Mark `Reproduce` as `in_progress`.
+6. **Seed the TodoWrite ledger** with the bug-fix phases:
+   `Worktree → Reproduce → Red (failing test) → Green (minimal fix) → Verify → Ship`.
+   Mark `Worktree` as `in_progress`.
    See `skills/progress-tracking/SKILL.md` for the per-step tracking convention agents follow within each phase.
+
+## Worktree
+
+This is the **leading** phase, and the one hard gate in the pipeline. A fix
+never commits to the default branch. Everything after this phase runs in the
+checkout this phase resolves.
+
+### Branch gate
+
+Run this block first. It prints `on-default` when HEAD is the repository's
+default branch, and `ok <branch>` otherwise:
+
+```sh
+# Branch gate — a fix never commits to the default branch.
+default="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)"
+default="${default#origin/}"
+if [ -z "$default" ]; then
+  # No origin/HEAD (no remote, or an unset remote head): fall back to whichever
+  # conventional default-branch name actually exists locally.
+  for candidate in main master; do
+    if git show-ref --verify --quiet "refs/heads/$candidate"; then
+      default="$candidate"; break
+    fi
+  done
+fi
+head="$(git rev-parse --abbrev-ref HEAD)"
+if [ -n "$default" ] && [ "$head" = "$default" ]; then
+  echo "on-default"
+else
+  echo "ok $head"
+fi
+```
+
+- **`ok <branch>`** — HEAD is already on a non-default branch. Reuse it in
+  place. Create no worktree and no new branch, and announce the reuse once:
+  "Continuing on branch `<branch>`." This is also the linked-worktree reuse
+  case in `skills/team-worktree/SKILL.md` → "Detect existing worktree".
+- **`on-default`** — isolate before the first commit, per **Isolate** below.
+
+### Isolate
+
+Create the home worktree on branch `<id>` off `origin/HEAD`, exactly as
+`/team`'s leading WORKTREE phase does. See the single-repo block in
+`skills/team-worktree/SKILL.md` → "Create the worktree(s)" for the procedure
+and `skills/worktree-isolation/SKILL.md` for the topology:
+
+```sh
+git fetch origin --quiet
+git worktree add .claude/worktrees/<id> -b <id> origin/HEAD
+```
+
+Then continue the fix inside that worktree.
+
+**Edge — branch `<id>` already exists** (re-invocation): reuse the worktree
+that holds it. Do not recreate either one.
+
+**Edge — worktree creation fails**, on a shallow clone, certain CI systems,
+or permissions. Isolation is best-effort; **the branch is not.** Report the
+failure loudly, then branch in place and keep going:
+
+```sh
+git switch -c <id>
+```
+
+Re-run the branch gate afterward. It must print `ok <id>`. If the run cannot
+get off the default branch at all, stop and report — that is the one
+condition that aborts before any work, because the alternative is committing
+a fix to the default branch.
 
 ## Execution
 
@@ -101,9 +173,12 @@ assertion failure, not a crash. Do not proceed to the fix until confirmed.
 1. Commit in two commits:
    - `test:` commit with the failing test
    - `fix:` commit with the minimal fix
-2. **Open a draft PR automatically — do not stop to ask.** If working on
-   a branch, push it and open the PR as a **draft** (`gh pr create
-   --draft`). If not on a branch, commit to the working branch.
+2. **Open a draft PR automatically — do not stop to ask.** The WORKTREE
+   phase already put the run on a non-default branch, so push that branch
+   and open the PR as a **draft** (`gh pr create --draft`). Re-assert the
+   branch gate first — `git rev-parse --abbrev-ref HEAD` must not name the
+   default branch. If it does, push nothing and report: the commits are
+   local and recoverable, a push to the default branch is not.
 3. **Ticket — link now, in-review when ready.** If `ticketId` is non-null in
    `task.md`'s frontmatter, apply the ticket-lifecycle rules in
    `skills/tracking-tickets/SKILL.md`: link the PR to the ticket through the

--- a/tests/team-fix-skill.test.ts
+++ b/tests/team-fix-skill.test.ts
@@ -1,0 +1,214 @@
+// tests/team-fix-skill.test.ts
+//
+// Fences the branch gate in the `team-fix` RUNTIME skill
+// (skills/team-fix/SKILL.md). Two layers, per docs/testing.md:
+//
+//   L2 tripwire  — the leading WORKTREE phase exists, precedes every commit,
+//                  points at the canonical worktree skills, and the Ship step
+//                  no longer permits committing wherever HEAD happens to sit.
+//   L3 snapshot  — the documented branch-gate shell block is EXTRACTED from
+//                  SKILL.md and run against hermetic temp repos, so the
+//                  documented command and the tested command cannot drift
+//                  (same technique as tests/worktree-detection.test.ts).
+//
+// Regression fixture for #190: `/team-fix` had no branch or worktree step at
+// all, and its Ship step read "If working on a branch, push it … If not on a
+// branch, commit to the working branch" — a session sitting on the default
+// branch IS on a branch, so the pipeline committed `test:` and `fix:` straight
+// to main and pushed, opening no PR.
+//
+// Every assertion is guarded so a not-yet-existing skill file yields a failed
+// expect(), never an uncaught ENOENT — the mechanical gate rejects crashes,
+// not clean assertion failures.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { read, squash } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+// team-fix is a RUNTIME skill — under skills/ (distributed), not .claude/.
+const SKILL = join(REPO_ROOT, "skills", "team-fix", "SKILL.md");
+
+// Defensive read: missing file → "" so content assertions FAIL (not throw).
+function body(): string {
+  return existsSync(SKILL) ? read(SKILL) : "";
+}
+
+// Slice between two headings, or "" when the start heading is absent —
+// content assertions against "" fail cleanly.
+function sliceBetween(startHeading: string, endHeading: string): string {
+  const text = body();
+  const start = text.indexOf(startHeading);
+  if (start < 0) return "";
+  const rest = text.slice(start).slice(startHeading.length);
+  const end = rest.indexOf(endHeading);
+  return end >= 0 ? rest.slice(0, end) : rest;
+}
+function worktreeSection(): string {
+  return sliceBetween("## Worktree", "## Execution");
+}
+function shipSection(): string {
+  return sliceBetween("## Ship", "## Aborting");
+}
+
+describe("team-fix: the leading WORKTREE phase exists", () => {
+  test("skill file lives under runtime skills/ (distributed)", () => {
+    expect(existsSync(SKILL)).toBe(true);
+  });
+
+  test("the pipeline diagram runs WORKTREE before REPRODUCE", () => {
+    const t = body();
+    const worktree = t.indexOf("WORKTREE");
+    const reproduce = t.indexOf("REPRODUCE");
+    expect(worktree).toBeGreaterThanOrEqual(0);
+    expect(reproduce).toBeGreaterThan(worktree);
+  });
+
+  test("the seeded ledger names Worktree as its first item", () => {
+    // The backticked list is a template the skill tells the model to emit.
+    expect(body()).toContain(
+      "`Worktree → Reproduce → Red (failing test) → Green (minimal fix) → Verify → Ship`",
+    );
+  });
+
+  test("a `## Worktree` section precedes `## Execution` and `## Ship`", () => {
+    const t = body();
+    const worktree = t.indexOf("## Worktree");
+    const execution = t.indexOf("## Execution");
+    const ship = t.indexOf("## Ship");
+    expect(worktree).toBeGreaterThanOrEqual(0);
+    expect(execution).toBeGreaterThan(worktree);
+    expect(ship).toBeGreaterThan(execution);
+  });
+
+  test("delegates the worktree procedure to the canonical skills", () => {
+    // File-path contracts: a rename of either target must fail the build.
+    const s = worktreeSection();
+    expect(s).toContain("skills/team-worktree/SKILL.md");
+    expect(s).toContain("skills/worktree-isolation/SKILL.md");
+  });
+
+  test("branches off origin/HEAD with the documented worktree-add form", () => {
+    const s = worktreeSection();
+    expect(s).toContain("git worktree add .claude/worktrees/<id> -b <id> origin/HEAD");
+  });
+
+  test("worktree failure falls back to a branch in place, never to the default branch", () => {
+    // Isolation is best-effort; the branch is not. The fallback must still
+    // switch off the default branch before anything is committed.
+    const s = worktreeSection();
+    expect(s).toContain("git switch -c <id>");
+  });
+});
+
+describe("team-fix: Ship no longer commits wherever HEAD sits", () => {
+  test("Ship pushes the feature branch and opens a draft PR", () => {
+    const s = shipSection();
+    expect(s).toContain("gh pr create --draft");
+  });
+
+  test("Ship re-asserts the branch gate before pushing", () => {
+    expect(shipSection()).toContain("git rev-parse --abbrev-ref HEAD");
+  });
+
+  test("the permissive fallback claim is gone from the whole skill", () => {
+    // Negative sweep on a forbidden claim (docs/testing.md): the old wording
+    // authorized committing to whatever branch HEAD was on, default included.
+    const t = squash(body());
+    expect(t.length).toBeGreaterThan(0); // guard: empty body must not pass vacuously
+    expect(t).not.toContain("commit to the working branch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// L3: run the documented branch-gate block against real temp repos.
+// ---------------------------------------------------------------------------
+
+// Pull the gate snippet out of the sh code block that resolves the default
+// branch (the one naming refs/remotes/origin/HEAD).
+function gateSnippet(): string {
+  const blocks = [...body().matchAll(/```sh\n([\s\S]*?)```/g)].map((m) => m[1]!);
+  const matches = blocks.filter((b) => b.includes("refs/remotes/origin/HEAD"));
+  expect(matches.length).toBe(1); // guard: exactly one documented gate block
+  return matches[0]!;
+}
+
+// The gate prints "on-default" when HEAD is the default branch and
+// "ok <branch>" otherwise. Run it with the repo as cwd.
+function runGate(repoPath: string): string {
+  const res = spawnSync("bash", ["-c", gateSnippet()], {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+  return res.stdout.trim();
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const res = spawnSync(
+    "git",
+    ["-c", "user.email=test@test", "-c", "user.name=test", ...args],
+    { cwd, encoding: "utf8" },
+  );
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  }
+  return res.stdout.trim();
+}
+
+let root: string;
+let originRepo: string; // bare "remote"
+let onDefault: string; // clone sitting on the default branch (the bug's state)
+let onFeature: string; // clone switched to a feature branch
+let noOrigin: string; // repo with no remote at all
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "team-fix-branch-gate-"));
+
+  // A bare origin whose HEAD points at `main`, so clones get origin/HEAD set.
+  originRepo = join(root, "origin.git");
+  mkdirSync(originRepo);
+  git(originRepo, "init", "--bare", "-b", "main");
+
+  const seed = join(root, "seed");
+  mkdirSync(seed);
+  git(seed, "init", "-b", "main");
+  git(seed, "commit", "--allow-empty", "-m", "init");
+  git(seed, "remote", "add", "origin", originRepo);
+  git(seed, "push", "-u", "origin", "main");
+
+  onDefault = join(root, "on-default");
+  git(root, "clone", originRepo, onDefault);
+
+  onFeature = join(root, "on-feature");
+  git(root, "clone", originRepo, onFeature);
+  git(onFeature, "switch", "-c", "190-team-fix-branch-gate");
+
+  // No remote: origin/HEAD is unresolvable, so the gate falls back to the
+  // main/master name check and must still refuse.
+  noOrigin = join(root, "no-origin");
+  mkdirSync(noOrigin);
+  git(noOrigin, "init", "-b", "main");
+  git(noOrigin, "commit", "--allow-empty", "-m", "init");
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("team-fix branch gate: executed against real repos", () => {
+  test("refuses a checkout sitting on the default branch (the #190 state)", () => {
+    expect(runGate(onDefault)).toBe("on-default");
+  });
+
+  test("allows a checkout on a feature branch", () => {
+    expect(runGate(onFeature)).toBe("ok 190-team-fix-branch-gate");
+  });
+
+  test("refuses main even with no origin (origin/HEAD unresolvable)", () => {
+    expect(runGate(noOrigin)).toBe("on-default");
+  });
+});


### PR DESCRIPTION
## Why

`/team-fix` never created a branch or a worktree — there was no such step anywhere in the skill. Its Ship step said "If working on a branch, push it and open the PR as a draft. If not on a branch, commit to the working branch," and a session sitting on the default branch *is* on a branch. So the pipeline committed its `test:` and `fix:` commits to the default branch and pushed them, and opened no PR at all — there was no feature branch to open one from.

Team's own convention (the root clone stays on its default branch; feature work happens in worktrees) makes that the *default* state, not an edge case. Branch protection masks it on repos that have it; most plugin users do not. v0.33.0 made `/team-fix` reachable from natural language, so the path no longer requires deliberately typing the slash command.

## What changes

`/team-fix` now leads with a **WORKTREE phase**, mirroring `/team`:

- A documented shell block resolves the repository's default branch and refuses it. A checkout already on a non-default branch is reused in place; otherwise the run isolates into an `<id>` worktree branched off `origin/HEAD`.
- **Isolation is best-effort; the branch is not.** A worktree that cannot be created (shallow clone, restrictive CI, permissions) degrades to a plain `<id>` branch rather than to the default branch. A run that cannot leave the default branch at all aborts before it writes anything — the one condition that stops the pipeline before work begins.
- Ship re-asserts the gate before pushing. If HEAD still names the default branch, nothing is pushed: local commits are recoverable, a push to the default branch is not.

The permissive Ship fallback is gone, and the seeded todo ledger and the pipeline diagram both name the new leading phase.

## Test plan

- `tests/team-fix-skill.test.ts` (new). The L2 half pins the phase ordering, the delegation to `skills/team-worktree/SKILL.md` and `skills/worktree-isolation/SKILL.md`, the `git switch -c` fallback, and the absence of the permissive claim. The L3 half **extracts the gate block from `SKILL.md` and runs it** against hermetic temp clones — one on the default branch, one on a feature branch, one with no origin at all — so the documented command and the tested command cannot drift.
- Verified the test fails before the fix (12 clean assertion failures, no crashes) and passes after.
- Mutation-checked both halves: removing the `main`/`master` fallback from the gate block reddens the no-origin case, and restoring the old permissive Ship sentence reddens the negative sweep.
- `bun test`: 1072 pass, 0 fail across 40 files.

Follow-up filed separately for the same class of hole in `/team-pr` and in `/team`'s worktree-creation fallback — neither refuses the default branch today.

Closes #190
