### PR TITLE
docs(testing): require a positive control before trusting a negative check

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -141,7 +141,8 @@ change:
 - Numeric constants that bound behavior (`sleep 600`, `timeout 1800`).
 - The **absence** of a forbidden identifier or a forbidden claim. A negative
   sweep never breaks under a rewrite, because a rewrite does not add back the
-  thing you banned.
+  thing you banned. It can, however, pass for the wrong reason — see
+  *Prove a negative check can find a positive* below.
 
 **Never assert these.** They break on every honest edit and hold the prose
 still:
@@ -167,6 +168,52 @@ the instruction still lands. Do not simulate that at L2 with a regex.
 This layer is what lets a stochastic product stay correct cheaply: a huge
 fraction of "regressions" are really *contract violations*. Contracts stay
 deterministic even when behavior does not.
+
+#### Prove a negative check can find a positive
+
+A check that finds nothing has told you one of two things, and it does not say
+which: the thing is absent, or **the check cannot see it**. Treat the second as
+the default until you rule it out. Before you trust a clean result, point the
+same check at something you know is there and watch it fire. That is the whole
+discipline, and it costs one extra command.
+
+Two ways a check goes blind, both of which have shipped false confidence here:
+
+- **The haystack is empty or mis-scoped.** A section extractor that returns `""`
+  on a renamed heading makes every `not.toContain` under it pass. So does a
+  section whose bounds run to the wrong terminator, silently pulling in a later
+  section's prose or excluding the lines you meant to check. This is why every
+  absence assertion in this repo is preceded by a length guard:
+
+  ```ts
+  const promotion = section("## The promotion standard");
+  // Guard: a missing section must fail, not vacuously pass the absence checks.
+  expect(promotion.length).toBeGreaterThan(0);
+  for (const reference of UPWARD_REFERENCES) {
+    expect(promotion).not.toContain(reference);
+  }
+  ```
+
+  The guard is not ceremony. Without it, renaming a heading turns a real
+  tripwire into a permanently green no-op, and nothing announces that.
+
+- **The pattern cannot match the file's own line breaks.** This repo hard-wraps
+  prose, so a phrase that reads as one sentence is often two lines with
+  indentation between the halves. A single-line regex, or a `grep` for
+  `"skips the nine board steps"`, sweeps right past it and reports clean. Use
+  the `flat()` helper in the test suite, which flattens newlines before
+  matching, and squash the whitespace if the pattern crosses an indent.
+
+The same rule governs the shell commands you run while verifying a change by
+hand, not just committed tests. `git grep` for a phrase that is line-wrapped, or
+a `diff` of two `grep -n` outputs where a line-number shift reads as a content
+change, will both tell you everything is fine. Run the positive control first
+and you find out in seconds; skip it and you report a green check that was never
+looking.
+
+This is the same instinct as **No "pre-existing failure" without proof** in the
+cross-cutting principles: a clean result is a claim, and a claim needs a
+receipt.
 
 ### L3: In-process integration
 
@@ -372,6 +419,10 @@ The goal is a paid suite that costs a few dollars per change set, not hundreds.
   something other than your change, reproduce it on the base branch. Stochastic
   systems have invisible couplings. "Not my change" is a claim that needs a
   receipt.
+- **No clean result from an unproven check.** Its sibling, one layer down: a
+  check that finds nothing has not distinguished *absent* from *blind*. Point it
+  at a known positive first. See *Prove a negative check can find a positive*
+  under L2.
 - **Do not chase a coverage or lint number.** Accept a "worse" pattern when it
   is the correct engineering choice. Fix patterns that are genuinely bugs. The
   number is a smell test, not a target.


### PR DESCRIPTION
Fourth of eight PRs from the retro on the v0.39.0 `groom-backlog` port. Independent of #216, #217, #218.

**Dev-only** — touches `docs/` alone. `version-bump-required.sh` returns `OK: runtime_changed=false bumped=false`, so this lands plain: no version bump, no changelog cut.

## The problem

`docs/testing.md:142-144` endorses absence checks as unconditionally safe:

> The **absence** of a forbidden identifier or a forbidden claim. A negative sweep never breaks under a rewrite, because a rewrite does not add back the thing you banned.

True as far as it goes — but it omits that a negative sweep can pass because **the check never looked**. The word `vacuous` appears **41 times across 17 test files** and **zero times in any prose doc**: the discipline is a strong unwritten convention, so nothing teaches it to a new author or agent.

Three checks returned a false clean during the run that prompted this:

1. A `git grep` for stale step references missed **line-wrapped** phrases — this repo hard-wraps at ~95 columns, so `skips the nine board steps` spans two lines. The same trap hid that exact phrase from **two** design-review rounds.
2. A section-bounding bug reported a forbidden token present when it wasn't.
3. A "byte-identical" check diffed `grep -n` output, so a line-number shift read as a content change.

Each was caught only by running a **positive control** — pointing the check at something known to be present and watching it fire.

## The change

A new L2 subsection, *Prove a negative check can find a positive*, naming both blindness modes with the repo's own existing answers: the `// Guard:` length-assertion convention, and the `flat()` helper that flattens newlines before matching. It explicitly extends to the shell commands run while verifying by hand, not just committed tests.

Also: the absence bullet now points forward to the caveat, and §8 gains a sibling to *No "pre-existing failure" without proof* — same instinct, one layer down.

## Test plan

- [x] `bun test` — 1270 tests, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] `.github/scripts/version-bump-required.sh` — exit 0, `runtime_changed=false`, confirming no bump is owed
- [x] No tripwire added: `docs/testing.md` is pinned by no test (tests only cite it in comments), and pinning prose about not pinning prose would be self-defeating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm