### PR TITLE
docs(install): tell Claude Code users to enable marketplace auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,38 @@ The first command registers the checkout as a marketplace; the second installs
 from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
 hooks load with them.
 
+**Turn on auto-update, or you stay on the version you installed.** Claude Code
+enables auto-update for official Anthropic marketplaces by default and
+**disables it for local development marketplaces** — which is what a local
+checkout is. Without it, `git pull`ing this repo moves the source while your
+installed copy stays pinned, silently, with nothing to tell you a release
+happened. Toggle it in `/plugin` → **Marketplaces** → `team-dev` → **Enable
+auto-update**, or declare it in `~/.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "team-dev": {
+      "source": { "source": "directory", "path": "/path/to/team" },
+      "autoUpdate": true
+    }
+  }
+}
+```
+
+Claude Code then checks after a session starts, on a random delay of up to ten
+minutes, so the running session keeps what it launched with. When a plugin
+updates you are prompted to run `/reload-plugins` — a full restart is not
+needed. To update on demand instead, refresh the marketplace before the plugin:
+
+```bash
+claude plugin marketplace update team-dev
+claude plugin update team@team-dev
+```
+
+The order matters. `plugin update` reads the cached catalog, so on its own it
+reports nothing to do.
+
 </details>
 
 <details>

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,38 @@ The first command registers the checkout as a marketplace; the second installs
 from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
 hooks load with them.
 
+**Turn on auto-update, or you stay on the version you installed.** Claude Code
+enables auto-update for official Anthropic marketplaces by default and
+**disables it for local development marketplaces** — which is what a local
+checkout is. Without it, `git pull`ing this repo moves the source while your
+installed copy stays pinned, silently, with nothing to tell you a release
+happened. Toggle it in `/plugin` → **Marketplaces** → `team-dev` → **Enable
+auto-update**, or declare it in `~/.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "team-dev": {
+      "source": { "source": "directory", "path": "/path/to/team" },
+      "autoUpdate": true
+    }
+  }
+}
+```
+
+Claude Code then checks after a session starts, on a random delay of up to ten
+minutes, so the running session keeps what it launched with. When a plugin
+updates you are prompted to run `/reload-plugins` — a full restart is not
+needed. To update on demand instead, refresh the marketplace before the plugin:
+
+```bash
+claude plugin marketplace update team-dev
+claude plugin update team@team-dev
+```
+
+The order matters. `plugin update` reads the cached catalog, so on its own it
+reports nothing to do.
+
 Then run a phase end-to-end:
 
 ```bash


### PR DESCRIPTION
## Why

Claude Code enables marketplace auto-update for official Anthropic marketplaces by default and **disables it for local development marketplaces**. Team installs from a local checkout, so every reader of the install instructions lands in the disabled case — and nothing in the docs says so.

The failure is silent and open-ended. Pulling this repo moves the source while the installed plugin stays pinned at whatever version was current when it was installed. No warning, no version mismatch surfaced in the UI. A user can sit many releases behind while reading the current docs and running old skills.

That is not hypothetical: it is how this PR came to exist. An install had been pinned at 0.50.0 across seven releases with nothing indicating it.

## What changes

Both install surfaces — `README.md` and `docs/index.md` — gain the same block after the Claude Code install commands:

- the `/plugin` → Marketplaces toggle, and the `extraKnownMarketplaces` settings shape for a `directory` source
- what to expect once it is on: a check after session start on a random delay of up to ten minutes, then a `/reload-plugins` prompt rather than a restart
- the manual on-demand path, with the order stated explicitly — `plugin update` reads the cached catalog, so without the marketplace refresh first it reports nothing to do, which reads as "already current" rather than "stale cache"

Docs only. `version-bump-required.sh` classifies the diff `runtime_changed=false`, so this lands with no bump and a plain conventional title.

## Test plan

- Ran `.github/scripts/version-bump-required.sh` against the branch: `OK: runtime_changed=false bumped=false (0.57.0 -> 0.57.0)`, confirming the dev-only land path.
- Every documented claim verified against [the Claude Code docs](https://code.claude.com/docs/en/discover-plugins) — the per-marketplace defaults, the post-startup delay, the `/reload-plugins` prompt — and the two-command manual path was run end to end on a real install (0.50.0 → 0.57.0).
- Full suite green: 1484 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
