### PR TITLE
v0.38.0 feat(skills): give the changelog skill a baseline-discovery procedure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.37.0"
+    "version": "0.38.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The changelog skill now finds its own baseline, and running it twice no longer writes the same entry twice.** It knew which commits to keep but not where to start counting: "scan commits since the last changelog entry" left the starting point to be guessed, and a project whose releases are not git-tagged had nothing to resolve. The skill now reads the most recent versioned heading out of `CHANGELOG.md`, resolves that version to a commit by tag *or*, when no tag exists, by matching the version string inside the release commit's subject — matching the string rather than a fixed prefix, so a version-prefixed squash merge and a `chore(release):` commit both resolve. A commit too ambiguous to classify from its subject is now read from its diff instead of guessed. Two gaps close alongside it: the skill reads the existing `[Unreleased]` section before writing and skips anything already covered there, so a second run over an unchanged branch writes nothing; and a filter pass that keeps no commit now says so and leaves the file untouched, rather than treating an empty result as something to pad. [`skills/changelog/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/changelog/SKILL.md)
+
 ## [0.37.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-08-09
+
 ### Changed
 
 - **The changelog skill now finds its own baseline, and running it twice no longer writes the same entry twice.** It knew which commits to keep but not where to start counting: "scan commits since the last changelog entry" left the starting point to be guessed, and a project whose releases are not git-tagged had nothing to resolve. The skill now reads the most recent versioned heading out of `CHANGELOG.md`, resolves that version to a commit by tag *or*, when no tag exists, by matching the version string inside the release commit's subject — matching the string rather than a fixed prefix, so a version-prefixed squash merge and a `chore(release):` commit both resolve. A commit too ambiguous to classify from its subject is now read from its diff instead of guessed. Two gaps close alongside it: the skill reads the existing `[Unreleased]` section before writing and skips anything already covered there, so a second run over an unchanged branch writes nothing; and a filter pass that keeps no commit now says so and leaves the file untouched, rather than treating an empty result as something to pad. [`skills/changelog/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/changelog/SKILL.md)
@@ -426,7 +428,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.37.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.38.0...HEAD
+[0.38.0]: https://github.com/bostonaholic/team/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/bostonaholic/team/compare/v0.36.1...v0.37.0
 [0.36.1]: https://github.com/bostonaholic/team/compare/v0.36.0...v0.36.1
 [0.36.0]: https://github.com/bostonaholic/team/compare/v0.35.1...v0.36.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -95,6 +95,50 @@ what they can now do, what changed, what was fixed.
 The bad entries describe implementation details. They tell developers what
 changed in the code, not users what changed in their experience.
 
+## Finding the Baseline
+
+Before any commit is classified, find the **baseline** — the point in history
+the last release was cut from. Every commit after it is a candidate.
+
+1. **Read `CHANGELOG.md` and find the most recent *versioned* heading.** That
+   is the first `## [X.Y.Z] - YYYY-MM-DD` below `## [Unreleased]`. Its version
+   is the baseline version.
+
+2. **Resolve that version to a commit.** Try the tag first:
+
+   ```bash
+   git rev-parse -q --verify "v<X.Y.Z>^{commit}" \
+     || git rev-parse -q --verify "<X.Y.Z>^{commit}"
+   ```
+
+   The `^{commit}` suffix matters. An annotated tag resolves to the tag object
+   without it, not to the commit the tag points at.
+
+   **A project that ships without tags is normal, not an error.** When neither
+   name resolves, find the release commit by its subject. The version string is
+   in that subject whatever the project's convention:
+
+   ```bash
+   git log --oneline --grep="<X.Y.Z>" -1
+   ```
+
+   Release subjects differ by project — `v0.37.0 feat(scope): …` for a
+   version-prefixed squash merge, `chore(release): 0.37.0` elsewhere. Match on
+   the version string. Never assume a fixed prefix.
+
+3. **List the candidates:**
+
+   ```bash
+   git log --oneline <baseline>..HEAD
+   ```
+
+4. **Read any commit you cannot classify from its subject.** `git show --stat
+   <hash>` gives the blast radius, `git show <hash>` the change itself. Classify
+   an ambiguous commit from its diff. Do not guess from the subject.
+
+If `CHANGELOG.md` holds no versioned heading yet, the first release is not cut.
+The baseline is then the root commit, and every commit is a candidate.
+
 ## Filtering Commits for Changelog Entries
 
 When generating changelog entries from commit history, apply this filter:
@@ -125,21 +169,30 @@ When generating changelog entries from commit history, apply this filter:
 
 When the ship phase runs, before committing:
 
