### PR TITLE
v0.49.0 fix(pr-rebase): publish without stopping to confirm the force push

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.48.0"
+    "version": "0.49.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/pr-rebase` stopped at the finish line to ask permission it had already been given.** Step 7 was a pre-publish confirmation: after the baseline comparison came back clean, the run asked "rewrite the remote?" and pushed only on a yes, with a `--yes` flag as the documented bypass. But nothing reaches that prompt without a deliberate human invocation — the skill sets `disable-model-invocation: true` and fires only on explicit rebase intent — so the answer to "rewrite the remote?" was in the request that started the run, and every run stalled at the publish waiting on a question already answered. The confirmation and the now-dead `--yes` are both gone: once the step 6 verification gate reports no regression, the run publishes, and the skill states the rule positively because a model reading a publish procedure will otherwise reinsert a confirmation on its own instinct. The guards on the irreversible push are unchanged and mechanical, and none of them is a question — explicit rebase intent scopes the invocation, the verification gate hard-stops on any regression, remote divergence refuses before the rebase starts, and the lease still fails the push if the remote moved during the run. The all-`UNKNOWN` baseline case no longer asks either: it publishes on the invocation's authority but must be reported as unverified in exactly those words, never as checks matching a baseline, with the recovery anchor restated. Pinned by two L2 tripwires in [`tests/pr-rebase-skill.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/pr-rebase-skill.test.ts): `argument-hint` offers no `--yes`, and no `--yes` survives anywhere in the skill. [`skills/pr-rebase/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
+
 ## [0.48.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-08-13
+
 ### Fixed
 
 - **`/pr-rebase` stopped at the finish line to ask permission it had already been given.** Step 7 was a pre-publish confirmation: after the baseline comparison came back clean, the run asked "rewrite the remote?" and pushed only on a yes, with a `--yes` flag as the documented bypass. But nothing reaches that prompt without a deliberate human invocation — the skill sets `disable-model-invocation: true` and fires only on explicit rebase intent — so the answer to "rewrite the remote?" was in the request that started the run, and every run stalled at the publish waiting on a question already answered. The confirmation and the now-dead `--yes` are both gone: once the step 6 verification gate reports no regression, the run publishes, and the skill states the rule positively because a model reading a publish procedure will otherwise reinsert a confirmation on its own instinct. The guards on the irreversible push are unchanged and mechanical, and none of them is a question — explicit rebase intent scopes the invocation, the verification gate hard-stops on any regression, remote divergence refuses before the rebase starts, and the lease still fails the push if the remote moved during the run. The all-`UNKNOWN` baseline case no longer asks either: it publishes on the invocation's authority but must be reported as unverified in exactly those words, never as checks matching a baseline, with the recovery anchor restated. Pinned by two L2 tripwires in [`tests/pr-rebase-skill.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/pr-rebase-skill.test.ts): `argument-hint` offers no `--yes`, and no `--yes` survives anywhere in the skill. [`skills/pr-rebase/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
@@ -529,7 +531,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.48.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.49.0...HEAD
+[0.49.0]: https://github.com/bostonaholic/team/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/bostonaholic/team/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/bostonaholic/team/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/bostonaholic/team/compare/v0.45.0...v0.46.0

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -562,10 +562,12 @@ QRSPI phase: a self-contained action a user runs on demand.
   rebases onto the latest base, resolves each conflict from both sides'
   intent, re-runs the same checks, and force-pushes only when nothing
   regressed.
-- **`$ARGUMENTS`:** `[<pr-number-or-url>] [--yes]` — the PR reference is
+- **`$ARGUMENTS`:** `[<pr-number-or-url>]` — the PR reference is
   optional and only resolves the base branch; the rebased branch is always
-  the current checkout. `--yes` skips the pre-push confirmation for a
-  caller that already carries the user's authorization.
+  the current checkout. There is no pre-push confirmation to skip: the
+  deliberate invocation carries the authorization to publish, and the run
+  completes without stopping once the verification gate reports no
+  regression.
 - **Phase:** None. A standalone branch-maintenance action, not part of the
   pipeline.
 - **Key behaviors:** **User-invocable only** — it sets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -6,7 +6,7 @@ description: |
   latest base, resolve each conflict from both sides' intent with the
   rationale recorded to disk, re-run the same checks, and treat any check
   that passed before and fails after as a regression that blocks the push.
-  Ends with a confirmed, lease-verified publish through the repo's own
+  Ends with an unprompted, lease-verified publish through the repo's own
   publisher — a `--force-with-lease --force-if-includes` push by default.
   Invoke ONLY on explicit rebase intent — the user says "rebase onto main",
   "pull main and rebase", "update the branch", "get this branch current",
@@ -14,7 +14,7 @@ description: |
   remote: never infer rebase intent from a branch merely being behind its
   base, from a red CI run, or from a merge-conflict warning on the PR page.
 effort: high
-argument-hint: "[<pr-number-or-url>] [--yes]"
+argument-hint: "[<pr-number-or-url>]"
 disable-model-invocation: true
 ---
 
@@ -40,7 +40,10 @@ remote. Three things make it more than `git pull --rebase`:
 Model invocation is disabled (`disable-model-invocation: true`). The push
 rewrites published history: a teammate who has the branch checked out ends
 up on a discarded line of development, and no verification step can undo
-that after the fact. Only a deliberate human invocation starts the run.
+that after the fact. Only a deliberate human invocation starts the run —
+and that invocation carries the authorization to publish. Once the step 6
+gate reports no regression, the run publishes without stopping to re-ask
+(step 7).
 
 ## Input
 
@@ -51,10 +54,6 @@ that after the fact. Only a deliberate human invocation starts the run.
   which branch is rebased — the branch is always the current checkout, so a
   PR argument that names a different head branch is a refusal, not a
   checkout.
-- **`--yes`** skips the pre-publish confirmation (step 7). It belongs to a
-  caller that already carries the user's authorization to rewrite the
-  remote. **It is the caller's to pass, never yours to add** — running as
-  an agent does not make you a non-interactive caller.
 
 **The base branch is discovered, never assumed.** Resolve it through the
 fallback chain, in one bash call (an agent thread resets cwd between calls).
@@ -155,8 +154,9 @@ claims which side is correct.
 9. **A check with no baseline proves nothing after.** A check that could not
    run before the rebase is reported `UNKNOWN`, never counted as evidence
    that behavior was preserved (step 2). When *every* check is `UNKNOWN`, the
-   run verified nothing at all: the push still requires a confirmation that
-   names the absent evidence, and `--yes` does not skip it (step 7).
+   run verified nothing at all: the publish proceeds on the invocation's
+   authority, but it is reported as unverified in exactly those words —
+   never as checks matching a baseline (step 7).
 10. **No destructive command relies on a variable set in an earlier Bash
     invocation.** Shell state does not persist between invocations: the
     publish and any `git reset --hard` re-derive `$BRANCH`, `$BASE`, `$PUSH_REMOTE`,
@@ -570,7 +570,8 @@ suite-level comparison calls that clean.
 **When every row is UNKNOWN, say so in those words.** Zero regressions out
 of zero comparisons is not a clean verification, and reporting it as one is
 the most misleading thing this skill could do. Carry the no-evidence state
-into step 7, where it forces a confirmation `--yes` cannot skip.
+into step 7 and the completion, which must report the publish as
+unverified.
 
 **Any regression is a hard stop.** Do not push. Report which check and which
 named tests went from green to red, then offer the two real options: revisit
@@ -584,27 +585,29 @@ shows what each commit's content gained or lost in the replay — it is the
 fastest way to find a resolution that quietly dropped a hunk. It is a
 diagnostic to reach for on failure, not a required step.
 
-### Step 7 — confirm, then publish
+### Step 7 — publish
 
 Reached only with no regression and no unresolved escalation.
 
-**Ask for an explicit confirmation** before publishing — "rebased `<branch>`
-from `<ORIG_SHA>` onto `<BASE_REMOTE>/<base>` at `<new-sha>`; `<n>` conflicts
-resolved; checks match baseline; publishing to `<PUSH_REMOTE>` through
-`<publisher>` — rewrite the remote?" — and publish only on a yes. `--yes`
-skips this prompt and is the caller's to pass (see Input), with one
-exception below.
+**Do not ask the user to confirm the publish.** The invocation carried the
+authorization to rewrite the remote: model invocation is disabled, so only
+a deliberate human started this run, and a confirmation here re-requests
+permission that invocation granted — and every caller that chains into the
+run inherits the stop. The guards on this irreversible push are mechanical,
+not questions, and both have already run: explicit rebase intent scoped the
+invocation, and the step 6 gate stopped the run on any regression. Once
+step 6 reports no regression, publish.
 
