### PR TITLE
v0.40.0 feat(skills): state where each phase agent's output lives

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.39.2"
+    "version": "0.40.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.39.2",
+      "version": "0.40.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The orchestrator now states where each phase agent's output actually lives, and dispatches accordingly.** Phase agents split two ways: `questioner`, `design-author`, `structure-planner`, and `planner` write their artifacts to `docs/plans/<id>/` themselves, while `researcher` and `file-finder` hold no `Write` tool — by design, since that is what keeps research isolated — and return text the orchestrator persists. Nothing connected those two facts, so nothing said what a lost result costs: for a self-writing agent, nothing (the work is on disk); for a return-only agent, everything (the reply *was* the artifact). An orchestrator that dispatched research in a mode returning only a truncated preview therefore had to re-run both agents from scratch. The phase loop now requires a dispatch whose full result returns inline, and says to re-dispatch rather than work from a preview — a summary of a research report is not a research report, and DESIGN cannot tell the difference until it is already reasoning from a gap. A tripwire pins that the return-only agents really do lack `Write`, so the guidance fails loudly rather than going stale. [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)
+
 ## [0.39.2] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-08-10
+
 ### Added
 
 - **The orchestrator now states where each phase agent's output actually lives, and dispatches accordingly.** Phase agents split two ways: `questioner`, `design-author`, `structure-planner`, and `planner` write their artifacts to `docs/plans/<id>/` themselves, while `researcher` and `file-finder` hold no `Write` tool — by design, since that is what keeps research isolated — and return text the orchestrator persists. Nothing connected those two facts, so nothing said what a lost result costs: for a self-writing agent, nothing (the work is on disk); for a return-only agent, everything (the reply *was* the artifact). An orchestrator that dispatched research in a mode returning only a truncated preview therefore had to re-run both agents from scratch. The phase loop now requires a dispatch whose full result returns inline, and says to re-dispatch rather than work from a preview — a summary of a research report is not a research report, and DESIGN cannot tell the difference until it is already reasoning from a gap. A tripwire pins that the return-only agents really do lack `Write`, so the guidance fails loudly rather than going stale. [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)
@@ -456,7 +458,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.39.2...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.40.0...HEAD
+[0.40.0]: https://github.com/bostonaholic/team/compare/v0.39.2...v0.40.0
 [0.39.2]: https://github.com/bostonaholic/team/compare/v0.39.1...v0.39.2
 [0.39.1]: https://github.com/bostonaholic/team/compare/v0.39.0...v0.39.1
 [0.39.0]: https://github.com/bostonaholic/team/compare/v0.38.0...v0.39.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -92,6 +92,10 @@ loop:
   4. Dispatch the agent(s) (parallel where the phase table marks them).
      Subagents never pause for user input — each resolves its own open
      questions and records them as assumptions in its artifact.
+     Dispatch so the agent's result comes back to you **in full**. Some
+     dispatch modes return only a truncated notice and hold the body
+     elsewhere; that loses a return-only agent's entire output (see
+     "Where a phase agent's output lives" below).
   5. Write each returned artifact to docs/plans/<id>/<name>.md
      with the YAML frontmatter the agent specifies (see the agent file
      and skills/artifact-frontmatter/SKILL.md).
@@ -151,6 +155,29 @@ When dispatching `file-finder` and `researcher`, pass them only the path
 `docs/plans/<id>/questions.md`. They are forbidden from reading `task.md`
 and the orchestrator must not give the original description in their
 context.
+
+## Where a phase agent's output lives
+
+Phase agents split into two kinds, and the split decides what a lost result
+costs:
+
+| Kind | Agents | Output lands |
+|------|--------|--------------|
+| **Self-writing** | `questioner`, `design-author`, `structure-planner`, `planner` | on disk, in `docs/plans/<id>/` |
+| **Return-only** | `researcher`, `file-finder` | in the returned text, nowhere else |
+
+The return-only agents hold no `Write` tool by design — that is what keeps
+research isolated (`agents/researcher.md`: "Do not attempt to write files
+yourself"). The orchestrator persists what they return.
+
+So a lost result is cheap for the first kind and total for the second. A
+self-writing agent's work survives on disk and can be read back; a return-only
+agent's work exists solely in the reply, so losing it means dispatching the
+whole agent again. **Dispatch every phase agent so its full result returns to
+you.** If a result arrives truncated, or as a notification stub with the body
+held elsewhere, re-dispatch rather than working from the preview. A summary of
+a research report is not a research report, and DESIGN downstream cannot tell
+the difference until it is already reasoning from a gap.
 
 ## Gate Handling
 

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -976,3 +976,42 @@ describe("code-review direct invocation preserves separation", () => {
     expect(/Dispatch the\s+`code-reviewer` agent/.test(text)).toBe(true);
   });
 });
+
+// The orchestrator persists what a return-only agent returns, so a lost
+// result costs a full re-dispatch for those and nothing for the agents that
+// write their own artifacts. The asymmetry decides how a dispatch must be
+// shaped, and it was undocumented — the two kinds are named nowhere else.
+describe("phase agents split into self-writing and return-only", () => {
+  const TEAM = read(join(REPO_ROOT, "skills", "team", "SKILL.md"));
+
+  test("the orchestrator states where each kind's output lives", () => {
+    // Guard: a missing file must fail, not vacuously pass the checks below.
+    expect(TEAM.length).toBeGreaterThan(0);
+    expect(TEAM).toContain("## Where a phase agent's output lives");
+    for (const agent of ["questioner", "researcher", "file-finder"]) {
+      expect(TEAM).toContain(agent);
+    }
+  });
+
+  test("return-only agents genuinely hold no write tool", () => {
+    // The doc claims researcher and file-finder cannot persist their own
+    // output. If that ever stops being true the guidance is wrong, not stale.
+    for (const agent of ["researcher", "file-finder"]) {
+      const fm = frontmatter(read(join(REPO_ROOT, "agents", `${agent}.md`)));
+      expect(fm.length).toBeGreaterThan(0);
+      const tools = /^tools:(.*)$/m.exec(fm)?.[1] ?? "";
+      expect(tools.length).toBeGreaterThan(0);
+      expect(/\bWrite\b/.test(tools)).toBe(false);
+      expect(/\bEdit\b/.test(tools)).toBe(false);
+    }
+  });
+
+  test("self-writing agents genuinely hold a write tool", () => {
+    for (const agent of ["questioner", "design-author", "structure-planner", "planner"]) {
+      const fm = frontmatter(read(join(REPO_ROOT, "agents", `${agent}.md`)));
+      expect(fm.length).toBeGreaterThan(0);
+      const tools = /^tools:(.*)$/m.exec(fm)?.[1] ?? "";
+      expect(/\bWrite\b/.test(tools)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Third of eight PRs from the retro on the v0.39.0 `groom-backlog` port.

> **Stacked on #217** — both edit `skills/team/SKILL.md`. Base is `retro-typecheck-gate`; retarget to `main` once #217 lands.

## The problem

Phase agents split two ways, and nothing said so:

| Kind | Agents | Output lands |
|---|---|---|
| Self-writing | `questioner`, `design-author`, `structure-planner`, `planner` | on disk |
| Return-only | `researcher`, `file-finder` | in the reply, nowhere else |

The return-only agents hold no `Write` tool **by design** — `agents/researcher.md:66-70` says *"Do not attempt to write files yourself"*, and that read-only posture is what enforces research isolation.

The consequence nobody wrote down: **a lost result is free for one kind and total for the other.** In the run that prompted this, research was dispatched in a mode that returned only a truncated notification preview. The questioner's work survived — it was on disk. The researcher's and file-finder's evaporated, and both had to be re-dispatched from scratch (~130k subagent tokens).

`skills/team/SKILL.md:95` says *"Write each **returned** artifact"* — presuming an inline return without ever stating it, and no skill mentions dispatch mechanics at all.

## The change

- Phase-loop step 4 now requires a dispatch whose **full result returns inline**, and to re-dispatch rather than work from a preview.
- A new `## Where a phase agent's output lives` section names the two kinds and why the asymmetry matters.

## Test plan

- [x] `bun test` — 1278 tests, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested:** removing the new section turns the tripwire red; restoring turns it green
- [x] The tripwire also asserts `researcher`/`file-finder` genuinely lack `Write`/`Edit` and the four self-writing agents genuinely have `Write` — so if the tool grants ever change, the guidance fails loudly instead of silently becoming wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm