### PR TITLE
v0.41.0 feat(skills): check that every rule reaches every surface it must

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.40.1"
+    "version": "0.41.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.40.1",
+      "version": "0.41.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-08-11
+
 ### Added
 
 - **A design that defines more than one way in must now say which of its rules reach which path, and the review checks it.** The edge-case walk covers six categories — boundary values, invalid inputs, failure paths, concurrency, authorization, resource limits — and a design with two entry modes can satisfy all six *per mode in isolation* while the modes disagree with each other. Nothing asked for the cross-mode view, so a safeguard stated in the surface its author happened to be editing left a reader arriving through the other one governed by nothing. With fresh-context reviewers who keep no memory of prior rounds, the asymmetry surfaced one instance per round: three consecutive rounds, each finding one more. `design.md` now carries a `## Surfaces` matrix when it has more than one path in — one row per safeguard, every `no` stating its reason — and the review brief gains a step that reads a self-contained section **alone**, the way its readers will, rather than inferring what it inherits. An unexplained asymmetry is now a named REQUEST CHANGES trigger rather than a judgment call with no criterion behind it. [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) applies the same check to a diff, since a clean design can still land a rule in one surface only. [`skills/authoring-designs/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md), [`skills/eng-design-doc-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/eng-design-doc-review/SKILL.md)
@@ -468,7 +470,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.40.1...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.41.0...HEAD
+[0.41.0]: https://github.com/bostonaholic/team/compare/v0.40.1...v0.41.0
 [0.40.1]: https://github.com/bostonaholic/team/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/bostonaholic/team/compare/v0.39.2...v0.40.0
 [0.39.2]: https://github.com/bostonaholic/team/compare/v0.39.1...v0.39.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A design that defines more than one way in must now say which of its rules reach which path, and the review checks it.** The edge-case walk covers six categories — boundary values, invalid inputs, failure paths, concurrency, authorization, resource limits — and a design with two entry modes can satisfy all six *per mode in isolation* while the modes disagree with each other. Nothing asked for the cross-mode view, so a safeguard stated in the surface its author happened to be editing left a reader arriving through the other one governed by nothing. With fresh-context reviewers who keep no memory of prior rounds, the asymmetry surfaced one instance per round: three consecutive rounds, each finding one more. `design.md` now carries a `## Surfaces` matrix when it has more than one path in — one row per safeguard, every `no` stating its reason — and the review brief gains a step that reads a self-contained section **alone**, the way its readers will, rather than inferring what it inherits. An unexplained asymmetry is now a named REQUEST CHANGES trigger rather than a judgment call with no criterion behind it. [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md) applies the same check to a diff, since a clean design can still land a rule in one surface only. [`skills/authoring-designs/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md), [`skills/eng-design-doc-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/eng-design-doc-review/SKILL.md)
+
 ## [0.40.1] - 2026-08-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/authoring-designs/SKILL.md
+++ b/skills/authoring-designs/SKILL.md
@@ -112,6 +112,26 @@ Walk these categories explicitly so none gets skipped:
 Edge cases that are intentionally deferred belong in `## Out of scope`,
 not here — so structure and tests do not silently expand into them.>
 
+## Surfaces
+<Include this section ONLY when the design defines more than one way in:
+two entry modes, a self-contained path that can be loaded alone, a split
+across turns, or any procedure a reader can arrive at without reading the
+rest. A single-path design omits the section entirely.
+
+List the surfaces, then give one row per rule or safeguard the design
+introduces, marking which surfaces it reaches:
+
+| Safeguard | Mode A | Mode B | ... |
+|-----------|--------|--------|-----|
+| <rule>    | yes    | yes    |     |
+| <rule>    | yes    | no — <why not> | |
+
+Every `no` states its reason. An omission with no reason is the defect this
+section exists to surface: a rule stated once, in the surface its author
+happened to be editing, while a reader arriving through the other one is
+governed by nothing. Where a surface claims to be self-contained, that claim
+is itself a safeguard — say what makes it true.>
+
 ## Open questions (deferred)
 <low-priority questions parked for the structure or implement phase>
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -216,6 +216,15 @@ Two severity regimes apply:
    criterion is met by the implementation. Flag any that are missing or
    incomplete.
 
+   **Then check each rule the diff introduces reaches every surface it must.**
+   When the changed code or prose has more than one way in — two entry modes,
+   a path documented as usable on its own, a split across turns or processes —
+   a new rule or safeguard added to one of them is not added to the others by
+   implication. Take each rule the diff adds and name where it now holds.
+   A rule present in one surface and silently absent from a sibling is a
+   finding, and a stated reason for the absence answers it. Read a
+   self-contained path **alone**, the way its callers arrive at it.
+
 4. **Inspect the code.** For each changed file, check:
    - **Correctness** — Does the logic do what it claims? Are there off-by-one
      errors, missing null checks, or broken edge cases?

--- a/skills/eng-design-doc-review/SKILL.md
+++ b/skills/eng-design-doc-review/SKILL.md
@@ -168,18 +168,34 @@ it defines their format.
    path — is incomplete. Edge cases deliberately deferred must appear in
    "Out of scope" or "Non-Goals", not be silently omitted.
 
-5. **Check specificity.** Cite-by-file-and-line beats hand-waving. Flag any
+5. **Check every rule reaches every surface it must.** Skip this step when
+   the design defines one path in. When it defines more than one — two entry
+   modes, a section that claims to be loadable on its own, a split across
+   turns — take each rule or safeguard the design introduces and ask which
+   surfaces state it. A design can satisfy step 4 *per surface in isolation*
+   while the surfaces disagree with each other, so the categories above will
+   not catch this.
+
+   An omission is a finding unless the design says why it is deliberate.
+   Judge a `no` on its reasoning, not its presence: a safeguard that is
+   genuinely unnecessary on one path is fine, and one that is merely absent
+   there is the defect. Read a self-contained section **alone**, as its
+   readers will, rather than inferring what it inherits from the rest of the
+   document — self-containment is a claim the section makes, and this step is
+   where it gets tested.
+
+6. **Check specificity.** Cite-by-file-and-line beats hand-waving. Flag any
    "the auth module" where `services/auth/SessionManager.ts:88` was
    possible. Spot-check a few claims against the referenced files. If a
    citation does not exist, or does not say what the doc claims, that is a
    blocking issue.
 
-6. **Apply the engineering-standards lens.** Walk the Core Philosophy
+7. **Apply the engineering-standards lens.** Walk the Core Philosophy
    (Hickey/Carmack/Armstrong/Knuth/Liskov/Ousterhout) and the design-first
    workflow. Higher severity for failure-isolation or contract violations.
    Lower for stylistic concerns.
 
-7. **Check scope discipline.** Does the design stay within the repos and
+8. **Check scope discipline.** Does the design stay within the repos and
    subsystems implied by the predecessor artifacts? Flag scope creep
    (especially silent multi-repo expansion) as a blocking issue.
 
@@ -202,7 +218,8 @@ End with a verdict, using the same gate type as `code-reviewer`:
   enumerated, citations are accurate. No blocking issues.
 - **REQUEST CHANGES** — Blocking issues found (missing necessary section,
   unjustified decision, absent edge-case enumeration, false or unverifiable
-  citation, silent scope expansion). The author must revise before the
+  citation, silent scope expansion, a rule that reaches one surface and not
+  another with no reason given). The author must revise before the
   design can advance.
 - **COMMENT** — Non-blocking suggestions and nitpicks only. Document is
   acceptable but could be improved.

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -1042,3 +1042,41 @@ describe("skeptic passes weigh a stated rule above precedent (L2 tripwire)", () 
     expect(/where no written\s+rule speaks|no written rule speaks/i.test(text)).toBe(true);
   });
 });
