### PR TITLE
chore: align model IDs, pricing, and tiering docs with the Claude 5 lineup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -378,7 +378,13 @@ complex-work agents now run on `fable`.
   **permanently**, not as a fallback. Fable 5's cybersecurity safety
   classifiers flag security-review content. In a non-interactive subagent
   context, a flagged request ends the turn with a refusal instead of a
-  fallback.
+  fallback. `opus` is a floating alias — it resolves to Claude Code's
+  current Opus (Opus 5 today), and riding the latest Opus rather than
+  pinning a dated one is deliberate: the pin exists to avoid Fable's
+  classifiers, not to freeze a specific Opus. Opus-tier models carry
+  cybersecurity safeguards of their own (far milder than Fable's), so if
+  security reviews ever start ending in refusals after an Opus upgrade,
+  overriding to the prior Opus is the escape hatch.
 - **`sonnet` (bounded single-pass judgment):** `questioner`,
   `ux-reviewer`, `technical-writer`.
 - **`haiku` (mechanical checks):** `file-finder`, `verifier`.
@@ -393,8 +399,9 @@ Notes:
   below. `opus` remains the documented fallback tier for every `fable`
   agent.
 - **1M context window comes for free at the fable and opus tiers.** Fable
-  5's context window is 1M by default, and Opus 4.8 always runs with the
-  1M window on the Anthropic API. Max, Team, and Enterprise plans include
+  5's context window is 1M by default, and the current Opus models (Opus
+  5, like 4.8 before it) always run with the 1M window on the Anthropic
+  API. Max, Team, and Enterprise plans include
   the 1M upgrade with the subscription, and Pro degrades gracefully to
   200K. These agents thus need no `[1m]` suffix. The sonnet agents stay
   at 200K, because their bounded single-pass work is nowhere near the

--- a/evals/README.md
+++ b/evals/README.md
@@ -71,7 +71,7 @@ scheduled or manual sweeps.
 |---|---|---|
 | `EVALS_ALL` | Ignore diff-based selection. Run every test. | unset |
 | `EVALS_TIER` | Filter to one tier, `gate` or `periodic` | unset (all) |
-| `EVALS_MODEL` | Override the default model for the agent under test | `claude-sonnet-4-6` |
+| `EVALS_MODEL` | Override the default model for the agent under test | `claude-sonnet-5` |
 | `EVALS_CONCURRENCY` | Max parallel tests | 15 |
 | `EVALS_BASE` | Base ref for diff-based selection | `origin/main` (fallback chain) |
 | `EVALS_RESULTS_ROOT` | Override result storage root | `evals/results/` |

--- a/golden-master/RUNBOOK.md
+++ b/golden-master/RUNBOOK.md
@@ -157,7 +157,7 @@ summary. The vector records these fields as a minimum:
 ```json
 {
   "date": "YYYY-MM-DD",
-  "model": "claude-opus-4-8",
+  "model": "claude-opus-5",
   "provider": "anthropic",
   "backend": "claude-code",
   "pipeline_version": "team vX.Y.Z (commit …)",

--- a/tests/helpers/llm-judge.ts
+++ b/tests/helpers/llm-judge.ts
@@ -18,6 +18,9 @@ import type { GroundTruth } from "./fixtures";
 const UNTRUSTED_OPEN = "<<<UNTRUSTED_OUTPUT>>>";
 const UNTRUSTED_CLOSE = "<<<END_UNTRUSTED_OUTPUT>>>";
 
+// Deliberately pinned (not the floating `sonnet` alias): stored runs were
+// scored by this judge, and a judge swap silently moves every rubric
+// baseline. Bump only alongside a re-baseline of stored evals.
 const DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6";
 const HAIKU_MODEL = "claude-haiku-4-5-20251001";
 

--- a/tests/helpers/session-runner.ts
+++ b/tests/helpers/session-runner.ts
@@ -59,15 +59,19 @@ export interface RunAgentTestOptions {
   disallowedTools?: string[];
 }
 
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+// Matches what plugin users get: the shipped agents use floating aliases,
+// and Claude Code's `sonnet` resolves to Sonnet 5 today.
+const DEFAULT_MODEL = "claude-sonnet-5";
 const DEFAULT_TIMEOUT_MS = 120_000;
 
 // Rough public-pricing per million tokens (USD). Override at the call site
 // if you need stricter accounting; these are good-enough for relative deltas.
 const PRICING_PER_MILLION: Record<string, { input: number; output: number }> = {
+  "claude-sonnet-5": { input: 3, output: 15 },
   "claude-sonnet-4-6": { input: 3, output: 15 },
-  "claude-sonnet-4-7": { input: 3, output: 15 },
-  "claude-opus-4-7": { input: 15, output: 75 },
+  "claude-opus-5": { input: 5, output: 25 },
+  "claude-opus-4-8": { input: 5, output: 25 },
+  "claude-opus-4-7": { input: 5, output: 25 },
   "claude-fable-5": { input: 10, output: 50 },
   "claude-haiku-4-5-20251001": { input: 1, output: 5 },
 };


### PR DESCRIPTION
## Why

The Claude 5 family (Opus 5, Sonnet 5, Fable 5) shipped, and an audit of every model-specific reference in the repo found four stale or wrong spots: the eval harness priced a model that does not exist (`claude-sonnet-4-7`) and mispriced Opus 4.7 at 3× its actual cost, the harness default no longer matched what plugin users get through the shipped floating `sonnet` alias, the architecture doc's rationale for the `security-reviewer` model pin predated Opus 5, and a runbook example named a superseded model.

## What

- **Eval pricing table** now reflects public pricing: the fictional Sonnet 4.7 entry is gone, Opus 4.7 is corrected to $5/$25, and Sonnet 5, Opus 5, Opus 4.8, and Fable 5 entries are added.
- **Eval default model** is now `claude-sonnet-5`, matching what the shipped agents' floating `sonnet` alias resolves to today (README updated to agree). The LLM-judge model stays pinned at Sonnet 4.6 on purpose — swapping the judge silently moves every stored rubric baseline — and now carries a comment saying exactly that.
- **Architecture doc** records why `security-reviewer` stays on the floating `opus` alias permanently: the pin exists to avoid Fable's cybersecurity classifiers, not to freeze a dated Opus, so it deliberately rides the latest Opus. Overriding to the prior Opus is named as the escape hatch if a future Opus upgrade starts refusing security reviews. The 1M-context note now covers Opus 5.
- **Golden-master runbook** example result shape names a current model.

No distributed-plugin file changes — agent frontmatter tiering was audited and is correct as-is — so this lands with no version bump.

## Test plan

- Full free static gate passes: 1329 pass, 4 skip, 0 fail.
- Verified no test assertions pin the edited constants before changing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)