### PR TITLE
v0.39.1 fix(skills): stop non-blocking findings from costing a review round

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.39.0"
+    "version": "0.39.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.1] - 2026-08-10
+
 ### Fixed
 
 - **A review finding that calls itself non-blocking no longer costs a full re-review round.** The severity table priced `suggestion (non-blocking)` and security MEDIUM as **Major**, and every Major triggers the whole loop again: the implementer runs, then all five reviewers re-run from scratch. Prose review turns up some of both on nearly every pass, so the gate could only clear once five independent reviewers returned *zero* non-blocking findings — not a reachable state, and runs burned their 5-round cap discovering it. The table also contradicted the reviewers themselves: [`agents/security-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/security-reviewer.md) and [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) both say MEDIUM does not block, so a reviewer reporting MEDIUMs candidly was silently buying rounds. **Major** now holds only `ux-reviewer` REQUEST CHANGES; `suggestion (non-blocking)`, security MEDIUM, and technical-writer REQUIRED (previously unmapped, and escalated by at least one orchestrator) all land in Minor, which is the human's queue at PR review rather than a wastebasket. A tripwire now fails the build if the three files ever disagree about MEDIUM again. [`skills/review-severity-tiers/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
@@ -444,7 +446,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.39.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.39.1...HEAD
+[0.39.1]: https://github.com/bostonaholic/team/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/bostonaholic/team/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/bostonaholic/team/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/bostonaholic/team/compare/v0.36.1...v0.37.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A review finding that calls itself non-blocking no longer costs a full re-review round.** The severity table priced `suggestion (non-blocking)` and security MEDIUM as **Major**, and every Major triggers the whole loop again: the implementer runs, then all five reviewers re-run from scratch. Prose review turns up some of both on nearly every pass, so the gate could only clear once five independent reviewers returned *zero* non-blocking findings — not a reachable state, and runs burned their 5-round cap discovering it. The table also contradicted the reviewers themselves: [`agents/security-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/security-reviewer.md) and [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) both say MEDIUM does not block, so a reviewer reporting MEDIUMs candidly was silently buying rounds. **Major** now holds only `ux-reviewer` REQUEST CHANGES; `suggestion (non-blocking)`, security MEDIUM, and technical-writer REQUIRED (previously unmapped, and escalated by at least one orchestrator) all land in Minor, which is the human's queue at PR review rather than a wastebasket. A tripwire now fails the build if the three files ever disagree about MEDIUM again. [`skills/review-severity-tiers/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
+
 ## [0.39.0] - 2026-08-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/review-severity-tiers/SKILL.md
+++ b/skills/review-severity-tiers/SKILL.md
@@ -28,8 +28,37 @@ in exactly one tier.
 | Tier | Findings in this tier | Action |
 |------|-----------------------|--------|
 | **Blocking** | `issue (blocking)`, code-reviewer REQUEST CHANGES, security CRITICAL/HIGH, any verifier failure | Auto-fixed in the loop. **Never** surfaced to the user. |
-| **Major** | `suggestion (non-blocking)`, security MEDIUM, ux-reviewer REQUEST CHANGES | Auto-fixed in the loop. **Never** surfaced to the user. |
-| **Minor and below** | `nitpick (non-blocking)`, security LOW, technical-writer GAPS, any COMMENT-level note | Recorded in the PR body's `## Review notes` — never presented mid-run. |
+| **Major** | ux-reviewer REQUEST CHANGES | Auto-fixed in the loop. **Never** surfaced to the user. |
+| **Minor and below** | `suggestion (non-blocking)`, `nitpick (non-blocking)`, security MEDIUM, security LOW, technical-writer GAPS (REQUIRED and RECOMMENDED alike), any COMMENT-level note | Recorded in the PR body's `## Review notes` — never presented mid-run. |
+
+**A finding that calls itself non-blocking never costs a round.** Every
+auto-fix tier triggers a complete re-review: the implementer runs, then all
+five reviewers run again from scratch. So each tier assignment is a bet that
+the finding is worth that price. `suggestion (non-blocking)` and security
+MEDIUM are not. Both say in their own label that the work can ship without
+them, and prose review yields some of both on nearly every pass — so pricing
+them at a full round means the loop ends only when five independent reviewers
+return zero non-blocking findings, which is not a reachable state. The loop
+then burns its 5-round cap discovering that.
+
+The tier boundary is therefore **not** a judgment about whether a finding
+matters. A security MEDIUM can matter a great deal. It is a judgment about
+who acts on it: Blocking and Major are fixed by the loop with no human in
+sight, and everything below reaches the human at PR review, which is the
+checkpoint this pipeline already designates. Minor is not a wastebasket. It
+is the human's queue.
+
+Two consequences worth stating, because both have been read the other way:
+
+- **`security-reviewer`'s own instructions agree with this table.**
+  `agents/security-reviewer.md` and `skills/code-review/SKILL.md` both say
+  CRITICAL and HIGH are hard gates while MEDIUM and LOW do not block. That is
+  correct, and it is why the reviewer reports MEDIUMs freely. A table that
+  auto-fixed them would silently convert candid reporting into rounds.
+- **`technical-writer` REQUIRED is Minor, like RECOMMENDED.** That reviewer's
+  gate type is ADVISORY (above). REQUIRED and RECOMMENDED describe how badly
+  the *docs* need the change, not what the *pipeline* does about it. Neither
+  loops.
 
 **The no-consult rule (non-negotiable).** Findings are never presented to the
 user mid-run. Blocking and Major findings loop the implementer automatically

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -919,6 +919,43 @@ describe("checks and balances", () => {
     const tiers = read(join(REPO_ROOT, "skills", "review-severity-tiers", "SKILL.md"));
     expect(/\b5 rounds\b/.test(tiers)).toBe(true);
   });
+
+  // Every auto-fix tier costs a full re-review: implementer, then all five
+  // reviewers again. A finding whose own label says non-blocking must not
+  // carry that price, or the loop only ends when five reviewers return zero
+  // non-blocking findings — not a reachable state on prose.
+  const TIER_ROW = (tier: string): string => {
+    const tiers = read(join(REPO_ROOT, "skills", "review-severity-tiers", "SKILL.md"));
+    return (
+      tiers.split("\n").find((line) => line.startsWith(`| **${tier}**`)) ?? ""
+    );
+  };
+
+  for (const token of ["suggestion (non-blocking)", "security MEDIUM"]) {
+    test(`${token} is priced as Minor, not as an auto-fixed round`, () => {
+      const major = TIER_ROW("Major");
+      const minor = TIER_ROW("Minor and below");
+      // Guard: a missing or renamed row must fail, not vacuously pass below.
+      expect(major.length).toBeGreaterThan(0);
+      expect(minor.length).toBeGreaterThan(0);
+      expect(minor).toContain(token);
+      expect(major).not.toContain(token);
+    });
+  }
+
+  test("security-reviewer and code-review agree MEDIUM does not block", () => {
+    // Three files describe this one boundary. When the tier table auto-fixed
+    // MEDIUM while these two called it non-blocking, the reviewer reported
+    // MEDIUMs candidly and each one silently bought a round.
+    const agent = read(join(REPO_ROOT, "agents", "security-reviewer.md"));
+    const review = read(join(REPO_ROOT, "skills", "code-review", "SKILL.md"));
+    expect(agent.length).toBeGreaterThan(0);
+    expect(review.length).toBeGreaterThan(0);
+    expect(/MEDIUM and LOW do not block/.test(agent)).toBe(true);
+    expect(/MEDIUM\/LOW findings are reported but\s+do not block/.test(review)).toBe(true);
+    // And the tier table must not contradict them.
+    expect(TIER_ROW("Major")).not.toContain("MEDIUM");
+  });
 });
 
 describe("code-review direct invocation preserves separation", () => {


### PR DESCRIPTION
First of eight PRs from the retro on the v0.39.0 `groom-backlog` port, which took **4 review rounds and 20 reviewer dispatches** to land ~300 lines of prose. This one addresses the largest single cause.

## The problem

`skills/review-severity-tiers/SKILL.md` put these in the **Major** tier:

> `suggestion (non-blocking)`, security MEDIUM, ux-reviewer REQUEST CHANGES

Every Major triggers a complete re-review — the implementer runs, then all five reviewers run again from scratch (`skills/team/SKILL.md:296-297`, and three other files mandate the same with no subset option). Prose review turns up suggestions and MEDIUMs on nearly every pass, so **the gate could only clear on a round where five independent reviewers returned zero non-blocking findings.** That is not a reachable state. The loop burns its 5-round cap discovering it.

Worse, the table contradicted the reviewers it governs:

- `agents/security-reviewer.md:35` — *"CRITICAL and HIGH are hard gates. MEDIUM and LOW do not block."*
- `skills/code-review/SKILL.md:78-79` — *"MEDIUM/LOW findings are reported but do not block."*

So the security reviewer reports MEDIUMs freely, believing them informational, while the orchestrator silently converts each into a 5-dispatch round. In the run that prompted this, the reviewer wrote *"PASS — nothing here is a hard gate"* beside three MEDIUMs the table classified as Majors.

And `technical-writer` REQUIRED was **never mapped at all** — the REQUIRED/RECOMMENDED vocabulary exists only in `skills/reviewing-documentation/SKILL.md`, so an orchestrator had to guess. In that run, one guessed Major and looped on it.

## The change

| Tier | Now holds |
|---|---|
| **Blocking** | unchanged — `issue (blocking)`, code REQUEST CHANGES, security CRITICAL/HIGH, verifier failure |
| **Major** | `ux-reviewer` REQUEST CHANGES **only** |
| **Minor and below** | `suggestion (non-blocking)`, `nitpick`, security MEDIUM, security LOW, technical-writer GAPS **(REQUIRED and RECOMMENDED alike)** |

The skill now also states *why*, so the next reader doesn't quietly restore the old pricing: the tier boundary is not a judgment about whether a finding matters — a security MEDIUM can matter a great deal — it is a judgment about **who acts on it.** Blocking and Major are fixed by the loop with no human present; everything below reaches the human at PR review, which is the checkpoint this pipeline already designates. **Minor is not a wastebasket. It is the human's queue.**

No edit was needed to `agents/security-reviewer.md` or `skills/code-review/SKILL.md` — they were already right, and become consistent rather than contradicted.

## Test plan

- [x] `bun test` — 1269 pass, 4 skip, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested the new tripwire:** restoring the old Major row turns exactly 3 tests red; restoring the fix turns them green. A tripwire that never fails is not a tripwire, so this was verified by mutation rather than by a passing run
- [x] Both new absence checks carry vacuous-pass length guards, per `docs/testing.md`
- [x] The tripwire pins *tier membership*, not wording — a meaning-preserving rewrite of the table leaves it green

## Notes

- The `code-review` escalation ladder (`:95-190`) gets **more** meaningful, not less: a single occurrence is `suggestion` → review notes, a repeat escalates to `issue` → blocks. That gradient did nothing while both ends looped.
- `docs/skills.md:780` still describes ux REQUEST CHANGES as an auto-fixed Major — still true, left alone.
- Follow-on PRs from the same retro: typecheck at the mechanical gate, the dispatch contract, positive-control discipline, skeptic rule-over-precedent, cross-surface parity, environment preflight, and a ship-splitting heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm
