### PR TITLE
fix(version-bump): decide the level from blast radius, not commit type

### DIFF
--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -186,17 +186,78 @@ git log origin/main..HEAD --oneline
 git diff origin/main...HEAD --stat
 ```
 
-Pick the highest-impact **runtime** change in the PR:
+#### What SemVer actually says
 
-- **major** — breaking change to the plugin's contract (commands, artifact formats, hook behavior).
-- **minor** — new backward-compatible capability (`feat:`).
-- **patch** — everything else (`fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`).
+[SemVer 2.0.0](https://semver.org/spec/v2.0.0.html), quoted verbatim. Note the
+scope column — **items 6, 7, and 8 each carry an `x > 0` precondition:**
 
-The conventional-commit type only picks the *level*. It never overrides step 0. A
-`ci:`/`test:`/`docs:`/`chore:` commit that ships **no runtime change** never
-reaches this table — it already stopped at step 0 with no bump.
+| Item | Normative rule | Scope |
+|------|----------------|-------|
+| 6 | PATCH "MUST be incremented if only backward compatible bug fixes are introduced. A bug fix is defined as an internal change that fixes incorrect behavior." | `x.y.Z \| x > 0` |
+| 7 | MINOR "MUST be incremented if new, backward compatible functionality is introduced to the public API." | `x.Y.z \| x > 0` |
+| 8 | MAJOR "MUST be incremented if any backward incompatible changes are introduced to the public API." | `X.y.z \| X > 0` |
 
-State the chosen level and the reasoning. If genuinely ambiguous, ask.
+Team's version starts `0.`, so **not one of those three rules binds.** Item 4
+governs instead: "Major version zero (`0.y.z`) is for initial development.
+Anything MAY change at any time. The public API SHOULD NOT be considered
+stable." The spec assigns **no level at all** pre-1.0, which is why the rule
+below is Team's own convention — chosen so it keeps meaning the same thing once
+1.0.0 arrives. Item 5: "Version 1.0.0 defines the public API."
+
+#### The decision
+
+Ask these in order. **The first yes wins.** Judge the *change*, never the
+commit subject:
+
+1. **Can a plugin user observe the difference?** → **minor**
+
+   A user installs Team and runs its commands. Anything that changes what they
+   type, what they get back, or what the plugin does on their behalf is
+   observable: a command's name or arguments (`argument-hint`), documented
+   behavior, whether a step prompts them, an artifact's format or frontmatter
+   schema, hook behavior, an agent's model or tool access. New capability and
+   changed capability both land here.
+
+2. **Otherwise** → **patch**
+
+   Internal-only and backward compatible: prose that clarifies without changing
+   an instruction, a comment, restructuring that preserves behavior. This is
+   item 6's definition — "an internal change that fixes incorrect behavior" —
+   and it requires *both* qualifiers, not just a `fix:` subject.
+
+   **Expect patch to be rare.** Team ships prose that a model reads, so a
+   runtime edit usually changes what the plugin does, and question 1 catches it.
+   That is the intended consequence of this rule, not evidence it is
+   miscalibrated — do not widen patch to make the cadence feel familiar.
+
+**`major` is unreachable while the version starts `0.`** Item 8 is scoped
+`X > 0`, and 1.0.0 is the release that "defines the public API" (item 5). A
+breaking change pre-1.0 is a **minor**, not a major: bumping to 1.0.0 to
+describe one broken interface would commit the whole plugin to API stability,
+which is a far larger claim than the change makes. If a change looks like it
+warrants major, that is a signal to **ask whether it is time to declare 1.0.0**
+— a deliberate decision, never a side effect of this skill.
+
+#### The commit type is not the input
+
+A conventional-commit type describes the author's intent, not the blast radius,
+so it never decides the level. A `fix:` that changes observable behavior is a
+**minor**; a `feat:` confined to internals is a **patch**. Step 0 has already
+settled *whether* to bump, so a `ci:`/`test:`/`docs:`/`chore:` commit shipping
+no runtime change never reaches this decision at all.
+
+**Worked example — [PR #228](https://github.com/bostonaholic/team/pull/228),
+which this rule exists to get right.** `fix(shipit): merge without stopping for
+approval` removed the `--yes` argument and removed the pre-merge confirmation.
+Question 1: a user who typed `/shipit` stopped being asked to confirm, and a
+documented argument disappeared — observable. **minor** (0.43.2 → 0.44.0). The
+`fix:` subject is irrelevant, and the removed argument does not make it a major
+while Team is pre-1.0.
+
+State the chosen level and which question decided it. Both levels are reachable
+from any commit type, so a level that needed a judgment call is a signal the
+observability question above was not actually answered — answer it rather than
+asking the user.
 
 ### 2. Compute the next version
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -123,10 +123,9 @@ intend to land:
 0. **Runtime-vs-dev gate.** If the PR changes no runtime files, stop here: no
    bump, no changelog cut, plain title. Go straight to `/shipit`. Only a
    runtime change continues to the steps below.
-1. Decides the bump level from the PR's **runtime** commits (3-part
-   [SemVer](https://semver.org): breaking → major, `feat:` → minor, everything
-   else → patch). The commit type only picks the *level* once step 0 has
-   established that a bump is warranted at all.
+1. Decides the bump level from what the PR's **runtime** change does, not from
+   its commit type (see [Choosing the level](#choosing-the-level)): observable
+   to a plugin user → minor, internal-only and backward compatible → patch.
 2. Computes the next free version (`next-version.sh`).
 3. Bumps the five version strings.
 4. **Cuts the changelog section**: moves the `[Unreleased]` body into a dated
@@ -136,6 +135,36 @@ intend to land:
 6. Commits the bump (`chore(version): X.Y.Z`) and sets the PR title.
 
 Then run `/shipit` to push, wait for CI, and squash-merge.
+
+## Choosing the level
+
+Team is pre-1.0, and that changes which SemVer rules apply.
+[SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) scopes its MAJOR, MINOR, and
+PATCH rules (items 8, 7, 6) to `x > 0`. Team's version starts `0.`, so none of
+them binds. Item 4 governs: "Major version zero (`0.y.z`) is for initial
+development. Anything MAY change at any time. The public API SHOULD NOT be
+considered stable." The spec assigns no level pre-1.0, so the convention below
+is Team's, written to keep meaning the same thing after 1.0.0.
+
+| Level | When | Reachable pre-1.0 |
+|-------|------|-------------------|
+| **minor** | A plugin user can observe the difference: a command's name or arguments, documented behavior, an artifact format, hook behavior, an agent's model or tools. New *and* changed capability both. | yes |
+| **patch** | Internal-only and backward compatible — item 6's "internal change that fixes incorrect behavior", which needs both qualifiers. | yes |
+| **major** | Never, while the version starts `0.`. Item 8 is scoped `X > 0`, and 1.0.0 "defines the public API" (item 5). | **no** |
+
+Two consequences worth stating, because both were previously decided wrong:
+
+- **A breaking change pre-1.0 is a minor, not a major.** Bumping to 1.0.0 to
+  describe one broken interface commits the whole plugin to API stability.
+  Declaring 1.0.0 is a deliberate decision, never a side effect of a bump.
+- **The commit type is not the input.** It describes intent, not blast radius. A
+  `fix:` that changes observable behavior is a minor; a `feat:` confined to
+  internals is a patch. [PR #228](https://github.com/bostonaholic/team/pull/228)
+  is the worked example: a `fix:` that removed the `/shipit` `--yes` argument and
+  its confirmation prompt landed as **0.44.0**.
+
+The full decision procedure, with the spec quoted verbatim, is step 1 of
+[`.claude/skills/version-bump/SKILL.md`](https://github.com/bostonaholic/team/blob/main/.claude/skills/version-bump/SKILL.md).
 
 ## Land-time consistency assertion
 

--- a/tests/version-bump-skill.test.ts
+++ b/tests/version-bump-skill.test.ts
@@ -149,6 +149,78 @@ describe("version-bump skill ↔ version-bump-required.sh: shared signal anchors
   });
 });
 
+// Regression: PR #228 changed observable behavior (it removed the `--yes`
+// argument and the pre-merge confirmation) under a `fix:` subject. The old
+// three-bullet level table keyed off the conventional-commit TYPE, so the patch
+// row matched on `fix:`, the major row matched on the removed argument, and
+// minor — the correct answer — was not reachable at all. The run stopped and
+// asked a human for a level that should have been mechanical.
+//
+// The rule now keys off what SemVer keys off: public surface and backward
+// compatibility, with the pre-1.0 scope stated. These assertions pin the spec
+// identifiers that carry the rule, not the sentences that explain it.
+describe("version-bump skill: the level rule is SemVer-grounded and pre-1.0 aware", () => {
+  test("cites the SemVer 2.0.0 spec by URL", () => {
+    const t = body();
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).toContain("https://semver.org/spec/v2.0.0.html");
+  });
+
+  test("records the `x > 0` precondition that scopes spec items 6-8", () => {
+    // The load-bearing fact. MAJOR/MINOR/PATCH are each scoped `x > 0`, so none
+    // of those MUST rules binds while Team is at 0.y.z — which is why the table
+    // needed a stated local convention rather than a bare SemVer reference.
+    const t = body();
+    expect(t.length).toBeGreaterThan(0);
+    expect(/x > 0/i.test(t)).toBe(true);
+  });
+
+  test("names the major-version-zero clause and the 1.0.0 boundary", () => {
+    const t = body();
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).toContain("0.y.z");
+    expect(t).toContain("1.0.0");
+  });
+
+  // Negative sweeps on the three claims that produced the wrong level. A
+  // meaning-preserving rewrite never adds a banned claim back, so these cannot
+  // pin wording — and each one fired against the pre-fix table.
+  test("patch is no longer keyed off the `fix:` commit type", () => {
+    const t = body();
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).not.toContain("everything else (`fix:`");
+  });
+
+  test("minor is no longer keyed off the `feat:` commit type", () => {
+    const t = body();
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).not.toContain("new backward-compatible capability (`feat:`)");
+  });
+
+  test("a breaking change is no longer routed to major", () => {
+    const t = body();
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).not.toContain("breaking change to the plugin's contract");
+  });
+});
+
+// Two files state the level rule. A fix applied to only one leaves the other
+// teaching the defect to the next reader.
+describe("version-bump ↔ docs/versioning.md: the level rule agrees on both surfaces", () => {
+  const DOC = join(REPO_ROOT, "docs", "versioning.md");
+  const doc = existsSync(DOC) ? read(DOC) : "";
+
+  test("docs/versioning.md states the pre-1.0 scope", () => {
+    expect(doc.length).toBeGreaterThan(0);
+    expect(doc).toContain("0.y.z");
+  });
+
+  test("docs/versioning.md no longer compresses the rule to `breaking → major`", () => {
+    expect(doc.length).toBeGreaterThan(0);
+    expect(doc).not.toContain("breaking → major");
+  });
+});
+
 describe("version-bump skill: ordering — cut BEFORE the land-time assertion", () => {
   // The released-section + footer-link invariants can only be validated after
   // the cut has written them, so the consistency assertion must follow the cut.


### PR DESCRIPTION
## Problem

`version-bump` step 1 could not produce the correct level for [#228](https://github.com/bostonaholic/team/pull/228), so the run **stopped and asked a human** for something that should have been mechanical.

The table was:

```
major — breaking change to the plugin's contract (commands, artifact formats, hook behavior)
minor — new backward-compatible capability (`feat:`)
patch — everything else (`fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`)
```

Applied to #228 — a `fix:` that removed the `/shipit` `--yes` argument and its confirmation prompt:

| Row | Matched? | Why |
|---|---|---|
| patch | **yes** | the subject is `fix:` |
| major | **yes** | `--yes`, a documented command argument, disappeared |
| minor | **no** | no new capability was introduced |

Overlapping rows, no precedence, and **the correct answer was not reachable from the table at all.**

## Root causes

1. **Rows keyed off the conventional-commit type** rather than what SemVer keys off: public surface plus backward compatibility.
2. **No pre-1.0 clause.** Spec items 6, 7, and 8 each carry an `x > 0` precondition, so none of them binds at `0.y.z` — yet the major row fired anyway.
3. **`fix:` was treated as sufficient for patch**, dropping item 6's *two* qualifiers: "only backward compatible" **and** "an internal change".

## What SemVer 2.0.0 actually says

Quoted verbatim in the skill now. The scope column is the part that was missing:

| Item | Rule | Scope |
|---|---|---|
| 6 | PATCH — "only backward compatible bug fixes… an internal change that fixes incorrect behavior" | `x.y.Z \| x > 0` |
| 7 | MINOR — "new, backward compatible functionality… to the public API" | `x.Y.z \| x > 0` |
| 8 | MAJOR — "any backward incompatible changes… to the public API" | `X.y.z \| X > 0` |

Team's version starts `0.`, so **not one of those three binds.** Item 4 governs: *"Major version zero (0.y.z) is for initial development. Anything MAY change at any time."* The spec assigns **no level pre-1.0**, which is exactly why a bare "3-part SemVer" reference was not enough — the project needs a stated local convention.

## The new rule

One question, asked first:

1. **Can a plugin user observe the difference?** → **minor**  (command name/arguments, documented behavior, artifact format, hook behavior, an agent's model or tools; new *and* changed capability)
2. Otherwise → **patch**  (internal-only *and* backward compatible)

**`major` is unreachable while the version starts `0.`** Item 8 is scoped `X > 0`, and 1.0.0 is the release that "defines the public API" (item 5). A breaking change pre-1.0 is a **minor** — bumping to 1.0.0 to describe one broken interface would commit the whole plugin to API stability. If a change looks like it warrants major, that is a cue to ask whether it is time to declare 1.0.0, never a side effect of a bump.

#228 is written in as the worked example, resolving to minor (0.43.2 → 0.44.0).

## ⚠️ Consequence worth reviewing

**Patch becomes rare.** Team ships prose that a model reads, so most runtime edits change what the plugin does and question 1 catches them. Under this rule some past patch releases would have been minors — `v0.43.1` (pr-cleanup began running `git remote prune`) and `v0.40.1` (changed how skeptic passes weigh a stated rule) are both observable behavior changes.

That follows directly from "changing externally facing behavior should always result in a minor bump," and it matches item 4's expectation for `0.y.z`. The skill states it explicitly so the cadence is not later mistaken for miscalibration and quietly widened back. **Flagging it because it changes release cadence, not just accuracy.**

## Surfaces changed

| File | Change |
|---|---|
| `.claude/skills/version-bump/SKILL.md` | Step 1 rewritten: spec items 4-8 verbatim with scope, the ordered decision, the commit-type-is-not-the-input rule, #228 worked example |
| `docs/versioning.md` | Step 1 summary corrected; new `## Choosing the level` section |
| `tests/version-bump-skill.test.ts` | 8 L2 tripwires |

## Tests

Three pin the spec identifiers that carry the rule (spec URL, `x > 0`, the `0.y.z`/`1.0.0` boundary). Three are negative sweeps on the claims that produced the wrong level. Two pin `docs/versioning.md`, so a fix to one surface cannot leave the other teaching the defect.

## Test plan

- [x] All 8 tripwires fail before the change, with clean assertion failures (positive control per `docs/testing.md`)
- [x] `bun run typecheck` passes at the red step (Red→Green gate)
- [x] `bun test tests/version-bump-skill.test.ts` → 26 pass after the fix
- [x] `bun test` full free suite → 1301 pass, 0 fail
- [x] `docs-versioning` + `changelog-links` suites → 22 pass
- [x] The `#choosing-the-level` anchor resolves to a real heading
- [x] Dev-only confirmed by the gate: `OK: runtime_changed=false bumped=false`
- [ ] Reviewer confirms the rare-patch consequence above is the intended trade

## Notes

Dev-only (`.claude/`, `docs/`, `tests/`), so **no version bump and no changelog cut** — the changelog is for plugin end users and nothing user-facing changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T6cNJYKJRAc1ioyKVkfyL