### PR TITLE
v0.35.1 fix(plugin): point the homepage link at the docs site

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.35.0"
+    "version": "0.35.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Matthew Boston",
     "url": "https://matthewboston.com"
   },
-  "homepage": "https://github.com/bostonaholic/team",
+  "homepage": "https://team.bostonaholic.dev",
   "license": "MIT",
   "hooks": {
     "PostToolUse": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -14,6 +14,6 @@
     "shortDescription": "Autonomous feature pipeline: question, research, design, plan, implement, PR.",
     "developerName": "Matthew Boston",
     "category": "engineering",
-    "websiteURL": "https://github.com/bostonaholic/team"
+    "websiteURL": "https://team.bostonaholic.dev"
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-08-05
+
 ### Changed
 
 - **The plugin's homepage link now points at the documentation site.** Both host manifests advertised `https://github.com/bostonaholic/team`, so a user who followed the homepage link from a plugin listing landed on the source tree and had to find the docs from there. Team publishes a documentation site at [https://team.bostonaholic.dev](https://team.bostonaholic.dev), and that is what the link now opens: `homepage` in the Claude Code manifest, and `interface.websiteURL` in the Codex manifest. The repository is still one click away from the site. [`.claude-plugin/plugin.json`](https://github.com/bostonaholic/team/blob/main/.claude-plugin/plugin.json), [`.codex-plugin/plugin.json`](https://github.com/bostonaholic/team/blob/main/.codex-plugin/plugin.json)
@@ -402,7 +404,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.35.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.35.1...HEAD
+[0.35.1]: https://github.com/bostonaholic/team/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/bostonaholic/team/compare/v0.34.1...v0.35.0
 [0.34.1]: https://github.com/bostonaholic/team/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/bostonaholic/team/compare/v0.33.2...v0.34.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The plugin's homepage link now points at the documentation site.** Both host manifests advertised `https://github.com/bostonaholic/team`, so a user who followed the homepage link from a plugin listing landed on the source tree and had to find the docs from there. Team publishes a documentation site at [https://team.bostonaholic.dev](https://team.bostonaholic.dev), and that is what the link now opens: `homepage` in the Claude Code manifest, and `interface.websiteURL` in the Codex manifest. The repository is still one click away from the site. [`.claude-plugin/plugin.json`](https://github.com/bostonaholic/team/blob/main/.claude-plugin/plugin.json), [`.codex-plugin/plugin.json`](https://github.com/bostonaholic/team/blob/main/.codex-plugin/plugin.json)
+
 ## [0.35.0] - 2026-08-05
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Points both host manifests' homepage link at `https://team.bostonaholic.dev` instead of `https://github.com/bostonaholic/team`.

The documentation site already exists and is already canonical everywhere else — `docs/CNAME`, `docs/_config.yml`'s `url`, the repository's own GitHub homepage field, and `.claude-plugin/marketplace.json`'s author URL all point at it. The two plugin manifests were the holdouts, so a user following the homepage link from a plugin listing landed on the source tree and had to find the docs from there.

`.agents/plugins/marketplace.json` carries no URL field at all, so it needs no change. The repository stays one click away from the site.

## Changes

- `.claude-plugin/plugin.json` — `homepage` (Claude Code reads this)
- `.codex-plugin/plugin.json` — `interface.websiteURL` (Codex reads this)
- `CHANGELOG.md` — a `### Changed` bullet, cut into `## [0.35.1]`
- `chore(version): 0.35.1` — patch, per [docs/versioning.md](https://github.com/bostonaholic/team/blob/main/docs/versioning.md) (`feat:` earns minor; this is `fix:`)

Rebased onto `main` after #202 landed as v0.35.0, so the changelog cut sits above that section rather than conflicting with it.

## Test plan

- [x] **`bun test` is green on the branch** — `1052 pass / 4 skip / 0 fail`, 1056 tests across 40 files. Matches the post-#202 `main` baseline exactly; this diff adds and removes no tests.
- [x] **The runtime-vs-dev bump gate passes** — `.github/scripts/version-bump-required.sh` reports `OK: runtime_changed=true bumped=true (0.35.0 -> 0.35.1)`. It classifies this as runtime because a *non-version* line changed in a manifest dir, which is the condition that requires a bump.
- [x] **Land-time consistency assertion holds** — the `## [0.35.1] - 2026-08-05` section exists, `[0.35.1]:` has a footer compare link, and `[Unreleased]` compares from `v0.35.1...HEAD`.
- [x] **All five version strings agree at `0.35.1`** — `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (×2), `.codex-plugin/plugin.json`. Zero stale occurrences of `0.35.0`.
- [x] **Release notes will not be empty** — `release-on-merge.yml` hard-fails on blank notes, so its exact `awk` extraction was run against the cut section: 2 non-blank lines.
- [x] **All four manifests still parse** — `JSON.parse` succeeds on both marketplace files and both plugin files.
- [x] **The target URL is live** — `curl -sSL -o /dev/null -w '%{http_code}'` on `https://team.bostonaholic.dev` returns `200`. GitHub Pages reports `cname: team.bostonaholic.dev`, `https_enforced: true`, certificate approved.
- [x] **The changelog entry passes the absolute-link tripwire** — all link targets in the new bullet are absolute `https://` URLs, as `tests/changelog-links.test.ts` requires for text cut into release notes.
- [x] **No stale GitHub-URL homepage fields remain** — a repo-wide grep for `homepage`/`websiteURL` returns only the two changed fields plus `docs/` site config, which correctly carries the domain.
- [ ] **Link rendering in a live plugin listing** — *not verified here, needs a human.* Whether Claude Code's and Codex's plugin UIs surface `homepage`/`websiteURL` as a clickable link can only be seen in an installed session. Only the value moved; the field names are unchanged, so the shape is unaltered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8fSn726SS9JSFs2PuXnDf