-1. **Scan commits since the last changelog entry.** Use `git log` to find
-   commits since the last version tag or the last changelog update.
+1. **Find the baseline and list the commits after it.** Follow
+   [Finding the Baseline](#finding-the-baseline) above.
 
 2. **Filter to user-facing commits** using the Include/Exclude rules above.
 
-3. **Translate each included commit to a user-facing bullet.** Rewrite the
+3. **Drop what `[Unreleased]` already says.** Read the existing `[Unreleased]`
+   section before you write anything, and skip every commit already covered
+   there. A second run over a current changelog must change nothing.
+
+4. **Translate each included commit to a user-facing bullet.** Rewrite the
    commit message in plain language if the commit message is technical.
    The entry should complete the sentence: "Users can now..." or "We fixed..."
 
-4. **Add entries under `[Unreleased]`** in the applicable section.
+5. **Add entries under `[Unreleased]`** in the applicable section.
 
-5. **Sort within sections:** most impactful changes first.
+6. **Sort within sections:** most impactful changes first.
 
-6. **Include the changelog update in the ship commit.** The `CHANGELOG.md`
+7. **Include the changelog update in the ship commit.** The `CHANGELOG.md`
    change should be part of the same commit as the code changes it documents.
+
+8. **Report what happened.** If no commit survived the filter, say so and leave
+   `CHANGELOG.md` untouched. A release with no user-facing change is a correct
+   outcome, not a failure — do not pad `[Unreleased]` to have something to show.
+   Otherwise, show the entries you wrote.
 
 ### Example Transformation
 
@@ -173,6 +226,9 @@ commits are rewritten in user-facing language.
   notice the change in behavior, it does not go in the changelog.
 - **One entry per user-visible change.** Multiple commits that implement a
   single feature produce one entry.
+- **Never duplicate an entry.** Check `[Unreleased]` before you add to it. This
+  skill runs more than once against the same branch, so it must be safe to
+  repeat: the second run over an unchanged branch writes nothing.
 - **Write in past tense.** "Added X" not "Add X". The changelog records what
   happened.
 - **Keep entries short.** One to two sentences maximum. Link to documentation


### PR DESCRIPTION
## What

Merges the missing procedural half of the global `changelog` skill into Team's own `skills/changelog/SKILL.md`.

Team already shipped a changelog skill that supersedes the global one on methodology (writing-prose lint, conventional-commit include/exclude filter, absolute-URL rule, ship-phase integration). What it lacked was the *mechanical* part: where to start counting. Step 1 of the ship-phase procedure — "scan commits since the last changelog entry" — was the one step the procedure did not specify.

## Changes

- `skills/changelog/SKILL.md`
  - New `## Finding the Baseline` section: read the most recent versioned heading from `CHANGELOG.md`, resolve that version to a commit by tag, fall back to a subject search on the version string, then list `<baseline>..HEAD` and classify ambiguous commits from their diff.
  - Ship-phase steps 6 → 8: adds the de-duplication read and the report step.
  - One new rule bullet: never duplicate an entry.
- `CHANGELOG.md` — `[Unreleased]` bullet.

## Notes for the reviewer

**The tag lookup peels with `^{commit}`.** Without it, an annotated tag resolves to the tag object rather than the commit it points at. This repo's tags are annotated, so the un-peeled form returns the wrong object type — it happens to work inside a `..HEAD` range because git peels there, but not if the sha is used directly.

**The subject fallback is not dead code here, but it is not exercised here either.** This repo is fully tagged (54 tags, current through `v0.37.0`), so Team itself always takes the tag path. The fallback exists because the skill ships to projects that do not tag. It matches the version *string* rather than a fixed prefix, so a version-prefixed squash merge (`v0.37.0 feat(scope): …`) and a `chore(release): 0.37.0` commit both resolve without either convention being hardcoded.

No version bump: a drafted PR carries no version. This is a runtime change, so `version-bump` runs at land time.

## Test plan

- [x] `bun test` — 1255 pass, 0 fail
- [x] `tests/changelog-links.test.ts` — absolute-URL rule holds for the new entry
- [x] Tag path resolves on this repo: `git rev-parse -q --verify "v0.37.0^{commit}"` → `ba5408c`, the `v0.37.0` release commit
- [x] Subject fallback resolves the same commit when the tag path is skipped: `git log --oneline --grep="0.37.0" -1` → `ba5408c`
- [x] Range from that baseline lists only this branch's commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAu6i4DkRpRS5QeZJio68T