### PR TITLE
v0.48.0 fix(code-review): pin an explicit report format for review reports

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.47.0"
+    "version": "0.48.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-08-13
+
 ### Added
 
 - **Review reports now follow one explicit format, on every surface a review crosses.** The code-review skill pinned how a single finding is written (Conventional Comments) and which verdict tokens exist, but never the shape of the full report — so each dispatched reviewer invented its own structure, and a directly invoked `/code-review` relayed whatever subset of the subagent's report the session chose. The skill now carries a `## Report Format` template — the parseable verdict line first, then Summary, Findings, and Checks, with conditional sections like the skeptic pass's `### Refuted by verification` appended rather than improvised — and binds every producer to it: the dispatched reviewer's final report, a subagent reviewing on a dispatcher's behalf, and the top-level relay, which must reproduce the report in full instead of summarizing it. [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md), [`agents/code-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/code-reviewer.md)
@@ -523,7 +525,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.47.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.48.0...HEAD
+[0.48.0]: https://github.com/bostonaholic/team/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/bostonaholic/team/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/bostonaholic/team/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/bostonaholic/team/compare/v0.44.0...v0.45.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Review reports now follow one explicit format, on every surface a review crosses.** The code-review skill pinned how a single finding is written (Conventional Comments) and which verdict tokens exist, but never the shape of the full report — so each dispatched reviewer invented its own structure, and a directly invoked `/code-review` relayed whatever subset of the subagent's report the session chose. The skill now carries a `## Report Format` template — the parseable verdict line first, then Summary, Findings, and Checks, with conditional sections like the skeptic pass's `### Refuted by verification` appended rather than improvised — and binds every producer to it: the dispatched reviewer's final report, a subagent reviewing on a dispatcher's behalf, and the top-level relay, which must reproduce the report in full instead of summarizing it. [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md), [`agents/code-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/code-reviewer.md)
+
 ## [0.47.0] - 2026-08-13
 
 ### Fixed

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -73,7 +73,9 @@ of `skills/nested-agents/SKILL.md` (preloaded).
 
 ## Verdict
 
-End with a verdict the orchestrator parses:
+Structure the whole report per the `## Report Format` section of
+`skills/code-review/SKILL.md` (preloaded): the verdict line leads the
+report. The orchestrator parses it as one of:
 
 - **APPROVE** — all done criteria met, no blocking issues, tests pass.
 - **REQUEST CHANGES** — blocking issues found. The loop auto-fixes them, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -20,9 +20,10 @@ When a user asks for a review in the main session ("review this diff",
 `/code-review`), the session itself is not a valid reviewer — it holds the
 conversation history this skill forbids. Do not review inline. Dispatch the
 `code-reviewer` agent (or, if unavailable, a fresh read-only subagent
-instructed to follow this skill) against the requested diff, then relay its
-verdict and findings. Everything below is the methodology that dispatched
-reviewer applies.
+instructed to follow this skill) against the requested diff, then present
+its report in full, in the shape `## Report Format` pins — never a summary
+of it. Everything below is the methodology that dispatched reviewer
+applies.
 
 ## Generator-Evaluator Separation
 
@@ -54,6 +55,52 @@ Findings from the code, security, and docs reviewers use the Conventional
 Comments format in `skills/conventional-comments/SKILL.md`. The one exception
 is the ux-reviewer: its live-verification report uses its own
 Working/Broken/Could Improve format.
+
+## Report Format
+
+One report shape binds every surface a code review crosses: the
+code-reviewer's final report, the report a subagent returns when it
+reviews a diff on a dispatcher's behalf, and the full output the top-level
+session presents after a direct invocation. A relay reproduces the report
+in full — never a paraphrase, never a subset. A reviewer that carries its
+own report template in its agent file (the security-reviewer, the
+ux-reviewer, the technical-writer, the verifier) keeps it; this shape
+governs the code review.
+
+```markdown
+**Verdict: <APPROVE | REQUEST CHANGES | COMMENT>**
+
+### Summary
+
+<What was reviewed — the diff or range — and why the verdict. Two to
+five sentences.>
+
+### Findings
+
+<One finding per entry, Blocking tier first. Exactly "No findings."
+when there are none.>
+
+### Checks
+
+<Each done criterion, met or not met. The test-suite command and its
+result. Any other check run, with its result.>
+
+### Refuted by verification
+
+<Findings dropped because verification refuted them. Omit the section
+when nothing was refuted.>
+```
+
+- **The verdict line comes first.** The orchestrator parses it. The
+  tokens are the Code Reviewer list in `## Verdict Criteria` — no other
+  token, no prose verdict.
+- `### Findings` entries use the Conventional Comments format
+  (`## Conventional Comments` above), each with its `file:line`
+  reference.
+- **Conditional sections extend the report; they never replace a fixed
+  section.** A pass that produced a record appends its own `###` section
+  after `### Checks` — `### Refuted by verification` is the skeptic pass's.
+  A pass that did not run appends nothing.
 
 ## Gate Types and Severity Tiers
 

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -1105,3 +1105,62 @@ describe("slicing asks whether a slice deserves its own PR (L2 tripwire)", () =>
     expect(text).toContain("## Cross-slice concerns");
   });
 });
+
+// ---------------------------------------------------------------------------
+// One report shape must bind every surface a review crosses: the dispatched
+// reviewer's final report, a subagent reviewing on a dispatcher's behalf, and
+// the full output the top-level session presents after a direct invocation.
+// Without a pinned shape, each reviewer invents its own report structure and
+// the relay trims whatever it likes.
+// ---------------------------------------------------------------------------
+describe("code-review report format (L2 content tripwire)", () => {
+  const SKILL_FILE = join(REPO_ROOT, "skills", "code-review", "SKILL.md");
+  const CODE_REVIEWER = join(REPO_ROOT, "agents", "code-reviewer.md");
+
+  // Text between two markers; "" when either marker is missing. Callers guard
+  // the slice as non-empty so a missing section fails loud, never vacuously.
+  // The module-level sectionFrom cannot slice this section: its next-heading
+  // regex (\n##) also matches the ### template headings inside it.
+  function between(text: string, startMarker: string, endMarker: string): string {
+    const start = text.indexOf(startMarker);
+    if (start === -1) return "";
+    const end = text.indexOf(endMarker, start + startMarker.length);
+    if (end === -1) return "";
+    return text.slice(start, end);
+  }
+
+  test("the skill pins one report template: verdict line first, then Summary, Findings, Checks", () => {
+    // Newline-anchored start: the heading, not an inline `## Report Format`
+    // cross-reference elsewhere in the skill.
+    const section = between(read(SKILL_FILE), "\n## Report Format\n", "\n## ");
+    // Guard: a missing section must fail, not vacuously pass the checks below.
+    expect(section.length).toBeGreaterThan(0);
+    // Template strings the reviewer must emit, in emission order.
+    const verdict = section.indexOf("**Verdict:");
+    const summary = section.indexOf("### Summary");
+    const findings = section.indexOf("### Findings");
+    const checks = section.indexOf("### Checks");
+    expect(verdict).toBeGreaterThan(-1);
+    expect(summary).toBeGreaterThan(verdict);
+    expect(findings).toBeGreaterThan(summary);
+    expect(checks).toBeGreaterThan(findings);
+    // The verdict token vocabulary stays in Verdict Criteria; the template
+    // points there instead of duplicating the per-reviewer token lists.
+    expect(section).toContain("Verdict Criteria");
+    // The skeptic-pass record is a named conditional section of the report.
+    expect(section).toContain("### Refuted by verification");
+  });
+
+  test("the direct-invocation relay binds to the report format", () => {
+    const invoked = between(read(SKILL_FILE), "\n## When Invoked Directly\n", "\n## ");
+    // Guard: a missing section must fail, not vacuously pass the check below.
+    expect(invoked.length).toBeGreaterThan(0);
+    expect(invoked).toContain("Report Format");
+  });
+
+  test("code-reviewer defers its report structure to the skill's report format", () => {
+    const text = read(CODE_REVIEWER);
+    expect(text).toContain("Report Format");
+    expect(text).toContain("skills/code-review/SKILL.md");
+  });
+});


### PR DESCRIPTION
## Why

The code-review skill pins how a single finding is written (Conventional Comments) and which verdict tokens exist, but never the shape of the full review report. Every other reviewer agent carries its own report template; the code reviewer was the one left without one. The result: each dispatched reviewer invents its own report structure, and a directly invoked `/code-review` relays whatever subset of the subagent's report the session chooses — two runs on the same diff produce structurally different output.

## What

- `skills/code-review/SKILL.md` now carries a `## Report Format` template: the parseable verdict line first, then Summary, Findings, and Checks, with conditional sections (the skeptic pass's `### Refuted by verification`) appended rather than improvised.
- The format binds every surface a code review crosses: the dispatched reviewer's final report, a subagent reviewing a diff on a dispatcher's behalf, and the top-level relay, which now must reproduce the report in full instead of summarizing it.
- `agents/code-reviewer.md` defers its report structure to the skill's template. Reviewers that already carry their own template (security, ux, docs, verifier) keep theirs.
- New L2 tripwires pin the template's section order, the relay binding, and the agent's deferral.

## Test plan

- The new tripwires fail at the test commit (pre-fix) with assertion failures and pass after the fix; a mutation check confirmed renaming the report-format heading turns them red again.
- Full free suite and typecheck are green.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)