### PR TITLE
v0.51.0 feat(code-review): add standard emojis to review verdict tokens

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.50.0"
+    "version": "0.51.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-08-14
+
 ### Changed
 
 - **The code-review verdict line now carries the standard verdict emoji.** The pinned report template and the Code Reviewer verdict vocabulary render each verdict with its emoji — ✅ APPROVE, ❌ REQUEST CHANGES, 💬 COMMENT — so a report's outcome reads at a glance on every surface the report crosses. The word token, not the emoji, remains what the orchestrator matches on, so verdict parsing is unchanged. [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md), [`agents/code-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/code-reviewer.md)
@@ -542,7 +544,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.50.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.51.0...HEAD
+[0.51.0]: https://github.com/bostonaholic/team/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/bostonaholic/team/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/bostonaholic/team/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/bostonaholic/team/compare/v0.47.0...v0.48.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The code-review verdict line now carries the standard verdict emoji.** The pinned report template and the Code Reviewer verdict vocabulary render each verdict with its emoji — ✅ APPROVE, ❌ REQUEST CHANGES, 💬 COMMENT — so a report's outcome reads at a glance on every surface the report crosses. The word token, not the emoji, remains what the orchestrator matches on, so verdict parsing is unchanged. [`skills/code-review/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md), [`agents/code-reviewer.md`](https://github.com/bostonaholic/team/blob/main/agents/code-reviewer.md)
+
 ## [0.50.0] - 2026-08-13
 
 ### Added

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -92,10 +92,10 @@ Structure the whole report per the `## Report Format` section of
 `skills/code-review/SKILL.md` (preloaded): the verdict line leads the
 report. The orchestrator parses it as one of:
 
-- **APPROVE** — all done criteria met, no blocking issues, tests pass.
-- **REQUEST CHANGES** — blocking issues found. The loop auto-fixes them, and
+- **✅ APPROVE** — all done criteria met, no blocking issues, tests pass.
+- **❌ REQUEST CHANGES** — blocking issues found. The loop auto-fixes them, and
   they never go to the user to triage.
-- **COMMENT** — non-blocking suggestions only.
+- **💬 COMMENT** — non-blocking suggestions only.
 
 Every finding uses Conventional Comments (issue, suggestion, nitpick) with a
 `file:line` reference. List skeptic-refuted findings under a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -68,7 +68,7 @@ ux-reviewer, the technical-writer, the verifier) keeps it; this shape
 governs the code review.
 
 ```markdown
-**Verdict: <APPROVE | REQUEST CHANGES | COMMENT>**
+**Verdict: <✅ APPROVE | ❌ REQUEST CHANGES | 💬 COMMENT>**
 
 ### Summary
 
@@ -93,7 +93,9 @@ when nothing was refuted.>
 
 - **The verdict line comes first.** The orchestrator parses it. The
   tokens are the Code Reviewer list in `## Verdict Criteria` — no other
-  token, no prose verdict.
+  token, no prose verdict. Each token carries its standard emoji prefix
+  (✅ APPROVE, ❌ REQUEST CHANGES, 💬 COMMENT); the word token, not the
+  emoji, is what the orchestrator matches on.
 - `### Findings` entries use the Conventional Comments format
   (`## Conventional Comments` above), each with its `file:line`
   reference.
@@ -125,10 +127,10 @@ verdict-aggregation rules.
 
 ### Code Reviewer
 
-- **APPROVE:** All done criteria met, no blocking issues, tests pass.
-- **REQUEST CHANGES:** Blocking issues found. The pipeline MUST loop back to
+- **✅ APPROVE:** All done criteria met, no blocking issues, tests pass.
+- **❌ REQUEST CHANGES:** Blocking issues found. The pipeline MUST loop back to
   IMPLEMENT. No override.
-- **COMMENT:** Non-blocking suggestions only. Implementation is correct.
+- **💬 COMMENT:** Non-blocking suggestions only. Implementation is correct.
 
 **Test-quality flags.** Test files are part of the diff. Walk every changed
 `*test*` / `*spec*` / `__tests__/*` file against `skills/test-style/SKILL.md`.


### PR DESCRIPTION
## Why

A code review report's verdict is the one line every reader looks for first, but the pinned report format rendered it as bare text. Adding the standard emoji to each verdict makes the outcome read at a glance on every surface the report crosses — the dispatched reviewer's report, a subagent relay, and the top-level `/code-review` output.

## What

- The `## Report Format` template's verdict line and the Code Reviewer list in `## Verdict Criteria` now render each verdict with its standard emoji: ✅ APPROVE, ❌ REQUEST CHANGES, 💬 COMMENT.
- The `code-reviewer` agent's emitted verdict list carries the same emoji-prefixed tokens, keeping the emitter and the skill in sync.
- The word token, not the emoji, remains what the orchestrator matches on, so verdict parsing is unchanged.

## Test plan

- Verified the format-pinning tripwires still pass (`tests/methodology.test.ts` pins the `**Verdict:` prefix and section order; `tests/protocol.test.ts` unchanged) — 219/219 pass.
- Verified the skill template, the verdict criteria, and the agent's verdict list all state the same three emoji-prefixed tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)