### PR TITLE
v0.44.0 fix(shipit): merge without stopping for approval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.43.2"
+    "version": "0.44.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.43.2",
+      "version": "0.44.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.43.2",
+  "version": "0.44.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.43.2",
+  "version": "0.44.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-08-12
+
 ### Fixed
 
 - **`/shipit` stopped halfway through landing a PR to ask permission it had already been given.** Step 4 of the skill was a pre-merge confirmation: after pushing and waiting out CI, the run asked "about to merge PR #N into `<base>` — proceed?" and merged only on a yes. The problem is what reaches that prompt. `/shipit` fires only on explicit ship intent — the user typed `/shipit`, or said "ship it" or "land the PR" — so the answer to "shall I merge this?" was in the request that started the run. The prompt re-requested authorization the invocation carried, and because this is the distributed runtime skill, every caller that chains into it inherited the stop: an approved PR would sit unmerged waiting on a question already answered. A `--yes` flag existed to bypass it, which meant the documented way to make the skill do its job was to pass a flag saying you meant what you said. The confirmation step and the now-dead `--yes` are both gone, and the Land sequence is four steps that run start to finish with no prompt in the middle. Two guards still stand in front of an irreversible merge, and neither one is a question: **explicit ship intent** scopes the invocation, so a PR merely being approved, green, or finished never starts a land, and the **bounded CI-green wait** halts mechanically before `gh pr merge` on a red or timed-out check. The skill now states the rule positively rather than only omitting the prompt, because a model reading a land procedure will otherwise reinsert a confirmation on its own instinct. Pinned by three L2 tripwires in [`tests/shipit-skill.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/shipit-skill.test.ts): `argument-hint` offers no `--yes`, no `--yes` survives anywhere in the skill, and exactly one numbered step heading sits between the CI gate and the merge command — a structural count that fires on *any* step re-inserted there, whatever it is titled. [`skills/shipit/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)
@@ -498,7 +500,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.43.2...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.44.0...HEAD
+[0.44.0]: https://github.com/bostonaholic/team/compare/v0.43.2...v0.44.0
 [0.43.2]: https://github.com/bostonaholic/team/compare/v0.43.1...v0.43.2
 [0.43.1]: https://github.com/bostonaholic/team/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/bostonaholic/team/compare/v0.42.0...v0.43.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/shipit` stopped halfway through landing a PR to ask permission it had already been given.** Step 4 of the skill was a pre-merge confirmation: after pushing and waiting out CI, the run asked "about to merge PR #N into `<base>` — proceed?" and merged only on a yes. The problem is what reaches that prompt. `/shipit` fires only on explicit ship intent — the user typed `/shipit`, or said "ship it" or "land the PR" — so the answer to "shall I merge this?" was in the request that started the run. The prompt re-requested authorization the invocation carried, and because this is the distributed runtime skill, every caller that chains into it inherited the stop: an approved PR would sit unmerged waiting on a question already answered. A `--yes` flag existed to bypass it, which meant the documented way to make the skill do its job was to pass a flag saying you meant what you said. The confirmation step and the now-dead `--yes` are both gone, and the Land sequence is four steps that run start to finish with no prompt in the middle. Two guards still stand in front of an irreversible merge, and neither one is a question: **explicit ship intent** scopes the invocation, so a PR merely being approved, green, or finished never starts a land, and the **bounded CI-green wait** halts mechanically before `gh pr merge` on a red or timed-out check. The skill now states the rule positively rather than only omitting the prompt, because a model reading a land procedure will otherwise reinsert a confirmation on its own instinct. Pinned by three L2 tripwires in [`tests/shipit-skill.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/shipit-skill.test.ts): `argument-hint` offers no `--yes`, no `--yes` survives anywhere in the skill, and exactly one numbered step heading sits between the CI gate and the merge command — a structural count that fires on *any* step re-inserted there, whatever it is titled. [`skills/shipit/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)
+
 ## [0.43.2] - 2026-08-12
 
 ### Changed

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -265,9 +265,7 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 - **Purpose:** Land a reviewed pull request: push unpushed commits, wait for
   CI to go green, then squash-merge (the PR title becomes the commit subject).
