### PR TITLE
v0.43.0 feat(skills): ask whether a slice deserves its own PR

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.42.0"
+    "version": "0.43.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-08-11
+
 ### Added
 
 - **Slicing now asks whether a slice deserves its own pull request, not just its own commit.** Those are different questions, and only the first was ever asked. When one slice introduces a first — a delete, a public write, an outbound message, anything a person cannot quietly take back — it earns rounds of adversarial review that the others do not, and everything bundled with it waits through every round. In the run that prompted this, two of three behaviors passed review unchanged from the first round and still sat through four, because the third was a destructive mutation being argued about. The heuristic is a judgment call rather than a rule, and it names the cost of splitting too — two reviews, two land-time bumps, and a dependency if the safe work builds on the dangerous work — but the call now gets **stated in `## Cross-slice concerns` either way**, so a judgment left unmade is distinguishable from one left unwritten. [`skills/slicing-work/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/slicing-work/SKILL.md)
@@ -480,7 +482,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.42.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.43.0...HEAD
+[0.43.0]: https://github.com/bostonaholic/team/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/bostonaholic/team/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/bostonaholic/team/compare/v0.40.1...v0.41.0
 [0.40.1]: https://github.com/bostonaholic/team/compare/v0.40.0...v0.40.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Slicing now asks whether a slice deserves its own pull request, not just its own commit.** Those are different questions, and only the first was ever asked. When one slice introduces a first — a delete, a public write, an outbound message, anything a person cannot quietly take back — it earns rounds of adversarial review that the others do not, and everything bundled with it waits through every round. In the run that prompted this, two of three behaviors passed review unchanged from the first round and still sat through four, because the third was a destructive mutation being argued about. The heuristic is a judgment call rather than a rule, and it names the cost of splitting too — two reviews, two land-time bumps, and a dependency if the safe work builds on the dangerous work — but the call now gets **stated in `## Cross-slice concerns` either way**, so a judgment left unmade is distinguishable from one left unwritten. [`skills/slicing-work/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/slicing-work/SKILL.md)
+
 ## [0.42.0] - 2026-08-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/slicing-work/SKILL.md
+++ b/skills/slicing-work/SKILL.md
@@ -99,3 +99,19 @@ does not accidentally include it>
 - **Multi-repo: contract-first when ordering matters.** If repo A's
   consumer depends on repo B's contract, the slice that defines the
   contract goes first, and the slice that consumes it cites it.
+- **A slice carrying a destructive, irreversible, or externally-visible
+  mutation may deserve its own PR.** Slices decide what commits atomically;
+  this asks a separate question the structure is the last place to ask it:
+  what ships together. Where one slice introduces a first — a delete, a
+  public write, a credential, an outbound message, anything a person cannot
+  quietly take back — and the others do not, their review costs differ by an
+  order of magnitude. The dangerous one earns rounds of adversarial
+  attention, and everything bundled with it waits through every round. Split
+  them and the cheap work lands while the expensive work is still being
+  argued about.
+
+  This is a judgment call, not a rule, and the cost runs both ways: two PRs
+  mean two reviews, two land-time bumps, and a dependency between them if the
+  safe work builds on the dangerous work. Weigh it and **state the call in
+  `## Cross-slice concerns` either way**, so the planner and the human both
+  know it was decided rather than overlooked.

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -1080,3 +1080,25 @@ describe("cross-surface parity is checked (L2 tripwire)", () => {
     expect(/reaches every surface/i.test(squash(CODE_REVIEW))).toBe(true);
   });
 });
+
+// Slices decide what commits atomically. What ships together is a separate
+// question, and the structure is the last place to ask it: a slice carrying
+// the first irreversible mutation earns rounds of adversarial review, and
+// anything bundled with it waits through every one of them.
+describe("slicing asks whether a slice deserves its own PR (L2 tripwire)", () => {
+  const SLICING = read(join(REPO_ROOT, "skills", "slicing-work", "SKILL.md"));
+
+  test("the heuristic names the irreversible-mutation case", () => {
+    // Guard: a missing file must fail, not vacuously pass the checks below.
+    expect(SLICING.length).toBeGreaterThan(0);
+    const text = squash(SLICING);
+    expect(/its own PR/i.test(text)).toBe(true);
+    expect(/irreversible/i.test(text)).toBe(true);
+  });
+
+  test("the call is recorded in the structure either way", () => {
+    // A judgment left unstated is indistinguishable from one never made.
+    const text = squash(SLICING);
+    expect(text).toContain("## Cross-slice concerns");
+  });
+});


### PR DESCRIPTION
Last of eight PRs from the retro on the v0.39.0 `groom-backlog` port. Independent of the others.

## The problem

Slicing decides what commits atomically. **What ships together is a different question, and nothing asked it.**

In the run that prompted this, three behaviors were ported in one PR. Two of them — claim verification and a ranking heuristic — passed review essentially unchanged from round 1. The third was evidence-backed issue closure: the first irreversible public mutation that skill had ever owned, and it produced **every blocking finding across all four review rounds**.

So two cheap behaviors sat through four rounds of adversarial review waiting for one expensive one. The structure-planner reasoned carefully about consolidating slices, and that reasoning was sound *for commits*. It just never considered that the two could ship separately.

## The change

A heuristic in `skills/slicing-work/SKILL.md`: when one slice introduces a **first** — a delete, a public write, a credential, an outbound message, anything a person cannot quietly take back — and the others do not, their review costs differ by an order of magnitude. Consider separate PRs.

Deliberately framed as a judgment call rather than a rule, and it names the cost of splitting too: two reviews, two land-time bumps, and a dependency between them if the safe work builds on the dangerous work. Sometimes bundling is right.

The part that makes it useful: **the call gets stated in `## Cross-slice concerns` either way.** A judgment left unwritten is indistinguishable from one never made, and the planner and the human both read that section.

## Test plan

- [x] `bun test` — 1272 tests, 0 fail
- [x] `bun run typecheck` — exit 0
- [x] **Mutation-tested:** removing the heuristic turns 1 test red; restoring turns it green
- [x] The second assertion pins that the structure records the decision, which is the half that makes the heuristic auditable rather than advisory

## Confidence

Lowest of the eight. The other seven fix something mechanically broken — a contradiction, a missing gate, a check that could not see. This one adds a judgment prompt, and judgment prompts are the kind of prose that gets read past. It is cheap and it is recorded, so it should at worst be inert; but if you want to drop one from the set, this is the one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Axyuk5uUw1EdC4jcF7gLm