+
+// A design with two entry modes can satisfy the six edge-case categories
+// per mode in isolation while the modes disagree with each other. Nothing
+// asked for the surface x safeguard matrix, so three consecutive review
+// rounds each found one more asymmetry, one instance at a time.
+describe("cross-surface parity is checked (L2 tripwire)", () => {
+  const AUTHORING = read(join(REPO_ROOT, "skills", "authoring-designs", "SKILL.md"));
+  const REVIEW = read(join(REPO_ROOT, "skills", "eng-design-doc-review", "SKILL.md"));
+  const CODE_REVIEW = read(join(REPO_ROOT, "skills", "code-review", "SKILL.md"));
+
+  test("the design template asks for a surfaces section", () => {
+    // Guard: a missing file must fail, not vacuously pass the checks below.
+    expect(AUTHORING.length).toBeGreaterThan(0);
+    expect(AUTHORING).toContain("## Surfaces");
+  });
+
+  test("the review brief has a step for it, and a verdict trigger", () => {
+    expect(REVIEW.length).toBeGreaterThan(0);
+    const text = squash(REVIEW);
+    expect(/reaches every surface/i.test(text)).toBe(true);
+    // Without a named blocking trigger the finding rests on judgment alone.
+    expect(/one surface and not\s*another/i.test(text)).toBe(true);
+  });
+
+  test("the review-process steps stay uniquely numbered after the insert", () => {
+    // The new step renumbered its successors; a duplicate number is the
+    // classic casualty of that edit.
+    const process = REVIEW.slice(REVIEW.indexOf("### Review process"));
+    const numbers = [...process.matchAll(/^(\d+)\. \*\*/gm)].map((m) => Number(m[1]));
+    expect(numbers.length).toBeGreaterThan(0);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
+
+  test("code-review applies the same check to a diff", () => {
+    expect(CODE_REVIEW.length).toBeGreaterThan(0);
+    expect(/reaches every surface/i.test(squash(CODE_REVIEW))).toBe(true);
+  });
+});


### PR DESCRIPTION
Sixth of eight PRs from the retro on the v0.39.0 `groom-backlog` port. **This is the one that addresses the actual doom loop.**

> **Stacked on #216** — both edit `skills/code-review/SKILL.md`. Base is `retro-severity-tiers`; retarget to `main` once #216 lands.

## The problem

The `groom-backlog` skill has two entry modes — a board pass, and a promotion standard that declares itself *"self-contained… so it can be loaded on its own"* — plus two turn boundaries. Any safeguard for its new destructive mutation has to reach up to four surfaces.

Three consecutive review rounds each found one more place it didn't:

| Round | Finding |
|---|---|
| 2 | The promotion standard proposes closures with **none** of the four safeguards |
| 3 | Promotion move 1 got four safeguards, **missed the working-tree precondition** |
| 4 | The board-mode comment-skip is **narrower** than promotion's |

Round 4's is the telling one: it appeared in the commit whose *entire purpose* was a parity sweep. Even an explicit instruction to check all four surfaces left one asymmetry.

**Why the design review didn't catch it.** Step 4 walks a closed list of six edge-case categories — boundary values, invalid inputs, failure paths, concurrency, authorization, resource limits. *"The same safeguard, in the second entry mode"* is not among them, and a design can satisfy all six **per surface in isolation** while the surfaces disagree. The blocking-verdict triggers matched nothing either, so a reviewer who noticed had to file it on judgment alone.

Combined with fresh-context reviewers who keep no memory of prior rounds (`skills/team-implement/SKILL.md:177-178`), each round rediscovered the pattern **one instance at a time**.

The most telling detail: the round-3 blocker came from the **UX reviewer**, not security or code review — because it alone did what the section claims to support and **read the promotion standard by itself**. Self-containment was a stated contract that nothing verified.

## The change

**Producer side** (`authoring-designs`): a `## Surfaces` section, included only when the design has more than one path in. One row per safeguard, one column per surface, and **every `no` states its reason**. An omission with no reason is exactly the defect.

**Reviewer side** (`eng-design-doc-review`): a new step 5 that takes each rule and asks which surfaces state it — explicitly noting that step 4's categories will not catch this. It judges a `no` on its reasoning, not its presence, and reads a self-contained section **alone, as its readers will**. An unexplained asymmetry becomes a named REQUEST CHANGES trigger.

**Diff side** (`code-review`): the same check, because a clean design can still land a rule in one surface only — which is precisely how rounds 3 and 4 happened.

## Test plan

- [x] `bun test` — 1277 tests, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested twice:** dropping the three additions turns 2 tests red; reintroducing a duplicate step number turns 1 red. Restoring turns all green
- [x] A tripwire asserts the review-process step numbers stay **unique** — inserting a step into a numbered list is exactly where that breaks, and it caught my own duplicate `6.` while writing this
- [x] Every absence check carries a vacuous-pass length guard

## Note

`eng-design-doc-review/SKILL.md:227-230` warns that the Review brief **is** the pipeline's DESIGN gate, so editing it changes pipeline behavior. That is intended here and the tests move with it.

The highest-value regression test available is behavioral rather than static: re-run `/eng-design-doc-review` against the **round-1** revision of the `groom-backlog` design (still under `docs/plans/2026-08-09-groom-backlog-dropped-behaviors/`) and confirm step 5 surfaces the promotion-mode asymmetry that took three rounds to find. A real design with a known defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm