### PR TITLE
v0.39.2 fix(skills): run static checks at the test-first mechanical gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.39.1"
+    "version": "0.39.2"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.39.1",
+      "version": "0.39.2",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.2] - 2026-08-10
+
 ### Fixed
 
 - **The test-first mechanical gate now runs the project's static checks, not just the suite.** It confirmed that every new test failed with an assertion rather than a crash, and advanced — but many runners transpile without type-checking, so a type error sits invisible behind a green suite. The first actor to notice was the `verifier`, one of the five reviewers, which means a broken type check cost a full review round plus a fix round to learn something `tsc --noEmit` answers in seconds. The gate is now two conditions: assertion-shaped test failures **and** every detected static check passing, reusing the detection order already in [`skills/running-quality-checks/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md). `test-architect` reports a `Static checks pass: YES/NO` line beside its failure table, and a failing check routes back to it rather than downstream. This closes a gap the test-first step was actively creating: it directs the author to write type stubs that are "obviously incomplete," which is exactly the state a type checker rejects. The compressed [`/team-fix`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md) pipeline carried the identical test-only gate and gets the same fix. [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md), [`skills/team-implement/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md), [`skills/test-first-development/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
@@ -450,7 +452,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.39.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.39.2...HEAD
+[0.39.2]: https://github.com/bostonaholic/team/compare/v0.39.1...v0.39.2
 [0.39.1]: https://github.com/bostonaholic/team/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/bostonaholic/team/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/bostonaholic/team/compare/v0.37.0...v0.38.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The test-first mechanical gate now runs the project's static checks, not just the suite.** It confirmed that every new test failed with an assertion rather than a crash, and advanced — but many runners transpile without type-checking, so a type error sits invisible behind a green suite. The first actor to notice was the `verifier`, one of the five reviewers, which means a broken type check cost a full review round plus a fix round to learn something `tsc --noEmit` answers in seconds. The gate is now two conditions: assertion-shaped test failures **and** every detected static check passing, reusing the detection order already in [`skills/running-quality-checks/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md). `test-architect` reports a `Static checks pass: YES/NO` line beside its failure table, and a failing check routes back to it rather than downstream. This closes a gap the test-first step was actively creating: it directs the author to write type stubs that are "obviously incomplete," which is exactly the state a type checker rejects. The compressed [`/team-fix`](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md) pipeline carried the identical test-only gate and gets the same fix. [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md), [`skills/team-implement/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md), [`skills/test-first-development/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
+
 ## [0.39.1] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ WORKTREE → QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → IMPLEME
 - **Design** *(design review)*. Design author drafts a ~200-line alignment doc, resolving its own open questions as recorded assumptions. An adversarial design review gates advancement.
 - **Structure.** Break the design into vertical slices with verification checkpoints. Produced autonomously. Advances to Plan with no gate.
 - **Plan.** Tactical implementation plan derived from the structure. Read by the implementer. Not gated.
-- **Implement.** Test-first, where test-architect writes failing tests and a mechanical gate checks them. Then slice execution, where implementer commits each vertical slice atomically. Then adversarial verification, with 5 parallel reviewers and a typed failure-class retry loop, capped at 5 rounds.
+- **Implement.** Test-first, where test-architect writes failing tests and a mechanical gate checks them and the project's static checks. Then slice execution, where implementer commits each vertical slice atomically. Then adversarial verification, with 5 parallel reviewers and a typed failure-class retry loop, capped at 5 rounds.
 - **PR.** Update changelog, commit, open pull request with inline UI screenshots when applicable, surface the tracking item.
 
 ## Screenshots in PRs

--- a/agents/test-architect.md
+++ b/agents/test-architect.md
@@ -72,7 +72,18 @@ After all tests are written and confirmed failing, report:
 - [Any fixtures, stubs, or config changes made]
 
 ### All tests fail cleanly: YES/NO
+
+### Static checks pass: YES/NO
+| Check | Command | Result |
+|-------|---------|--------|
+| Typecheck | `<detected command>` | PASS |
 ```
 
 If any test cannot be made to fail cleanly, explain why and flag it for the
 orchestrator.
+
+Static checks are a separate line because a green suite does not imply they
+pass — many runners execute tests without type-checking them, so a type error
+hides behind a passing test. The stubs you write are deliberately incomplete,
+which is the state a type checker rejects. Report `NO` and fix it before
+handing off; the mechanical gate blocks on this line.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,8 +260,10 @@ No gate. The plan is mechanically derived from the structure.
 
 **Sub-pipeline:**
 1. **Test-first.** `test-architect` writes failing acceptance tests.
-2. **Mechanical gate.** The orchestrator runs the suite. All tests must
-   fail with assertion errors, not crashes.
+2. **Mechanical gate.** The orchestrator runs the suite and the project's
+   static checks. All tests must fail with assertion errors, not crashes,
+   and every static check must pass — a runner that transpiles without
+   type-checking leaves a red type checker behind a green suite.
 3. **Slice execution.** `implementer` works through the plan one slice
    at a time, committing each atomically.
 4. **Code review.** 5 reviewers in parallel: `code-reviewer`,

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -801,8 +801,10 @@ context (see [architecture.md](architecture.md#design-guidelines)).
 - **Purpose:** Treat acceptance tests as the immutable scope fence.
 - **Loaded by:** test-architect, code-reviewer, and the orchestrator.
 - **Key behaviors:** Tests are written first and never edited to pass. The
-  implementation must satisfy them as the contract. The style rules every
-  acceptance test follows live in `test-style`.
+  implementation must satisfy them as the contract. Every new test must fail
+  with an assertion, never an error, and the project's static checks must pass
+  before handoff — a green suite does not imply a green type checker. The style
+  rules every acceptance test follows live in `test-style`.
 
 ### test-style
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -89,7 +89,8 @@ sub-phase and 5-reviewer adversarial verification with hard-gate retry loop.
 
 - **Sub-phases:**
   1. Test-first — `test-architect` writes failing acceptance tests
-  2. Mechanical gate — all tests fail with assertion errors (not crashes)
+  2. Mechanical gate — all tests fail with assertion errors (not crashes),
+     and every static check the project defines passes
   3. Slice execution — `implementer` works through vertical slices, commits
      each slice when its tests pass
   4. Code review — 5 parallel reviewers (code, security, docs, ux,

--- a/skills/team-fix/SKILL.md
+++ b/skills/team-fix/SKILL.md
@@ -166,7 +166,10 @@ Mark each TodoWrite item `in_progress` when you begin and `completed`
 when it finishes.
 
 **Mechanical gate between Red and Green:** the new test must fail with an
-assertion failure, not a crash. Do not proceed to the fix until confirmed.
+assertion failure, not a crash, and the project's static checks (typecheck,
+lint, build) must pass. Do not proceed to the fix until both are confirmed. A
+runner that executes tests without type-checking them leaves a red type checker
+behind a green suite.
 
 ## Ship
 

--- a/skills/team-implement/SKILL.md
+++ b/skills/team-implement/SKILL.md
@@ -131,7 +131,13 @@ Before any agent dispatch, decide where to work:
    mode it derives acceptance criteria from `$ARGUMENTS/task.md` instead
    of `structure.md`.
 3. **Mechanical gate** — confirm all tests fail with assertion errors
-   (not crashes). On crash, fix test infrastructure before proceeding.
+   (not crashes), **and** that every static check the project defines
+   passes (typecheck, lint, format, build — detected as
+   `skills/running-quality-checks/SKILL.md` detects them). On crash, fix
+   test infrastructure before proceeding. On a failing static check, send it
+   back to the `test-architect`: a runner that executes tests without
+   type-checking them leaves a red type checker behind a green suite, and
+   the next actor to notice is the `verifier`, a full review round later.
 4. Dispatch `implementer` → executes slices with per-slice commits. In
    standalone mode it works from `$ARGUMENTS/task.md` and the failing
    tests.

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -277,8 +277,21 @@ When the design review passes:
 When the `test-architect` returns failing tests:
 
 1. Run the test suite.
-2. If all tests fail with assertion errors (not crashes), advance.
-3. If tests crash or error, fix infrastructure and re-run.
+2. Run every **static** check the project defines — typecheck, lint, format,
+   build — detected as `skills/running-quality-checks/SKILL.md` detects them.
+   Skip the test entry there: step 1 already ran it.
+3. Advance only when both hold: all tests fail with assertion errors (not
+   crashes), **and** every static check passes.
+4. If tests crash or error, fix infrastructure and re-run.
+5. If a static check fails, send it back to the `test-architect` and re-run.
+
+A failing static check here is not a detail to clean up later. Many runners
+execute tests without type-checking them, so a suite can be green while the
+type checker is red — and the first actor to notice is otherwise the
+`verifier`, one of the five reviewers, which costs a full review round and a
+fix round to learn something a static check answers in seconds. Test-first
+deliberately produces incomplete stubs, which is exactly the state that
+type-checks badly, so this gate is where that shows up.
 
 ### Aggregate Gate (review collection)
 

--- a/skills/test-first-development/SKILL.md
+++ b/skills/test-first-development/SKILL.md
@@ -48,6 +48,13 @@ Run the full test suite after writing all acceptance tests. Every new test must:
 A test that errors is not a failing test — it is a broken test. The
 distinction matters.
 
+**Then run the project's static checks and make them pass.** A green suite is
+not the same as sound code. Many runners transpile without type-checking, so a
+type error sits invisible behind passing tests. Step 3 below has you write type
+stubs that are deliberately incomplete, which is precisely the state a type
+checker rejects — so check it here, where the fix is one file away, rather than
+leaving it for a reviewer. Report the result alongside the failure table.
+
 ### 3. Fix Errors, Not Failures
 
 When a test errors instead of fails:

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -719,6 +719,40 @@ describe("test-first-development lens (L2 content tripwire)", () => {
   test("audit table (in test-style) has a Deterministic inputs row (moved from test-architect)", () => {
     expect(read(TEST_STYLE_FILE)).toContain("| Deterministic inputs |");
   });
+
+  // A green suite does not imply a green type checker: many runners transpile
+  // without type-checking, and test-first deliberately writes incomplete
+  // stubs. Without a static check here the first actor to notice is the
+  // verifier — one of the five reviewers — which costs a whole review round.
+  // Pinned everywhere the gate is stated, so the three copies cannot drift.
+  const GATE_FILES: Array<[string, string]> = [
+    ["team", join(REPO_ROOT, "skills", "team", "SKILL.md")],
+    ["team-implement", join(REPO_ROOT, "skills", "team-implement", "SKILL.md")],
+    ["team-fix", join(REPO_ROOT, "skills", "team-fix", "SKILL.md")],
+  ];
+
+  for (const [label, file] of GATE_FILES) {
+    test(`${label}'s mechanical gate requires a static check, not only tests`, () => {
+      const text = squash(read(file));
+      // Guard: a missing file must fail, not vacuously pass the checks below.
+      expect(text.length).toBeGreaterThan(0);
+      expect(/mechanical gate/i.test(text)).toBe(true);
+      expect(/static check/i.test(text)).toBe(true);
+      expect(/typecheck/i.test(text)).toBe(true);
+    });
+  }
+
+  test("test-first-development requires static checks before handoff", () => {
+    const text = squash(read(SKILL_FILE));
+    expect(text.length).toBeGreaterThan(0);
+    expect(/static check/i.test(text)).toBe(true);
+  });
+
+  test("the test-architect report carries a static-check line", () => {
+    const text = squash(read(join(REPO_ROOT, "agents", "test-architect.md")));
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("Static checks pass");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Second of eight PRs from the retro on the v0.39.0 `groom-backlog` port. Independent of #216.

## The problem

The test-first mechanical gate was one condition (`skills/team/SKILL.md:275-282`):

> 1. Run the test suite.
> 2. If all tests fail with assertion errors (not crashes), advance.

Bun — like most JS runners — transpiles without type-checking. So in the run that prompted this, `bun test` was green while `bun run typecheck` had **4 TypeScript errors** in the test file that had just been written. The gate advanced. The errors were caught by the **`verifier`, in review round 1** — after all five reviewers had already been dispatched. Cost: a full review round plus a fix round, for something `tsc --noEmit` answers in two seconds.

This repo already knew. `.github/workflows/harness-checks.yml:70-74`:

```yaml
- name: Type-check harness
  # `bun test` transpiles without type-checking, so type errors pass it
  # silently. `tsc --noEmit` is the cheapest deterministic gate (static,
  # free) and blocks the PR on any type error — see docs/testing.md.
```

CI honored it. The pipeline's own gate didn't.

**And the test-first step was manufacturing the condition.** `skills/test-first-development/SKILL.md:58` directs the author to add type stubs, and `:60-62` requires them to be "obviously incomplete" — precisely the state a type checker rejects while the suite stays green.

## The change

The gate is now **two** conditions: assertion-shaped test failures **and** every detected static check passing. Detection reuses `skills/running-quality-checks/SKILL.md:14-27`, which already orders format → lint → typecheck → build → test — a reuse, not a new mechanism.

- A failing static check routes back to `test-architect`, not downstream.
- `agents/test-architect.md` gains a `Static checks pass: YES/NO` line beside its existing `All tests fail cleanly` line, so the gate has something to read.
- `skills/team-fix/SKILL.md:168-169` carried the identical test-only gate for the compressed bug-fix pipeline; same fix.
- Consistency mirrors updated so the four restatements don't drift: `skills/qrspi-workflow/SKILL.md`, `docs/architecture.md`, `docs/skills.md`, `README.md`.

## Test plan

- [x] `bun test` — 1271 pass, 4 skip, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested:** stripping the static check back out of `skills/team/SKILL.md` turns the tripwire red (95 pass/0 fail → 94/1); restoring turns it green
- [x] The tripwire pins all three gate statements (`team`, `team-implement`, `team-fix`) so a future edit can't fix one and leave the others
- [x] Every new absence check carries a vacuous-pass length guard, per `docs/testing.md`

## Notes

- My first version of the tripwire asserted `toContain("Mechanical gate")` and failed — `team/SKILL.md` writes "Mechanical **G**ate", `team-implement` writes lowercase. The mutation test is what surfaced it; a case-sensitive assertion had been failing for the wrong reason and masking whether the check discriminated at all. Now case-insensitive.
- No test pinned the gate wording before this, which is why the gap survived. There is one now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm
