### PR TITLE
docs(site): add Codex CLI and Antigravity CLI install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ agents, so they will not run the pipeline. The standalone utilities do.
 > guards:
 >
 > ```bash
-> rm -rf "$CODEX_HOME/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
-> rm -rf "$CODEX_HOME/plugins/cache"/*/team/*/skills/pr-rebase
+> rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
+> rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-rebase
 > ```
 >
 > Re-running `codex plugin add` restores them.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,7 @@ so it installs as a native Antigravity plugin — all 55 skills and all 13 agent
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
 install copies the checkout, so upgrading means installing again. Unlike Codex,
 this host honors `disable-model-invocation`, so nothing needs removing
-afterward. The `/team-*` pipeline commands install but are not claimed to run
-here yet, because agent dispatch on this host is untested
-([#56](https://github.com/bostonaholic/team/issues/56)).
+afterward.
 
 Developing Team itself? The install copies, so link your checkout instead:
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ from a local checkout. Pick yours.
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-claude plugin add /path/to/team
+claude plugin marketplace add /path/to/team
+claude plugin install team@team-dev
 ```
 
-That is the whole install. Skills register as slash commands (`/team`,
-`/shipit`), and agents and hooks load with them.
+The first command registers the checkout as a marketplace; the second installs
+from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
+hooks load with them.
 
 </details>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,8 +86,8 @@ Code agents, so they will not run the pipeline. The standalone utilities do.
 > ignores that key**. To keep the guards:
 
 ```bash
-rm -rf "$CODEX_HOME/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
-rm -rf "$CODEX_HOME/plugins/cache"/*/team/*/skills/pr-rebase
+rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
+rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-rebase
 ```
 
 Re-running `codex plugin add` restores them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,11 +49,13 @@ Pick yours.
 ### Claude Code
 
 ```bash
-claude plugin add /path/to/team
+claude plugin marketplace add /path/to/team
+claude plugin install team@team-dev
 ```
 
-That is the whole install. Skills register as slash commands (`/team`,
-`/shipit`), and agents and hooks load with them.
+The first command registers the checkout as a marketplace; the second installs
+from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
+hooks load with them.
 
 Then run a phase end-to-end:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Team is a Claude Code plugin. It orchestrates specialized agents that implement features end-to-end through the QRSPI pipeline."
+description: "Team orchestrates specialized agents that implement features end-to-end through the QRSPI pipeline. The full pipeline runs on Claude Code; the standalone utilities also work on Codex CLI and Antigravity CLI."
 permalink: /
 audience: [user, developer]
 nav_order: 1
@@ -41,11 +41,19 @@ WORKTREE → QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → IMPLEME
 
 ## Install
 
-Team is a Claude Code plugin. Add it to your Claude Code installation:
+Team ships a native manifest for each host, so one repo installs on all three
+from a local checkout. The full pipeline needs Claude Code, because that is the
+host that dispatches the agents. The standalone utilities work on all three.
+Pick yours.
+
+### Claude Code
 
 ```bash
 claude plugin add /path/to/team
 ```
+
+That is the whole install. Skills register as slash commands (`/team`,
+`/shipit`), and agents and hooks load with them.
 
 Then run a phase end-to-end:
 
@@ -57,6 +65,55 @@ For a focused bug fix that skips the QRSPI ceremony:
 
 ```bash
 /team-fix Users see stale cache after profile update
+```
+
+### Codex CLI
+
+```bash
+codex plugin marketplace add /path/to/team
+codex plugin add team@team-dev
+```
+
+Skills arrive **namespaced** — ask for `team:shipit`, not `shipit`. Codex
+budgets its skill catalog, so it shortens the longest descriptions; the skills
+still work. The `/team-*` pipeline commands load but cannot dispatch Claude
+Code agents, so they will not run the pipeline. The standalone utilities do.
+
+> **Two skills lose a safety guard here.** `team:pr-watch-as-reviewer` casts an
+> approval that can transitively merge a PR, and `team:pr-rebase` force-pushes
+> a rewritten branch over published history. Both set
+> `disable-model-invocation` so only a person can start them, and **Codex
+> ignores that key**. To keep the guards:
+
+```bash
+rm -rf "$CODEX_HOME/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
+rm -rf "$CODEX_HOME/plugins/cache"/*/team/*/skills/pr-rebase
+```
+
+Re-running `codex plugin add` restores them.
+
+### Antigravity CLI
+
+```bash
+agy plugin install /path/to/team
+```
+
+Team ships `plugin.json` at the repo root, which is this host's plugin marker,
+so it installs as a native Antigravity plugin — every skill and every agent
+installs with it. `agy plugin uninstall team` removes it.
+
+Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
+install copies the checkout, so upgrading means installing again. Unlike
+Codex, this host honors `disable-model-invocation`, so nothing needs removing
+afterward. The `/team-*` pipeline commands install but are not claimed to run
+here yet, because agent dispatch on this host is untested
+([#56](https://github.com/bostonaholic/team/issues/56)).
+
+Developing Team itself? The install copies, so link your checkout instead:
+
+```bash
+script/dev-install antigravity
+script/dev-uninstall antigravity
 ```
 
 ## Read next

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,9 +107,7 @@ installs with it. `agy plugin uninstall team` removes it.
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
 install copies the checkout, so upgrading means installing again. Unlike
 Codex, this host honors `disable-model-invocation`, so nothing needs removing
-afterward. The `/team-*` pipeline commands install but are not claimed to run
-here yet, because agent dispatch on this host is untested
-([#56](https://github.com/bostonaholic/team/issues/56)).
+afterward.
 
 Developing Team itself? The install copies, so link your checkout instead:
 

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -2,7 +2,7 @@
 //
 // L2 tripwire (free, deterministic): README.md and docs/index.md are the two
 // self-contained install surfaces (GitHub and team.bostonaholic.dev). Each
-// must carry all seven install/uninstall command strings verbatim, and every
+// must carry all eight install/uninstall command strings verbatim, and every
 // `rm -rf` safety-guard invocation on each surface must point at the Codex
 // plugin cache prefix — a mistyped prefix is a silent no-op for the reader.
 //
@@ -40,13 +40,14 @@ function rmRfTargets(text: string): string[] {
   return [...text.matchAll(/rm -rf\s+(\S+)/g)].map((m) => m[1] ?? "");
 }
 
-describe("docs-install-parity: README.md and docs/index.md each carry all seven install/uninstall command strings verbatim", () => {
-  test("README.md carries all seven install/uninstall command strings verbatim", () => {
+describe("docs-install-parity: README.md and docs/index.md each carry all eight install/uninstall command strings verbatim", () => {
+  test("README.md carries all eight install/uninstall command strings verbatim", () => {
     const readme = readIf(README_MD);
     // Guard: a missing README must fail cleanly, not vacuously pass.
     expect(readme.length).toBeGreaterThan(0);
 
-    expect(readme).toContain("claude plugin add /path/to/team");
+    expect(readme).toContain("claude plugin marketplace add /path/to/team");
+    expect(readme).toContain("claude plugin install team@team-dev");
     expect(readme).toContain("codex plugin marketplace add /path/to/team");
     expect(readme).toContain("codex plugin add team@team-dev");
     expect(readme).toContain("agy plugin install /path/to/team");
@@ -55,12 +56,13 @@ describe("docs-install-parity: README.md and docs/index.md each carry all seven 
     expect(readme).toContain("script/dev-uninstall antigravity");
   });
 
-  test("docs/index.md carries all seven install/uninstall command strings verbatim", () => {
+  test("docs/index.md carries all eight install/uninstall command strings verbatim", () => {
     const docsIndex = readIf(DOCS_INDEX_MD);
     // Guard: a missing docs page must fail cleanly, not vacuously pass.
     expect(docsIndex.length).toBeGreaterThan(0);
 
-    expect(docsIndex).toContain("claude plugin add /path/to/team");
+    expect(docsIndex).toContain("claude plugin marketplace add /path/to/team");
+    expect(docsIndex).toContain("claude plugin install team@team-dev");
     expect(docsIndex).toContain("codex plugin marketplace add /path/to/team");
     expect(docsIndex).toContain("codex plugin add team@team-dev");
     expect(docsIndex).toContain("agy plugin install /path/to/team");

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -30,8 +30,9 @@ function readIf(path: string): string {
 }
 
 // The path prefix every removal command must target. The skill name after
-// the prefix belongs to the set-equality invariant, not this file.
-const RM_RF_PREFIX = '"$CODEX_HOME/plugins/cache"/*/team/*/skills/';
+// the prefix belongs to the set-equality invariant, not this file. The :?
+// expansion makes an unset CODEX_HOME abort loudly instead of no-opping.
+const RM_RF_PREFIX = '"${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/';
 
 // Every rm -rf invocation's target token, path shape only — prose around
 // the command can change freely without touching this extraction.
@@ -69,7 +70,7 @@ describe("docs-install-parity: README.md and docs/index.md each carry all seven 
   });
 });
 
-describe('docs-install-parity: every rm -rf invocation on each surface targets the prefix "$CODEX_HOME/plugins/cache"/*/team/*/skills/', () => {
+describe('docs-install-parity: every rm -rf invocation on each surface targets the prefix "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/', () => {
   test("README.md has rm -rf invocations and every one targets the Codex cache prefix", () => {
     const readme = readIf(README_MD);
     expect(readme.length).toBeGreaterThan(0);

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -1,0 +1,98 @@
+// tests/docs-install-parity.test.ts
+//
+// L2 tripwire (free, deterministic): README.md and docs/index.md are the two
+// self-contained install surfaces (GitHub and team.bostonaholic.dev). Each
+// must carry all seven install/uninstall command strings verbatim, and every
+// `rm -rf` safety-guard invocation on each surface must point at the Codex
+// plugin cache prefix — a mistyped prefix is a silent no-op for the reader.
+//
+// This file pins WHERE removal points (the path prefix). WHICH skills are
+// named after the prefix is a separate invariant — set equality against the
+// guarded-skill set on disk, in tests/pr-watch-as-reviewer-skill.test.ts.
+// The skill names are deliberately not pinned here: freezing them in this
+// file would fight that invariant.
+//
+// Defensive reads: a missing file → "" so content assertions FAIL cleanly
+// rather than throwing ENOENT (the mechanical gate rejects crashes).
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+const README_MD = join(REPO_ROOT, "README.md");
+const DOCS_INDEX_MD = join(REPO_ROOT, "docs", "index.md");
+
+function readIf(path: string): string {
+  return existsSync(path) ? read(path) : "";
+}
+
+// The path prefix every removal command must target. The skill name after
+// the prefix belongs to the set-equality invariant, not this file.
+const RM_RF_PREFIX = '"$CODEX_HOME/plugins/cache"/*/team/*/skills/';
+
+// Every rm -rf invocation's target token, path shape only — prose around
+// the command can change freely without touching this extraction.
+function rmRfTargets(text: string): string[] {
+  return [...text.matchAll(/rm -rf\s+(\S+)/g)].map((m) => m[1] ?? "");
+}
+
+describe("docs-install-parity: README.md and docs/index.md each carry all seven install/uninstall command strings verbatim", () => {
+  test("README.md carries all seven install/uninstall command strings verbatim", () => {
+    const readme = readIf(README_MD);
+    // Guard: a missing README must fail cleanly, not vacuously pass.
+    expect(readme.length).toBeGreaterThan(0);
+
+    expect(readme).toContain("claude plugin add /path/to/team");
+    expect(readme).toContain("codex plugin marketplace add /path/to/team");
+    expect(readme).toContain("codex plugin add team@team-dev");
+    expect(readme).toContain("agy plugin install /path/to/team");
+    expect(readme).toContain("agy plugin uninstall team");
+    expect(readme).toContain("script/dev-install antigravity");
+    expect(readme).toContain("script/dev-uninstall antigravity");
+  });
+
+  test("docs/index.md carries all seven install/uninstall command strings verbatim", () => {
+    const docsIndex = readIf(DOCS_INDEX_MD);
+    // Guard: a missing docs page must fail cleanly, not vacuously pass.
+    expect(docsIndex.length).toBeGreaterThan(0);
+
+    expect(docsIndex).toContain("claude plugin add /path/to/team");
+    expect(docsIndex).toContain("codex plugin marketplace add /path/to/team");
+    expect(docsIndex).toContain("codex plugin add team@team-dev");
+    expect(docsIndex).toContain("agy plugin install /path/to/team");
+    expect(docsIndex).toContain("agy plugin uninstall team");
+    expect(docsIndex).toContain("script/dev-install antigravity");
+    expect(docsIndex).toContain("script/dev-uninstall antigravity");
+  });
+});
+
+describe('docs-install-parity: every rm -rf invocation on each surface targets the prefix "$CODEX_HOME/plugins/cache"/*/team/*/skills/', () => {
+  test("README.md has rm -rf invocations and every one targets the Codex cache prefix", () => {
+    const readme = readIf(README_MD);
+    expect(readme.length).toBeGreaterThan(0);
+
+    const targets = rmRfTargets(readme);
+    // Positive control: the extractor must find the invocations known to
+    // exist, or the prefix assertions below prove nothing.
+    expect(targets.length).toBeGreaterThan(0);
+    for (const target of targets) {
+      expect(target).toStartWith(RM_RF_PREFIX);
+    }
+  });
+
+  test("docs/index.md has rm -rf invocations and every one targets the Codex cache prefix", () => {
+    const docsIndex = readIf(DOCS_INDEX_MD);
+    expect(docsIndex.length).toBeGreaterThan(0);
+
+    const targets = rmRfTargets(docsIndex);
+    // Positive control: a page with no removal commands has lost the safety
+    // guard entirely — that must fail here, not vacuously pass the loop.
+    expect(targets.length).toBeGreaterThan(0);
+    for (const target of targets) {
+      expect(target).toStartWith(RM_RF_PREFIX);
+    }
+  });
+});

--- a/tests/pr-watch-as-reviewer-skill.test.ts
+++ b/tests/pr-watch-as-reviewer-skill.test.ts
@@ -285,15 +285,21 @@ describe("pr-watch-as-reviewer skill: PENDING-review check is a fenced snippet",
   });
 });
 
-describe("pr-watch-as-reviewer skill: README Codex removal command targets the guarded skill", () => {
-  // Codex ignores disable-model-invocation, so the README tells Codex users
-  // to remove this skill after installing. A rename or move of the skill
-  // must fail the build until the README's removal path moves with it.
+describe("pr-watch-as-reviewer skill: Codex removal commands target the guarded skills on both install surfaces", () => {
+  // Codex ignores disable-model-invocation, so both install surfaces —
+  // README.md (GitHub) and docs/index.md (team.bostonaholic.dev) — tell
+  // Codex users to remove the guarded skills after installing. A rename or
+  // move of a skill must fail the build until each surface's removal path
+  // moves with it.
   const README = join(REPO_ROOT, "README.md");
+  const DOCS_INDEX = join(REPO_ROOT, "docs", "index.md");
 
   // Defensive read: missing file → "" so assertions FAIL (not throw).
   function readmeBody(): string {
     return existsSync(README) ? read(README) : "";
+  }
+  function docsIndexBody(): string {
+    return existsSync(DOCS_INDEX) ? read(DOCS_INDEX) : "";
   }
 
   // Every rm -rf target must be a real skill that actually sets the flag —
@@ -351,5 +357,14 @@ describe("pr-watch-as-reviewer skill: README Codex removal command targets the g
     const readme = readmeBody();
     expect(readme.length).toBeGreaterThan(0);
     expect([...new Set(removalTargets(readme))].sort()).toEqual(guardedSkills());
+  });
+
+  test("rm -rf targets in docs/index.md equal the guarded-skill set on disk", () => {
+    // Same set equality, second surface: a docs page whose removal list is a
+    // stale subset of README's ships a silently weakened safety guard.
+    const docsIndex = docsIndexBody();
+    // Guard: a missing docs page must fail cleanly, not vacuously pass.
+    expect(docsIndex.length).toBeGreaterThan(0);
+    expect([...new Set(removalTargets(docsIndex))].sort()).toEqual(guardedSkills());
   });
 });


### PR DESCRIPTION
## Summary
- The docs site's Install section ([team.bostonaholic.dev](https://team.bostonaholic.dev)) documented only Claude Code while the README documents three install hosts; its content had not changed since the site's original commit (`7a1877b`, May 2026). This brings `docs/index.md` to full substance parity with README's `## Install`: Claude Code, Codex CLI, and Antigravity CLI, each with its commands and host-specific caveats.
- Two static tripwires now pin the parity so this drift class cannot silently recur: `tests/docs-install-parity.test.ts` (eight install/uninstall command strings verbatim on both surfaces, plus the Codex guard-removal path prefix per invocation) and a widened describe block in `tests/pr-watch-as-reviewer-skill.test.ts` (the guarded-skill `rm -rf` set equality now also holds on `docs/index.md`).
- Two verified Blocking findings from the pipeline's review loop forced small README fixes alongside: the published Codex guard-restoration commands now use the fail-fast `"${CODEX_HOME:?}"` form (previously an unset `CODEX_HOME` made them silently no-op while the reader believed a safety guard was restored), and the Claude Code install was corrected to the two-command form — CLI 2.1.233 has no `claude plugin add` subcommand; the working install is `claude plugin marketplace add /path/to/team` + `claude plugin install team@team-dev` (marketplace name from `.claude-plugin/marketplace.json`).

## Design Decisions
- **h3 subsections instead of README's `<details>` blocks** — in-content `<details>` has no CSS on the site and no docs page uses it; one h3 per host matches the `docs/skills.md` precedent.
- **Full substance parity, not command-only** — every Codex/Antigravity caveat crossed over (namespacing, catalog budgeting, pipeline-dispatch limits, the guard-removal callout with restore step, copy-vs-link, `disable-model-invocation` behavior, dev-install/uninstall).
- **The Antigravity dispatch-untested hedge (the old [#56](https://github.com/bostonaholic/team/issues/56) sentence) was dropped from both surfaces** per maintainer direction — the docs state the install plainly, assuming it works as designed.
- **Numeral-free counts in the Antigravity subsection** ("every skill and every agent") to avoid creating a second test-pinned count-sweep location in `docs/index.md`.
- **Flattened guard callout** (blockquote, then a plain fenced block) instead of README's fence-nested-in-blockquote — no docs page nests a fence in a blockquote, so the site ships only proven idioms.
- **Front-matter `description` updated** to open host-neutrally — `jekyll-seo-tag` publishes it to search previews, and the old text claimed Claude Code exclusivity.
- **README edits (two `rm -rf` lines + the Claude Code install block) deliberately exceed the design's original scope** — each resolves a verified Blocking finding from the review loop, and the parity pins make a single-surface fix impossible by design (both surfaces and the test constants must move together).

## Changes
- `docs/index.md` — front-matter `description` + `## Install` rewritten into three host subsections (heading byte-identical, `#install` anchor survives; usage examples moved inside the Claude Code subsection; two-command Claude Code install).
- `README.md` — the two guard-removal lines switch to `"${CODEX_HOME:?}/..."`, the Claude Code install block becomes the two-command marketplace-add + install form (with one connecting sentence), and the Antigravity dispatch-untested sentence is removed (matching the docs page).
- `tests/docs-install-parity.test.ts` (new) — L2 tripwire: eight verbatim command pins per surface; every `rm -rf` invocation on each surface must target the fail-fast Codex cache prefix (with positive controls).
- `tests/pr-watch-as-reviewer-skill.test.ts` — widened describe block: `docs/index.md`'s `rm -rf` targets must equal the guarded-skill set on disk (per-surface tests so a failure names the drifted file).

## How to Verify
- [x] `bun test` — full free suite green (1417 pass / 0 fail), including the acceptance tests in the two touched test files *(verified; one run showed 2 transient failures that vanished on immediate re-run — consistent with the pre-existing flake noted below)*
- [x] `bun run typecheck` — clean
- [x] `claude plugin --help` (2.1.233) — confirms no `add` subcommand exists; `claude plugin marketplace add` + `claude plugin install <plugin@marketplace>` do
- [x] `git diff origin/main..HEAD -- README.md` shows only the three documented changes: the two-command install block (with its connecting sentence), the two `"${CODEX_HOME:?}"` guard lines, and the removed Antigravity dispatch hedge *(item wording updated — it originally predated the last two commits)*
- [x] `(cd docs && JEKYLL_ENV=production bundle exec jekyll build)` — builds clean; `docs/_site/index.html` renders `#claude-code`, `#codex-cli`, `#antigravity-cli`, keeps `#install`, and both `rm -rf "${CODEX_HOME:?}/..."` commands appear verbatim in the rendered code block
- [x] Perturbation: deleted the `pr-rebase` `rm -rf` line from `docs/index.md` → exactly one test failed (`rm -rf targets in docs/index.md equal the guarded-skill set on disk`), naming the docs surface; restored, 41/41 green

## Review notes
Minor-and-below findings deferred to this review, tagged by source (from the final review round; the two Blocking findings the loop already fixed are described in the Summary). All five reviewers approved the final round.

- [security-reviewer] LOW: with `-f`, an unmatched glob makes the guard-removal command exit 0 having deleted nothing (bash-specific; zsh fails loudly), and the docs give the reader no way to confirm removal took effect. Suggest a verification line after the block, e.g. `ls "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/ | grep -E 'pr-rebase|pr-watch-as-reviewer'` expecting no output.
- [security-reviewer] LOW: on the docs site the `rm -rf` fence renders outside the warning blockquote (README keeps it inside); optional `> ` prefix on the fence lines if the nested form renders correctly under the site's kramdown config.
- [code-reviewer] suggestion (via codex, self-verified): the fail-fast `"${CODEX_HOME:?}"` aborts for the common Codex install that never exports the variable, and neither surface names a next step. One prose line naming the default (`~/.codex`) or an expansion like `${CODEX_HOME:-$HOME/.codex}` would make the guard executable for the default install — noting that change moves the pinned prefix across three files, which the parity test correctly forces together.
- [code-reviewer] suggestion: a loop-free form of the prefix assertions that also prints all offenders at once: `expect(targets.filter((t) => !t.startsWith(RM_RF_PREFIX))).toEqual([])`.
- [code-reviewer] nitpick: `removalTargets(readme: string)` and two adjacent comments still speak only of README though the helper now serves both surfaces; rename to `body`/`surface` and generalize the comments.
- [code-reviewer] nitpick: the restore sentence ("Re-running `codex plugin add` restores them") names the command without its argument; inlining `codex plugin add team@team-dev` would make it copy-paste-true at the cost of one word's divergence from README.
- [technical-writer] suggestion: the Antigravity paragraph's numeral-free phrasing ("every skill and every agent") diverges from README's specific counts — deliberate per the design (avoids a second test-pinned count location), noted as an internal-consistency wobble for your call.
- [design-review-4] suggestion: design decision 7 rejects section-scoped test assertions saying scoping "needs a Markdown section parser", but the repo already slices by heading (`tests/changelog-links.test.ts:20-26`, `tests/cross-model-review.test.ts:751`); the decision stands on its other reason.
- [design-review-4] nitpick: decisions 7 and 8 split the removal-command contract across two test files; one clause distinguishing split-by-dimension from duplicated-invariant would close the tension.
- [design-review-4] nitpick: decision 6 doesn't name that `docs/cross-host-portability.md` sits behind the developer-only nav dropdown, making the Read-next bullet the page's only prominent route to host-portability depth.
- [design-review-4] nitpick: the "self-contained install path" claim should be bounded to README parity — the Antigravity fsmonitor caveat (`docs/cross-host-portability.md:348-351`) reaches neither install surface (README omits it too).
- [design-review-4] nitpick: design prose runs past the project's ASD-STE100 bar (drift signal only).
- [orchestrator] note (outside the diff): `tests/pre-merge-guard.test.ts:610` flaked once during a round-1 full-suite run and passed on re-runs — pre-existing intermittent flake worth a maintainer's eye, unrelated to this change.
- [cross-model-notes] Full cross-model review record (all design and implement rounds):



> **Design round 1**
>
> ### Cross-model disposition
>
> **Round 1 — agy**
>
> - Adopted (blocking): the excluded front-matter description leaves the page metadata Claude-Code-only. Confirmed at `docs/index.md:3` and `docs/_config.yml:20`. Promoted on my own check, not on the vendor's assertion.
> - Adopted (suggestion): the parity pins miss the second Codex install command. Confirmed at `README.md:30-31` against `design.md:122-128`.
> - Adopted (suggestion): no pull-request check builds the site, so a build break surfaces after merge. Confirmed at `.github/workflows/pages.yml:3-9` and `.github/workflows/harness-checks.yml:14-16`. Reported once, folded with the codex claim about what a build can detect.
> - Adopted (suggestion): the closing link sits close to the existing Read-next link. Confirmed at `docs/index.md:60` and `docs/index.md:68`.
> - Adopted (suggestion): the nested fence inside a blockquote is unproven on this site. Confirmed by a grep of `docs/` for a fenced block inside a blockquote, which returns nothing, matching `design.md:162`.
> - Refuted in part: the proposal to move the usage examples into a separate section modeled on `README.md:81`. That heading exists and is `## Usage`. The premise that such a section would carry standalone-tool examples for the other hosts fails, because the README's own `## Usage` block at `README.md:83-104` lists only `/team*` pipeline commands. The restructuring also reaches past the Install section that `task.md:62-65` fixes as the scope.
> - No action: the observation that numeral-free count phrasing is appropriate raises no defect.
>
> **Round 1 — codex**
>
> - Corroboration only: the missing fourth install pin. Same claim as agy's first, reported once above.
> - Adopted (blocking): the commit-count claim is false, because `3128327` also touched the section. Confirmed against `research.md:128-132` and `git log -L '/^## Install/,/^## /:docs/index.md'`.
> - Adopted (suggestion): a Jekyll build cannot detect a visual mis-render. Folded into the rendering-guard finding above.
> - Adopted (suggestion): "only host where they run" overstates the evidence for Antigravity. Confirmed at `README.md:68-70`.
> - Corroboration only: the excluded search description. Same claim as agy's second, reported once above.
>
> **Skips:** none. Both CLIs returned output in round 1 (`cross-model-raw.md:9,21`). The working tree is clean, so neither full-access vendor wrote to it.

> **Design round 2**
>
> ### Cross-model disposition
>
> **Round 2 — agy**
>
> - Adopted (suggestion): the presentation branches on the implementer's toolchain, so the published markup varies by environment. Confirmed at `design.md:209-223`, where neither branch is marked as the default. The live-render half of the claim raises nothing new, because `design.md:227-234` and `design.md:264-266` already disclose it.
> - Adopted (blocking and suggestion, split): the pin set leaves the removal commands and the dev scripts untested. Confirmed at `design.md:104-120` against `design.md:151-161`. The safety half promoted to Blocking on my own check of `tests/pr-watch-as-reviewer-skill.test.ts:347-354`; the decision-quality half stands as a suggestion.
> - Adopted (nitpick): the pins truncate three of four commands. Confirmed at `design.md:152-154` and `README.md:11-12`.
> - Refuted in part: the claim that excluding `docs/_config.yml:6` leaves the page's structured data Claude-only. The string and the tag both check out (`docs/_config.yml:6`, `docs/_layouts/default.html:16`), but all nine published pages carry their own `description` front matter, and `docs/index.md:3` is what decision 9 fixes. The design also states its reason at `design.md:189-195` and defers the question with an owner at `design.md:246-249`. The plugin's internal resolution order is unverifiable here, because the gem is not vendored in this repository.
> - Adopted (nitpick): the cited read pattern is defensive, not direct. Confirmed at `tests/docs-versioning.test.ts:24-26`. The crash consequence is refuted at the design level — `design.md:250-253` leaves test mechanics to implement, so nothing forbids the defensive form.
> - No new finding: the absence of a pull-request Jekyll build. The design already carries it at `design.md:200`, `design.md:227-234`, and `design.md:264-266`. Corroboration only.
>
> **Round 2 — codex**
>
> - Unverifiable: the claim that a named Claude Code build rejects the `add` verb. This repository carries the same string at `README.md:18` and `docs/index.md:47` and pins no host CLI version, so nothing here confirms or refutes it. `design.md:188` also puts `README.md` out of scope, so the remedy would sit outside this design.
> - Adopted (suggestion): the removal path collapses when the environment variable is unset. Confirmed as a shell property of `README.md:46-47`. Reported as a missing open question, not as a README fix.
> - Adopted (blocking): the copied removal targets fall outside the parity checks, and the existing set-equality invariant covers one surface only. Confirmed at `tests/pr-watch-as-reviewer-skill.test.ts:288-354` against `design.md:162-167` and `design.md:197-198`. Promoted on my own check, not on the vendor's assertion.
> - Adopted (nitpick): whole-file substring checks accept a misplaced command. Folded with agy's third claim and reported once.
> - Adopted (suggestion): the build command omits the site's working directory. Confirmed at `.github/workflows/pages.yml:28-35` and `docs/_config.yml:1-4`.
> - Refuted: the claim that the first visible tagline undercuts the goal without a stated reason. `design.md:189-195` gives the reason, and `design.md:246-249` defers the change with a named owner and time.
>
> **Skips:** none. Both CLIs returned output in round 2. The working tree is clean, so neither full-access vendor wrote to it.

> **Design round 3**
>
> ### Cross-model disposition
>
> **Round 3 — codex**
>
> - Refuted at the blocking tier, adopted as a nitpick: the claim that the checklist drops the agents-and-hooks fact. The cited range `README.md:17-22` carries that clause at `README.md:22`, so the checklist item points at it. The label alone omits it, which is a wording finding, not a dropped requirement.
> - Refuted in part, unverifiable in part: the claim about an unset `CODEX_HOME`. The half that says the command can delete matches under `/plugins/cache` depends on the reader's filesystem, and this repository settles nothing about it, so it stands as a nitpick on the design's phrasing. The conclusion that `design.md:247` wrongly excludes a two-surface replacement is refuted: `task.md:46-54` and `task.md:62-65` fix the change at `docs/index.md`, `design.md:247-249` states the exclusion, and `design.md:336-345` records the hazard with a named owner and time.
> - Adopted (suggestion): whole-file presence checks accept a misplaced command. Confirmed at `design.md:170-172`, which sets no section scope, against the same whole-file shape at `tests/thin-agents.test.ts:303-307`. The exact-per-section remedy the claim proposes is reported as a suggestion.
> - No claim from codex reached this round's blocking finding. That finding rests on the reviewer's own check of `tests/thin-agents.test.ts:297-307` against `README.md:62` and `README.md:210`.
>
> **Round 3 — agy**
>
> - Skip: the runner reported exit code 1 with a vendor timeout while waiting for a response. No claims arrived from agy this round, so the round's external input is codex alone.
>
> `git status --porcelain` returns nothing, so no full-access vendor wrote to the tree.

> **Design round 4**
>
> ### Cross-model disposition
>
> **Round 4 — agy**
>
> - Refuted: the claim that the design cites non-existent line ranges in `tests/pr-watch-as-reviewer-skill.test.ts`. The file has 355 lines, not 343. The describe block opens at line 288 and closes at line 355, and the set-equality test runs 347-354 with its assertion at line 353. Lines 334-341 are the per-target existence loop inside the *first* test, which is a different assertion. Every range the design cites for that file checks out: 288-355, 292-297, 299-324, 301-307, 311-324, and 347-354.
> - Refuted: the claim that decision 4 leaves Codex and Antigravity readers with no usage path. README's Install carries no standalone-utility examples either. It carries invocation-naming notes at `README.md:34` and `README.md:65`, and decision 2's checklist crosses both over at `design.md:131-138`. A standalone usage section exceeds the change surface `task.md:62-65` fixes.
> - Refuted: the claim that excluding the tagline leaves an unresolved contradiction. `design.md:276-282` states the exclusion with a reason, and `design.md:361-364` defers the question to the repo maintainer at PR review.
> - Refuted: the claim that the README install-path count is left unprotected as an oversight. `design.md:351` marks the cell `no` with the reason, and `design.md:379-387` defers it with a named owner and time. That is the resolution round 3 asked for.
> - Verified in part, adopted as a nitpick: the claim about decision 8 splitting the invariant across two files. The split is real and is reported in the round's findings. The proposed remedy is the one `design.md:227-228` rejects with a reason that still stands.
> - Verified in part, adopted as a nitpick: the claim that a later `CODEX_HOME` fix breaks the parity suite. It does, and that is the pin doing its job. The finding taken from it is the undercounted surface list at `design.md:377-378`, not the pin.
> - Verified, adopted as a nitpick: the claim about `docs/cross-host-portability.md` sitting behind the contributing dropdown. Confirmed at `docs/cross-host-portability.md:4` and `docs/_layouts/default.html:31-41`.
> - Corroboration only: agreement with the prose-drift risk at `design.md:391-395`. The design already records it; no second finding.
>
> **Round 4 — codex**
>
> - Refuted at the blocking tier: the claim that both surfaces should adopt a fail-fast `${CODEX_HOME:?}`. `task.md:46-54` and `task.md:62-65` fix the change surface, `design.md:273-275` states the README exclusion, and `design.md:369-378` records the hazard with an owner and a time. The commands in question restore a safety guard after install; they are not the install commands the acceptance signal calls working.
> - Verified, adopted as a suggestion: the claim that the repository already slices by heading. Confirmed at `tests/changelog-links.test.ts:20-26` and `tests/cross-model-review.test.ts:751`. Reported against decision 7's stated cost, not against its outcome.
> - Verified as fact, refuted as a parity defect, adopted as a nitpick: the fsmonitor claim. The caveat exists at `docs/cross-host-portability.md:348-351` and reaches neither install surface. README omits it too, so the design's parity target is met.
> - Refuted: the claim that the design should add a PR-time Jekyll build. `design.md:287` puts docs CI out of scope, and `design.md:306-309` and `design.md:396-399` record the residual. New CI exceeds the change surface `task.md` fixes.
> - Refuted: the claim that `CHANGELOG.md` belongs in the co-changing surfaces. `skills/changelog/SKILL.md:157-158` excludes `docs:` commits unless documentation is the product and is the release's only change. The learned rule in `CLAUDE.md` lands a dev-only PR with no changelog cut. `CHANGELOG.md:164`, the nearest precedent, documents a change to the distributed manifests, which is runtime.
>
> No skips this round. Both CLIs returned output. `git status --porcelain` returns nothing, so no full-access vendor wrote to the tree.

> **Implement round 1 (code-reviewer)**
>
> ### Cross-model disposition
>
> Round 1 ran with both CLIs detected ready; both calls ended in skips, so no external claims entered this review.
>
> - **codex:** skip — the call hit the 600 s timeout cap. No output, no claims to disposition.
> - **agy:** skip — produced no output. The courier-relayed call returned nothing, and the inline fallback run also exited with zero bytes on stdout (an empty-stdout run is a skip, not a clean pass).
>
> Post-pass tree checks after both vendor runs: `git status` clean — no mutations from either full-access vendor CLI. The pass was unavailable this round; per the skill this does not soften the verdict, which rests entirely on my own verification above.

> **Implement round 2 (code-reviewer)**
>
> ### Cross-model disposition
>
> - **codex:** skip — `detect` reported ready and the courier-dispatched call was still executing at the orchestrator's report cutoff (within the runner's 600 s budget); no output was read, no claims adopted.
> - **agy:** skip — same: call in flight at report cutoff, no output read, no claims adopted.
>
> No vendor claim reached this report; the verdict rests entirely on my own verification, and per the skill the pass's unavailability does not soften it. The tree check at cutoff found no vendor mutation.
>
> Orchestrator note: the round's agy courier first delivered its output to the orchestrator after the reviewer's initial cutoff; the orchestrator relayed it and the reviewer issued the final disposition below, which supersedes the agy skip recorded above.

> **Implement round 2 (code-reviewer, final — supersedes the agy skip above)**
>
> ### Cross-model disposition
>
> - **agy:** output (arrived via orchestrator relay after the courier misrouted its reply; handled as untrusted data). Four claims, each verified myself:
>   - *Adopted (nitpick):* the prefix extractor captures only the first argument of each removal command and scans whole files rather than the Install section. The first-argument half is mechanically true and adopted with my own confirmation that the set-equality invariant turns any such gap into a red build (tests/pr-watch-as-reviewer-skill.test.ts:310, 362-369). The whole-file-scoping half is refuted as a defect: design decision 7 chose whole-file pins deliberately and states exactly that tradeoff, and an unrelated removal command appearing on an install surface failing loudly is the pinned intent.
>   - *Refuted:* the claim that skill existence and the `disable-model-invocation` flag go unverified on `docs/index.md`. The set-equality test at tests/pr-watch-as-reviewer-skill.test.ts:362-369 compares the page's targets against `guardedSkills()`, which is built (lines 317-330) only from skills that exist on disk and set the flag — equality therefore proves both properties for every docs target, strictly stronger than the per-target README test at line 332.
>   - *Corroborating:* the `readme`-named parameter reused for the docs surface — already my own suggestion; reported once.
>   - *Refuted as a finding:* the site-wide description at docs/_config.yml:6 differing from the page's new front-matter description. The observation is factually accurate (I read the line), but the design's Out of scope section (design.md lines 277-282) keeps that string untouched with a stated reason — it is positioning that remains true, since the full pipeline runs only on Claude Code — and the design's first deferred open question already assigns it to the maintainer at PR review. A stated reason for the absence answers the finding, and the two strings do not contradict.
> - **codex:** skip — the call was still executing at the orchestrator's report cutoff (within the runner's 600 s budget); no output read, no claims adopted.
>
> No external claim was promoted beyond nitpick without my own `file:line` verification, and the partial pass does not soften the verdict. The tree check after the pass window found no vendor mutation.

> **Implement round 3 (code-reviewer)**
>
> ### Cross-model disposition
>
> Courier dispatch failed (no tmux pane space), so both `run` calls executed through the inline background fallback. Both CLIs returned output; no skips. Tree clean after the pass.
>
> **codex**
> - Adopted (suggestion tier, marked via codex): the `:?` expansion aborts when `CODEX_HOME` is unexported, which is the common install state — I confirmed `CODEX_HOME` is unset in this environment and that neither surface offers a recovery hint. Adopted at suggestion, not Blocking, because the fail-loud shape was the deliberate, sanctioned resolution of a verified HIGH security finding and is strictly safer than the silent no-op it replaced.
> - Partially adopted (nitpick): the restore sentence names the command without its argument, and I confirmed via the CLI's help that the bare invocation would error. Refuted as a material defect — the sentence is inline prose pointing at the fully-argumented command block directly above (docs/index.md:76), not a runnable snippet — and kept only as a copy-paste-clarity nitpick.
>
> **agy** (its output repeated each claim twice; three distinct claims)
> - Refuted as a defect: the docs-page callout ends before the code block while README nests it. The rendering description is accurate, but this is design decision 9's explicit choice — no docs page nests a fence inside a blockquote, and the flattened form composes only idioms proven on the site. Checked at docs/index.md:84-93 against design.md decision 9.
> - Refuted as a defect: the whole-document `rm -rf` extraction would fail on a future unrelated removal command elsewhere on either page. Mechanism confirmed at tests/docs-install-parity.test.ts:41-44, but design decision 7 records exactly this tradeoff and rejects section scoping; a red build on any new `rm -rf` on an install surface is an acceptable review-forcing outcome, not brittleness.
> - Refuted as a coverage gap: the per-target existence/frontmatter test runs only against README while docs/index.md gets set equality alone. The asymmetry is real (tests/pr-watch-as-reviewer-skill.test.ts:332-351 vs :362-369), but `guardedSkills()` admits only skills that exist on disk and set the flag, so set equality subsumes the per-target checks — no invalid docs target can pass.

## References
- Design: docs/plans/2026-08-19-docs-site-install-instructions/design.md (worktree-local, untracked)
- Plan:   docs/plans/2026-08-19-docs-site-install-instructions/plan.md (worktree-local, untracked)