-- **`$ARGUMENTS`:** `[<pr-number>] [--yes]` is an optional PR number
-  override. `--yes` skips the interactive pre-merge confirmation for
-  non-interactive callers.
+- **`$ARGUMENTS`:** `[<pr-number>]` is an optional PR number override.
 - **Phase:** None. A standalone land action, not part of the pipeline.
 - **Key behaviors:** Discovers the open PR for the current branch through
   the §2B fallback chain (refuses if there is none, or if it is already
@@ -281,12 +279,14 @@ QRSPI phase: a self-contained action a user runs on demand.
   lands in `git log`. **Project-agnostic**: it does no versioning,
   changelog editing, or release work. Those, if a project needs them, run
   in a separate step before `/shipit` (in this repo, the dev `version-bump`
-  skill). Model-invocable, but the merge is irreversible, so three guards
+  skill). Model-invocable, but the merge is irreversible, so two guards
   replace the former hard flag: it fires only on explicit ship intent
   ("ship it", "land the PR", `/shipit`) and never on a PR that is merely
-  approved or green. The pre-merge confirmation stands unless the caller
-  already carries the user's authorization (`--yes`). The CI-green wait
-  also gates the merge mechanically. On a merge that **landed**, it runs
+  approved or green, and the CI-green wait gates the merge mechanically.
+  Neither guard is a question put to the user mid-run — **it does not stop
+  to confirm the merge**, because ship intent already carried the
+  authorization and every caller chaining into `/shipit` would inherit the
+  stop. On a merge that **landed**, it runs
   `/pr-cleanup` rather than recommending it — resyncing the default branch
   and deleting the merged branch carry no decision, and Mode A gates itself
   on merged-PR verification. A run that stopped short (failing check, CI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.43.2",
+  "version": "0.44.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/skills/shipit/SKILL.md
+++ b/skills/shipit/SKILL.md
@@ -11,7 +11,7 @@ description: |
   "/shipit". Landing merges, which is irreversible: never infer ship intent
   from a PR merely being approved, green, or finished.
 effort: medium
-argument-hint: "[<pr-number>] [--yes]"
+argument-hint: "[<pr-number>]"
 ---
 
 # shipit — land a reviewed PR
@@ -30,23 +30,27 @@ version at land time, that happens in a separate project-specific step *before*
 [docs/versioning.md](../../docs/versioning.md)). `shipit` only cares that the
 branch is ready to land.
 
-`gh pr merge` is irreversible, so three things guard it — none of them a
-frontmatter flag:
+`gh pr merge` is irreversible, so two things guard it — neither of them a
+frontmatter flag, and neither of them a question put to the user mid-run:
 
 1. **Explicit ship intent.** The skill fires only on a direct "ship it" / "land
    the PR" / `/shipit`. An approved, green, or finished-looking PR is *not*
    ship intent — the user decides when to land.
-2. **The pre-merge confirmation** (step 4), which the model never skips on its
-   own initiative: `--yes` belongs to a caller that already carries the user's
-   authorization to merge.
-3. **CI green** (step 3), which gates the merge mechanically — a red or timed
+2. **CI green** (step 3), which gates the merge mechanically — a red or timed
    out check stops the land before `gh pr merge` ever runs.
+
+**Do not ask the user to confirm the merge.** Ship intent already carried the
+authorization to merge, so a confirmation re-requests permission the invocation
+granted, and every caller that chains into `/shipit` inherits the stop. Once
+step 3 reports green, merge. The guard against merging the wrong thing is
+refusing to start without ship intent, not stopping halfway through a land the
+user asked for.
 
 ## Input acquisition
 
 `shipit` lands the open PR for the **current branch**. Discover it with
 `gh pr view --json baseRefName,number,state,title` and a base-branch fallback.
-Never hardcode the base branch. The `title` is captured here because step 5
+Never hardcode the base branch. The `title` is captured here because step 4
 lands it as the squash commit subject. Run this in one bash call (an agent
 thread resets cwd between calls):
 
@@ -69,9 +73,9 @@ echo "BASE: $BASE"
 
 ## Land sequence
 
