### PR TITLE
v0.43.1 fix(skills): prune the stale tracking ref that keeps a deleted branch alive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.43.0"
+    "version": "0.43.1"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-08-11
+
+### Fixed
+
+- **Cleaning up a merged branch left its commits on disk, and every check agreed the repo was clean.** When a pull request merges, GitHub deletes the head branch on its own server. Your clone keeps its own pointer to that branch, and git counts every commit the pointer reaches as still in use. So the cleanup ran, reported success, and freed nothing. What made this hard to catch is that the obvious checks agreed with it: `git fsck` found nothing stray, and `git gc --prune=now` deleted nothing. Neither was broken — the commits really were still in use, so a repo in this state looks exactly like a clean one, and "nothing stray" reads as "already done". The cleanup skill listed `git remote prune origin` under optional tidying. It is the step that makes the branch deletion take effect, and it now runs whenever the branch is gone from the remote. The two commands that actually free the disk space are written up on their own and still ask first, because they erase the recovery record for **every** commit no branch points at — a bad rebase, an abandoned experiment — not only the branch being cleaned up. Order is called out too: collect garbage before pruning the pointer and git sees a branch still in use and does nothing. Applied across 48 real clones, the corrected order freed 3.58 GB and removed 2,305 dead pointers that the old procedure would have left in place. [`skills/pr-cleanup/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md), [`skills/worktree-isolation/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
+
 ## [0.43.0] - 2026-08-11
 
 ### Added
@@ -482,7 +488,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.43.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.43.1...HEAD
+[0.43.1]: https://github.com/bostonaholic/team/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/bostonaholic/team/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/bostonaholic/team/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/bostonaholic/team/compare/v0.40.1...v0.41.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/pr-cleanup/SKILL.md
+++ b/skills/pr-cleanup/SKILL.md
@@ -413,8 +413,44 @@ not discard work.
    deletion if it does. Then run the external-state ask and the scratch
    removal exactly as Mode B steps 5 and 6 describe them.
 
-6. **Optional tidy:** offer `git -C "$PRIMARY_ROOT" remote prune origin`
-   to drop stale remote-tracking refs. Run only on confirmation.
+6. **Sever the stale tracking ref, and offer to reclaim the space.**
+   Deleting a branch does not release its commits. When GitHub deletes the
+   head branch on merge — or `gh pr close --delete-branch` deletes it
+   through the API — the deletion happens server-side, and the local
+   `refs/remotes/origin/$BRANCH` survives. That ref keeps every commit on
+   the branch **reachable**, so the repo looks clean while still pinning
+   the objects: `git fsck` reports zero unreachable, and
+   `git gc --prune=now` collects nothing, because from git's view nothing
+   is garbage yet. Pruning the tracking ref is what turns those commits
+   into garbage:
+
+   ```sh
+   git -C "$PRIMARY_ROOT" remote prune origin
+   ```
+
+   Run this whenever the remote branch is gone — `ls-remote` in step 5
+   already answered that. `git fetch --prune` does the same thing.
+
+   Reclaiming the disk space needs two more commands, and they are
+   **destructive well beyond this branch**:
+
+   ```sh
+   git -C "$PRIMARY_ROOT" reflog expire --expire-unreachable=now --all
+   git -C "$PRIMARY_ROOT" gc --prune=now
+   ```
+
+   The reflog expiry drops every repository-wide reflog entry pointing at
+   an unreachable commit, so anything not reachable from a branch, tag,
+   stash, or worktree HEAD becomes unrecoverable — a botched rebase's
+   pre-rebase state, an abandoned experiment, a detached HEAD. Commits and
+   uncommitted work still referenced by a live ref are untouched. Offer
+   these two only when reclaiming space is the actual goal, and run them
+   only on explicit confirmation; cleaning up one merged branch never
+   requires them.
+
+   Order is load-bearing. Run `gc` before the prune and it sees a
+   reachable branch and no-ops, leaving the objects exactly where they
+   were — a cleanup that reports success and frees nothing.
 
 ### Mode B — closed / abandoned
 
@@ -471,6 +507,17 @@ order child before parent throughout.
    git -C "${PRIMARY_ROOT:?}" push origin --delete -- "${BRANCH:?}" [<branch>...]
    ```
 
+   `push --delete` removes the local `refs/remotes/origin/$BRANCH` along
+   with the remote branch, so nothing further is needed on the happy path.
+   It is a different story when the branch was already deleted
+   server-side — `gh pr close --delete-branch`, or someone clicking the
+   button in the GitHub UI. The push then fails with "remote ref does not
+   exist" and the stale local tracking ref is left behind, still holding
+   the whole branch reachable. Run
+   `git -C "$PRIMARY_ROOT" remote prune origin` to sever it; Mode A step 6
+   explains why that matters and what the full space-reclaim sequence
+   costs.
+
 5. **External-state ask.** Whenever a worktree was removed, ask one
    question: does this repo provision per-worktree external state (for
    example a test database named after the worktree)? If the user names a
@@ -516,6 +563,8 @@ order child before parent throughout.
   the default branch is fast-forwarded to the merge.
 - Mode B: every targeted PR is closed, and every trace — worktree, local
   and remote branches, scratch — is gone.
+- No stale `refs/remotes/origin/$BRANCH` is left behind for a branch that
+  no longer exists on origin.
 - Nothing protected, tracked, or unconfirmed was deleted.
 
 ## Pitfalls
@@ -528,6 +577,14 @@ order child before parent throughout.
   rejection verbatim; never force.
 - **Fetch before the gate.** A just-merged PR is invisible to the merged
   check until `git fetch` runs (Hard Rule 3).
+- **A deleted branch is not a released branch.** Every branch deleted
+  server-side leaves `refs/remotes/origin/<branch>` behind in the local
+  clone, and that ref keeps the branch's whole history reachable. The
+  usual diagnostics agree that nothing is wrong — `git fsck` finds zero
+  unreachable objects, `git gc` frees nothing — because the objects are
+  genuinely still referenced. Do not read that as "already clean";
+  `git remote prune origin` is what severs the ref, and only afterward do
+  the objects become collectable (Mode A step 6).
 
 ## Completion
 

--- a/skills/worktree-isolation/SKILL.md
+++ b/skills/worktree-isolation/SKILL.md
@@ -162,7 +162,13 @@ When teardown is warranted (post-merge or on explicit request):
    `git worktree list`, and never a primary clone.
 5. After the worktree is gone, update the repo's local default branch
    with the merge: `git -C <repo-path> pull --rebase origin <base>`.
-   Always rebase — never a merge commit — so history stays linear.
+   Always rebase — never a merge commit — so history stays linear. When
+   the merge also deleted the branch on origin, follow with
+   `git -C <repo-path> remote prune origin`: that deletion is
+   server-side, so the local `refs/remotes/origin/<id>` survives and keeps
+   every commit on the branch reachable — `git branch -D` in step 3 frees
+   nothing while it stands. `skills/pr-cleanup/SKILL.md` Mode A step 6
+   covers this and the space-reclaim sequence that follows it.
 6. Remove the feature's local planning docs: `rm -rf docs/plans/<id>`.
    These are untracked QRSPI scratch that only existed to drive the work
    to a merged PR. Deleting them is part of teardown, alongside the


### PR DESCRIPTION
Found while cleaning up after an abandoned PR: I closed it with `--delete-branch`, ran the documented teardown, reported the work permanently gone — and it was still there. All 19 commits, fully intact.

## The problem

Deleting a branch does not release its commits.

GitHub's head-branch delete on merge happens **server-side**. The local `refs/remotes/origin/<branch>` survives, and that ref keeps every commit on the branch *reachable*. The cleanup runs, reports success, and frees nothing.

What makes this hard to catch is that the usual diagnostics agree with the cleanup. `git fsck` finds zero unreachable objects. `git gc --prune=now` collects nothing. Neither is malfunctioning — the objects genuinely are still referenced, so from git's view nothing is garbage yet. A repo in this state is indistinguishable from a clean one by every check you would think to run, and the natural reading of "0 unreachable" is "already clean."

`pr-cleanup` documented `remote prune origin` as **"Optional tidy: … to drop stale remote-tracking refs. Run only on confirmation."** That is the step that makes the deletion take effect, filed as housekeeping.

## The change

Mode A step 6 now says what the ref does and why severing it comes first. `git remote prune origin` is run whenever the remote branch is gone — step 5's `ls-remote` already answers that.

The two commands that actually reclaim the disk (`reflog expire --expire-unreachable=now --all`, then `gc --prune=now`) are documented **separately** and stay confirmation-gated, because they are destructive well beyond the branch being cleaned up: every repository-wide reflog entry pointing at an unreachable commit goes, taking a botched rebase's pre-rebase state or an abandoned experiment with it. Cleaning up one merged branch never needs them.

Ordering is called out as load-bearing. Run `gc` before the prune and it sees a reachable branch and no-ops.

Mode B gets the asymmetry it was missing: `push --delete` removes the tracking ref itself, but `gh pr close --delete-branch` and the GitHub UI button do not — that push fails with "remote ref does not exist" and the stale ref is left behind.

Also a Pitfall entry warning specifically against reading a clean `fsck`/`gc` as "already clean," and the matching note in `worktree-isolation`'s teardown, where `git branch -D` frees nothing while the tracking ref stands.

## Test plan

- [x] `bun test` — 1292 tests across 44 files, 0 fail
- [x] `bun test tests/pr-cleanup-skill.test.ts tests/worktree-teardown-sweep.test.ts` — 70 pass, 0 fail
- [x] Verified against 48 real clones: `remote prune` first, then reflog expire, then `gc --prune=now` — 2,305 stale tracking refs severed, 3.58 GB reclaimed that the documented procedure alone would have left in place

Not verified locally: `bun run typecheck`. `bun install --frozen-lockfile` fails here with tarball integrity errors across several packages (`typescript`, `@types/node`, `@stablelib/base64`) and a cleared bun cache did not fix it. The tests run without `node_modules`; typecheck cannot. Leaving that to CI — the diff is prose in two `SKILL.md` bodies, so there is no TypeScript in it.

Version assigned at land time per `docs/versioning.md`: **v0.43.1** (patch — a fix to a documented procedure), with the `[Unreleased]` changelog body cut into a dated section in the same `chore(version)` commit. The land-time consistency assertion passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

