### PR TITLE
v0.34.1 fix(skills): run /pr-cleanup after a merge that landed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.34.0"
+    "version": "0.34.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/shipit` no longer stops after a merge to tell you to go clean up.** Its Completion step ended with a handoff line — `Next: run /pr-cleanup` — so every landed PR left the default branch unsynced and the merged branch alive until someone typed a second command. Nothing in that step is a decision: the merge already happened, and `/pr-cleanup`'s Mode A gates itself on merged-PR verification (identity plus containment) before it deletes anything. `/shipit` now runs cleanup on a merge that landed. Two limits hold: a run that stopped at a failing check, the CI timeout, or a branch-protection rejection merged nothing and reaches no cleanup, and only Mode A is reachable this way — Mode B (closed / abandoned) force-deletes remote branches and worktrees on the strength of an explicit abandon request, so it stays user-triggered. [`skills/shipit/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)
+
 ## [0.34.0] - 2026-08-04
 
 ### Added
 
 - **The prose canon now carries mechanical ban rules, two named modes, and a pre-return self-lint.** `writing-prose` gains a delete-list of marketing adjectives, modal hedges, and filler — words you delete, never replace. It adds fifteen substitution rows, extends two in place, and adds a stacked-auxiliaries rule, an American-spelling bullet, and an empty-closer smell row. Every consumer that already points at the skill inherits them with no edit of its own. A "Two modes" section names the split the skill only implied: strict governs instruction text, STE-flavored governs descriptive prose. The modes differ in exactly three deltas (sentence cap, form, conditional mood) and share every ban list. A nine-item "Self-lint" checklist runs before any governed text is final. The delete-list idea, the mode split, and the self-lint structure come from the ["cure for AI slop" writing kit](https://github.com/woosal1337/blog/tree/main/videos/ep01-the-cure-for-ai-slop). The kit carries the MIT License, © 2026 Ege Çelebi. The skill restates the ideas in its own words. The `design-author` agent now preloads the full skill. The nine consumer blurbs across eight skills collapse into one canonical variant that names STE-flavored mode and points at the self-lint. A bundled scorer, `skills/writing-prose/ste-lint.mjs`, reports violations of the mechanical rules per 100 words. It runs on Node, gates nothing, and exists to compare prose against a recorded baseline. It works the same on Claude Code and Codex, because the documented command names the skill's own directory instead of a host-only variable. [`skills/writing-prose/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md), [`agents/design-author.md`](https://github.com/bostonaholic/team/blob/main/agents/design-author.md)
-
 ## [0.33.2] - 2026-08-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.1] - 2026-08-05
+
 ### Fixed
 
 - **`/shipit` no longer stops after a merge to tell you to go clean up.** Its Completion step ended with a handoff line — `Next: run /pr-cleanup` — so every landed PR left the default branch unsynced and the merged branch alive until someone typed a second command. Nothing in that step is a decision: the merge already happened, and `/pr-cleanup`'s Mode A gates itself on merged-PR verification (identity plus containment) before it deletes anything. `/shipit` now runs cleanup on a merge that landed. Two limits hold: a run that stopped at a failing check, the CI timeout, or a branch-protection rejection merged nothing and reaches no cleanup, and only Mode A is reachable this way — Mode B (closed / abandoned) force-deletes remote branches and worktrees on the strength of an explicit abandon request, so it stays user-triggered. [`skills/shipit/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)
@@ -390,7 +392,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.34.1...HEAD
+[0.34.1]: https://github.com/bostonaholic/team/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/bostonaholic/team/compare/v0.33.2...v0.34.0
 [0.33.2]: https://github.com/bostonaholic/team/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/bostonaholic/team/compare/v0.33.0...v0.33.1

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -284,7 +284,12 @@ QRSPI phase: a self-contained action a user runs on demand.
   ("ship it", "land the PR", `/shipit`) and never on a PR that is merely
   approved or green. The pre-merge confirmation stands unless the caller
   already carries the user's authorization (`--yes`). The CI-green wait
-  also gates the merge mechanically.
+  also gates the merge mechanically. On a merge that **landed**, it runs
+  `/pr-cleanup` rather than recommending it — resyncing the default branch
+  and deleting the merged branch carry no decision, and Mode A gates itself
+  on merged-PR verification. A run that stopped short (failing check, CI
+  timeout, branch protection) merged nothing and reaches no cleanup, and
+  `/pr-cleanup` Mode B (closed / abandoned) stays user-triggered.
 
 ### pr-open-comments
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/shipit/SKILL.md
+++ b/skills/shipit/SKILL.md
@@ -183,8 +183,23 @@ Report the merge result. If it stopped short, report the reason: a failing
 check, a timeout, or branch protection. If the project publishes a release on
 merge, that runs asynchronously after the merge. Point the operator at
 `gh run watch`, or `gh run list`, so they can observe it rather than assume it
-is already done. End with the handoff: `Next: run /pr-cleanup to resync the
-default branch and delete the merged branch.`
+is already done.
+
+**On a merge that landed, run `/pr-cleanup`. Do not stop to recommend it.**
+The merge already happened. A resync of the default branch and a delete of
+the merged branch carry no decision. `/pr-cleanup` **Mode A** verifies the
+merged PR first, by identity and by containment, before it deletes anything.
+A handoff line here costs the operator a second command for no decision.
+
+Two limits hold, and both are load-bearing:
+
+- **Only a landed merge reaches cleanup.** A run that stopped at a failing
+  check, at the CI timeout, or at a branch-protection rejection merged
+  nothing. No merged branch exists to remove. `/pr-cleanup` must not run.
+- **Only Mode A is reachable this way.** Mode B (closed / abandoned) deletes
+  remote branches, worktrees, and planning scratch by force. An explicit
+  abandon request is its only gate. It stays user-triggered, and this
+  chaining never reaches it.
 
 `shipit` touches no tracker or board — it stays generic. If the PR links a
 ticket (e.g. `Closes #<n>`), the tracker closes that ticket when the merge

--- a/tests/shipit-skill.test.ts
+++ b/tests/shipit-skill.test.ts
@@ -130,8 +130,39 @@ describe("shipit skill: push, wait for CI, merge", () => {
   });
 });
 
