### PR TITLE
fix(docs): blink the home-page cursor immediately

### DIFF
--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -373,7 +373,7 @@ body.home main>h1::after {
   content: "█";
   margin-left: 2px;
   color: var(--muted);
-  animation: blink 1.1s steps(1) 1.6s infinite;
+  animation: blink 1.1s steps(1) infinite;
 }
 
 /* --- focus-visible (sharp outline) --------------------------------------- */

--- a/tests/regression-blink-cursor-delay.test.ts
+++ b/tests/regression-blink-cursor-delay.test.ts
@@ -1,0 +1,85 @@
+// tests/regression-blink-cursor-delay.test.ts
+//
+// L2 tripwire (free, deterministic): the home-page block cursor must start
+// blinking on the first frame. Regression pin for the defect where
+// `body.home main>h1::after` carried `animation: blink 1.1s steps(1) 1.6s
+// infinite` — in the `animation` shorthand the SECOND <time> is the delay, so
+// the cursor sat solid for 1.6s (first visible blink at 1.6s + 0.55s) and the
+// page read as unresponsive on load.
+//
+// Asserted as a numeric constant that bounds behavior, per docs/testing.md
+// ("A tripwire asserts a contract, never a wording"). The rule's colors,
+// spacing, and glyph are free to change; a non-zero delay is not.
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { read } from "./helpers/text";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SITE_CSS = join(REPO_ROOT, "docs/assets/css/site.css");
+
+// Declaration block of the first rule whose selector list contains `selector`,
+// i.e. the text between that rule's `{` and its closing `}`. Returns null when
+// no such rule exists, so a renamed selector fails loudly rather than passing
+// on an empty string.
+function ruleBody(css: string, selector: string): string | null {
+  const at = css.indexOf(selector);
+  if (at === -1) return null;
+  const open = css.indexOf("{", at);
+  const close = css.indexOf("}", open);
+  if (open === -1 || close === -1) return null;
+  return css.slice(open + 1, close);
+}
+
+// Value of the `animation` shorthand in a declaration block.
+function animationShorthand(body: string): string | null {
+  const m = /(?:^|;)\s*animation\s*:\s*([^;}]+)/.exec(body);
+  return m ? m[1]!.trim() : null;
+}
+
+// Ordered <time> values in a shorthand, in seconds. Per the CSS Animations
+// spec the first is `animation-duration` and the second is `animation-delay`.
+function times(shorthand: string): number[] {
+  const out: number[] = [];
+  const re = /(-?\d*\.?\d+)(ms|s)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(shorthand)) !== null) {
+    const n = Number(m[1]);
+    out.push(m[2] === "ms" ? n / 1000 : n);
+  }
+  return out;
+}
+
+// `animation-delay` per the shorthand's positional rule: the second <time>,
+// defaulting to 0 when the shorthand names only a duration.
+function delaySeconds(shorthand: string): number {
+  return times(shorthand)[1] ?? 0;
+}
+
+describe("docs home page: the block cursor blinks immediately", () => {
+  const css = read(SITE_CSS);
+  const body = ruleBody(css, "body.home main>h1::after");
+
+  test("the cursor rule exists and animates", () => {
+    expect(body).not.toBeNull();
+    expect(animationShorthand(body!)).not.toBeNull();
+  });
+
+  test("the cursor animation has no start delay", () => {
+    const shorthand = animationShorthand(body!)!;
+    // Surfaces the offending shorthand in the failure message.
+    expect({ shorthand, delaySeconds: delaySeconds(shorthand) }).toEqual({
+      shorthand,
+      delaySeconds: 0,
+    });
+  });
+
+  // Guards the guard: prove the positional parse actually reads the SECOND
+  // time as the delay, so a future refactor cannot turn this into a no-op.
+  test("the shorthand parser reads the second <time> as the delay", () => {
+    expect(delaySeconds("blink 1.1s steps(1) 1.6s infinite")).toBe(1.6);
+    expect(delaySeconds("blink 1.1s steps(1) infinite")).toBe(0);
+    expect(delaySeconds("blink 1.1s steps(1) 0s infinite")).toBe(0);
+    expect(delaySeconds("blink 1100ms steps(1) 250ms infinite")).toBe(0.25);
+  });
+});


### PR DESCRIPTION
## Problem

On the docs home page the block cursor after the `Team` `<h1>` sits solid for over two seconds before its first blink. It should blink from the moment the page loads.

Reproduced against the live site — `getComputedStyle(h1, '::after')` reported:

```
animationName:  blink      animationDuration: 1.1s
animationDelay: 1.6s   <-- the defect
```

The `blink` keyframes hold `opacity: 1` for the first 49% of each cycle, so the first visible blink landed at `1.6s + 0.55s = 2.15s`.

## Root cause

`docs/assets/css/site.css`, the `body.home main>h1::after` rule:

```css
animation: blink 1.1s steps(1) 1.6s infinite;
```

In the `animation` shorthand the first `<time>` is the duration and the **second is the delay**. That trailing `1.6s` is an `animation-delay` — plausibly intended as a typewriter beat, but it reads as an unresponsive page.

## Fix

```diff
-  animation: blink 1.1s steps(1) 1.6s infinite;
+  animation: blink 1.1s steps(1) infinite;
```

One line. The `prefers-reduced-motion` override (`animation: none`) is untouched.

## Test

`tests/regression-blink-cursor-delay.test.ts` — an L2 tripwire that parses the `animation` shorthand positionally and asserts the delay is `0`. It asserts a numeric constant that bounds behavior, per `docs/testing.md`; the rule's colors, spacing, and glyph stay free to change. Includes a guard-the-guard case proving the parser really reads the second `<time>`, so a later refactor cannot turn it into a no-op.

Committed test-first: `test:` (red) then `fix:` (green).

## Test plan

- [x] New test fails with an assertion failure before the fix (`delaySeconds: 1.6` vs `0`), not a crash
- [x] New test passes after the fix
- [x] Full free suite green — 1087 pass, 0 fail
- [x] `bun run typecheck` clean
- [x] Browser verification against the real stylesheet: computed `animation-delay` is `0s`, cursor cycles from frame zero (dark 0–400ms, lit 600–1000ms, dark 1200–1400ms)
- [x] `version-bump-required.sh` → `runtime_changed=false bumped=false` (docs-only, no bump)

## Versioning

Docs-site CSS only — no change to `agents/`, `skills/`, `hooks/`, or the manifest dirs. Dev-only per the runtime-vs-development split, so **no version bump and no changelog cut**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DA4L4nfcePb9zodpCrjXtB