### PR TITLE
v0.61.0 feat(team-pr): add a Pre-merge section to the PR body

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.60.0"
+    "version": "0.61.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PR bodies now carry a `## Pre-merge` section for the work that has to happen before the merge, and `## How to Verify` no longer emits checkboxes that block one.** A `- [ ]` item in a PR body is not decoration — the `square-task-list-completed` bot refuses to merge until a human ticks it. `## How to Verify` was written with checkboxes, so every PR the phase opened shipped a merge gate over verification the author had already run, and somebody had to tick off finished work before the PR could land. Those become plain bullets, and `- [ ]` is now reserved for the one thing it means: an action that must complete before *this* PR merges. That is what the new conditional [`## Pre-merge`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md) section collects — a dependency PR that has to merge or deploy first (with its URL and the reason the order matters), ordered operational steps such as running migrations, artifacts that could not be regenerated in the authoring environment and will fail CI until someone regenerates them, and verification that genuinely gates the merge rather than merely informing the reviewer. Post-merge follow-ups stay plain bullets. In multi-repo mode the dependency is recorded in one direction only, derived from which side is inert without the other — a UI change that no-ops until its backend ships waits on the backend, and the backend PR gets no mirrored checkbox, because two PRs each blocking the other is a deadlock the bot will happily enforce. Dependency URLs are unknown when the PRs are opened, so the section is added by the same open-then-edit pass that adds `## Companion PRs`, and it is ordered ahead of it. **What this asks of you:** nothing, and one fewer box to tick — the phase never checks a box on your behalf, since a checked box asserts the work is done and only you can assert that.
+
 ## [0.60.0] - 2026-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-08-28
+
 ### Added
 
 - **PR bodies now carry a `## Pre-merge` section for the work that has to happen before the merge, and `## How to Verify` no longer emits checkboxes that block one.** A `- [ ]` item in a PR body is not decoration — the `square-task-list-completed` bot refuses to merge until a human ticks it. `## How to Verify` was written with checkboxes, so every PR the phase opened shipped a merge gate over verification the author had already run, and somebody had to tick off finished work before the PR could land. Those become plain bullets, and `- [ ]` is now reserved for the one thing it means: an action that must complete before *this* PR merges. That is what the new conditional [`## Pre-merge`](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md) section collects — a dependency PR that has to merge or deploy first (with its URL and the reason the order matters), ordered operational steps such as running migrations, artifacts that could not be regenerated in the authoring environment and will fail CI until someone regenerates them, and verification that genuinely gates the merge rather than merely informing the reviewer. Post-merge follow-ups stay plain bullets. In multi-repo mode the dependency is recorded in one direction only, derived from which side is inert without the other — a UI change that no-ops until its backend ships waits on the backend, and the backend PR gets no mirrored checkbox, because two PRs each blocking the other is a deadlock the bot will happily enforce. Dependency URLs are unknown when the PRs are opened, so the section is added by the same open-then-edit pass that adds `## Companion PRs`, and it is ordered ahead of it. **What this asks of you:** nothing, and one fewer box to tick — the phase never checks a box on your behalf, since a checked box asserts the work is done and only you can assert that.
@@ -614,7 +616,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.60.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.61.0...HEAD
+[0.61.0]: https://github.com/bostonaholic/team/compare/v0.60.0...v0.61.0
 [0.60.0]: https://github.com/bostonaholic/team/compare/v0.59.0...v0.60.0
 [0.59.0]: https://github.com/bostonaholic/team/compare/v0.58.0...v0.59.0
 [0.58.0]: https://github.com/bostonaholic/team/compare/v0.57.0...v0.58.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/team-pr/SKILL.md
+++ b/skills/team-pr/SKILL.md
@@ -184,8 +184,12 @@ done
 omitted entirely when no manifest exists]
 
 ## How to Verify
-- [ ] [Automated verification command]
-- [ ] [Manual verification step]
+- [Automated verification command]
+- [Manual verification step]
+
+## Pre-merge
+[Conditional — actions that must complete before this PR merges; omitted
+entirely when there are none]
 
 ## Review notes
 [Conditional — deferred findings for the human's PR review; see below]
@@ -196,6 +200,46 @@ omitted entirely when no manifest exists]
 
 Closes #<n>
 ```
+
+**`## Pre-merge` (conditional):** this section carries only the actions that
+must complete *before* this PR merges. Four things qualify. (a) A dependency
+PR — another PR that has to merge, and sometimes deploy, before this one, as a
+checkbox carrying its full URL and a clause saying *why* the order matters,
+not merely that it does. (b) Ordered operational steps the merge depends on,
+such as running SHIFT migrations. (c) Artifacts that could not be regenerated
+in the authoring environment and will fail a CI verify check until someone
+regenerates them. (d) Verification that genuinely gates the merge, rather than
+verification that merely informs the reviewer. Post-merge follow-ups do not
+belong here.
+**Omit the section entirely when empty — never emit a bare heading.**
+
+**Checkbox discipline.** A `- [ ]` item hard-gates the merge through the
+`square-task-list-completed` bot: an unchecked box blocks merging until a human
+ticks it. So use `- [ ]` only for pre-merge actions, and plain `- ` bullets for
+anything informational or post-merge. This is why `## How to Verify` uses plain
+bullets — its steps report verification the author already ran, and a checkbox
+there would emit a PR the bot refuses to merge until someone ticks off
+finished work. Verification that truly must be re-run by a human before the
+merge belongs in `## Pre-merge` instead. Never tick a box on the user's
+behalf: a checked box asserts the work is done, and only the human can assert
+that.
+
+**Dependency direction (multi-repo).** The dependency is asymmetric and the
+section must reflect that. Only the PR that has to wait carries the
+"merge/deploy X first" checkbox. The PR being waited on gets no mirrored item —
+at most a plain bullet naming the deploy order. Two PRs each blocking the other
+is a deadlock the bot will happily enforce. Derive the direction from which
+side is inert without the other: a UI change that no-ops until its backend
+ships waits on the backend, not the reverse. When neither side is inert, emit
+no dependency item.
+
+**Timing.** Dependency URLs are unknown at creation time, exactly like
+`## Companion PRs`, so reuse that mechanism: open the PRs first, then edit each
+body to add the section once all URLs are known. The note below about "final
+line of the PR body" referring to creation-time authoring covers this section
+too — a post-open appended `## Pre-merge` is expected, not a violation. Keep
+the ordering stable: `## Pre-merge` comes before `## Companion PRs` in the
+final body.
 
 **`## Review notes` (conditional):** this section carries the findings
 deferred to the human's PR review. (a) Every Minor-and-below finding from


### PR DESCRIPTION
## Summary

- The PR body template used `- [ ]` for `## How to Verify` steps. Those items hard-gate the merge through the `square-task-list-completed` bot, so every PR the phase opened blocked on a human ticking off verification the author had already run.
- `- [ ]` is now reserved for what it actually means: an action that must complete before *this* PR merges. A new conditional `## Pre-merge` section collects those, so a PR can state its real merge preconditions instead of spending the gate on finished work.

## Design Decisions

- **One home for the bot mechanics.** The `square-task-list-completed` behavior is stated once, in the checkbox-discipline paragraph, and every other rule refers back to it rather than restating it.
- **Dependency direction is asymmetric by construction.** Only the PR that has to wait carries the "merge/deploy X first" checkbox; the PR being waited on gets at most a plain bullet naming the deploy order. Two PRs each blocking the other is a deadlock the bot will happily enforce. The direction is derived from which side is inert without the other — a UI change that no-ops until its backend ships waits on the backend. When neither side is inert, no dependency item is emitted.
- **Reuse the Companion-PRs timing mechanism.** Dependency URLs are unknown at creation time, so the section is added by the same open-then-edit pass, and the existing "final line of the PR body refers to creation-time authoring" note covers it. Ordering is fixed: `## Pre-merge` before `## Companion PRs`.
- **Conditional, never a bare heading** — the same rule `## Screenshots` and `## Review notes` already follow.

## Changes

- `skills/team-pr/SKILL.md` — added `## Pre-merge` to the PR body template between `## How to Verify` and `## Review notes`; converted the `## How to Verify` items from `- [ ]` to plain bullets; added four prose paragraphs covering what qualifies for the section, checkbox discipline, multi-repo dependency direction, and post-open timing.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## How to Verify

- `bun test` — the static gate passes (one unrelated pre-existing hook-timeout flake in `tests/team-fix-skill.test.ts`)
- Read the template block: no `- [ ]` remains outside `## Pre-merge`, and the new section is marked conditional the way `## Screenshots` and `## Review notes` are
- Confirm the bot mechanics appear in exactly one place in the file

## References

- Skill: `skills/team-pr/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