-describe("shipit skill: post-merge handoff", () => {
-  test("the Completion report hands off to /pr-cleanup", () => {
+describe("shipit skill: post-merge cleanup", () => {
+  test("the Completion report names /pr-cleanup", () => {
     expect(completionSection()).toContain("/pr-cleanup");
+  });
+
+  // A merged PR leaves the default branch unsynced and the branch undeleted.
+  // Nothing about that is a decision — the merge already happened, and
+  // /pr-cleanup's Mode A gates itself on merged-PR verification. Telling the
+  // operator to go run it re-inserts a human gate the pipeline is designed
+  // not to have, and because this is the RUNTIME skill, every caller inherits
+  // the stop. Completion must run cleanup, not recommend it.
+  test("Completion instructs running /pr-cleanup, not recommending it", () => {
+    const c = flat(completionSection());
+    // Negative sweep: the passive framings. A meaning-preserving rewrite never
+    // reintroduces a phrasing the contract bans, so this cannot pin wording.
+    expect(/end with the handoff/i.test(c)).toBe(false);
+    expect(/Next:\s*run \/pr-cleanup/i.test(c)).toBe(false);
+  });
+
+  // NOT asserted here: that cleanup is *conditioned* on the merge succeeding.
+  // That is prose semantics, and the only L2 shape available for it is a
+  // proximity span between "/pr-cleanup" and "merged" — which docs/testing.md
+  // bans outright ("Proximity spans test if an author put two ideas in one
+  // sentence. That is a style question, not a contract"). It also failed to
+  // discriminate: the span matched the buggy text too, so it would have
+  // passed while the bug shipped. Conditional-on-success belongs at L5/L6,
+  // where a model can judge whether the instruction lands.
+
+  // Mode B force-deletes remote branches and worktrees on the strength of an
+  // explicit abandon request. It must never be reachable by automatic chaining.
+  test("only Mode A is auto-reachable; Mode B stays user-triggered", () => {
+    const c = flat(completionSection());
+    expect(/Mode A/.test(c)).toBe(true);
+    expect(/Mode B/.test(c)).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

`/shipit` stopped after a successful merge to tell the operator to go run `/pr-cleanup` themselves:

> `End with the handoff: `Next: run /pr-cleanup to resync the default branch and delete the merged branch.``

Nothing in that step is a decision. The merge already happened, and `/pr-cleanup`'s **Mode A** gates itself on merged-PR verification — identity (same-repo `headRepositoryOwner`, matching `headRefOid`) plus containment (the merge commit is an ancestor of `origin/<default>`) — before it deletes anything. So every landed PR left the default branch unsynced and the merged branch alive until a human typed a second command.

This lives in the **runtime** skill, so every caller inherits the stop, not just this repo. It re-inserts a human gate into exactly the kind of mechanical step [the ethos](https://github.com/bostonaholic/team/blob/main/docs/ethos.md) says should run autonomously.

**The existing test did not catch it** because it asserted only that the Completion section *contains the string* `/pr-cleanup` — which the passive handoff satisfied. The contract that mattered was unpinned.

## What changes

`## Completion` now instructs running cleanup on a merge that landed, with two limits stated in the skill because both are load-bearing:

- **Only a landed merge reaches cleanup.** A run that stopped at a failing check, the CI timeout, or a branch-protection rejection merged nothing — there is no merged branch to tear down.
- **Only Mode A is reachable this way.** Mode B (closed / abandoned) force-deletes remote branches, worktrees, and planning scratch on the strength of an explicit abandon request. It stays user-triggered and is never reached by chaining.

This does **not** make `shipit` project-aware. It stays generic and still does no versioning, changelog, or release work; `/pr-cleanup` ships in the same plugin.

`docs/skills.md`'s `shipit` entry records the new behavior.

## Test plan

- [x] `bun test` — **1084 pass, 4 skip, 0 fail** across 41 files (1088 tests). Re-run on the rebased branch; the count rose from 1080 because v0.34.0 added tests to `main`.
- [x] **Red before green, verified.** Restoring `skills/shipit/SKILL.md` to its `origin/main` state reddens exactly 2 tests, both `expect(received).toBe(expected)` — clean assertion failures, zero crashes, satisfying `/team-fix`'s mechanical Red→Green gate.
- [x] **Mutation-checked.** Fixed skill: 15 pass / 0 fail. Append the old `End with the handoff: Next: run /pr-cleanup` line back: 14 pass / **1 fail**, and the failure is the negative sweep specifically. Restore: 15 pass / 0 fail, tree clean. The sweep bites rather than passing vacuously.
- [x] **The old assertion proven non-discriminating.** Against the buggy skill, `the Completion report names /pr-cleanup` (the `toContain` check) **passes**, while both new assertions fail. Against the fixed skill all three pass. The old framing could not separate the two states — which is exactly how the bug shipped under a green test.

**Deliberately not asserted:** that cleanup is *conditioned* on the merge succeeding. The only L2 shape available is a proximity span between `/pr-cleanup` and `merged`, which [docs/testing.md](https://github.com/bostonaholic/team/blob/main/docs/testing.md) bans outright ("Proximity spans test if an author put two ideas in one sentence. That is a style question, not a contract"). I wrote that assertion first, found it **passed against the buggy text too**, and removed it — it would have shipped as false confidence. Conditional-on-success is prose semantics and belongs at L5/L6.

**Not verified:** that a live `/shipit` run now chains into cleanup end-to-end. This is a prose contract in a skill body; the deterministic layer can pin what the instruction says, not that a model follows it. An eval would be the real check.

## Notes

- Runtime change (`skills/`), so `version-bump` assigns the version at land time and the changelog bullet sits under `## [Unreleased]`. **`version-bump-check` is expected red until then.**
- A stopgap rule was added to `AGENTS.md` (`## Learned rules`) before this fix existed, and is **not** in this PR — it is still uncommitted on `main`. Now that the skill enforces the behavior and a tripwire pins it, that rule is redundant prose in an always-loaded router file and should be dropped rather than landed.
- Not on the project board — this needs a `P0` bug issue to link.

