### PR TITLE
v0.33.2 fix(hooks): stop the dangerous-command guard failing open

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.33.1"
+    "version": "0.33.2"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.33.1",
+      "version": "0.33.2",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.2] - 2026-08-04
+
 ### Fixed
 
 - **The dangerous-command guard was failing open — it detected destructive commands and let them run anyway.** `pre-bash-guard` emitted its `permissionDecision: "ask"` inside a payload missing `hookEventName`, which Claude Code's hook output schema requires. The harness rejected the whole payload as malformed and discarded the decision, so commands the guard matched — `rm -rf /`, `git push --force`, `git reset --hard`, `mkfs`, a fork bomb — executed with no prompt. The guard has been silently ineffective for every install, and its own test suite stayed green throughout, because the hook did emit the decision; only the envelope around it was invalid. The payload now names its event, so matched commands prompt as intended. Two checks pin it: the hook's tests assert the envelope on every guarded command rather than the decision alone, and a tripwire fails the build if any hook writes a `hookSpecificOutput` payload to stdout without naming its event. [`hooks/pre-bash-guard.mjs`](https://github.com/bostonaholic/team/blob/main/hooks/pre-bash-guard.mjs)
@@ -379,7 +381,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.33.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.33.2...HEAD
+[0.33.2]: https://github.com/bostonaholic/team/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/bostonaholic/team/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/bostonaholic/team/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/bostonaholic/team/compare/v0.31.1...v0.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The dangerous-command guard was failing open — it detected destructive commands and let them run anyway.** `pre-bash-guard` emitted its `permissionDecision: "ask"` inside a payload missing `hookEventName`, which Claude Code's hook output schema requires. The harness rejected the whole payload as malformed and discarded the decision, so commands the guard matched — `rm -rf /`, `git push --force`, `git reset --hard`, `mkfs`, a fork bomb — executed with no prompt. The guard has been silently ineffective for every install, and its own test suite stayed green throughout, because the hook did emit the decision; only the envelope around it was invalid. The payload now names its event, so matched commands prompt as intended. Two checks pin it: the hook's tests assert the envelope on every guarded command rather than the decision alone, and a tripwire fails the build if any hook writes a `hookSpecificOutput` payload to stdout without naming its event. [`hooks/pre-bash-guard.mjs`](https://github.com/bostonaholic/team/blob/main/hooks/pre-bash-guard.mjs)
+
 ## [0.33.1] - 2026-08-03
 
 ### Fixed

--- a/hooks/pre-bash-guard.mjs
+++ b/hooks/pre-bash-guard.mjs
@@ -79,6 +79,10 @@ async function readStdin() {
 function askUser(reason) {
   const payload = JSON.stringify({
     hookSpecificOutput: {
+      // Required by Claude Code's hook output schema. Without it the whole
+      // payload fails validation and the decision is DISCARDED — the guard
+      // fails open and the dangerous command runs unprompted.
+      hookEventName: "PreToolUse",
       permissionDecision: "ask",
     },
     systemMessage: `⚠️ Dangerous command detected: ${reason}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/tests/hook-output-schema.test.ts
+++ b/tests/hook-output-schema.test.ts
@@ -1,0 +1,56 @@
+// tests/hook-output-schema.test.ts
+//
+// L2 tripwire: a hook that writes a `hookSpecificOutput` payload to STDOUT
+// must name its event in `hookEventName`.
+//
+// Claude Code schema-validates hook JSON on stdout. A payload missing
+// `hookEventName` fails validation and the decision inside it is DISCARDED —
+// so a PreToolUse guard that meant to block silently fails open. The failure
+// is invisible to a test that only asserts the decision field, because the
+// hook still emits it; only the harness rejects the envelope.
+//
+// Payloads written to STDERR are not schema-validated (that path carries
+// context/warnings, not decisions), so those hooks are out of scope here.
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const HOOK_DIRS = [
+  join(process.cwd(), "hooks"),
+  join(process.cwd(), ".claude", "hooks"),
+];
+
+function hookFiles(): string[] {
+  return HOOK_DIRS.flatMap((dir) => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return [];
+    }
+    return entries.filter((f) => f.endsWith(".mjs")).map((f) => join(dir, f));
+  });
+}
+
+describe("hook output schema: stdout payloads name their event", () => {
+  const files = hookFiles();
+
+  test("there are hook files to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf-8");
+    const writesPayloadToStdout =
+      source.includes("hookSpecificOutput") &&
+      source.includes("process.stdout.write");
+
+    test.if(writesPayloadToStdout)(
+      `${file.replace(process.cwd() + "/", "")} sets hookEventName`,
+      () => {
+        expect(source).toContain("hookEventName");
+      },
+    );
+  }
+});

--- a/tests/pre-bash-guard.test.ts
+++ b/tests/pre-bash-guard.test.ts
@@ -27,35 +27,57 @@ function decision(command: string): string | undefined {
   return JSON.parse(out)?.hookSpecificOutput?.permissionDecision;
 }
 
-describe("pre-bash-guard: teardown deletion commands surface as ask", () => {
-  // Both the bare form and the skill's `git -C "$PRIMARY_ROOT"` anchored
-  // form must match — the skills only ever emit the anchored form.
-  const guarded = [
-    `git branch -D feature/x`,
-    `git -C "$PRIMARY_ROOT" branch -D -- "$BRANCH"`,
-    `git push origin --delete stale-branch`,
-    `git -C "$PRIMARY_ROOT" push origin --delete -- "$BRANCH"`,
-    `git worktree remove ../wt --force`,
-    `git -C "$PRIMARY_ROOT" worktree remove --force "$WORKTREE_PATH"`,
-    // The skills' current sinks expand with :? — the guard must match
-    // the exact form the fenced blocks instruct the agent to emit.
-    `git -C "\${PRIMARY_ROOT:?}" branch -D -- "\${BRANCH:?}"`,
-    `git -C "\${PRIMARY_ROOT:?}" push origin --delete -- "\${BRANCH:?}"`,
-    `git -C "\${PRIMARY_ROOT:?}" worktree remove --force "\${WORKTREE_PATH:?}"`,
-    `rm -rf "\${PRIMARY_ROOT:?}/docs/plans/\${ID:?}"`,
-    `rm -rf "$WORKTREE_PATH"`,
-    // A quoted repo path with a space must not void the -C group —
-    // \S+ alone cannot span it, and a failed optional group is a MISS.
-    `git -C "/Users/x/My Repo" branch -D -- b`,
-    `git -C '/Users/x/My Repo' branch -D -- b`,
-    `git -C "/Users/x/My Repo" push origin --delete -- b`,
-    `git -C "/Users/x/My Repo" worktree remove --force /p`,
-    // `--delete --force` is the long spelling of -D.
-    `git branch --delete --force old-branch`,
-    `git -C /repo branch --delete --force b`,
-    `git branch --force --delete old-branch`,
-  ];
+// Both the bare form and the skill's `git -C "$PRIMARY_ROOT"` anchored
+// form must match — the skills only ever emit the anchored form.
+const guarded = [
+  `git branch -D feature/x`,
+  `git -C "$PRIMARY_ROOT" branch -D -- "$BRANCH"`,
+  `git push origin --delete stale-branch`,
+  `git -C "$PRIMARY_ROOT" push origin --delete -- "$BRANCH"`,
+  `git worktree remove ../wt --force`,
+  `git -C "$PRIMARY_ROOT" worktree remove --force "$WORKTREE_PATH"`,
+  // The skills' current sinks expand with :? — the guard must match
+  // the exact form the fenced blocks instruct the agent to emit.
+  `git -C "\${PRIMARY_ROOT:?}" branch -D -- "\${BRANCH:?}"`,
+  `git -C "\${PRIMARY_ROOT:?}" push origin --delete -- "\${BRANCH:?}"`,
+  `git -C "\${PRIMARY_ROOT:?}" worktree remove --force "\${WORKTREE_PATH:?}"`,
+  `rm -rf "\${PRIMARY_ROOT:?}/docs/plans/\${ID:?}"`,
+  `rm -rf "$WORKTREE_PATH"`,
+  // A quoted repo path with a space must not void the -C group —
+  // \S+ alone cannot span it, and a failed optional group is a MISS.
+  `git -C "/Users/x/My Repo" branch -D -- b`,
+  `git -C '/Users/x/My Repo' branch -D -- b`,
+  `git -C "/Users/x/My Repo" push origin --delete -- b`,
+  `git -C "/Users/x/My Repo" worktree remove --force /p`,
+  // `--delete --force` is the long spelling of -D.
+  `git branch --delete --force old-branch`,
+  `git -C /repo branch --delete --force b`,
+  `git branch --force --delete old-branch`,
+];
 
+describe("pre-bash-guard: the emitted payload passes Claude Code's schema", () => {
+  // Regression pin. The guard shipped without `hookEventName`, which the
+  // hook output schema requires. Claude Code rejected the whole payload
+  // ("hookSpecificOutput is missing required field") and DISCARDED the
+  // decision, so a matched dangerous command ran with no prompt — the guard
+  // failed open while every assertion below on permissionDecision stayed
+  // green. Asserting the decision alone cannot catch that; the envelope has
+  // to be checked too.
+  test("carries hookEventName so the decision is not discarded", () => {
+    const payload = JSON.parse(hookOutput("rm -rf /"));
+    expect(payload.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+  });
+
+  // Every guarded command must emit a valid envelope, not just the one above.
+  test("carries hookEventName on every guarded command", () => {
+    for (const command of guarded) {
+      const payload = JSON.parse(hookOutput(command));
+      expect(payload.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    }
+  });
+});
+
+describe("pre-bash-guard: teardown deletion commands surface as ask", () => {
   for (const command of guarded) {
     test(`asks on: ${command}`, () => {
       expect(decision(command)).toBe("ask");


### PR DESCRIPTION
## Why

`pre-bash-guard` has been inert for every install.

It emitted its `permissionDecision: "ask"` inside a `hookSpecificOutput` object with no `hookEventName`. Claude Code's hook output schema requires that field, so it rejected the payload wholesale and **discarded the decision inside it**:

```
Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"
The hook's output was: {"hookSpecificOutput":{"permissionDecision":"ask"},"systemMessage":"⚠️ Dangerous command detected: Blocked: recursive forced deletion of root or home directory"}
```

Every command the guard matches — `rm -rf /`, `git push --force`, `git reset --hard`, `mkfs`, `dd of=/dev/disk`, the fork bomb, and the `git branch -D` / `git worktree remove --force` sinks the teardown skills emit — ran with **no prompt**. The guard detected them, tried to gate them, and was overruled by its own malformed envelope. 20 such rejections appear in local transcripts over a four-day window.

The failure was silent in both directions: the user saw no prompt, and CI saw no red.

## What changes

One field, plus the comment that explains why it is load-bearing:

```js
hookSpecificOutput: {
  // Required by Claude Code's hook output schema. Without it the whole
  // payload fails validation and the decision is DISCARDED — the guard
  // fails open and the dangerous command runs unprompted.
  hookEventName: "PreToolUse",
  permissionDecision: "ask",
},
```

**The test design is the other half of the fix.** `tests/pre-bash-guard.test.ts` asserted `hookSpecificOutput.permissionDecision` and nothing else. The hook genuinely emitted that field — only the envelope around it was invalid, and no assertion looked at the envelope. Asserting a decision the harness never accepts proves nothing, so:

- The guarded cases now check the envelope on **every** command, not a sample (L3).
- A new tripwire, `tests/hook-output-schema.test.ts`, fails the build if any hook under `hooks/` or `.claude/hooks/` writes a `hookSpecificOutput` payload to **stdout** without setting `hookEventName` (L2). The regression pin proves this hook is right today; the tripwire covers the next hook someone adds.

**Scope.** The other four hooks (`pre-compact-anchor`, `session-start-recover`, `post-write-validate`, `check-registry-sync`) write their payloads to **stderr**, which Claude Code does not schema-validate — that path carries context and warnings, not decisions. They were never affected, and the tripwire skips them rather than holding them to a contract that does not apply.

## Test plan

- [ ] `bun test` — 1078 pass, 4 skip, 0 fail across 41 files.
- [ ] **Regression pin proven to catch the bug.** Reverting the one-line fix turns `tests/pre-bash-guard.test.ts` red (2 fail); restoring it turns it green. A regression test that does not fail on the bug is worthless, so this was verified, not assumed.
- [ ] **Tripwire proven to catch the class.** Same revert turns `tests/hook-output-schema.test.ts` red (1 fail), green on restore. Its 4 skips are the stderr hooks, correctly out of scope.
- [ ] Hook driven directly with the documented stdin contract; emitted payload now carries `"hookEventName": "PreToolUse"` alongside the decision.
- [ ] Schema confirmed against the running Claude Code binary (2.1.221), not from memory: `hookSpecificOutput is missing required field "hookEventName"`, and `permissionDecisionReason` documented as "Reason for the permission decision (PreToolUse only)".

**Not verified:** that a real session now shows the permission prompt end-to-end. That needs a live session with the rebuilt plugin loaded and a deliberately dangerous command, which I did not run. The evidence here is that the payload matches the schema the harness enforces and that the rejection error is structural, not that the prompt was observed.

## Notes

- No version bump, and the changelog entry sits under `## [Unreleased]` with a plain conventional title — per [docs/versioning.md](docs/versioning.md), `version-bump` cuts both at land time. **The `version-bump-check` CI job is expected to be red until then**, since `hooks/` is runtime and the version is unchanged. Severity reads as a patch, but the level is `version-bump`'s call.
- `permissionDecisionReason` is the documented home for the reason on a PreToolUse decision; this PR leaves the reason in `systemMessage` where it already was, to keep the fix minimal. Worth a follow-up.
- Not yet tracked on the project board — this needs an issue (a bug, so `P0`) to link.
