### PR TITLE
docs: add pipeline and skill-graph diagrams, and render mermaid on the site

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -46,5 +46,9 @@
     <main class="container">{{ content }}</main>
     {% include footer.html %}
     <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
+    {%- comment -%} Renders ```mermaid fenced blocks client-side (Jekyll ships
+    them as plain code). The script no-ops on a page with no diagram, so the
+    mermaid bundle is fetched only where one exists. {%- endcomment -%}
+    <script src="{{ '/assets/js/mermaid.js' | relative_url }}" defer></script>
   </body>
 </html>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,70 @@ phase needs the prior phase's artifact on disk.
 WORKTREE → QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → IMPLEMENT → PR → SHIPPED
 ```
 
+### End-to-end flow
+
+The autonomous run ends at the draft PR. Everything past it is the human
+checkpoint: the human marks the PR ready, and the watch and resolution
+utilities carry it to a merge. Those utilities are standalone slash
+commands, not QRSPI phases — the orchestrator points at them and stops.
+Solid arrows are automatic. Dotted arrows need an explicit human
+instruction.
+
+```mermaid
+flowchart TD
+    DESC["Feature description<br/><i>ticket · issue URL<br/>free-form text</i>"] --> WT
+
+    subgraph AUTO["Autonomous run · no mid-run human gates"]
+        direction TB
+        WT["1 · WORKTREE<br/>orchestrator-emit<br/><i>branch + docs/plans/id/</i>"] --> Q
+        Q["2 · QUESTION<br/>questioner<br/><i>task.md · questions.md</i>"] --> R
+        R["3 · RESEARCH<br/>file-finder + researcher<br/>in parallel<br/><i>isolated: questions.md only</i>"] --> D
+        D["4 · DESIGN<br/>design-author<br/><i>design.md</i>"] --> DR
+        DR{"REVIEW gate<br/>read-only Explore subagent<br/><i>design-review-n.md</i>"}
+        DR -->|"REQUEST CHANGES<br/>redraft at revision n+1"| D
+        DR -->|"APPROVE or COMMENT"| S
+        S["5 · STRUCTURE<br/>structure-planner<br/><i>structure.md · no gate</i>"] --> P
+        P["6 · PLAN<br/>planner<br/><i>plan.md · no gate</i>"] --> TA
+        TA["7 · IMPLEMENT · test-first<br/>test-architect writes failing tests"] --> MG
+        MG{"MECHANICAL gate<br/>do all tests fail<br/>on assertions?"}
+        MG -->|"no · crashes or errors"| TA
+        MG -->|"yes"| IMP
+        IMP["implementer<br/><i>one vertical slice per commit</i>"] --> REV
+        REV["5 reviewers in parallel<br/>code · security · docs<br/>ux · verifier"] --> AG
+        AG{"AGGREGATE gate<br/>any Blocking<br/>or Major finding?"}
+        AG -->|"yes · fix the typed<br/>failure class"| IMP
+        AG -->|"clean"| PRP
+        PRP["8 · PR<br/>changelog · push<br/>gh pr create --draft"]
+    end
+
+    DR -.->|"revision cap 5"| HALT["Terminal halt<br/><i>no PR · the human takes over</i>"]
+    AG -.->|"round cap 5"| HALT
+
+    PRP --> DRAFT
+
+    subgraph HUMAN["Human checkpoint · PR review and resolution watching"]
+        direction TB
+        DRAFT["Draft PR open<br/><i>worktree stays in place</i>"]
+        DRAFT -.->|"/pr-verify · read-only"| PV["Test-plan verification<br/><i>READY · NEEDS ATTENTION · NOT READY</i>"]
+        DRAFT -.->|"the PR is ready for review"| WATCH
+        WATCH["/pr-watch-as-author<br/>undraft · baseline<br/>poll ~31 min for up to 24 h"] --> NEW
+        NEW{"poll result"}
+        NEW -->|"new feedback"| TRIAGE
+        TRIAGE["/pr-open-comments<br/>verify each unresolved thread<br/>against current code<br/>rate confidence"] --> CONF
+        CONF{"above 90% and<br/>passes every hard rule?"}
+        CONF -->|"yes"| APPLY["Apply · push · reply · resolve"]
+        CONF -->|"no"| PUNCH["Numbered punch list<br/><i>presents and stops for the user</i>"]
+        APPLY --> WATCH
+        PUNCH -.->|"user picks actions"| WATCH
+        NEW -->|"timeout · close<br/>repeated poll failures"| STOP["Watch stops<br/><i>reports and exits</i>"]
+        RW["Reviewer's own session<br/>/pr-watch-as-reviewer<br/><i>polls until their threads<br/>resolve, then approves once</i>"] -.-> NEW
+        NEW -->|"approved"| HANDOFF["Hands off to /shipit<br/><i>the watch never runs it</i>"]
+        HANDOFF -.->|"explicit ship intent"| SHIP
+        SHIP["/shipit<br/>push · wait for CI · squash-merge"] --> CLEANA["/pr-cleanup Mode A<br/>remove worktree<br/>resync default · delete branch"]
+        DRAFT -.->|"explicit abandon intent"| CLEANB["/pr-cleanup Mode B<br/>close the PR · delete every trace"]
+    end
+```
+
 ### Phase 1: Worktree
 
 **Action:** orchestrator-emit (the leading phase) **Predecessor:** none.
