### PR TITLE
v0.42.0 feat(skills): preflight the environment at the worktree phase

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.41.0"
+    "version": "0.42.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The pipeline reads three environment signals before it starts, and reports them instead of stopping.** An unreachable `ssh-agent`, a missing `gh` login, and a global `commit.gpgsign` that scratch repositories inherit each predict a specific failure hours later — a push that fails at the PR phase after all the work is done, or a test suite that stalls signing throwaway commits until they time out, turning a one-minute run into ten and failing in places unrelated to the diff. Read at the start, those are one line of context. Discovered at the end, they look like a regression in the branch, and get reported as one. The checks are read-only, take a second, and **never block the run** — a cold credential is worth naming, never worth stopping for. [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)
+
 ## [0.41.0] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-08-11
+
 ### Added
 
 - **The pipeline reads three environment signals before it starts, and reports them instead of stopping.** An unreachable `ssh-agent`, a missing `gh` login, and a global `commit.gpgsign` that scratch repositories inherit each predict a specific failure hours later — a push that fails at the PR phase after all the work is done, or a test suite that stalls signing throwaway commits until they time out, turning a one-minute run into ten and failing in places unrelated to the diff. Read at the start, those are one line of context. Discovered at the end, they look like a regression in the branch, and get reported as one. The checks are read-only, take a second, and **never block the run** — a cold credential is worth naming, never worth stopping for. [`skills/team/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)
@@ -474,7 +476,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.41.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.42.0...HEAD
+[0.42.0]: https://github.com/bostonaholic/team/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/bostonaholic/team/compare/v0.40.1...v0.41.0
 [0.40.1]: https://github.com/bostonaholic/team/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/bostonaholic/team/compare/v0.39.2...v0.40.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -189,6 +189,33 @@ so a `/team` run authors `docs/plans/<id>/` inside an isolated worktree on
 branch `<id>` from phase 1. The home checkout's `git status` thus stays
 clean for the whole run.
 
+0. **Preflight the environment, then continue regardless.** Run these three
+   read-only checks once and report what they say. **None of them blocks the
+   run** — the pipeline never stops because a credential is cold.
+
+   ```bash
+   ssh-add -l >/dev/null 2>&1 && echo "ssh-agent: keys loaded" || echo "ssh-agent: UNREACHABLE"
+   gh auth status >/dev/null 2>&1 && echo "gh auth: ok" || echo "gh auth: NOT LOGGED IN"
+   echo "global commit.gpgsign: $(git config --global --get commit.gpgsign || echo unset)"
+   ```
+
+   Each answer predicts a specific failure hours later, and knowing it up
+   front is the difference between naming a cause and hunting one:
+
+   - **An unreachable `ssh-agent`** breaks the push at the PR phase, and
+     breaks any test that commits to a scratch repository while global
+     `commit.gpgsign` is `true` — those inherit the setting, try to sign, and
+     stall until they time out. A suite that normally runs in a minute takes
+     ten and fails in places unrelated to the diff.
+   - **A missing `gh` login** breaks the PR phase only, at the very end,
+     after all the work is done.
+
+   Report the readings plainly and move on. When a later failure matches one
+   of them, say so instead of diagnosing the symptom: a suite that fails only
+   under the developer's own git config is an environment reading, not a
+   regression in the branch, and reporting it as the latter sends someone
+   after a bug that is not there.
+
 1. **Create the home worktree** on branch `<id>` off `origin/HEAD`, with
    Claude Code's native worktree support. See the single-repo block in
    `skills/team-worktree/SKILL.md` → "Create the worktree(s)". Only the

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1015,3 +1015,25 @@ describe("phase agents split into self-writing and return-only", () => {
     }
   });
 });
+
+// An unreachable ssh-agent breaks the push at the PR phase and stalls every
+// scratch-repo test while global commit.gpgsign is true. Read once at the
+// start, it names a cause; discovered later, it looks like a regression in
+// the branch. The checks are read-only and never block the run.
+describe("the worktree phase preflights the environment", () => {
+  const TEAM = read(join(REPO_ROOT, "skills", "team", "SKILL.md"));
+
+  test("it reads the three signals that predict a later failure", () => {
+    // Guard: a missing file must fail, not vacuously pass the checks below.
+    expect(TEAM.length).toBeGreaterThan(0);
+    for (const probe of ["ssh-add -l", "gh auth status", "commit.gpgsign"]) {
+      expect(TEAM).toContain(probe);
+    }
+  });
+
+  test("the preflight is explicitly non-blocking", () => {
+    // A preflight that can halt a run is a gate, and this one must not be:
+    // a cold credential is worth naming, never worth stopping for.
+    expect(/blocks the run/i.test(squash(TEAM))).toBe(true);
+  });
+});


### PR DESCRIPTION
Seventh of eight PRs from the retro on the v0.39.0 `groom-backlog` port.

> **Stacked on #218** (itself stacked on #217) — all three edit `skills/team/SKILL.md`. Retarget down the chain as each lands.

## The problem

Mid-run, the ssh-agent became unreachable. The consequences arrived scattered across hours, each looking like something else:

- **26 test failures** in suites that create scratch git repositories. They inherit the developer's global `commit.gpgsign=true`, try to SSH-sign, and stall until each test times out. The suite took **512s instead of 55s** and failed in places with no relationship to the diff.
- I diagnosed the mechanism correctly but **framed it wrongly** — reported it as *"your `bun test` is unreliable, use `GIT_CONFIG_GLOBAL=/dev/null`"* when the truth was *"it breaks only while the agent is down."* That is a claim about the user's repo that wasn't true, and retracting it took a second round of investigation.
- Then `git push` failed at the PR phase, after all the work was done.

Nothing checks any of this, so every symptom was diagnosed from scratch at the moment it appeared.

## The change

Three read-only checks at the start of the WORKTREE phase, reported once:

```bash
ssh-add -l                                  # keys loaded?
gh auth status                              # logged in?
git config --global --get commit.gpgsign    # will scratch repos inherit signing?
```

Each reading predicts a *specific* later failure, and the skill says which — so when one arrives it gets named rather than hunted. The framing that matters: **a suite that fails only under the developer's own git config is an environment reading, not a regression in the branch**, and reporting it as the latter sends someone after a bug that isn't there.

**Explicitly non-blocking.** The pipeline never stops because a credential is cold. A preflight that can halt a run is a gate, and this isn't one.

## Test plan

- [x] `bun test` — 1280 tests, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested:** removing the preflight turns 2 tests red; restoring turns them green
- [x] One tripwire asserts the three probes are present; the other asserts the preflight states it does not block — the property that keeps it from silently becoming a gate

## Related, not included

The scratch-repo suites should pass `-c commit.gpgsign=false` when creating their throwaway repos, so they don't depend on a signing key at all. That's a `tests/` fix rather than a skill fix and belongs in its own PR; this one only makes the condition visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm
