### PR TITLE
test: drop the unreachable scalar-style throw

### DIFF
--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -299,12 +299,6 @@ describe("user-invocable trigger phrases", () => {
       // one "phrase" and pass with zero real trigger phrases. A quote that
       // opens but never closes on the line is an unsupported style — throw
       // rather than scan text that YAML would parse differently.
-      // The other block indicators are unused here. Returned as-is they
-      // would become the whole "description", so the skill lists as an
-      // offender for the wrong reason. Throw with the real cause instead.
-      if (/^[|>][0-9+-]*$/.test(inline)) {
-        throw new Error(`unsupported description scalar style: ${inline}`);
-      }
       const quote = inline[0];
       if (quote === '"' || quote === "'") {
         if (inline.length < 2 || !inline.endsWith(quote)) {


### PR DESCRIPTION
## Why

#193 added a throw for the YAML block indicators `>`, `|-`, and `>-` in `descriptionText`. Nothing reaches it. Every skill's `description` uses either an inline scalar or bare `|`, and `descriptionText` is local to its `describe` block, so the branch is not unit-testable either. It shipped as dead code with no coverage.

The finding it came from (#189, review note 2) asked only for a clearer failure *message* in a case that does not occur — the pre-existing behavior already failed closed by listing the skill as an offender. That did not warrant shipped code, and promoting it to a fix went against the project's own YAGNI rule.

The insert also separated the quoted-scalar comment from the quoted-scalar code by five lines, leaving one comment blob that described two branches in reverse order.

## What changes

Six deletions in `tests/architecture.test.ts`. The comment re-pairs with the code it explains.

Behavior for an unsupported block indicator returns to what it was before v0.33.0: the skill lists as an offender and the assertion fails closed. Only the message is less pointed, which is the state the reviewer described as acceptable.

## Test plan

- [x] `bun test` — 1074 pass, 0 fail
- [x] `tsc --noEmit` clean on the changed file
- [x] `version-bump-required.sh`: `runtime_changed=false bumped=false` — dev-only, lands with no bump and a plain conventional title

🤖 Generated with [Claude Code](https://claude.com/claude-code)