### PR TITLE
v0.40.1 fix(skills): weigh a stated rule above precedent in skeptic passes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.40.0"
+    "version": "0.40.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A skeptic pass can no longer refute a rule violation by pointing at more of the same violation.** The pass exists to kill false positives before they cost a review round; it killed a true positive instead. Two things caused it. The neutrality rule told the reviewer to strip its reasoning from the claim, which also stripped the *rule being cited* — so "this comment carries a plan/slice marker, which `engineering-standards` bans" reached the skeptic as "this comment references a plan phase", an observation any skeptic finds true and unremarkable. And the admissible-evidence list was entirely code-shaped (guards, callers, sanitization, type definitions, tests), so no project rule was ever in scope. The skeptic did what it was told, found the pattern on the default branch, and refuted on precedent. A later round raised the same finding and confirmed it. Now a rule-violation claim carries the rule and points the skeptic at the file stating it, and precedent is explicitly not a refutation: a pattern's presence on the default branch says it shipped, not that it is permitted. Only two things refute such a claim — the rule does not say what the claim says, or the code falls under an exemption the rule itself states. [`skills/systems-thinking/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md) asked the opposite question unqualified and now defers where a written rule speaks. [`skills/nested-agents/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
+
 ## [0.40.0] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.1] - 2026-08-10
+
 ### Fixed
 
 - **A skeptic pass can no longer refute a rule violation by pointing at more of the same violation.** The pass exists to kill false positives before they cost a review round; it killed a true positive instead. Two things caused it. The neutrality rule told the reviewer to strip its reasoning from the claim, which also stripped the *rule being cited* — so "this comment carries a plan/slice marker, which `engineering-standards` bans" reached the skeptic as "this comment references a plan phase", an observation any skeptic finds true and unremarkable. And the admissible-evidence list was entirely code-shaped (guards, callers, sanitization, type definitions, tests), so no project rule was ever in scope. The skeptic did what it was told, found the pattern on the default branch, and refuted on precedent. A later round raised the same finding and confirmed it. Now a rule-violation claim carries the rule and points the skeptic at the file stating it, and precedent is explicitly not a refutation: a pattern's presence on the default branch says it shipped, not that it is permitted. Only two things refute such a claim — the rule does not say what the claim says, or the code falls under an exemption the rule itself states. [`skills/systems-thinking/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md) asked the opposite question unqualified and now defers where a written rule speaks. [`skills/nested-agents/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
@@ -462,7 +464,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.40.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.40.1...HEAD
+[0.40.1]: https://github.com/bostonaholic/team/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/bostonaholic/team/compare/v0.39.2...v0.40.0
 [0.39.2]: https://github.com/bostonaholic/team/compare/v0.39.1...v0.39.2
 [0.39.1]: https://github.com/bostonaholic/team/compare/v0.39.0...v0.39.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/nested-agents/SKILL.md
+++ b/skills/nested-agents/SKILL.md
@@ -138,6 +138,40 @@ sub-agent through the `Agent` tool and try to get it refuted.
   > file:line evidence, <= 10 lines. If your evidence is inconclusive,
   > reply CONFIRMED. Do not write files or spawn agents.
 
+- **A rule-violation claim carries the rule.** Withholding your verdict and
+  severity is right — those are conclusions the skeptic must reach on its own.
+  The rule you are citing is neither. It is the thing that makes the claim
+  falsifiable at all, and a claim stripped of it becomes a different, weaker
+  claim that the skeptic will answer correctly and uselessly. "This comment
+  carries a plan/slice marker, which `engineering-standards` bans" is
+  checkable. "This comment references a plan phase" is just an observation,
+  and any skeptic will find that observation true and unremarkable. Name the
+  skill and the rule, never your judgment of how bad it is:
+
+  > Read <file> around line <n>. Claim: "<what is there> violates <rule>,
+  > stated in `skills/<skill>/SKILL.md`". Read that rule, then attempt to
+  > REFUTE the claim: does the rule say what the claim says, and does this
+  > code fall outside it — through a stated exemption, or because the rule
+  > does not reach this case? Reply REFUTED or CONFIRMED with file:line
+  > evidence, <= 10 lines. If your evidence is inconclusive, reply
+  > CONFIRMED. Do not write files or spawn agents.
+
+- **A stated rule outranks observed precedent.** The same pattern existing
+  elsewhere in the tree does not refute a rule-violation claim. Precedent
+  records what someone did; a rule records what is permitted, and the gap
+  between them is exactly the debt a rule exists to stop growing. A skeptic
+  that answers "this already appears on the default branch" has found more
+  instances of the violation, not a defence of it. Only two things refute
+  such a claim: the rule does not say what the claim says, or the code falls
+  under an exemption the rule itself states. Where a repo convention and a
+  written rule genuinely conflict, that is a finding for the report, not a
+  refutation to act on alone.
+
+  This cuts against the system-fit lens in `skills/systems-thinking/SKILL.md`,
+  which asks whether a change follows the conventions established elsewhere.
+  Both hold, in this order: follow convention where no rule speaks, and follow
+  the rule where one does.
+
 - **Default-keep.** Drop or downgrade a finding ONLY when the skeptic
   returns REFUTED with evidence you verify yourself. Inconclusive means the
   finding stands — severity is never softened on an uncertain skeptic reply.

--- a/skills/systems-thinking/SKILL.md
+++ b/skills/systems-thinking/SKILL.md
@@ -108,7 +108,10 @@ The questions behind the `System Fit` checklist item in
   changed files *and* the neighbors whose expectations they carry.
 - **Does the change follow the conventions established elsewhere?** Cite
   the specific convention when flagging a divergence, so the finding is
-  checkable rather than a taste claim.
+  checkable rather than a taste claim. Convention governs where no written
+  rule speaks. Where one does, the rule wins and the precedent is a second
+  violation rather than a defence — a pattern's presence on the default
+  branch says it shipped, not that it is permitted.
 
 ## Lens, Not Dogma
 

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -1010,3 +1010,35 @@ describe("comment red flags (L2 content tripwire)", () => {
     expect(/skills\/code-review\/SKILL\.md|engineering-standards/.test(directive)).toBe(true);
   });
 });
+
+// A skeptic pass exists to kill false positives before they cost a round. It
+// killed a true positive instead: the neutrality rule stripped the cited rule
+// out of the claim, so the skeptic found the pattern on the default branch and
+// refuted on precedent. Both halves are pinned — the claim carries its rule,
+// and precedent does not outrank one.
+describe("skeptic passes weigh a stated rule above precedent (L2 tripwire)", () => {
+  const NESTED = read(join(REPO_ROOT, "skills", "nested-agents", "SKILL.md"));
+  const SYSTEMS = read(join(REPO_ROOT, "skills", "systems-thinking", "SKILL.md"));
+
+  test("a rule-violation claim carries the rule it cites", () => {
+    // Guard: a missing file must fail, not vacuously pass the checks below.
+    expect(NESTED.length).toBeGreaterThan(0);
+    const text = squash(NESTED);
+    expect(/rule-violation claim carries the rule/i.test(text)).toBe(true);
+    // The claim template must point the skeptic at the rule's own file.
+    expect(text).toContain("skills/<skill>/SKILL.md");
+  });
+
+  test("nested-agents states that a rule outranks precedent", () => {
+    const text = squash(NESTED);
+    expect(/stated rule outranks observed precedent/i.test(text)).toBe(true);
+    expect(text).toContain("systems-thinking/SKILL.md");
+  });
+
+  test("systems-thinking defers to a written rule where one speaks", () => {
+    expect(SYSTEMS.length).toBeGreaterThan(0);
+    const text = squash(SYSTEMS);
+    expect(/conventions established elsewhere/i.test(text)).toBe(true);
+    expect(/where no written\s+rule speaks|no written rule speaks/i.test(text)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fifth of eight PRs from the retro on the v0.39.0 `groom-backlog` port. Independent of the others.

## The problem

The skeptic pass exists to kill false positives before they cost a review round. In the run that prompted this it **killed a true positive**, then a later round raised the same finding and confirmed it — two rounds of attention and one reversal, on a two-line fix.

The finding: `// Slice 1:` / `// Slice 2:` comment markers, which `skills/engineering-standards/SKILL.md:76-83` bans outright (*"No ticket/issue IDs, plan/slice/phase markers... They rot"*).

- **Round 1 skeptic: REFUTED**, on precedent — the same labeling exists on `main` in `tests/progress-tracking.test.ts`.
- **Round 2 skeptic: CONFIRMED**, on the rule.

Both reasoned correctly from what they were given. The spec produced the reversal:

1. `nested-agents/SKILL.md:129-130` says *"Never include your verdict, severity, or reasoning."* That is right for a verdict — but it also strips **the rule being cited**. "This comment carries a plan/slice marker, which `engineering-standards` bans" becomes "this comment references a plan phase": true, unremarkable, and a *different claim* the skeptic answers correctly and uselessly.
2. The admissible-evidence list (`:136-137`) is entirely code-shaped — *guards, callers, sanitization, validation layers, type definitions, tests*. **No project rule is in scope.** A skeptic reading that list has no cue that `engineering-standards` is even in play.
3. The only precedent-ranking text in the repo pointed the *other* way: `skills/systems-thinking/SKILL.md:109-111` asks *"Does the change follow the conventions established elsewhere?"* unqualified.

## The change

- **A rule-violation claim carries its rule.** Withholding verdict and severity stays; the cited rule travels, with its own claim template pointing the skeptic at the file stating it. The rule is what makes the claim falsifiable — it is not the reviewer's reasoning.
- **A stated rule outranks observed precedent.** Precedent records what someone did; a rule records what is permitted, and the gap is the debt the rule exists to stop growing. A skeptic answering *"this already appears on the default branch"* has found **more instances of the violation, not a defence of it.** Only two things refute such a claim: the rule does not say what the claim says, or the code falls under an exemption the rule itself states.
- **`systems-thinking` now defers where a written rule speaks** — convention governs where none does. Both lenses hold, in that order.

Where a convention and a rule genuinely conflict, that is a finding for the report, not a refutation to act on alone.

## Test plan

- [x] `bun test` — 1273 tests, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested:** stripping the precedence bullet from `nested-agents` and reverting `systems-thinking` to its unqualified form turns **2 tests red**; restoring both turns them green
- [x] Both files are pinned, so the two halves cannot drift apart — the failure mode here was precisely two files disagreeing

## Note

The plan flagged extending skeptic coverage to the Major tier (`nested-agents:121-124` covers only Blocking/CRITICAL/HIGH today). **Deliberately not done here.** #216 shrinks Major to `ux-reviewer` REQUEST CHANGES alone, which may make the extension unnecessary — worth re-measuring after that lands rather than guessing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm