### PR TITLE
v0.53.0 feat(groom-backlog): define the grooming actions in performance order

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.52.0"
+    "version": "0.53.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-08-19
+
 ### Added
 
 - **`/groom-backlog` now defines its grooming actions, in the order a run performs them.** The `## Vocabulary` section gains a twelve-entry action list — Verify, Rank, Cluster, Describe, Retarget, Place, Refine, Triage, File, Close, Link, Promote — one line each, ordered as the run performs them, with the load-bearing ordering rationales stated inline: priority follows the rewrite because the tiers weigh verified scope and the rewrite pins the scope down, and links go last among the writes because one that touches a just-closed endpoint must die at the endpoint re-read. Aligning the list against both modes exposed one real contradiction: the board-mode execute step ran state/priority/label hygiene before description rewrites while promotion mode rewrote before setting priority, so the execution chain now rewrites first and both modes agree with the list. [`skills/groom-backlog/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
@@ -558,7 +560,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.52.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.53.0...HEAD
+[0.53.0]: https://github.com/bostonaholic/team/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/bostonaholic/team/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/bostonaholic/team/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/bostonaholic/team/compare/v0.49.0...v0.50.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/groom-backlog` now defines its grooming actions, in the order a run performs them.** The `## Vocabulary` section gains a twelve-entry action list — Verify, Rank, Cluster, Describe, Retarget, Place, Refine, Triage, File, Close, Link, Promote — one line each, ordered as the run performs them, with the load-bearing ordering rationales stated inline: priority follows the rewrite because the tiers weigh verified scope and the rewrite pins the scope down, and links go last among the writes because one that touches a just-closed endpoint must die at the endpoint re-read. Aligning the list against both modes exposed one real contradiction: the board-mode execute step ran state/priority/label hygiene before description rewrites while promotion mode rewrote before setting priority, so the execution chain now rewrites first and both modes agree with the list. [`skills/groom-backlog/SKILL.md`](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
+
 ## [0.52.0] - 2026-08-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/groom-backlog/SKILL.md
+++ b/skills/groom-backlog/SKILL.md
@@ -49,6 +49,33 @@ The method is tracker-agnostic. Only the nouns change, and GitHub Projects v2 is
 A **dependency link** orders two pieces of work in time. A **decomposition link** says one is
 part of the other. They are not interchangeable, and no tracker infers either.
 
+The actions the steps below take, in the order a run performs them — one word each:
+
+- **Verify** — check an issue's factual claims against the code and the tracker before
+  trusting them.
+- **Rank** — order the verified candidates by the four-tier heuristic, so the promotion pick
+  is an argument rather than a mood.
+- **Cluster** — group open issues by the outcome they serve, not the component they touch.
+- **Describe** — create a grouping construct, or write or extend its description: one or two
+  present-tense sentences stating a property of the system that is either true or false.
+- **Retarget** — move a construct's date out of the past, into the project window and the
+  remaining iterations.
+- **Place** — put a cluster under the grouping construct whose description covers its outcome.
+- **Refine** — rewrite an issue body to the ready-to-work standard: problem, verifiable
+  outcome, acceptance criteria.
+- **Triage** — give an unsorted issue its first classification: priority, labels, and state,
+  so it stops being invisible to every filter. Priority comes after the refine, because the
+  tiers weigh verified scope and the rewrite is what pins the scope down.
+- **File** — create a new issue, only against its own explicitly answered question — never as
+  a side effect of another answer.
+- **Close** — end an issue whose premise evaporated, with dated evidence, behind its own
+  approval.
+- **Link** — record a dependency or decomposition relationship so the board's ready-signals
+  can see it. Links go last among the writes: a link can only name issues that already
+  exist, and one that touches a just-closed endpoint must die at the endpoint re-read.
+- **Promote** — bring one item to the ready-to-work standard, then move its card into the
+  ready column. The board pass offers one; only promotion mode performs one.
+
 ## Input
 
 `$ARGUMENTS` carries an optional board reference and an optional mode flag:
@@ -395,8 +422,8 @@ approved plan is a separate turn that reads `$RUN_DIR/plan.md`.
 
 ### Step 9 — Execute in dependency order
 
-Create constructs → retarget and describe → assign issues → state, priority, and label
-hygiene → description rewrites → new issues → closures → dependency links. Links go last
+Create constructs → describe and retarget → assign issues → description rewrites → state,
+priority, and label hygiene → new issues → closures → dependency links. Links go last
 because a link can only name issues that already exist, including any this run just filed,
 and a link that touches a just-closed endpoint dies at the endpoint re-read below. Run mutations
 serially with backoff so a secondary rate limit cannot shred a half-applied plan. Re-read


### PR DESCRIPTION
## Why

`/groom-backlog` leans on a set of action verbs — triage, refine, promote, close, and friends — without ever defining them, so a reader has to reverse-engineer what each word means from where it appears. Worse, the two modes disagreed on the order of one pair: board mode executed state/priority/label hygiene before description rewrites, while promotion mode rewrote the body before setting priority.

## What

- The `## Vocabulary` section now carries a twelve-entry definitions list — Verify, Rank, Cluster, Describe, Retarget, Place, Refine, Triage, File, Close, Link, Promote — one line each, ordered as a run performs the actions.
- The two load-bearing ordering rationales are stated inline: priority follows the rewrite because the tiers weigh verified scope and the rewrite is what pins scope down; links go last among the writes because a link that touches a just-closed endpoint must die at the endpoint re-read.
- Board mode's execute chain now rewrites descriptions before running hygiene, resolving the cross-mode contradiction in favor of promotion mode's principled order. The orderings with stated correctness reasons (constructs before assignment, closes before links, links last, promote terminal) are untouched.
- Changelog bullet under `## [Unreleased]`; no version bump until land time, so the version-bump gate is expected to stay red through review.

## Test plan

- Verified every definition maps 1:1 onto a step in board mode or promotion mode, and that both modes now perform the actions in the list's order.
- Prose-only change to one skill; no code paths touched.
