### PR TITLE
fix(pre-merge-guard): judge a merge by the gate script the PR lands

### DIFF
--- a/.claude/hooks/pre-merge-guard.mjs
+++ b/.claude/hooks/pre-merge-guard.mjs
@@ -9,6 +9,18 @@
  * actually merge (the PR's remote head vs the fetched base tip) and denies the
  * merge unless the script exits 0 printing an `OK:` line.
  *
+ * The script is read out of the PR HEAD COMMIT, never from this checkout's
+ * working tree (#232). The script IS the definition of "runtime file", so a PR
+ * that extends that definition must be judged by the definition it lands, not
+ * by the one it replaces. This file's own location is no guide to that: hooks
+ * resolve through $CLAUDE_PROJECT_DIR, and worktrees live under
+ * <repo>/.claude/worktrees/, so the path above routinely lands in the OUTER
+ * main checkout while the branch being merged sits in a worktree. Reading from
+ * the commit removes the coupling entirely. A fork head is the exception —
+ * running its script would execute unreviewed code locally, which this repo
+ * already refuses for fork PRs (docs/testing.md §5) — so a fork whose script
+ * differs from this checkout's denies instead.
+ *
  * Failure direction: fail open only before jurisdiction is decided
  * (unparseable stdin, a parsed command with no `gh pr merge` simple
  * command). A command the tokenizer cannot parse fails CLOSED whenever its
@@ -24,17 +36,22 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const INVARIANT_SCRIPT = join(
-  REPO_ROOT,
-  ".github",
-  "scripts",
-  "version-bump-required.sh",
-);
+// Repo-relative, because the script is read out of a commit. The absolute path
+// below is used only to compare against a fork head's copy.
+const INVARIANT_SCRIPT_PATH = ".github/scripts/version-bump-required.sh";
+const INVARIANT_SCRIPT = join(REPO_ROOT, ...INVARIANT_SCRIPT_PATH.split("/"));
 
 // All external calls (gh, the fetches, the script run) share ONE overall
 // budget, kept below the registered hook timeout (.claude/settings.json) so a
@@ -82,11 +99,28 @@ function describeFailure(what, result) {
   return `pre-merge guard: ${what} failed (exit ${result.status})${stderr ? `: ${stderr}` : ""}`;
 }
 
+// The extracted gate script lives in a temp dir for the length of one run.
+// deny() exits the process, so `finally` never runs — every exit path clears it
+// explicitly instead, or the guard litters tmp on each denied merge.
+let scratchDir = null;
+
+function clearScratch() {
+  if (scratchDir === null) return;
+  const dir = scratchDir;
+  scratchDir = null;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // A leftover temp dir is not worth failing a verdict over.
+  }
+}
+
 // Dual deny channel: the permission payload denies the tool call, and exit 2
 // is a blocking error whose stderr Claude Code feeds back to the model. The
 // deny text is the only text the denied session is guaranteed to read, so it
 // must carry the recovery route itself.
 function deny(text) {
+  clearScratch();
   process.stdout.write(
     JSON.stringify({
       hookSpecificOutput: {
@@ -907,7 +941,7 @@ function gate(mergeWords) {
     "view",
     ...(selector !== undefined ? [selector] : []),
     "--json",
-    "number,headRefOid,baseRefName",
+    "number,headRefOid,baseRefName,isCrossRepository",
   ]);
   if (!succeeded(view)) {
     deny(
@@ -926,17 +960,20 @@ function gate(mergeWords) {
   const number = pr?.number;
   const headRefOid = pr?.headRefOid;
   const baseRefName = pr?.baseRefName;
+  const isCrossRepository = pr?.isCrossRepository;
   // The full-oid shape check keeps headRefOid from ever reaching git as an
   // option-shaped or ref-expression argument.
   if (
     !Number.isInteger(number) ||
     typeof headRefOid !== "string" ||
     !/^[0-9a-f]{40}$/.test(headRefOid) ||
-    typeof baseRefName !== "string"
+    typeof baseRefName !== "string" ||
+    typeof isCrossRepository !== "boolean"
   ) {
     deny(
       "pre-merge guard: unexpected gh pr view output (expected an integer " +
-        "number, a 40-hex-char headRefOid, and a string baseRefName): " +
+        "number, a 40-hex-char headRefOid, a string baseRefName, and a " +
+        "boolean isCrossRepository): " +
         `${view.stdout.trim()}\n` +
         "Recovery: check gh (gh --version, gh auth status), then re-run /shipit.",
     );
@@ -1006,21 +1043,55 @@ function gate(mergeWords) {
     );
   }
 
-  if (!existsSync(INVARIANT_SCRIPT)) {
+  // The gate script as of the PR head, which is the definition of "runtime
+  // file" that this merge lands (#232). A head that carries no script yields no
+  // verdict.
+  const headScript = run("git", [
+    "show",
+    `${headRefOid}:${INVARIANT_SCRIPT_PATH}`,
+  ]);
+  if (!succeeded(headScript) || (headScript.stdout ?? "") === "") {
     deny(
-      `pre-merge guard: missing ${INVARIANT_SCRIPT}. Recovery: restore it ` +
-        `(git checkout origin/${defaultBranch} -- .github/scripts/version-bump-required.sh), ` +
-        "then re-run /shipit.",
+      `pre-merge guard: the PR head carries no ${INVARIANT_SCRIPT_PATH}. ` +
+        "Recovery: restore it on the branch " +
+        `(git checkout origin/${defaultBranch} -- ${INVARIANT_SCRIPT_PATH}), ` +
+        "push, then re-run /shipit.",
     );
   }
+
+  // A fork head's script is unreviewed code, and this repo withholds trust from
+  // fork PRs by policy (docs/testing.md §5), so it is never executed. An
+  // identical copy is this checkout's own content and runs normally; a divergent
+  // one denies and hands the operator the diff.
+  if (isCrossRepository) {
+    const local = existsSync(INVARIANT_SCRIPT)
+      ? readFileSync(INVARIANT_SCRIPT, "utf-8")
+      : null;
+    if (local !== headScript.stdout) {
+      deny(
+        `pre-merge guard: PR #${number} comes from a fork and its ` +
+          `${INVARIANT_SCRIPT_PATH} differs from this checkout's. The guard ` +
+          "does not execute a gate script it has not reviewed, so it cannot " +
+          "render a verdict. Recovery: read the head's copy " +
+          `(git show ${headRefOid}:${INVARIANT_SCRIPT_PATH}), and land the PR ` +
+          "deliberately outside this guard once you trust it.",
+      );
+    }
+  }
+
+  scratchDir = mkdtempSync(join(tmpdir(), "pre-merge-guard-gate-"));
+  const scriptPath = join(scratchDir, "version-bump-required.sh");
+  writeFileSync(scriptPath, headScript.stdout);
+
   // BASE_SHA is the base TIP, never a pre-computed merge-base: the script
   // reduces the pair to the fork point itself, exactly as CI did.
-  const verdict = run("bash", [INVARIANT_SCRIPT], {
+  const verdict = run("bash", [scriptPath], {
     HEAD_SHA: headRefOid,
     BASE_SHA: baseTipOid,
   });
   if (succeeded(verdict) && (verdict.stdout ?? "").startsWith("OK:")) {
     // Allow silently (check-registry-sync.mjs precedent: no output on allow).
+    clearScratch();
     return;
   }
   const text =

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -77,9 +77,14 @@ with **no bump, no changelog cut, and a plain conventional title** (precedent:
 the bump commit, through `.github/scripts/version-bump-required.sh`, which
 `tests/version-bump-required.test.ts` pins. CI does not enforce the invariant.
 Enforcement is mechanical at the merge attempt: the pre-merge dev hook
-(`.claude/hooks/pre-merge-guard.mjs`) runs the same script against the PR's
+(`.claude/hooks/pre-merge-guard.mjs`) runs the script against the PR's
 remote head and **denies a violating `gh pr merge`** on either violation — a
-dev-only diff that bumped, or a runtime diff that did not. The script measures
+dev-only diff that bumped, or a runtime diff that did not. It reads the script
+**out of the PR head commit**, not from the working tree, because the script is
+itself the definition of "runtime file": a PR that widens that definition has to
+be judged by the definition it lands. A fork head is the exception. Its script
+is unreviewed code, so a fork whose copy differs from the local one is denied
+rather than executed. The script measures
 "did this branch bump?" against the merge-base, which is the fork point. A
 bump-less PR behind a version-bumped `main` thus reads correctly as "no
 bump". [PR title sync](#pr-title) uses the same branch-relative measure.
@@ -353,6 +358,19 @@ for a wrongful one — and in the wrongful case also re-title: a re-entry that
 ends at "no bump" must strip the stale `vX.Y.Z` prefix back to the plain
 conventional title itself, because the title backstop never strips a stale
 prefix (`version-bump`'s step 8 names this). Then re-run `/shipit`.
+
+### The pre-merge guard denied the merge (no verdict available)
+
+Two denials say the guard could not render a verdict at all, so neither is about
+the bump:
+
+- **The head carries no `.github/scripts/version-bump-required.sh`.** Restore it
+  on the branch (`git checkout origin/<default> -- <path>`), push, and re-run
+  `/shipit`.
+- **A fork head's copy of that script differs from the local one.** The guard
+  will not execute a gate script it has not reviewed. Read the head's copy
+  (`git show <head>:<path>`), and once you trust it, land the PR deliberately
+  outside the guard (the scope caveat above lists the routes).
 
 ### A version string was missed and the tag is already pushed
 

--- a/tests/pre-merge-guard.test.ts
+++ b/tests/pre-merge-guard.test.ts
@@ -17,7 +17,7 @@
 // own output, never a re-typed copy. The stubs answer exactly the calls the
 // invariant run makes:
 //
-//   gh pr view --json number,headRefOid,baseRefName   (PR selector)
+//   gh pr view --json number,headRefOid,…,isCrossRepository  (PR selector)
 //   gh repo view --json defaultBranchRef               (default-branch resolve)
 //   git symbolic-ref refs/remotes/origin/HEAD          (default-branch fallback)
 //   git remote get-url origin                          (home-repo derivation)
@@ -25,6 +25,7 @@
 //   git rev-parse ...                                  (origin tip / head oid)
 //   git merge-base --is-ancestor <base tip> <head>     (up-to-date precondition)
 //   git merge-base <head> <base tip>                   (the script's fork point)
+//   git show <head>:.github/scripts/…required.sh       (the gate script itself)
 //   git show <ref>:.claude-plugin/plugin.json          (the script's versions)
 //   git diff --name-only ...                           (the script's file list)
 //
@@ -34,13 +35,30 @@
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const REPO_ROOT = process.cwd();
 const HOOK = join(REPO_ROOT, ".claude", "hooks", "pre-merge-guard.mjs");
 const SETTINGS = join(REPO_ROOT, ".claude", "settings.json");
+// This checkout's committed gate script. The hook reads its copy out of the PR
+// head commit instead (#232), so the stub seam serves this file's content as
+// what the head carries — every verdict below is still the real script's own.
+const REAL_SCRIPT = join(
+  REPO_ROOT,
+  ".github",
+  "scripts",
+  "version-bump-required.sh",
+);
 
 // The verdict fixtures run the real version-bump-required.sh, which needs jq —
 // same gating convention as tests/version-bump-required.test.ts.
@@ -95,6 +113,12 @@ function scriptedStubs(opts: {
   gh?: "ok" | "fail" | "hang";
   repoView?: "ok" | "fail"; // gh repo view (the default-branch resolve)
   symbolicRefName?: string; // the LOCAL origin/HEAD branch name (can be stale)
+  isFork?: boolean; // gh pr view's isCrossRepository
+  // Which gate script the PR head carries. "same" is this checkout's committed
+  // copy. "extendedRuntime" is that copy with docs/ added to RUNTIME_DIRS — a
+  // faithful stand-in for a PR that widens the runtime definition, which is the
+  // shape that exposed #232. "missing" is a head with no script at all.
+  headScript?: "same" | "extendedRuntime" | "missing";
 }): string {
   const {
     headVersion = "0.33.2",
@@ -105,8 +129,34 @@ function scriptedStubs(opts: {
     gh = "ok",
     repoView = "ok",
     symbolicRefName = "main",
+    isFork = false,
+    headScript = "same",
   } = opts;
   const dir = newStubDir();
+
+  // What `git show <head>:.github/scripts/version-bump-required.sh` answers.
+  let showScriptArm = `cat '${REAL_SCRIPT}'`;
+  if (headScript === "missing") {
+    showScriptArm = `printf 'fatal: path does not exist in HEAD\\n' >&2; exit 128`;
+  } else if (headScript === "extendedRuntime") {
+    const original = readFileSync(REAL_SCRIPT, "utf-8");
+    const patched = original.replace(
+      "RUNTIME_DIRS=(agents skills hooks)",
+      "RUNTIME_DIRS=(agents skills hooks docs)",
+    );
+    // Anti-vacuity (docs/testing.md): a renamed array would leave the fixture
+    // identical to the committed script, and the test would then pass by
+    // measuring nothing.
+    if (patched === original) {
+      throw new Error(
+        "fixture is inert: RUNTIME_DIRS=(agents skills hooks) not found in " +
+          REAL_SCRIPT,
+      );
+    }
+    const path = join(dir, "head-gate-script.sh");
+    writeFileSync(path, patched);
+    showScriptArm = `cat '${path}'`;
+  }
 
   const repoViewArm =
     repoView === "ok"
@@ -121,7 +171,7 @@ function scriptedStubs(opts: {
   case "\${3:-}" in
     "("|")") printf 'LOUD STUB: grouping paren read as the PR selector\\n' >&2; exit 99 ;;
   esac
-  printf '%s\\n' '{"number":5,"headRefOid":"${HEAD_OID}","baseRefName":"main"}'
+  printf '%s\\n' '{"number":5,"headRefOid":"${HEAD_OID}","baseRefName":"main","isCrossRepository":${isFork}}'
   exit 0
 fi
 if [ "\${1:-}" = "repo" ] && [ "\${2:-}" = "view" ]; then
@@ -148,6 +198,7 @@ case "$cmd" in
     printf '${MERGE_BASE_OID}\\n' ;;
   show)
     case "\${1:-}" in
+      *:.github/scripts/version-bump-required.sh) ${showScriptArm} ;;
       ${HEAD_OID}:*) printf '{"version":"${headVersion}"}\\n' ;;
       *) printf '{"version":"${baseVersion}"}\\n' ;;
     esac ;;
@@ -455,6 +506,108 @@ describe.if(HAS_JQ)("verdict mapping through the real script", () => {
     );
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("cannot merge until version-bump runs at land time");
+  });
+});
+
+// Regression pin for #232, kept beside the seam it needs rather than in its own
+// tests/regression-*.ts file: reproducing the bug takes the whole scripted
+// gh/git harness above, and a second copy of that harness is a worse bug risk
+// than a misplaced file.
+//
+// The defect: the hook resolved the gate script from its own file location, so
+// under the mandated <repo>/.claude/worktrees/ layout it read the OUTER main
+// checkout's copy. The gate script *is* the definition of "runtime file", so a
+// PR that widens that definition was judged by the definition it replaces and
+// denied on an obsolete verdict.
+describe.if(HAS_JQ)("the gate script is read from the PR head (#232)", () => {
+  // The inputs both tests below share: a bumped version and a docs-only diff.
+  // Under this checkout's script that is the "dev-only PR must land with no
+  // bump" violation; under a head that counts docs/ as runtime it is the happy
+  // path. Same merge, two definitions — which is the whole bug.
+  const WIDENED_RUNTIME = {
+    headVersion: "0.34.0",
+    baseVersion: "0.33.2",
+    changedFiles: "docs/notes.md",
+  } as const;
+
+  test("this checkout's copy would deny the same merge", () => {
+    // The control. Without it, the allow below could pass because the fixture
+    // is benign rather than because the head's definition won.
+    const r = runHook("gh pr merge 5 --squash", scriptedStubs(WIDENED_RUNTIME));
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("must land with no bump");
+  });
+
+  test("allows when the head's copy counts the change as runtime", () => {
+    const r = runHook(
+      "gh pr merge 5 --squash",
+      scriptedStubs({ ...WIDENED_RUNTIME, headScript: "extendedRuntime" }),
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  test("denies when the head carries no gate script", () => {
+    // Fail closed: no script at the head means no verdict, and a merge without
+    // a verdict is exactly what the guard exists to stop.
+    const r = runHook(
+      "gh pr merge 5 --squash",
+      scriptedStubs({ ...WIDENED_RUNTIME, headScript: "missing" }),
+    );
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain(".github/scripts/version-bump-required.sh");
+    expect(r.stderr).toContain("Recovery:");
+  });
+
+  test("still renders a verdict for a fork head with a matching script", () => {
+    // The fork branch must not degrade into a blanket deny: an identical script
+    // is this checkout's own content, so the invariant is enforced as usual.
+    const r = runHook(
+      "gh pr merge 5 --squash",
+      scriptedStubs({ ...WIDENED_RUNTIME, isFork: true }),
+    );
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("must land with no bump");
+  });
+
+  test("refuses to execute a fork head's divergent script", () => {
+    // A fork's script is unreviewed code. Running it would let a PR author
+    // choose the verdict on their own merge and run arbitrary bash locally, so
+    // the guard denies with the diff route instead — and the head's verdict
+    // (which would have been an allow) never appears.
+    const r = runHook(
+      "gh pr merge 5 --squash",
+      scriptedStubs({
+        ...WIDENED_RUNTIME,
+        isFork: true,
+        headScript: "extendedRuntime",
+      }),
+    );
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("comes from a fork");
+    expect(r.stderr).toContain("git show");
+    expect(r.stdout).not.toBe("");
+  });
+
+  test("leaves no extracted script behind, on allow or on deny", () => {
+    // The hook exits through process.exit, so `finally` never runs — every exit
+    // path has to clear the temp dir itself or the guard litters tmp on each
+    // denied merge.
+    const leaked = () =>
+      readdirSync(tmpdir())
+        .filter((entry) => entry.startsWith("pre-merge-guard-gate-"))
+        .sort();
+    // Compared against a baseline rather than against []: a leak left by an
+    // older build would otherwise pin this test red for reasons this run did
+    // not cause. What matters is that neither exit path adds to the set.
+    const before = leaked();
+    runHook(
+      "gh pr merge 5 --squash",
+      scriptedStubs({ ...WIDENED_RUNTIME, headScript: "extendedRuntime" }),
+    );
+    expect(leaked()).toEqual(before);
+    runHook("gh pr merge 5 --squash", scriptedStubs(WIDENED_RUNTIME));
+    expect(leaked()).toEqual(before);
   });
 });
 


### PR DESCRIPTION
The pre-merge guard denied a merge on a verdict that was already obsolete, and the recovery text it printed would have made things worse.

## Why

`.github/scripts/version-bump-required.sh` decides what counts as a runtime file, and that decision is what the guard gates the merge on. The guard resolved the script relative to its own file location. Hooks resolve through `$CLAUDE_PROJECT_DIR`, and worktrees live under `<repo>/.claude/worktrees/`, so that path lands in the outer main checkout while the branch being merged sits in a worktree. A PR that widens the runtime definition was therefore judged by the definition it replaces.

Observed on a branch that adds a new distributed manifest path. Same two commits, same machine, two copies of the script:

```
# the branch copy — the definition this merge lands
OK: runtime_changed=true bumped=true (0.44.0 -> 0.45.0)   exit 0

# the main-checkout copy the guard executed
::error::version bumped but no runtime files changed —
a dev-only PR must land with no bump                       exit 1
```

The printed recovery ("drop the chore(version) commit … land plain") pointed away from the correct outcome: the bump was right, and following the advice would have shipped a changed distributed manifest with no version change and no release.

## What changes

The guard now reads the gate script out of the PR head commit, so its verdict is the verdict of the definition being merged. Two denials are new, and both are absences of a verdict rather than bump violations: a head that carries no gate script, and a fork head whose copy differs from the local one. A fork head's script is unreviewed code that would otherwise run locally at merge time, and this repo already withholds trust from fork PRs, so it is compared rather than executed. An identical copy is the local content and runs as before.

No runtime file changes, so this lands with no bump and no changelog cut.

## Test plan

- Three of the six new cases fail against the old hook and pass against the new one, so the pin is not vacuous.
- The regression fixture is the committed gate script with `docs/` added to its runtime set — the same shape as the PR that exposed this — and a control case proves the local copy denies the very merge the head's copy allows.
- Fork handling covered both ways: a matching script still renders the ordinary verdict, a divergent one denies without running.
- The extracted script leaves nothing in the temp dir on either exit path.
- Full free suite green (1307 pass, 0 fail) and `tsc --noEmit` clean.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)