### PR TITLE
v0.55.0 fix(skills): drop the $<digit> tokens the slash-command loader substitutes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.54.0"
+    "version": "0.55.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -206,6 +206,13 @@ seeds `docs/plans/<id>/` for the archetype-A consumers downstream.)
 - Each shell block is its own process — recompute derived vars. Do not rely on persistence.
 - An argument carries a scalar (URL/window/ID) or an OPTIONAL artifact-dir path that
   discovery resolves when omitted — never the document's contents.
+- **Never write a `$` immediately followed by a digit anywhere in a SKILL.md.** The
+  loader reads it as an argument placeholder and substitutes the caller's Nth argument,
+  which silently rewrites awk record/field variables and shell positional parameters in
+  your snippets. Read a line into a named variable and match it with `case`, or reach
+  for `cut`/`sed`, instead. The documented backslash escape is not enough: a host that
+  substitutes the placeholder without implementing the escape leaves the backslash in
+  the command. `tests/regression-skill-body-positional-args.test.ts` enforces this.
 
 ---
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-08-20
+
 ### Fixed
 
 - **Three skills carried shell snippets that the slash-command loader silently rewrote before you read them.** A `$` immediately followed by a digit is not inert in a skill body: the loader treats it as an argument placeholder and substitutes the caller's Nth argument. So `/pr-cleanup PR 244` turned the worktree-path lookup's `awk` program into `substr(PR,10)` and `PR=="branch "b`, matching an unset variable — the lookup returned nothing, every consumer read that as "this branch lives in no worktree", and the worktree survived a teardown that reported success while the dirty-tree check inside it never ran. Because a placeholder with no matching argument is left alone, whether a given site broke depended on how many arguments you typed, which is why this read as intermittent rather than broken. [`pr-cleanup`](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md) now derives the path with a `case`-matched read loop, which also compares the branch name as a string instead of interpolating it into a pattern; [`team-structure`](https://github.com/bostonaholic/team/blob/main/skills/team-structure/SKILL.md)'s frontmatter scan matches the closing marker as a regex; and [`pr-rebase`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)'s conflict-stage query reads the stage column with `cut`. Each rewrite drops the token rather than leaning on the documented backslash escape, since a host that substitutes the placeholder without implementing the escape would leave the backslash in the command. **What this asks of you:** nothing — but a `/pr-cleanup` run that reported success while leaving a worktree behind was this bug, and that worktree is still on disk.
@@ -570,7 +572,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.54.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.55.0...HEAD
+[0.55.0]: https://github.com/bostonaholic/team/compare/v0.54.0...v0.55.0
 [0.54.0]: https://github.com/bostonaholic/team/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/bostonaholic/team/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/bostonaholic/team/compare/v0.51.0...v0.52.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Three skills carried shell snippets that the slash-command loader silently rewrote before you read them.** A `$` immediately followed by a digit is not inert in a skill body: the loader treats it as an argument placeholder and substitutes the caller's Nth argument. So `/pr-cleanup PR 244` turned the worktree-path lookup's `awk` program into `substr(PR,10)` and `PR=="branch "b`, matching an unset variable — the lookup returned nothing, every consumer read that as "this branch lives in no worktree", and the worktree survived a teardown that reported success while the dirty-tree check inside it never ran. Because a placeholder with no matching argument is left alone, whether a given site broke depended on how many arguments you typed, which is why this read as intermittent rather than broken. [`pr-cleanup`](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md) now derives the path with a `case`-matched read loop, which also compares the branch name as a string instead of interpolating it into a pattern; [`team-structure`](https://github.com/bostonaholic/team/blob/main/skills/team-structure/SKILL.md)'s frontmatter scan matches the closing marker as a regex; and [`pr-rebase`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)'s conflict-stage query reads the stage column with `cut`. Each rewrite drops the token rather than leaning on the documented backslash escape, since a host that substitutes the placeholder without implementing the escape would leave the backslash in the command. **What this asks of you:** nothing — but a `/pr-cleanup` run that reported success while leaving a worktree behind was this bug, and that worktree is still on disk.
+
 ## [0.54.0] - 2026-08-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-cleanup/SKILL.md
+++ b/skills/pr-cleanup/SKILL.md
@@ -313,9 +313,9 @@ a protected branch, not the branch to clean up.
 Run `git -C "$PRIMARY_ROOT" status --porcelain` — and when the target
 branch lives in a linked worktree, run
 `git -C "$WORKTREE_PATH" status --porcelain` there too, deriving
-`$WORKTREE_PATH` with the `worktree list --porcelain` awk shown in Mode A
-step 2 (Mode B step 2 uses the same derivation) — never invent another
-lookup. Untracked generated reports are disposable in
+`$WORKTREE_PATH` with the `worktree list --porcelain` read loop shown in
+Mode A step 2 (Mode B step 2 uses the same derivation) — never invent
+another lookup. Untracked generated reports are disposable in
 Mode B only; tracked modifications always stop the run. Surface them — do
 not discard work.
 
@@ -366,8 +366,15 @@ not discard work.
    capture its path in the same invocation as the removal:
 
    ```sh
+   # Never reach for awk's record variable here: a `$` before a digit is an
+   # argument placeholder the loader substitutes before you read this.
    WORKTREE_PATH="$(git -C "$PRIMARY_ROOT" worktree list --porcelain |
-     awk -v b="refs/heads/$BRANCH" '/^worktree /{w=substr($0,10)} $0=="branch "b{print w; exit}')"
+     while IFS= read -r line; do
+       case "$line" in
+         "worktree "*)                candidate="${line#worktree }" ;;
+         "branch refs/heads/$BRANCH") printf '%s\n' "$candidate"; break ;;
+       esac
+     done)"
    ```
 
    Empty `$WORKTREE_PATH` → the branch lives in no worktree; skip this
@@ -473,8 +480,15 @@ order child before parent throughout.
    in the same invocation as the removal:
 
    ```sh
+   # Never reach for awk's record variable here: a `$` before a digit is an
+   # argument placeholder the loader substitutes before you read this.
    WORKTREE_PATH="$(git -C "$PRIMARY_ROOT" worktree list --porcelain |
-     awk -v b="refs/heads/$BRANCH" '/^worktree /{w=substr($0,10)} $0=="branch "b{print w; exit}')"
+     while IFS= read -r line; do
+       case "$line" in
+         "worktree "*)                candidate="${line#worktree }" ;;
+         "branch refs/heads/$BRANCH") printf '%s\n' "$candidate"; break ;;
+       esac
+     done)"
    ```
 
    Empty `$WORKTREE_PATH` → no worktree; skip this step. Otherwise:

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -436,8 +436,14 @@ add/add conflict, and one of `:2:`/`:3:` is absent on every modify/delete.
 Ask the index which stages are present, then branch on the answer:
 
 ```sh
-git ls-files -u -- "<path>" | awk '{print $3}' | sort -u   # prints the stage numbers present
+git ls-files -u -- "<path>" | cut -d' ' -f3 | cut -f1 | sort -u   # the stage numbers present
 ```
+
+Each `ls-files -u` line is `<mode> <object> <stage>` and then a tab before the
+path, so the first `cut` takes the third space-separated field and the second
+trims the path off it. Do not collapse the pair into `awk` addressing a
+numbered field: a `$` before a digit is an argument placeholder that the
+slash-command loader substitutes before this skill ever reaches you.
 
 | Stages present | Conflict type | What it means |
 |----------------|---------------|---------------|

--- a/skills/team-structure/SKILL.md
+++ b/skills/team-structure/SKILL.md
@@ -60,7 +60,7 @@ for dir in docs/plans/*/; do
   # Frontmatter-only verdict parse (mirrors the hooks): line 1 must be ---,
   # the scan stops at the closing --- (60-line window), so a body line
   # quoting "verdict: APPROVE" can never pass. Fail-closed.
-  awk 'NR==1 { if ($0 != "---") exit; next } /^---$/ { exit } NR > 60 { exit } { print }' "$rv" \
+  awk 'NR==1 { if (!/^---$/) exit; next } /^---$/ { exit } NR > 60 { exit } { print }' "$rv" \
     | grep -qE '^verdict:[[:space:]]*(APPROVE|COMMENT)[[:space:]]*$' || continue
   m=-1
   for p in $PHASE_FILES; do

--- a/tests/regression-skill-body-positional-args.test.ts
+++ b/tests/regression-skill-body-positional-args.test.ts
@@ -1,0 +1,203 @@
+// tests/regression-skill-body-positional-args.test.ts
+//
+// Regression pin for the defect where a skill body carried a bare `$<digit>`
+// inside a shell snippet and the slash-command loader ate it.
+//
+// `$N` in a skill body is not inert. Claude Code substitutes it as shorthand
+// for `$ARGUMENTS[N]` — `$0` is the FIRST argument, `$1` the second. So
+// `/pr-cleanup PR 244` rewrote pr-cleanup's worktree-path awk from
+//
+//   awk -v b="refs/heads/$BRANCH" '/^worktree /{w=substr($0,10)} $0=="branch "b{print w; exit}'
+//
+// to `substr(PR,10)` and `PR=="branch "b` before the model ever read it.
+// `PR` is an unset awk variable, so the program matched nothing and printed
+// nothing. Every consumer reads an empty `$WORKTREE_PATH` as "the branch lives
+// in no worktree, skip this step" — the worktree survived a teardown that
+// reported success, and step 3's dirty-tree check inside it never ran.
+//
+// A placeholder with no corresponding argument is left unchanged, so whether a
+// given site breaks depends on how many arguments the caller typed. That makes
+// the defect intermittent rather than absent, which is why the fix removes the
+// token rather than counting on nobody passing arguments.
+//
+// Two layers, because each catches what the other cannot:
+//
+//   1. L2 NEGATIVE SWEEP — no skill body contains `$<digit>` at all. Per
+//      docs/testing.md this is a forbidden-pattern tripwire on an identifier,
+//      not on a wording, so a meaning-preserving rewrite never turns it red.
+//      A positive control proves the matcher can still see the token.
+//   2. L3 EXECUTABLE — the pr-cleanup derivation, extracted from the SKILL.md
+//      itself, resolves real worktrees in a hermetic fixture repo. Without
+//      this, a token-free but broken replacement would sail through layer 1.
+//
+// The ban is absolute rather than allowing the documented `\$0` backslash
+// escape. Team distributes to Claude Code, Codex, and Antigravity; a host that
+// substitutes `$N` without implementing the escape leaves a literal `\$0` in
+// the body, which is a differently broken command. Avoiding the token is the
+// only form that is correct on every host.
+//
+// Scope is the SKILL.md bodies, which are what a slash-command invocation
+// substitutes. Supporting files beside a SKILL.md (prompt templates) are read
+// as files, never as the command body, so they are not substituted.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+
+// Every slash-command body in the repo: the distributed plugin's skills plus
+// the dev-only ones under .claude/, which are invoked the same way and so are
+// substituted the same way.
+function skillBodies(): { label: string; path: string }[] {
+  const roots = [join("skills"), join(".claude", "skills")];
+  const found: { label: string; path: string }[] = [];
+  for (const root of roots) {
+    const abs = join(REPO_ROOT, root);
+    if (!existsSync(abs)) continue;
+    for (const name of readdirSync(abs).sort()) {
+      const rel = join(root, name, "SKILL.md");
+      if (existsSync(join(REPO_ROOT, rel))) {
+        found.push({ label: rel, path: join(REPO_ROOT, rel) });
+      }
+    }
+  }
+  return found;
+}
+
+// `$` followed by a digit — the whole banned family, `$0` through `$9`. Kept
+// un-anchored and NON-global: a /g regex carries `lastIndex` between `.test()`
+// calls, which would make the per-line scan below skip lines at random.
+const POSITIONAL = /\$[0-9]/;
+
+describe("regression: no skill body carries a bare $<digit> the loader would substitute", () => {
+  const bodies = skillBodies();
+
+  // Guard: an empty corpus would make every sweep below pass vacuously.
+  test("the skill corpus is non-empty", () => {
+    expect(bodies.length).toBeGreaterThan(0);
+  });
+
+  // Positive control (docs/testing.md, "Prove a negative check can find a
+  // positive"): point the matcher at a known offender and watch it fire. A
+  // clean sweep is only meaningful once this passes.
+  test("the matcher fires on a known positive", () => {
+    const planted = `awk '/^worktree /{w=substr($0,10)}'`;
+    expect(POSITIONAL.test(planted)).toBe(true);
+  });
+
+  for (const { label, path } of bodies) {
+    test(`${label} contains no $<digit>`, () => {
+      const offenders = read(path)
+        .split("\n")
+        .map((line, index) => ({ line: index + 1, text: line }))
+        .filter((entry) => POSITIONAL.test(entry.text))
+        .map((entry) => `${label}:${entry.line}: ${entry.text.trim()}`);
+      expect(offenders).toEqual([]);
+    });
+  }
+});
+
+// --- L3: the pr-cleanup derivation actually resolves worktrees ---------------
+
+const PR_CLEANUP = join(REPO_ROOT, "skills", "pr-cleanup", "SKILL.md");
+
+// Pull the worktree-path derivation out of the SKILL.md so the documented
+// command and the tested command cannot drift. Mode A and Mode B each carry a
+// copy; they must stay identical, since step 3 tells the reader that both use
+// the same derivation.
+function derivationSnippet(): string {
+  const blocks = [...read(PR_CLEANUP).matchAll(/```sh\n([\s\S]*?)```/g)].map(
+    (m) => m[1]!,
+  );
+  const matches = blocks.filter((b) => b.includes('WORKTREE_PATH="$('));
+  expect(matches.length).toBe(2); // guard: Mode A + Mode B, no more, no fewer
+  expect(matches[1]).toBe(matches[0]); // the two copies have not drifted
+  return matches[0]!;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  const res = spawnSync(
+    "git",
+    ["-c", "user.email=test@test", "-c", "user.name=test", ...args],
+    { cwd, encoding: "utf8" },
+  );
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  }
+  return res.stdout.trim();
+}
+
+describe("regression: the extracted pr-cleanup derivation resolves worktree paths", () => {
+  let root: string;
+  let primary: string; // the main working tree, on branch `main`
+  let linked: string; // a linked worktree, on a branch whose name holds a `/`
+
+  beforeAll(() => {
+    // realpath: on macOS $TMPDIR is a symlink into /private, and git reports
+    // the resolved path. Comparing against the unresolved one fails on the
+    // symlink, not on the derivation under test.
+    root = realpathSync(mkdtempSync(join(tmpdir(), "skill-positional-args-test-")));
+    primary = join(root, "repo");
+    linked = join(root, "linked");
+
+    mkdirSync(primary);
+    git(primary, "init", "-b", "main");
+    git(primary, "commit", "--allow-empty", "-m", "init");
+    git(primary, "worktree", "add", linked, "-b", "feature/slash-in-name");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Run the documented snippet with the two variables it reads supplied by the
+  // caller, exactly as the surrounding skill steps supply them.
+  function derive(branch: string): string {
+    const script = [
+      `PRIMARY_ROOT=${JSON.stringify(primary)}`,
+      `BRANCH=${JSON.stringify(branch)}`,
+      derivationSnippet(),
+      'printf "%s" "$WORKTREE_PATH"',
+    ].join("\n");
+    const res = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    return res.stdout;
+  }
+
+  test("resolves the primary working tree's own branch", () => {
+    expect(derive("main")).toBe(primary);
+  });
+
+  // A branch name holding `/` is the case a regex-interpolating rewrite would
+  // silently break, so it is pinned rather than left to a plain name.
+  test("resolves a linked worktree whose branch name contains a slash", () => {
+    expect(derive("feature/slash-in-name")).toBe(linked);
+  });
+
+  test("resolves to empty for a branch that lives in no worktree", () => {
+    git(primary, "branch", "detached-branch");
+    expect(derive("detached-branch")).toBe("");
+  });
+
+  test("resolves to empty for a branch that does not exist", () => {
+    expect(derive("no-such-branch")).toBe("");
+  });
+
+  test("does not match a branch name by prefix", () => {
+    // `main` must not answer for `mai` — the comparison is exact, not a prefix
+    // or a regex match.
+    expect(derive("mai")).toBe("");
+  });
+});


### PR DESCRIPTION
## Why

A `$` immediately followed by a digit is not inert in a skill body. The slash-command loader reads it as an argument placeholder and substitutes the caller's Nth argument — `$0` is the *first* argument, `$1` the second. Three distributed skills carried shell snippets that relied on it meaning something else, so the loader quietly rewrote them before the model ever read them.

The worst case is `pr-cleanup`. Invoked as `/pr-cleanup PR 244`, its worktree-path lookup became `substr(PR,10)` and `PR=="branch "b`. `PR` is an unset awk variable, so the program matched nothing and printed nothing — and every consumer reads an empty result as "this branch lives in no worktree, skip this step." The worktree survived a teardown that reported success, and the dirty-tree check inside it never ran. A teardown skill failing silently is the worst available failure mode.

Because a placeholder with no matching argument is left unchanged, whether a given site broke depended on how many arguments the caller typed. That is why this read as intermittent rather than plainly broken.

## What changed

- **`pr-cleanup`** derives the worktree path with a `case`-matched read loop. It compares the branch name as a string rather than interpolating it into a pattern, so a name holding `/` or a regex metacharacter still resolves.
- **`team-structure`** matches the closing frontmatter marker as a regex instead of comparing awk's record variable.
- **`pr-rebase`** reads the conflict-stage column with `cut`, with a note on the line format so nobody folds it back into a numbered field reference.
- The skill-authoring guide's input invariants carry the rule, so a new skill does not reintroduce the token.

Each site **drops** the token rather than leaning on the documented backslash escape. Team distributes to Claude Code, Codex, and Antigravity; a host that substitutes the placeholder without implementing the escape would leave the backslash in the command, which is a differently broken command. Avoiding the token is the only form correct on every host.

## Test plan

- New `tests/regression-skill-body-positional-args.test.ts`, in two layers because neither catches the other's failure:
  - an L2 negative sweep over every `SKILL.md` body, with a positive control so a clean sweep cannot mean the matcher went blind;
  - an L3 executable check that extracts `pr-cleanup`'s derivation from the `SKILL.md` itself and runs it against a hermetic fixture repo, so a token-free but broken replacement cannot pass the sweep unnoticed. It pins a branch name containing `/`, a branch in no worktree, a nonexistent branch, and a prefix near-miss.
- Confirmed red before the fix on exactly the three offending skills, green after.
- All three rewrites were checked byte-equivalent to the originals against real fixtures before the swap: the worktree lookup on three branches including the empty case, the frontmatter scan on four frontmatter shapes, and the conflict-stage query on a real unmerged index.
- Reproduced the substitution itself end to end through a throwaway skill: `$0` came back as the literal first argument, matching the original report character for character.
- Full free suite green (1484 pass, 0 fail). `tsc --noEmit` clean. `.claude/scripts/check-discovery-consistency.sh` passes, which covers the `team-structure` discovery block.

## Notes

- Runtime change, so it carries a version bump: 0.54.0 -> 0.55.0, minor. Minor rather than patch because a plugin user can observe the difference — a `/pr-cleanup` run that silently left the worktree behind now removes it.
- Local `bun install` is broken on this machine (every tarball fails its integrity check while `npm install` of the same packages succeeds), so `tsc` was run from an npm-installed copy rather than the lockfile's. CI installs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