-**The no-evidence case overrides `--yes`.** When *every* configured check
-came back `UNKNOWN` — or the project configures no checks at all — the
-comparison in step 6 had nothing to compare, so the run has produced **zero
-evidence** that behavior was preserved. The skill's premise is unmet. Ask
-regardless of `--yes`, and say exactly that: "no check produced a usable
-baseline, so nothing verified that this rebase preserved behavior —
-force-push anyway?" Never render this case as "checks match baseline";
-they did not match, they were absent. A repo with no checks is legitimate,
-which is why this is a confirmation and not a refusal — but the user
-confirms an unverified push knowing it is unverified.
+**The no-evidence case publishes but never claims verification.** When
+*every* configured check came back `UNKNOWN` — or the project configures no
+checks at all — the comparison in step 6 had nothing to compare, so the run
+has produced **zero evidence** that behavior was preserved. Publish on the
+invocation's authority, and say exactly that in the completion: "no check
+produced a usable baseline, so nothing verified that this rebase preserved
+behavior." Never render this case as "checks match baseline"; they did not
+match, they were absent. A repo with no checks is legitimate — the recovery
+anchor (`git reset --hard <ORIG_SHA>`) is the safety net an unverified
+publish leans on, so restate it with the completion.
 
 **Capture the PR's draft state before anything publishes** — a publisher can
 change it, and the re-check at the end of this step is how that is caught:

--- a/tests/pr-rebase-skill.test.ts
+++ b/tests/pr-rebase-skill.test.ts
@@ -75,10 +75,14 @@ describe("pr-rebase skill: frontmatter and invocation surface", () => {
     expect(/^disable-model-invocation:\s*true\s*$/m.test(f)).toBe(true);
   });
 
-  test("argument-hint declares both the PR selector and --yes", () => {
+  test("argument-hint declares the PR selector and offers no --yes", () => {
+    // Guard: a missing frontmatter must fail, not vacuously pass the
+    // absence check below. The flag existed only to bypass the pre-publish
+    // confirmation, which is gone.
     const f = fm();
+    expect(f.length).toBeGreaterThan(0);
     expect(/^argument-hint:.*pr-number/m.test(f)).toBe(true);
-    expect(/^argument-hint:.*--yes/m.test(f)).toBe(true);
+    expect(/^argument-hint:.*--yes/m.test(f)).toBe(false);
   });
 
   test("description carries a quoted trigger phrase and the slash name", () => {
@@ -366,6 +370,21 @@ describe("pr-rebase skill: the push form", () => {
     for (const line of fencedLines().filter((l) => /^\s*git push/.test(l))) {
       expect(line).toContain("${BRANCH:?}");
     }
+  });
+});
+
+// The invocation IS the authorization: `disable-model-invocation: true` means
+// only a deliberate human invocation starts the run, so a second ask before
+// the publish re-requests permission the invocation carried. The guards on
+// the irreversible push are mechanical, not questions: explicit rebase intent
+// scopes the invocation, and the step 6 verification gate stops the run on
+// any regression before step 7 is reached.
+describe("pr-rebase skill: the publish is not gated on a human confirmation", () => {
+  test("no --yes escape hatch anywhere in the skill", () => {
+    const t = body();
+    // Guard: a missing file reads as "" and would vacuously pass.
+    expect(t.length).toBeGreaterThan(0);
+    expect(t).not.toContain("--yes");
   });
 });
 


### PR DESCRIPTION
## Why

`/pr-rebase` stopped at step 7 on every run to ask "rewrite the remote?" before publishing, so a rebase that passed its verification gate still required a human to come back and answer. Nothing reaches that prompt without a deliberate human invocation — the skill sets `disable-model-invocation: true` and fires only on explicit rebase intent — so the answer to the question was already in the request that started the run. This is the same defect `/shipit` had, fixed the same way in v0.44.0.

## What

The skill now completes autonomously once kicked off. The pre-publish confirmation and the `--yes` bypass flag are both gone; once the verification gate reports no regression, the run publishes. The skill states the no-confirmation rule positively so a model reading the procedure does not reinsert a prompt on instinct.

The guards on the irreversible push are unchanged and mechanical: explicit rebase intent scopes the invocation, the verification gate hard-stops on any regression, remote divergence refuses before the rebase starts, and the lease still fails the push if the remote moved during the run. The all-`UNKNOWN` baseline case no longer asks either — it publishes on the invocation's authority but must be reported as unverified in exactly those words, with the recovery anchor restated. The one remaining `AskUserQuestion` is the undecidable-conflict escalation, which is a genuine decision, not a confirmation.

## Test plan

- Two new L2 tripwires in `tests/pr-rebase-skill.test.ts` pin the contract: the `argument-hint` offers no `--yes`, and no `--yes` escape hatch survives anywhere in the skill. Both were confirmed red against the old skill (clean assertion failures) before the fix.
- Full free suite green: 1339 pass, 0 fail across 45 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)