-The steps below are the **scriptable core**. The one interactive confirmation
-(the pre-merge confirm in step 4) **wraps** it: a non-interactive caller passes
-`--yes` to skip the prompt, leaving a pure push → wait → merge sequence.
+The steps below are the whole sequence, and they are **scriptable end to end**:
+a pure push → wait → merge with no prompt in the middle. Nothing here waits on a
+human.
 
 ### 1. Pre-flight merge-button check
 
@@ -99,7 +103,7 @@ git push
 ```
 
 If the local branch and remote diverged because someone rebased the branch
-locally, see the force-with-lease guidance in step 5. Never use a bare
+locally, see the force-with-lease guidance in step 4. Never use a bare
 `--force`.
 
 ### 3. Wait for CI
@@ -136,16 +140,7 @@ of three outcomes:
 commits are already on the branch — `shipit` simply pushes any new ones, waits
 again, and merges. It is safe to re-run.
 
-### 4. Pre-merge confirmation
-
-`gh pr merge` is irreversible. **Ask for an explicit confirmation** before
-merging — "about to merge PR #N into `<base>` — proceed?" — and only merge on a
-yes. `--yes` skips this prompt, but it is **the caller's to pass, never yours to
-add**: it means the invoker already authorized the merge. Running as an agent
-does not make you a non-interactive caller — when `--yes` is absent, ask.
-The prompt wraps the scriptable core, it does not live inside it.
-
-### 5. Rebase if behind the base, then merge
+### 4. Rebase if behind the base, then merge
 
 **PR behind its base.** Before merging, check if the base branch advanced since
 CI last ran. If the PR is **behind `<base>`**, bring it up to date:

--- a/tests/shipit-skill.test.ts
+++ b/tests/shipit-skill.test.ts
@@ -41,6 +41,10 @@ function completionSection(): string {
   const start = text.indexOf("## Completion");
   return start >= 0 ? text.slice(start) : "";
 }
+// The value of the argument-hint frontmatter line, or "" when absent.
+function argumentHint(): string {
+  return /^argument-hint:.*$/m.exec(fm())?.[0] ?? "";
+}
 
 describe("shipit skill: it is a runtime skill, project-agnostic", () => {
   test("skill file lives under runtime skills/ (distributed)", () => {
@@ -53,8 +57,8 @@ describe("shipit skill: it is a runtime skill, project-agnostic", () => {
 
   test("frontmatter does NOT set disable-model-invocation (model-invocable by design)", () => {
     // shipit is irreversible (it merges), but the guard is explicit ship
-    // intent + the pre-merge confirmation + CI-green gating, not a hard flag —
-    // so the model can reach it when the user asks it to land the PR.
+    // intent + CI-green gating, not a hard flag — so the model can reach it
+    // when the user asks it to land the PR.
     const f = fm();
     // Guard: an empty frontmatter must fail, not vacuously pass the absence check.
     expect(f.length).toBeGreaterThan(0);
@@ -127,6 +131,48 @@ describe("shipit skill: push, wait for CI, merge", () => {
     const t = flat(body());
     expect(/--json[^.]{0,80}title/i.test(t)).toBe(true);
     expect(body()).toContain("--subject");
+  });
+});
+
+// The invocation IS the authorization: `/shipit` fires only on explicit ship
+// intent, so a second ask before `gh pr merge` re-requests permission the user
+// already granted. Because this is the RUNTIME skill, every caller that chains
+// into it inherits that stop. Two guards remain and both are mechanical:
+// explicit ship intent scopes the invocation, and the CI-green wait halts the
+// land before `gh pr merge` runs.
+describe("shipit skill: the merge is not gated on a human confirmation", () => {
+  test("argument-hint offers no --yes (there is no prompt left to skip)", () => {
+    // Guard: a missing argument-hint must fail, not vacuously pass the absence
+    // check below. The flag existed only to bypass the confirmation.
+    const hint = argumentHint();
+    expect(hint.length).toBeGreaterThan(0);
+    expect(hint).toContain("pr-number");
+    expect(hint).not.toContain("--yes");
+  });
+
+  test("no --yes escape hatch anywhere in the skill", () => {
+    const t = body();
+    // Guard: a missing file reads as "" and would vacuously pass.
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).not.toContain("--yes");
+  });
+
+  // A structural check, not a wording pin: it counts numbered step headings
+  // between the CI gate and the merge command, so it fires on ANY step
+  // re-inserted there regardless of what that step is titled. Exactly one
+  // heading may appear — the merge step's own — because the CI-wait step's
+  // body continues past its fenced command.
+  test("no numbered step sits between the CI-green gate and the merge", () => {
+    const t = body();
+    const ciGate = t.indexOf("timeout 1800 gh pr checks");
+    const merge = t.indexOf("gh pr merge <pr-number>");
+    // Guards: both anchors must exist, in this order, or the slice below is
+    // meaningless and the heading count would pass for the wrong reason.
+    expect(ciGate).toBeGreaterThan(-1);
+    expect(merge).toBeGreaterThan(ciGate);
+    const between = t.slice(ciGate, merge);
+    const steps = [...between.matchAll(/^###\s+\d+\./gm)];
+    expect(steps.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Problem

`/shipit` stopped halfway through landing a PR to ask permission it had already been given.

Step 4 of the skill was a pre-merge confirmation: after pushing and waiting out CI, the run asked *"about to merge PR #N into `<base>` — proceed?"* and merged only on a yes. The problem is what reaches that prompt. `/shipit` fires **only on explicit ship intent** — the user typed `/shipit`, or said "ship it" / "land the PR" — so the answer to "shall I merge this?" was already in the request that started the run.

Two consequences:

- The prompt re-requested authorization the invocation carried. Because this is the **distributed runtime** skill, every caller chaining into it inherited the stop: an approved, green PR would sit unmerged waiting on a question already answered.
- A `--yes` flag existed to bypass it, which made the documented way to get the skill to do its job "pass a flag saying you meant what you said."

## Fix

The confirmation step and the now-dead `--yes` are both gone. The Land sequence is **four steps that run start to finish** with no prompt in the middle.

Two guards still stand in front of the irreversible merge, and neither is a question:

1. **Explicit ship intent** scopes the invocation — a PR merely being approved, green, or finished never starts a land.
2. The **bounded CI-green wait** halts mechanically before `gh pr merge` on a red or timed-out check.

The skill now states the rule *positively* rather than only omitting the prompt, because a model reading a land procedure will otherwise reinsert a confirmation on its own instinct.

## Surfaces changed

| File | Change |
|---|---|
| `skills/shipit/SKILL.md` | `argument-hint` drops `--yes`; guard list 3 → 2 plus an explicit "do not ask" rule; step 4 deleted; step 5 → 4; cross-references renumbered |
| `docs/skills.md` | `shipit` entry: `$ARGUMENTS` and the guard description |
| `tests/shipit-skill.test.ts` | three new L2 tripwires + stale comment |
| `CHANGELOG.md` | `[Unreleased]` bullet |

## Tests

Three L2 tripwires, each verified to fire against the pre-fix text as its positive control (per `docs/testing.md`):

- [x] `argument-hint` offers no `--yes`
- [x] no `--yes` survives anywhere in the skill
- [x] exactly **one** numbered step heading sits between the CI gate and the merge command — a *structural* count, not a wording pin, so it fires on any step re-inserted there whatever it is titled

## Test plan

- [x] `bun test tests/shipit-skill.test.ts` fails 3/18 on the pre-fix skill, with clean assertion failures (no crashes)
- [x] `bun run typecheck` passes at the red step (Red→Green mechanical gate)
- [x] `bun test tests/shipit-skill.test.ts` → 18 pass after the fix
- [x] `bun test` full free suite → 1291 pass, 0 fail
- [x] `bun run typecheck` → clean
- [x] Land sequence step headings are contiguous `1..4` and every in-text step cross-reference resolves
- [ ] Reviewer confirms removing the confirmation is the intended trade: explicit ship intent is now the *only* human authorization in the land path

## Notes

This is a **runtime** change (`skills/shipit/SKILL.md` is distributed), so it needs a version bump at **land time** — not now. `.github/scripts/version-bump-required.sh` exiting 1 on this branch is the expected state throughout review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T6cNJYKJRAc1ioyKVkfyL