@@ -552,6 +616,136 @@ methodology that is also a user command.)
 
 For the full per-skill reference (all 53 skills, their arguments,
 consumers, and behaviors), see [skills.md](skills.md).
+
+### Skill interaction graph
+
+Every edge below is a reference one skill body makes to another skill —
+either loading it as methodology or handing off to it as the next action.
+Two things are deliberately left out. `progress-tracking` is referenced by
+nearly every multi-step skill, so drawing those ~20 edges would bury the
+rest of the graph. And a skill reached only through an agent's `skills:`
+frontmatter (`finding-files`, `researching-codebases`, `slicing-work`,
+`planning-implementation`, `implementing-slices`, `refactoring-to-patterns`,
+`product-thinking`) has no skill-to-skill edge to draw — the
+skill ↔ agent ↔ phase table in [skills.md](skills.md#skill--agent--phase)
+is the authority for those.
+
+```mermaid
+flowchart TB
+    subgraph ENTRY["Entry points · QRSPI phases"]
+        direction TB
+        TEAM["team"]
+        TQ["team-question"]
+        TR["team-research"]
+        TD["team-design"]
+        TS["team-structure"]
+        TP["team-plan"]
+        TI["team-implement"]
+        TPR["team-pr"]
+        TW["team-worktree"]
+        TF["team-fix"]
+        EDR["eng-design-doc-review"]
+    end
+
+    subgraph UTIL["Standalone utilities · post-PR and backlog"]
+        direction TB
+        WA["pr-watch-as-author"]
+        WR["pr-watch-as-reviewer"]
+        POC["pr-open-comments"]
+        SHIP["shipit"]
+        PCL["pr-cleanup"]
+        PV["pr-verify"]
+        GB["groom-backlog"]
+    end
+
+    subgraph PROTO["Protocol · artifacts and state"]
+        direction TB
+        QRSPI["qrspi-workflow"]
+        AFM["artifact-frontmatter"]
+        WI["worktree-isolation"]
+        TT["tracking-tickets"]
+    end
+
+    subgraph AUTHOR["Authoring · design and prose"]
+        direction TB
+        AD["authoring-designs"]
+        PRD["product-requirements-doc"]
+        DI["decomposing-intent"]
+        TDD["technical-design-doc"]
+        DD["documenting-decisions"]
+        WP["writing-prose"]
+        CL["changelog"]
+        GC["git-commit"]
+        ST["systems-thinking"]
+    end
+
+    subgraph REVIEW["Review · verdicts and standards"]
+        direction TB
+        CR["code-review"]
+        CC["conventional-comments"]
+        RST["review-severity-tiers"]
+        RS["reviewing-security"]
+        RD["reviewing-documentation"]
+        ES["engineering-standards"]
+        SP["solid-principles"]
+        VUX["verifying-ux"]
+        RQC["running-quality-checks"]
+        NA["nested-agents"]
+    end
+
+    subgraph TESTS["Testing and debugging"]
+        direction TB
+        TFD["test-first-development"]
+        TSTY["test-style"]
+        TDBF["test-driven-bug-fix"]
+        SD["systematic-debugging"]
+    end
+
+    TEAM --> TW & TPR & QRSPI & AFM & RST & CL & TT & WI & EDR
+    TQ --> DI & PRD & QRSPI
+    TD --> EDR
+    TI --> RST & TPR
+    TPR --> CL & GC & TT & VUX & WI
+    TW --> QRSPI & WI
+    TF --> TW & TDBF & SD & TT & WI
+    EDR --> TEAM & WP
+
+    TPR -.->|"points at, does not run"| WA
+    WA --> POC & TT
+    WA -.->|"hands off on approval"| SHIP
+    WR --> POC
+    SHIP -->|"on a merge that landed"| PCL
+    PV --> NA & RQC
+    WI --> PCL & TW
+
+    QRSPI --> AFM & RST & TEAM & WI
+    AFM --> QRSPI & PRD & WI
+    DI --> AFM & PRD
+    AD --> AFM & PRD & ST & WP
+    ST --> CR
+    CR --> CC & ES & RST & RS & SP & TSTY & WP
+    ES --> CC & SP
+    TSTY --> CR & TFD
+    TFD --> TSTY
+    TDBF --> SD
+    CL --> WP
+    GC --> WP
+    DD --> WP
+    PRD --> WP
+    TDD --> WP
+    RD --> WP
+    WP --> RD
+```
+
+Reading the graph: `team` is the hub for the whole run, `writing-prose` is
+the sink every authoring skill drains into, and `code-review` is the hub of
+the review cluster. The one true cycle is `writing-prose ↔
+reviewing-documentation` — the bar for prose Team writes is the same bar it
+holds other prose to. Four nodes are drawn with no edges at all:
+`team-research`, `team-structure`, and `team-plan` reference nothing but
+`progress-tracking` (their methodology reaches them through the dispatched
+agent's frontmatter), and `groom-backlog` is a user action on the tracker,
+upstream of any pipeline run.
 
 ### Design guidelines
 

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -320,6 +320,40 @@ pre code {
   padding: 0;
 }
 
+/* --- mermaid diagrams ----------------------------------------------------- */
+/* assets/js/mermaid.js swaps each ```mermaid block for one of these figures.
+   Until it does — and if it never does, because the CDN is blocked — the block
+   stays on the page as a plain <pre>, styled above. */
+.mermaid-figure {
+  margin: 1em 0;
+  padding: 1rem;
+  overflow-x: auto;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+}
+
+/* A graph too wide for the 800px prose column breaks out of it and centers on
+   the viewport, so more is visible before the reader scrolls sideways. Both the
+   class and --diagram-width (the diagram's natural width) are set by mermaid.js
+   after render: a diagram that already fits the column never breaks out, and
+   one that does grows only as far as it actually needs. */
+.mermaid-figure.is-wide {
+  --breakout: min(
+    96vw,
+    1600px,
+    calc(var(--diagram-width, 1600px) + 2rem + 2px)
+  );
+
+  width: var(--breakout);
+  margin-left: calc((100% - var(--breakout)) / 2);
+}
+
+/* Diagrams render at natural size (see useMaxWidth in mermaid.js) and the
+   figure scrolls, so labels stay legible on a narrow screen. */
+.mermaid-figure svg {
+  height: auto;
+}
+
 /* --- tables (thin borders, header tint, no zebra) ------------------------ */
 table {
   width: 100%;

--- a/docs/assets/js/mermaid.js
+++ b/docs/assets/js/mermaid.js
@@ -1,0 +1,175 @@
+(function () {
+  "use strict";
+
+  // Pinned: a mermaid release can never silently change how the docs render.
+  var MERMAID_URL =
+    "https://cdn.jsdelivr.net/npm/mermaid@11.16.1/dist/mermaid.esm.min.mjs";
+
+  // kramdown emits `<pre><code class="language-mermaid">` for a fenced
+  // ```mermaid block. The second selector covers the rouge-wrapped shape
+  // (`div.language-mermaid > div.highlight > pre > code`) in case a future
+  // highlighter config produces it — the two shapes never both match.
+  var SELECTOR = "pre > code.language-mermaid, .language-mermaid pre > code";
+
+  // The whole site is monospace (body font-family in site.css). Diagram labels
+  // follow, or they read as a foreign element on the page.
+  var FONT =
+    'ui-monospace, SFMono-Regular, Menlo, Monaco, "Courier New", monospace';
+
+  var diagrams = [];
+  var mermaid = null;
+  var pass = 0;
+
+  function cssVar(name, fallback) {
+    var value = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    return value || fallback;
+  }
+
+  // Diagrams are themed from the site's own custom properties rather than a
+  // built-in mermaid theme, so light/dark stay in step with everything else.
+  function themeVariables() {
+    var bg = cssVar("--bg", "#fff");
+    var fg = cssVar("--fg", "#111");
+    var fill = cssVar("--code-bg", "rgba(0, 0, 0, 0.04)");
+    var border = cssVar("--muted", "#5a5a5a");
+    return {
+      background: bg,
+      primaryColor: fill,
+      secondaryColor: fill,
+      tertiaryColor: bg,
+      primaryTextColor: fg,
+      secondaryTextColor: fg,
+      tertiaryTextColor: fg,
+      primaryBorderColor: fg,
+      secondaryBorderColor: fg,
+      tertiaryBorderColor: border,
+      nodeBorder: fg,
+      mainBkg: fill,
+      lineColor: fg,
+      textColor: fg,
+      titleColor: fg,
+      clusterBkg: bg,
+      clusterBorder: border,
+      edgeLabelBackground: bg,
+      fontFamily: FONT,
+      fontSize: "13px"
+    };
+  }
+
+  function collect() {
+    var codes = document.querySelectorAll(SELECTOR);
+    var found = [];
+    for (var i = 0; i < codes.length; i++) {
+      found.push({
+        // textContent decodes the HTML-escaped `<br/>` and `<i>` tags in the
+        // fenced source back to the markup mermaid expects in node labels.
+        source: codes[i].textContent,
+        pre: codes[i].parentNode,
+        figure: null
+      });
+    }
+    return found;
+  }
+
+  function mount() {
+    diagrams.forEach(function (diagram) {
+      var figure = document.createElement("figure");
+      figure.className = "mermaid-figure";
+      diagram.pre.parentNode.replaceChild(figure, diagram.pre);
+      diagram.figure = figure;
+    });
+  }
+
+  // Only a graph too wide for the prose column earns the breakout, and it grows
+  // no wider than it needs; see .mermaid-figure.is-wide in site.css. The class
+  // comes off before measuring, so the decision is made against the column
+  // width and a re-render can never flip a borderline diagram back and forth.
+  function fit(figure) {
+    var width = figure.querySelector("svg").getBoundingClientRect().width;
+    figure.style.setProperty("--diagram-width", Math.ceil(width) + "px");
+    figure.classList.remove("is-wide");
+    if (width > figure.clientWidth) {
+      figure.classList.add("is-wide");
+    }
+  }
+
+  function render() {
+    if (!mermaid) {
+      return;
+    }
+    // A re-render (theme switch) needs fresh ids: mermaid keys internal state
+    // off them, so reusing an id from the previous pass collides.
+    pass++;
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: "base",
+      themeVariables: themeVariables(),
+      // useMaxWidth: false keeps each SVG at its natural size — scaling a graph
+      // this large down to a phone's width makes the labels unreadable, so the
+      // figure scrolls instead. Straight edges and tight spacing suit the
+      // terminal aesthetic and keep the tall graphs from stretching further.
+      flowchart: {
+        htmlLabels: true,
+        useMaxWidth: false,
+        curve: "linear",
+        nodeSpacing: 40,
+        rankSpacing: 45
+      },
+      fontFamily: FONT
+    });
+    diagrams.forEach(function (diagram, index) {
+      mermaid
+        .render("mermaid-" + pass + "-" + index, diagram.source)
+        .then(function (result) {
+          diagram.figure.innerHTML = result.svg;
+          fit(diagram.figure);
+        })
+        .catch(function (error) {
+          // Fail loud but local: restore the source rather than leave an empty
+          // box where a diagram should be.
+          diagram.figure.innerHTML = "";
+          diagram.figure.appendChild(diagram.pre);
+          console.error("mermaid: diagram " + index + " failed to render", error);
+        });
+    });
+  }
+
+  // The toggle sets data-theme for a forced mode and removes it for "system";
+  // an attributeFilter observer sees both. The media listener covers a system
+  // mode change while no theme is forced.
+  function watchTheme() {
+    new MutationObserver(render).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"]
+    });
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", render);
+  }
+
+  function init() {
+    diagrams = collect();
+    if (diagrams.length === 0) {
+      // No diagrams on this page: never pull ~1 MB of mermaid over the wire.
+      return;
+    }
+    import(MERMAID_URL)
+      .then(function (module) {
+        mermaid = module.default;
+        // Swap the markup only once mermaid is in hand, so a blocked CDN or an
+        // offline reader keeps the diagrams readable as fenced source.
+        mount();
+        render();
+        watchTheme();
+      })
+      .catch(function (error) {
+        console.error("mermaid: failed to load " + MERMAID_URL, error);
+      });
+  }
+
+  // The script tag uses `defer`, so the document is fully parsed before this
+  // runs and every fenced block already exists. No readiness guard needed.
+  init();
+})();

--- a/tests/docs-mermaid-rendering.test.ts
+++ b/tests/docs-mermaid-rendering.test.ts
@@ -1,0 +1,126 @@
+// tests/docs-mermaid-rendering.test.ts
+//
+// L2 tripwire (free, deterministic): the docs site renders its ```mermaid
+// fenced blocks client-side, and that only works while four separate files
+// agree. Jekyll ships a mermaid fence as a plain <pre><code>, so nothing here
+// fails visibly in a build — a broken contract shows up only as a code block
+// where a diagram should be, on a page nobody reruns locally.
+//
+// Per docs/testing.md ("A tripwire asserts a contract, never a wording") these
+// assert the machine-read seams only: the script the layout loads, the selector
+// and class names the JS and CSS share, the custom property they hand across,
+// and the exact CDN version pin. Comments, palette, and spacing are free.
+//
+// Defensive reads: a missing file → "" so assertions FAIL cleanly rather than
+// throwing ENOENT (the mechanical gate rejects crashes).
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+const DOCS = join(REPO_ROOT, "docs");
+const LAYOUT = join(DOCS, "_layouts", "default.html");
+const RENDERER = join(DOCS, "assets", "js", "mermaid.js");
+const SITE_CSS = join(DOCS, "assets", "css", "site.css");
+
+function readIf(path: string): string {
+  return existsSync(path) ? read(path) : "";
+}
+
+// Every ```mermaid fence body across the docs' markdown pages.
+function mermaidFences(): { page: string; body: string }[] {
+  const out: { page: string; body: string }[] = [];
+  for (const entry of readdirSync(DOCS)) {
+    if (!entry.endsWith(".md")) continue;
+    const text = read(join(DOCS, entry));
+    for (const match of text.matchAll(/```mermaid\n([\s\S]*?)```/g)) {
+      out.push({ page: entry, body: match[1]! });
+    }
+  }
+  return out;
+}
+
+describe("docs site: the mermaid renderer is wired into the layout", () => {
+  const layout = readIf(LAYOUT);
+
+  test("every page loads the renderer", () => {
+    expect(layout).toContain("assets/js/mermaid.js");
+  });
+
+  test("the renderer exists", () => {
+    expect(existsSync(RENDERER)).toBe(true);
+  });
+});
+
+describe("docs site: the renderer and the stylesheet agree", () => {
+  const renderer = readIf(RENDERER);
+  const css = readIf(SITE_CSS);
+
+  // The JS creates the figure with this class and the CSS styles it. Renaming
+  // one alone leaves diagrams unstyled, which no build step notices.
+  test("the figure class the JS sets is styled", () => {
+    expect(renderer).toContain('figure.className = "mermaid-figure"');
+    expect(css).toContain(".mermaid-figure");
+  });
+
+  // The breakout for a diagram wider than the prose column: the JS decides,
+  // the CSS applies. Both halves must name the same class.
+  test("the breakout class the JS toggles is styled", () => {
+    expect(renderer).toMatch(/classList\.(add|remove|toggle)\("is-wide"/);
+    expect(css).toContain(".mermaid-figure.is-wide");
+  });
+
+  // The measured natural width crosses from JS to CSS through this property.
+  test("the custom property the JS sets is consumed by the CSS", () => {
+    expect(renderer).toContain('"--diagram-width"');
+    expect(css).toContain("var(--diagram-width");
+  });
+
+  // Jekyll emits `<pre><code class="language-mermaid">`. A selector that stops
+  // matching that shape silently renders nothing.
+  test("the renderer targets the markup Jekyll emits", () => {
+    expect(renderer).toContain("code.language-mermaid");
+  });
+});
+
+describe("docs site: the mermaid dependency is pinned", () => {
+  const renderer = readIf(RENDERER);
+
+  // An exact version keeps a mermaid release from changing how the docs render
+  // without a commit here. A floating tag would.
+  test("the CDN URL carries an exact version", () => {
+    expect(renderer).toMatch(/mermaid@\d+\.\d+\.\d+\//);
+  });
+
+  test("the CDN URL floats no tag", () => {
+    expect(renderer).not.toMatch(/mermaid@(latest|next|\d+(\.\d+)?)\//);
+  });
+});
+
+describe("docs site: every mermaid fence declares a diagram type", () => {
+  // The renderer feeds a fence body straight to mermaid, which throws on a
+  // body whose first directive it does not recognize — and that failure is
+  // only visible in a browser. Catch a typo'd or empty fence here instead.
+  const TYPES =
+    /^(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(-v2)?|erDiagram|journey|gantt|pie|quadrantChart|requirementDiagram|gitGraph|mindmap|timeline|zenuml|sankey(-beta)?|xychart-beta|block-beta|packet-beta|architecture-beta|kanban|radar|treemap)\b/;
+
+  const fences = mermaidFences();
+
+  test("the docs carry at least one diagram", () => {
+    expect(fences.length).toBeGreaterThan(0);
+  });
+
+  test.each(fences.map((fence, index) => [`${fence.page} #${index}`, fence]))(
+    "%s opens with a mermaid diagram type",
+    (_label, fence) => {
+      const first = (fence as { body: string }).body
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length > 0 && !line.startsWith("%%"));
+      expect(first ?? "").toMatch(TYPES);
+    }
+  );
+});


### PR DESCRIPTION
## Why

The architecture doc explained the pipeline and the skill relationships in prose and tables. Two shapes read poorly that way: the path a change takes from a feature description to a merge, and which skills reach which other skills. Both are graphs.

Separately, the site could not render a diagram at all. Jekyll ships a fenced `mermaid` block as a plain code block, so the three diagrams already living in `docs/testing.md` have always displayed as raw source to every reader of the published site.

## What

**Two diagrams in `docs/architecture.md`.**

- **End-to-end flow**, in section 3. The autonomous run with every gate as a decision node — the design review loop, the mechanical test gate, the aggregate review loop, and the two round caps converging on a terminal halt — then the human checkpoint past the draft PR: undraft, the bounded watch loop, comment triage with its confidence rule, the hand-off that stops short of landing, the merge, and teardown. Solid arrows are automatic; dotted arrows need an explicit human instruction, which is where the boundary between the autonomous middle and the human's checkpoint actually falls.
- **Skill interaction graph**, in section 6. Every edge is a reference one skill body makes to another, extracted from all 53 `SKILL.md` files rather than recalled. `progress-tracking`'s inbound edges and the agent-frontmatter-only skills are omitted, and the prose says so and points at the authoritative table.

**Client-side rendering for the whole site.** A renderer swaps each fenced block for a figure and draws it, themed from the site's own CSS custom properties so diagrams track light and dark with everything else. It fetches mermaid only on a page that has a diagram, pins an exact version so a mermaid release cannot change how the docs render without a commit here, and leaves the fence as readable source if the fetch fails. A diagram wider than the prose column breaks out of it and centers on the viewport, grown only as far as it needs — scaling these graphs down to the column makes their labels unreadable. `docs/testing.md`'s three diagrams now render as a side effect.

**A tripwire for the wiring.** Rendering depends on four files agreeing, and nothing in a Jekyll build fails when they stop: a broken seam shows up only as a code block where a diagram should be. `tests/docs-mermaid-rendering.test.ts` pins the machine-read seams — the script the layout loads, the class and selector names the JS and CSS share, the property they hand across, the version pin, and that every fence opens with a diagram type mermaid recognizes.

No version bump and no changelog entry: `docs/` is a development concern, not the distributed plugin.

## Test plan

- [x] `bun test` — 1220 pass, 0 fail, 44 files.
- [x] Both new diagrams parse under mermaid 11.16.1, the pinned version.
- [x] Built the site locally and drove it in Chromium: both new diagrams render (30 nodes / 35 edges / 3 clusters, and 45 / 73 / 6), and `docs/testing.md`'s three render where they previously showed as source.
- [x] Theme toggle re-renders correctly through system → light → dark → system: identical widths each pass, exactly one SVG per diagram, no duplicates or orphaned source blocks.
- [x] Fetch-failure fallback exercised for real by pointing the URL at a 404: every fence stays on the page as readable source, with no empty figures.
- [x] No page-level horizontal overflow introduced at 1700px or 390px. Mobile pages do overflow, but a diagram-free page overflows more (wide tables) — pre-existing, and left alone.
- [x] Each new tripwire verified to fail on a real break: renaming the breakout class in the CSS alone, floating the version pin, typo-ing a fence's diagram type, and dropping the script tag each turn the suite red; restoring returns it to green.

## Review notes

- This adds the site's first third-party runtime dependency (jsdelivr, pinned exact). The alternative is vendoring ~3 MB of `mermaid.min.js`; hosting from the CDN was chosen deliberately.
- `docs/.ruby-version` pins Ruby 3.3.6, which is not installed on this machine. The local site build used 3.4.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
