### PR TITLE
feat(docs): serve an RSS release feed at /rss.xml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,9 @@ on:
       - "docs/**"
       - "!docs/plans/**" # plans are excluded from the site (_config.yml exclude)
       - ".github/workflows/pages.yml"
+      # the release feed generator: editing it must redeploy the site
+      - "scripts/build-release-feed.ts"
+      - "script/build-release-feed"
   workflow_dispatch:
 
 permissions:
@@ -28,6 +31,22 @@ jobs:
           working-directory: docs # reads docs/.ruby-version
           bundler-cache: true
       - uses: actions/configure-pages@v6
+      # The feed generator imports only node: builtins, so no `bun install`.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install xmllint
+        # The well-formedness check hard-gates the deploy, so the workflow
+        # declares the package rather than inheriting it from the runner image.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
+      - name: Build the release feed
+        # Runs from the repo root, which the wrapper anchors itself at anyway.
+        # `gh` and `jq` come from the runner image.
+        run: script/build-release-feed
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Build site
         working-directory: docs
         run: bundle exec jekyll build

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -25,6 +25,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write # dispatch pages.yml so the new release reaches /rss.xml
 
 jobs:
   release:
@@ -40,6 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Tag and release
+        id: release
         run: |
           set -euo pipefail
           V=$(jq -r .version .claude-plugin/plugin.json)
@@ -48,6 +50,7 @@ jobs:
 
           if gh release view "v$V" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release v$V already exists; nothing to do."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -69,4 +72,13 @@ jobs:
           fi
 
           gh release create "v$V" --repo "$GITHUB_REPOSITORY" --title "v$V" --notes-file notes.md
+          echo "published=true" >> "$GITHUB_OUTPUT"
           echo "Published release v$V."
+
+      - name: Refresh the release feed
+        if: steps.release.outputs.published == 'true'
+        # The feed is rebuilt by the Pages deploy, and GitHub does not start a
+        # workflow from an event caused by GITHUB_TOKEN — so dispatch it here.
+        # A failed dispatch leaves the feed stale, never broken; docs/versioning.md
+        # documents the manual re-run.
+        run: gh workflow run pages.yml

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ docs/plans/
 .playwright-mcp/
 
 # Jekyll site build artifacts
+# regenerated from the live Releases API on every build
+docs/rss.xml
 docs/_site/
 docs/.jekyll-cache/
 docs/.sass-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Follow Team releases from any RSS reader.** The docs site now serves an RSS 2.0 feed at [https://team.bostonaholic.dev/rss.xml](https://team.bostonaholic.dev/rss.xml) carrying every published release — the version as the title, the exact publish time, a link to the release page, and the release notes as GitHub-rendered HTML. Feed readers discover it automatically from any page of the site, and a footer link points to it. The feed is rebuilt from the GitHub Releases API on every site deploy, and publishing a release now triggers that deploy, so a new version reaches subscribers without any manual step.
+
 ## [0.58.0] - 2026-08-27
 
 ### Fixed

--- a/dev.yml
+++ b/dev.yml
@@ -32,7 +32,7 @@ commands:
       antigravity: "script/dev-uninstall antigravity"
   docs:
     desc: "Build and serve the docs site locally at http://localhost:4000"
-    run: "cd docs && bundle config set --local path 'vendor/bundle' && bundle install && bundle exec jekyll serve --livereload"
+    run: "script/build-release-feed && cd docs && bundle config set --local path 'vendor/bundle' && bundle install && bundle exec jekyll serve --livereload"
   evals:
     desc: "Run the paid behavioral evals — live agent runs + LLM judge (requires EVALS_ANTHROPIC_API_KEY; spends real money)"
     run: "bun run test:evals"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,8 @@
 title: Team
 description: Autonomous feature delivery for Claude Code
 url: "https://team.bostonaholic.dev"
+# rss.xml derives its absolute URLs from `url` alone, so a non-empty baseurl
+# means teaching script/build-release-feed to concatenate it.
 baseurl: ""
 author: Matthew Boston
 

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,5 +2,6 @@
   <div class="container">
     <span class="copyright">© 2026 {{ site.author | escape }}</span>
     <a href="https://github.com/bostonaholic/team" rel="noreferrer noopener">github</a>
+    <a href="{{ '/rss.xml' | relative_url }}">rss</a>
   </div>
 </footer>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -15,6 +15,7 @@
     </script>
     {%- seo -%}
     <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
+    <link rel="alternate" type="application/rss+xml" title="Team releases" href="{{ '/rss.xml' | relative_url }}">
   </head>
   <body {% if page.url == '/' %}class="home"{% endif %}>
     <header>

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -326,7 +326,26 @@ On every push to `main`, `release-on-merge.yml`:
 Because `version-bump` cut the section before landing, the section the release
 workflow reads is exactly what `version-bump` wrote.
 
+### The release feed
+
+A published release then dispatches `pages.yml` with `gh workflow run`, which
+rebuilds the site and, with it, the RSS feed at `/rss.xml`. The feed is
+regenerated in full from the Releases API on every build, so it always carries
+every published release. A release that no-ops (the release already existed)
+dispatches nothing.
+
 ## Recovery
+
+### The release feed is missing a release, or shows a corrected one stale
+
+Either the dispatch failed, or the `pages.yml` run it started failed, or a
+release body was edited on GitHub after the last build. The release itself is
+fine — only the feed is behind. One command fixes all three, by re-running the
+Pages deploy through its `workflow_dispatch` trigger:
+
+```bash
+gh workflow run pages.yml
+```
 
 ### `/shipit` stopped before merge (CI failed or timed out)
 

--- a/script/build-release-feed
+++ b/script/build-release-feed
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the RSS release feed at docs/rss.xml, for both site build paths.
+#
+#   script/build-release-feed
+#
+# Called by .github/workflows/pages.yml before `jekyll build`, and by `dev docs`
+# before `cd docs`. This script owns every side effect: it reads the site URL
+# out of docs/_config.yml, fetches the releases with `gh`, pipes them through
+# scripts/build-release-feed.ts, checks the result with `xmllint`, and only then
+# moves it into place — so no failed run can leave a truncated feed behind.
+#
+# One failure rule lives here and nowhere else: a fetch, generate, or check
+# failure is fatal in CI and a warning locally, so no caller adds `|| true`. A
+# malformed docs/_config.yml sits outside that tolerance — a repository defect
+# is loud on both paths.
+#
+# Requires: ruby, gh, jq, bun, xmllint. `gh` and `jq` come from the runner
+# image in CI, matching .github/workflows/release-on-merge.yml.
+
+die() { printf '::error::%s\n' "$1" >&2; exit 1; }
+
+# Anchored at the repository root, never $PWD: pages.yml builds from docs/ and
+# `dev docs` cd's into it.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="$ROOT/docs/_config.yml"
+FEED="$ROOT/docs/rss.xml"
+RELEASES_PATH='repos/bostonaholic/team/releases?per_page=100'
+# GitHub returns the pre-rendered `body_html` only under this media type.
+HTML_MEDIA_TYPE='Accept: application/vnd.github.html+json'
+SITE_URL_RE="^https://[^[:space:]\"']+\$"
+
+[ -f "$CONFIG" ] || die "no site config at $CONFIG"
+
+# Read `url` the way Jekyll reads it, then print it only as a structurally
+# valid https origin. A quote that survived, an empty host, a fragment, or a
+# path prefix would each reach the feed as a broken absolute URL.
+SITE_URL=$(ruby -ryaml -ruri -e '
+  config = YAML.load_file(ARGV[0])
+  url = config.is_a?(Hash) ? config["url"] : nil
+  exit unless url.is_a?(String)
+  begin
+    parsed = URI.parse(url.strip)
+  rescue URI::InvalidURIError
+    exit
+  end
+  exit unless parsed.scheme == "https" && parsed.host && !parsed.host.empty?
+  exit unless parsed.userinfo.nil? && parsed.query.nil? && parsed.fragment.nil?
+  exit unless parsed.path.nil? || parsed.path.empty? || parsed.path == "/"
+  origin = "#{parsed.scheme}://#{parsed.host}"
+  origin += ":#{parsed.port}" unless parsed.port == parsed.default_port
+  print origin
+' "$CONFIG") || die "could not read the site url from $CONFIG"
+
+[ -n "$SITE_URL" ] || die "$CONFIG has no usable https origin under 'url'"
+[[ "$SITE_URL" =~ $SITE_URL_RE ]] || die "site url is not a bare https origin: '$SITE_URL'"
+
+# Outside docs/, so a half-written document can never leak into the site.
+TMP="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-feed.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+build_feed() {
+  # `--paginate` prints one array per page, which `jq -s 'add'` flattens.
+  gh api --paginate "$RELEASES_PATH" -H "$HTML_MEDIA_TYPE" \
+    | jq -s 'add' \
+    | bun "$ROOT/scripts/build-release-feed.ts" "$SITE_URL" > "$TMP" || return 1
+  xmllint --noout "$TMP" || return 1
+  mv "$TMP" "$FEED"
+}
+
+if ! build_feed; then
+  [ -z "${CI:-}" ] || die "could not build the release feed"
+  printf 'warning: could not build the release feed; %s left untouched\n' "$FEED" >&2
+  exit 0
+fi

--- a/scripts/build-release-feed.ts
+++ b/scripts/build-release-feed.ts
@@ -65,11 +65,24 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
+ * Drop the entries GitHub itself marks as unpublished, before any field is
+ * validated. A draft is exempt from the item field contract because it is not
+ * feed content: a draft saved without a tag carries `tag_name: ""`, and
+ * validating first would abort the whole feed over a release that was never
+ * going to appear in it.
+ */
+function isUnpublished(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const raw = value as Record<string, unknown>;
+  return raw.draft === true || raw.published_at === null || raw.published_at === "";
+}
+
+/**
  * Check the required half of the item field contract. `tag_name`, `html_url`,
- * and `published_at` anchor identity, link, and date, so a release missing any
- * of them fails loud rather than emitting an item with an empty element.
- * A `published_at` of null is a different case: it means never published, and
- * the filter drops it.
+ * and `published_at` anchor identity, link, and date, so a published release
+ * missing any of them fails loud rather than emitting an item with an empty
+ * element. An absent `published_at` key is one of those failures — only an
+ * explicitly null or empty one means "never published".
  */
 function toRelease(value: unknown, index: number): Release {
   if (typeof value !== "object" || value === null) {
@@ -89,11 +102,6 @@ function toRelease(value: unknown, index: number): Release {
     throw new Error(`release ${index} has a non-string 'published_at'`);
   }
   return raw as unknown as Release;
-}
-
-/** Keep a release only when it is published and is not a draft. */
-function isPublished(release: Release): boolean {
-  return isNonEmptyString(release.published_at) && release.draft !== true;
 }
 
 function parsePublishedAt(release: Release): number {
@@ -126,9 +134,12 @@ function renderItem(release: Release, time: number): string {
  * @param siteUrl the site origin, with no trailing slash
  */
 export function buildReleaseFeed(releases: unknown[], siteUrl: string): string {
+  // Payload index is carried through the filter so a validation error still
+  // names the entry the caller sent, not its position after drafts were cut.
   const dated = releases
-    .map(toRelease)
-    .filter(isPublished)
+    .map((value, index) => ({ value, index }))
+    .filter(({ value }) => !isUnpublished(value))
+    .map(({ value, index }) => toRelease(value, index))
     .map((release) => ({ release, time: parsePublishedAt(release) }));
 
   // Newest first. A tie on the second breaks on plain lexicographic descending

--- a/scripts/build-release-feed.ts
+++ b/scripts/build-release-feed.ts
@@ -9,8 +9,7 @@
 // Two invariants make this file cheap to test and safe to pipe:
 //
 // - Stdout carries the feed and nothing else. Every failure goes to stderr as
-//   `::error::<msg>` with a non-zero exit, matching
-//   .github/scripts/pr-title-version.sh:26.
+//   `::error::<msg>` with a non-zero exit, so CI surfaces it as an annotation.
 // - Zero dependencies: only `node:` builtins are imported, because the Pages
 //   build runs this with no `bun install` step.
 //
@@ -92,7 +91,7 @@ function toRelease(value: unknown, index: number): Release {
   return raw as unknown as Release;
 }
 
-/** Keep a release only when it is published and is not a draft (decision 12). */
+/** Keep a release only when it is published and is not a draft. */
 function isPublished(release: Release): boolean {
   return isNonEmptyString(release.published_at) && release.draft !== true;
 }
@@ -121,8 +120,7 @@ function renderItem(release: Release, time: number): string {
 
 /**
  * Build the RSS 2.0 document. Pure: the same releases and site URL always
- * produce the same bytes, which is why the channel omits `lastBuildDate`
- * (decision 13).
+ * produce the same bytes, which is why the channel omits `lastBuildDate`.
  *
  * @param releases the GitHub Releases API payload, already flattened
  * @param siteUrl the site origin, with no trailing slash

--- a/scripts/build-release-feed.ts
+++ b/scripts/build-release-feed.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env bun
+// scripts/build-release-feed.ts
+//
+// CLI: `... | bun scripts/build-release-feed.ts <site-url>`
+// Reads the GitHub Releases JSON array on stdin and prints an RSS 2.0 feed to
+// stdout. Its only caller is `script/build-release-feed`, the bash wrapper that
+// owns every side effect (fetch, temp file, xmllint, move).
+//
+// Two invariants make this file cheap to test and safe to pipe:
+//
+// - Stdout carries the feed and nothing else. Every failure goes to stderr as
+//   `::error::<msg>` with a non-zero exit, matching
+//   .github/scripts/pr-title-version.sh:26.
+// - Zero dependencies: only `node:` builtins are imported, because the Pages
+//   build runs this with no `bun install` step.
+//
+// `buildReleaseFeed` is pure — no network, no clock, no filesystem — so the
+// whole document contract is unit-tested for free in
+// tests/build-release-feed.test.ts.
+
+import { readFileSync } from "node:fs";
+
+const CHANNEL_TITLE = "Team releases";
+const CHANNEL_DESCRIPTION =
+  "New releases of Team, a Claude Code plugin for autonomous feature delivery.";
+const CHANNEL_LANGUAGE = "en-us";
+const ATOM_NS = "http://www.w3.org/2005/Atom";
+
+/** A release, after the required-field contract has been checked. */
+interface Release {
+  tag_name: string;
+  name?: string | null;
+  html_url: string;
+  published_at: string | null;
+  draft?: boolean;
+  body_html?: string | null;
+}
+
+// Tab (9), newline (10), and carriage return (13) are the C0 controls XML 1.0
+// permits; every other one below 0x20 would produce a document no reader can
+// parse, so it is dropped.
+const PERMITTED_C0 = new Set([9, 10, 13]);
+
+function stripForbiddenControls(text: string): string {
+  let kept = "";
+  for (const character of text) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 && !PERMITTED_C0.has(code)) continue;
+    kept += character;
+  }
+  return kept;
+}
+
+/** Escape text for an XML text node or attribute value, exactly once. */
+function escapeXml(text: string): string {
+  return stripForbiddenControls(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Check the required half of the item field contract. `tag_name`, `html_url`,
+ * and `published_at` anchor identity, link, and date, so a release missing any
+ * of them fails loud rather than emitting an item with an empty element.
+ * A `published_at` of null is a different case: it means never published, and
+ * the filter drops it.
+ */
+function toRelease(value: unknown, index: number): Release {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`release ${index} is not an object`);
+  }
+  const raw = value as Record<string, unknown>;
+  for (const key of ["tag_name", "html_url", "published_at"]) {
+    if (!(key in raw)) throw new Error(`release ${index} is missing '${key}'`);
+  }
+  if (!isNonEmptyString(raw.tag_name)) {
+    throw new Error(`release ${index} has no usable 'tag_name'`);
+  }
+  if (!isNonEmptyString(raw.html_url)) {
+    throw new Error(`release ${index} has no usable 'html_url'`);
+  }
+  if (raw.published_at !== null && typeof raw.published_at !== "string") {
+    throw new Error(`release ${index} has a non-string 'published_at'`);
+  }
+  return raw as unknown as Release;
+}
+
+/** Keep a release only when it is published and is not a draft (decision 12). */
+function isPublished(release: Release): boolean {
+  return isNonEmptyString(release.published_at) && release.draft !== true;
+}
+
+function parsePublishedAt(release: Release): number {
+  const time = Date.parse(release.published_at ?? "");
+  if (Number.isNaN(time)) {
+    throw new Error(`release ${release.tag_name} has an unparseable 'published_at'`);
+  }
+  return time;
+}
+
+function renderItem(release: Release, time: number): string {
+  const title = isNonEmptyString(release.name) ? release.name : release.tag_name;
+  const description = typeof release.body_html === "string" ? release.body_html : "";
+  return [
+    "    <item>",
+    `      <title>${escapeXml(title)}</title>`,
+    `      <link>${escapeXml(release.html_url)}</link>`,
+    `      <guid isPermaLink="true">${escapeXml(release.html_url)}</guid>`,
+    `      <pubDate>${new Date(time).toUTCString()}</pubDate>`,
+    `      <description>${escapeXml(description)}</description>`,
+    "    </item>",
+  ].join("\n");
+}
+
+/**
+ * Build the RSS 2.0 document. Pure: the same releases and site URL always
+ * produce the same bytes, which is why the channel omits `lastBuildDate`
+ * (decision 13).
+ *
+ * @param releases the GitHub Releases API payload, already flattened
+ * @param siteUrl the site origin, with no trailing slash
+ */
+export function buildReleaseFeed(releases: unknown[], siteUrl: string): string {
+  const dated = releases
+    .map(toRelease)
+    .filter(isPublished)
+    .map((release) => ({ release, time: parsePublishedAt(release) }));
+
+  // Newest first. A tie on the second breaks on plain lexicographic descending
+  // `tag_name` — no semver dependency for an ordering nobody will see.
+  dated.sort((a, b) => {
+    if (a.time !== b.time) return b.time - a.time;
+    if (a.release.tag_name === b.release.tag_name) return 0;
+    return a.release.tag_name < b.release.tag_name ? 1 : -1;
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<rss version="2.0" xmlns:atom="${ATOM_NS}">`,
+    "  <channel>",
+    `    <title>${CHANNEL_TITLE}</title>`,
+    `    <link>${siteUrl}/</link>`,
+    `    <description>${CHANNEL_DESCRIPTION}</description>`,
+    `    <language>${CHANNEL_LANGUAGE}</language>`,
+    `    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml" />`,
+    ...dated.map(({ release, time }) => renderItem(release, time)),
+    "  </channel>",
+    "</rss>",
+    "",
+  ].join("\n");
+}
+
+function die(message: string): never {
+  process.stderr.write(`::error::${message}\n`);
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  const siteUrl = process.argv[2];
+  if (!siteUrl) die("site URL argument is required");
+
+  let stdin: string;
+  try {
+    stdin = readFileSync(0, "utf8");
+  } catch {
+    die("could not read the releases payload on stdin");
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdin);
+  } catch {
+    die("the releases payload on stdin is not valid JSON");
+  }
+
+  // Structural guards. Each of these would otherwise produce a document that
+  // looks like a working feed.
+  if (!Array.isArray(payload)) die("the releases payload is not a JSON array");
+  if (payload.length === 0) die("the releases payload is empty");
+  if (
+    !payload.some(
+      (item) => typeof item === "object" && item !== null && "body_html" in item,
+    )
+  ) {
+    die("no release carries 'body_html' — was the Accept header dropped?");
+  }
+
+  try {
+    process.stdout.write(buildReleaseFeed(payload, siteUrl));
+  } catch (error) {
+    die(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/tests/build-release-feed-wrapper.test.ts
+++ b/tests/build-release-feed-wrapper.test.ts
@@ -1,0 +1,337 @@
+// tests/build-release-feed-wrapper.test.ts
+//
+// Acceptance fence for Slice 1 of docs/plans/2026-08-28-rss-release-feed —
+// the bash side-effect wrapper `script/build-release-feed`.
+//
+// L3 in-process integration (docs/testing.md:218-224): free, fast, and the
+// cheapest layer that can catch what a source-pattern assertion cannot — a
+// wrong working directory, a quote that survived the YAML parse, a broken
+// `jq -s 'add'` flatten, or a partial write. So this file EXECUTES the
+// wrapper.
+//
+// Hermetic by construction (docs/testing.md §8): every case builds its own
+// temp tree keyed by `pid`, copies the wrapper and the CLI in at their real
+// relative paths so decision 6's root anchoring resolves there, writes a
+// fixture `docs/_config.yml`, puts a stub `gh` first on PATH that records its
+// argv, and invokes the wrapper from an UNRELATED working directory. Nothing
+// touches the network, the real repo, or the real `docs/rss.xml`.
+//
+// The `CI` variable is cleared explicitly for the local-branch cases:
+// harness-checks.yml:80 runs `bun test` inside GitHub Actions, where `CI` is
+// set and every child inherits it (design.md:443-447). Without the clear, the
+// exit-0 assertion passes locally and fails in CI.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const WRAPPER_SRC = join(REPO_ROOT, "script", "build-release-feed");
+const CLI_SRC = join(REPO_ROOT, "scripts", "build-release-feed.ts");
+
+// The wrapper shells out to all five. A missing one is an environment gap,
+// never a defect in the code under test, so the suite skips rather than
+// reporting a red that means nothing (the `describe.if` shape at
+// tests/pr-title-version.test.ts:109).
+const REQUIRED_TOOLS = ["bash", "bun", "jq", "ruby", "xmllint"];
+const HAS_TOOLS = REQUIRED_TOOLS.every(
+  (tool) => spawnSync(tool, ["--version"], { encoding: "utf8" }).status === 0,
+);
+
+const FIXTURE_BODY_HTML =
+  '<h3>Fixed</h3><ul><li><strong>a &amp; b</strong> <a href="https://x.test/?q=1&amp;r=2">link</a></li></ul>';
+
+function fixtureRelease(tag: string, publishedAt: string) {
+  return {
+    tag_name: tag,
+    name: tag,
+    html_url: `https://github.com/bostonaholic/team/releases/tag/${tag}`,
+    published_at: publishedAt,
+    draft: false,
+    prerelease: false,
+    body_html: FIXTURE_BODY_HTML,
+  };
+}
+
+// `gh api --paginate` prints ONE JSON array PER PAGE, which is why the wrapper
+// flattens with `jq -s 'add'`. Two pages here, three items total.
+const PAGE_ONE = JSON.stringify([
+  fixtureRelease("v0.58.0", "2026-08-27T20:26:05Z"),
+  fixtureRelease("v0.57.0", "2026-08-20T10:00:00Z"),
+]);
+const PAGE_TWO = JSON.stringify([fixtureRelease("v0.56.0", "2026-08-10T10:00:00Z")]);
+
+// Double-quoted AND slash-suffixed, the two shapes that broke earlier design
+// rounds: the quotes must not survive the YAML parse and the trailing slash
+// must not produce `https://host//rss.xml`.
+const CONFIG_OK = 'title: Team\nurl: "https://feed.example.test/"\nbaseurl: ""\n';
+
+// An unterminated double-quoted scalar: Ruby's YAML load RAISES here, and the
+// raise must route through the wrapper's `die()` as a real annotation rather
+// than aborting under `set -e` with a backtrace (design-review-5.md:22).
+const CONFIG_MALFORMED = 'title: Team\nurl: "https://feed.example.test\nbaseurl: ""\n';
+
+function ghStub(argvLog: string, pages: string[]): string {
+  return [
+    "#!/usr/bin/env bash",
+    `for arg in "$@"; do printf '%s\\n' "$arg" >> ${JSON.stringify(argvLog)}; done`,
+    "cat <<'GH_PAGES'",
+    ...pages,
+    "GH_PAGES",
+  ].join("\n");
+}
+
+function failingGhStub(argvLog: string): string {
+  return [
+    "#!/usr/bin/env bash",
+    `for arg in "$@"; do printf '%s\\n' "$arg" >> ${JSON.stringify(argvLog)}; done`,
+    "printf 'gh: could not reach api.github.com\\n' >&2",
+    "exit 1",
+  ].join("\n");
+}
+
+const tempDirs: string[] = [];
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
+type Tree = { root: string; feed: string; argvLog: string };
+
+/**
+ * Build the hermetic tree. The existence assertions come FIRST so a
+ * not-yet-written wrapper or CLI fails an assertion instead of throwing out of
+ * copyFileSync.
+ */
+function makeTree(opts: { config?: string; gh?: (log: string) => string } = {}): Tree {
+  expect(existsSync(WRAPPER_SRC)).toBe(true);
+  expect(existsSync(CLI_SRC)).toBe(true);
+
+  const root = mkdtempSync(join(tmpdir(), `rss-wrapper-${process.pid}-`));
+  tempDirs.push(root);
+
+  for (const dir of ["script", "scripts", "docs", "stub-bin", "elsewhere"]) {
+    mkdirSync(join(root, dir), { recursive: true });
+  }
+
+  const wrapper = join(root, "script", "build-release-feed");
+  copyFileSync(WRAPPER_SRC, wrapper);
+  chmodSync(wrapper, 0o755);
+  copyFileSync(CLI_SRC, join(root, "scripts", "build-release-feed.ts"));
+
+  writeFileSync(join(root, "docs", "_config.yml"), opts.config ?? CONFIG_OK);
+
+  const argvLog = join(root, "gh-argv.txt");
+  const gh = join(root, "stub-bin", "gh");
+  writeFileSync(gh, (opts.gh ?? ((log) => ghStub(log, [PAGE_ONE, PAGE_TWO])))(argvLog));
+  chmodSync(gh, 0o755);
+
+  return { root, feed: join(root, "docs", "rss.xml"), argvLog };
+}
+
+/** Run the wrapper from an unrelated cwd. `ci: false` clears inherited CI. */
+function runWrapper(tree: Tree, opts: { ci: boolean }) {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === "CI" || value === undefined) continue;
+    env[key] = value;
+  }
+  env.PATH = `${join(tree.root, "stub-bin")}:${process.env.PATH ?? ""}`;
+  if (opts.ci) env.CI = "1";
+
+  const result = spawnSync(join(tree.root, "script", "build-release-feed"), [], {
+    // Deliberately NOT the tree root: decision 6 anchors every path at the
+    // script's own location, so the wrapper must be correct from anywhere.
+    cwd: join(tree.root, "elsewhere"),
+    encoding: "utf8",
+    env,
+  });
+  return {
+    status: result.status ?? -1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+function itemBlocks(xml: string): string[] {
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].map((m) => m[1] ?? "");
+}
+
+function descriptionOf(itemXml: string): string {
+  return /<description>([\s\S]*?)<\/description>/.exec(itemXml)?.[1] ?? "";
+}
+
+/** One XML decode. `&amp;` resolves LAST so the pass is genuinely single. */
+function decodeXml(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/** The channel `<link>`: the first one, before any `<item>`. */
+function channelLink(xml: string): string {
+  const channel = xml.split("<item>")[0] ?? "";
+  return /<link>([^<]*)<\/link>/.exec(channel)?.[1] ?? "";
+}
+
+function selfHref(xml: string): string {
+  return /<atom:link\b[^>]*href="([^"]*)"/.exec(xml)?.[1] ?? "";
+}
+
+// The two shapes an unvalidated `url:` used to leak into the feed: a quote
+// that survived the YAML read, and a `//` left by naive slash stripping.
+const STRAY_QUOTE = /["']/;
+const DOUBLE_SLASH_AFTER_SCHEME = /^[a-z]+:\/\/[^\s]*\/\//;
+
+describe.if(HAS_TOOLS)("script/build-release-feed: a successful run", () => {
+  test("writes docs/rss.xml when invoked from an unrelated working directory", () => {
+    const tree = makeTree();
+    const { status, output } = runWrapper(tree, { ci: true });
+
+    expect(status).toBe(0);
+    expect(output).not.toContain("::error::");
+    expect(existsSync(tree.feed)).toBe(true);
+  });
+
+  test("derives the channel link and self href from the quoted, slash-suffixed url", () => {
+    const tree = makeTree();
+    runWrapper(tree, { ci: true });
+    expect(existsSync(tree.feed)).toBe(true);
+    const xml = readFileSync(tree.feed, "utf8");
+
+    expect(channelLink(xml)).toBe("https://feed.example.test/");
+    expect(selfHref(xml)).toBe("https://feed.example.test/rss.xml");
+  });
+
+  test("neither URL carries a stray quote or a double slash after the scheme", () => {
+    const tree = makeTree();
+    runWrapper(tree, { ci: true });
+    expect(existsSync(tree.feed)).toBe(true);
+    const xml = readFileSync(tree.feed, "utf8");
+
+    const link = channelLink(xml);
+    const self = selfHref(xml);
+
+    // Guard the guard: an empty URL would pass both matchers vacuously.
+    expect(link.length).toBeGreaterThan(0);
+    expect(link).not.toMatch(STRAY_QUOTE);
+    expect(link).not.toMatch(DOUBLE_SLASH_AFTER_SCHEME);
+
+    expect(self.length).toBeGreaterThan(0);
+    expect(self).not.toMatch(STRAY_QUOTE);
+    expect(self).not.toMatch(DOUBLE_SLASH_AFTER_SCHEME);
+  });
+
+  test("positive control: the URL matchers fire on a bad URL", () => {
+    expect(STRAY_QUOTE.test('"https://feed.example.test"')).toBe(true);
+    expect(DOUBLE_SLASH_AFTER_SCHEME.test("https://feed.example.test//rss.xml")).toBe(true);
+    expect(STRAY_QUOTE.test("https://feed.example.test/rss.xml")).toBe(false);
+    expect(DOUBLE_SLASH_AFTER_SCHEME.test("https://feed.example.test/rss.xml")).toBe(false);
+  });
+
+  test("flattens every page of the paginated response into one item list", () => {
+    const tree = makeTree();
+    runWrapper(tree, { ci: true });
+    expect(existsSync(tree.feed)).toBe(true);
+    const xml = readFileSync(tree.feed, "utf8");
+
+    // Two pages, two items then one — a broken `jq -s 'add'` yields 2, not 3.
+    expect(itemBlocks(xml)).toHaveLength(3);
+  });
+
+  test("requests GitHub's rendered HTML media type on the fetch", () => {
+    const tree = makeTree();
+    runWrapper(tree, { ci: true });
+    expect(existsSync(tree.argvLog)).toBe(true);
+
+    const argv = readFileSync(tree.argvLog, "utf8");
+    expect(argv).toContain("Accept: application/vnd.github.html+json");
+  });
+
+  test("one XML decode of an item description returns the fixture body_html", () => {
+    const tree = makeTree();
+    runWrapper(tree, { ci: true });
+    expect(existsSync(tree.feed)).toBe(true);
+    const xml = readFileSync(tree.feed, "utf8");
+
+    const description = descriptionOf(itemBlocks(xml)[0] ?? "");
+    expect(decodeXml(description)).toBe(FIXTURE_BODY_HTML);
+  });
+});
+
+describe.if(HAS_TOOLS)("script/build-release-feed: failures never leave a partial feed", () => {
+  test("a failing CLI leaves no docs/rss.xml behind", () => {
+    // No item carries `body_html`, so the CLI's structural guard fires and the
+    // wrapper must fail before the move (temp file -> xmllint -> mv).
+    const noBodyHtml = JSON.stringify([
+      {
+        tag_name: "v0.58.0",
+        name: "v0.58.0",
+        html_url: "https://github.com/bostonaholic/team/releases/tag/v0.58.0",
+        published_at: "2026-08-27T20:26:05Z",
+        draft: false,
+      },
+    ]);
+    const tree = makeTree({ gh: (log) => ghStub(log, [noBodyHtml]) });
+
+    const { status } = runWrapper(tree, { ci: true });
+
+    expect(status).not.toBe(0);
+    expect(existsSync(tree.feed)).toBe(false);
+  });
+});
+
+describe.if(HAS_TOOLS)("script/build-release-feed: the CI-versus-local branch (decision 9)", () => {
+  test("a failing gh warns and exits 0 when CI is unset, so `dev docs` survives", () => {
+    const tree = makeTree({ gh: failingGhStub });
+
+    const { status, output } = runWrapper(tree, { ci: false });
+
+    expect(status).toBe(0);
+    expect(output).toContain("warning:");
+    expect(existsSync(tree.feed)).toBe(false);
+  });
+
+  test("the same failing gh is fatal with ::error:: under CI=1", () => {
+    const tree = makeTree({ gh: failingGhStub });
+
+    const { status, output } = runWrapper(tree, { ci: true });
+
+    expect(status).not.toBe(0);
+    expect(/^::error::/m.test(output)).toBe(true);
+  });
+});
+
+describe.if(HAS_TOOLS)("script/build-release-feed: a malformed _config.yml is loud on BOTH branches", () => {
+  // A broken config is a repository defect, not an offline condition, so it
+  // sits outside the local tolerance (decision 5).
+  test("exits non-zero with an ::error:: line when CI is unset", () => {
+    const tree = makeTree({ config: CONFIG_MALFORMED });
+
+    const { status, output } = runWrapper(tree, { ci: false });
+
+    expect(status).not.toBe(0);
+    expect(/^::error::/m.test(output)).toBe(true);
+  });
+
+  test("exits non-zero with an ::error:: line under CI=1", () => {
+    const tree = makeTree({ config: CONFIG_MALFORMED });
+
+    const { status, output } = runWrapper(tree, { ci: true });
+
+    expect(status).not.toBe(0);
+    expect(/^::error::/m.test(output)).toBe(true);
+  });
+});

--- a/tests/build-release-feed-wrapper.test.ts
+++ b/tests/build-release-feed-wrapper.test.ts
@@ -1,25 +1,23 @@
 // tests/build-release-feed-wrapper.test.ts
 //
-// Acceptance fence for Slice 1 of docs/plans/2026-08-28-rss-release-feed —
-// the bash side-effect wrapper `script/build-release-feed`.
+// Acceptance fence for the bash side-effect wrapper `script/build-release-feed`.
 //
-// L3 in-process integration (docs/testing.md:218-224): free, fast, and the
-// cheapest layer that can catch what a source-pattern assertion cannot — a
-// wrong working directory, a quote that survived the YAML parse, a broken
-// `jq -s 'add'` flatten, or a partial write. So this file EXECUTES the
-// wrapper.
+// L3 in-process integration: free, fast, and the cheapest layer that can catch
+// what a source-pattern assertion cannot — a wrong working directory, a quote
+// that survived the YAML parse, a broken `jq -s 'add'` flatten, or a partial
+// write. So this file EXECUTES the wrapper.
 //
-// Hermetic by construction (docs/testing.md §8): every case builds its own
-// temp tree keyed by `pid`, copies the wrapper and the CLI in at their real
-// relative paths so decision 6's root anchoring resolves there, writes a
-// fixture `docs/_config.yml`, puts a stub `gh` first on PATH that records its
-// argv, and invokes the wrapper from an UNRELATED working directory. Nothing
-// touches the network, the real repo, or the real `docs/rss.xml`.
+// Hermetic by construction: every case builds its own temp tree keyed by
+// `pid`, copies the wrapper and the CLI in at their real relative paths so the
+// wrapper's root anchoring resolves there, writes a fixture
+// `docs/_config.yml`, puts a stub `gh` first on PATH that records its argv,
+// and invokes the wrapper from an UNRELATED working directory. Nothing touches
+// the network, the real repo, or the real `docs/rss.xml`.
 //
 // The `CI` variable is cleared explicitly for the local-branch cases:
-// harness-checks.yml:80 runs `bun test` inside GitHub Actions, where `CI` is
-// set and every child inherits it (design.md:443-447). Without the clear, the
-// exit-0 assertion passes locally and fails in CI.
+// harness-checks.yml runs `bun test` inside GitHub Actions, where `CI` is set
+// and every child inherits it. Without the clear, the exit-0 assertion passes
+// locally and fails in CI.
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
@@ -42,8 +40,7 @@ const CLI_SRC = join(REPO_ROOT, "scripts", "build-release-feed.ts");
 
 // The wrapper shells out to all five. A missing one is an environment gap,
 // never a defect in the code under test, so the suite skips rather than
-// reporting a red that means nothing (the `describe.if` shape at
-// tests/pr-title-version.test.ts:109).
+// reporting a red that means nothing.
 const REQUIRED_TOOLS = ["bash", "bun", "jq", "ruby", "xmllint"];
 const HAS_TOOLS = REQUIRED_TOOLS.every(
   (tool) => spawnSync(tool, ["--version"], { encoding: "utf8" }).status === 0,
@@ -79,7 +76,7 @@ const CONFIG_OK = 'title: Team\nurl: "https://feed.example.test/"\nbaseurl: ""\n
 
 // An unterminated double-quoted scalar: Ruby's YAML load RAISES here, and the
 // raise must route through the wrapper's `die()` as a real annotation rather
-// than aborting under `set -e` with a backtrace (design-review-5.md:22).
+// than aborting under `set -e` with a backtrace.
 const CONFIG_MALFORMED = 'title: Team\nurl: "https://feed.example.test\nbaseurl: ""\n';
 
 function ghStub(argvLog: string, pages: string[]): string {
@@ -150,8 +147,8 @@ function runWrapper(tree: Tree, opts: { ci: boolean }) {
   if (opts.ci) env.CI = "1";
 
   const result = spawnSync(join(tree.root, "script", "build-release-feed"), [], {
-    // Deliberately NOT the tree root: decision 6 anchors every path at the
-    // script's own location, so the wrapper must be correct from anywhere.
+    // Deliberately NOT the tree root: the wrapper anchors every path at the
+    // script's own location, so it must be correct from anywhere.
     cwd: join(tree.root, "elsewhere"),
     encoding: "utf8",
     env,
@@ -316,7 +313,7 @@ describe.if(HAS_TOOLS)("script/build-release-feed: the CI-versus-local branch (d
 
 describe.if(HAS_TOOLS)("script/build-release-feed: a malformed _config.yml is loud on BOTH branches", () => {
   // A broken config is a repository defect, not an offline condition, so it
-  // sits outside the local tolerance (decision 5).
+  // sits outside the local tolerance.
   test("exits non-zero with an ::error:: line when CI is unset", () => {
     const tree = makeTree({ config: CONFIG_MALFORMED });
 

--- a/tests/build-release-feed.test.ts
+++ b/tests/build-release-feed.test.ts
@@ -165,7 +165,7 @@ describe("buildReleaseFeed: ordering (design.md:383-398)", () => {
     const build = await loadBuilder();
     // Same instant to the second. Descending string comparison puts "v0.9.0"
     // ahead of "v0.10.0" ('9' > '1'); a semver-aware comparator would not.
-    // Decision 13 pins the plain lexicographic one — no semver dependency.
+    // The tiebreak is plain lexicographic — no semver dependency.
     const xml = build(
       [
         release({ tag_name: "v0.10.0", name: "v0.10.0", published_at: "2026-07-01T00:00:00Z" }),
@@ -209,6 +209,22 @@ describe("buildReleaseFeed: filters (decision 12)", () => {
           draft: true,
           published_at: "2026-08-01T00:00:00Z",
         }),
+      ],
+      SITE_URL,
+    );
+
+    const titles = itemBlocks(xml).map((item) => elementOf(item, "title"));
+    expect(titles).toEqual(["kept"]);
+  });
+
+  test("drops a draft with an empty tag_name instead of failing the whole feed", async () => {
+    const build = await loadBuilder();
+    // A draft saved without a tag comes back with tag_name: "". It must never
+    // reach the required-field contract, or one draft kills every item.
+    const xml = build(
+      [
+        release({ tag_name: "v1.0.0", name: "kept" }),
+        { tag_name: "", name: null, html_url: "x", published_at: null, draft: true },
       ],
       SITE_URL,
     );
@@ -308,7 +324,7 @@ describe("buildReleaseFeed: item field contract (design.md:593-620)", () => {
   });
 });
 
-// --- L1 unit: single-escape contract (decision 10) --------------------------
+// --- L1 unit: single-escape contract ----------------------------------------
 
 describe("buildReleaseFeed: body_html is XML-escaped exactly once (decision 10)", () => {
   test("escapes markup once: <h3>Fixed</h3> becomes &lt;h3&gt;Fixed&lt;/h3&gt;", async () => {

--- a/tests/build-release-feed.test.ts
+++ b/tests/build-release-feed.test.ts
@@ -1,0 +1,479 @@
+// tests/build-release-feed.test.ts
+//
+// Acceptance fence for Slice 1 of docs/plans/2026-08-28-rss-release-feed —
+// the RSS 2.0 release feed served at /rss.xml.
+//
+// Two halves, both free and deterministic (docs/testing.md):
+//
+// - L1 pure unit on the exported builder `buildReleaseFeed(releases, siteUrl)`.
+//   The builder is a pure f(input) -> XML string: no network, no clock, no
+//   filesystem, so every channel value, the ordering, the two filter
+//   predicates, the field contract, and the single-escape contract are pinned
+//   here for microseconds (design.md:73-90, :363-398, :593-620).
+//
+// - L1 subprocess on the thin CLI in the same file. The five structural
+//   failures (malformed stdin, non-array payload, missing site URL, an empty
+//   array, and a payload where no item carries a `body_html` key) must each
+//   exit non-zero, print nothing on stdout, and print `::error::` on stderr,
+//   matching .github/scripts/pr-title-version.sh:26.
+//
+// Defensive load: `scripts/build-release-feed.ts` is imported dynamically
+// behind an existence assertion, so a not-yet-written module FAILS an
+// assertion rather than throwing at import time (the mechanical gate rejects
+// crashes).
+//
+// Escaping and control-character assertions each carry a positive control in
+// the shape of tests/changelog-links.test.ts:52-60 — a check that finds
+// nothing has not distinguished "absent" from "blind"
+// (docs/testing.md:172-212).
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const BUILDER = join(REPO_ROOT, "scripts", "build-release-feed.ts");
+
+// A fixture site URL, deliberately NOT the production one: the builder takes
+// the origin as an argument (the bash wrapper prints it), so a hardcoded
+// team.bostonaholic.dev anywhere in the output would fail these assertions.
+const SITE_URL = "https://feed.example.test";
+
+// Declared locally rather than imported, so this file typechecks before
+// scripts/build-release-feed.ts exists.
+type BuildReleaseFeed = (releases: unknown[], siteUrl: string) => string;
+
+type ReleaseFixture = {
+  tag_name?: string | null;
+  name?: string | null;
+  html_url?: string | null;
+  published_at?: string | null;
+  draft?: boolean;
+  body_html?: string | null;
+};
+
+/**
+ * Load the exported builder. The existence + type assertions come FIRST so a
+ * missing module or a missing export surfaces as a failed assertion instead of
+ * an unhandled import throw.
+ */
+async function loadBuilder(): Promise<BuildReleaseFeed> {
+  expect(existsSync(BUILDER)).toBe(true);
+  const mod = (await import(pathToFileURL(BUILDER).href)) as {
+    buildReleaseFeed?: unknown;
+  };
+  expect(typeof mod.buildReleaseFeed).toBe("function");
+  return mod.buildReleaseFeed as BuildReleaseFeed;
+}
+
+function release(over: ReleaseFixture = {}): ReleaseFixture {
+  return {
+    tag_name: "v1.0.0",
+    name: "v1.0.0",
+    html_url: "https://github.com/bostonaholic/team/releases/tag/v1.0.0",
+    published_at: "2026-08-27T20:26:05Z",
+    draft: false,
+    body_html: "<h3>Fixed</h3>",
+    ...over,
+  };
+}
+
+// --- document readers -------------------------------------------------------
+
+function itemBlocks(xml: string): string[] {
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].map((m) => m[1] ?? "");
+}
+
+function descriptionOf(itemXml: string): string {
+  return /<description>([\s\S]*?)<\/description>/.exec(itemXml)?.[1] ?? "";
+}
+
+function elementOf(itemXml: string, tag: string): string {
+  return new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(itemXml)?.[1] ?? "";
+}
+
+/** One XML decode. `&amp;` resolves LAST so the pass is genuinely single. */
+function decodeXml(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+// C0 controls XML 1.0 forbids — tab (09), newline (0A), and carriage return
+// (0D) are the permitted three and are excluded from the class.
+const FORBIDDEN_C0 = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/;
+
+// --- L1 unit: channel -------------------------------------------------------
+
+describe("buildReleaseFeed: channel (design.md:73-80)", () => {
+  test("carries the four pinned channel values verbatim", async () => {
+    const build = await loadBuilder();
+    const xml = build([release()], SITE_URL);
+
+    expect(xml).toContain("<title>Team releases</title>");
+    expect(xml).toContain(`<link>${SITE_URL}/</link>`);
+    expect(xml).toContain(
+      "<description>New releases of Team, a Claude Code plugin for autonomous feature delivery.</description>",
+    );
+    expect(xml).toContain("<language>en-us</language>");
+  });
+
+  test("declares xmlns:atom on the root element and a self atom:link", async () => {
+    const build = await loadBuilder();
+    const xml = build([release()], SITE_URL);
+
+    const root = /<rss\b[^>]*>/.exec(xml)?.[0] ?? "";
+    expect(root).toContain('xmlns:atom="http://www.w3.org/2005/Atom"');
+
+    const atomLink = /<atom:link\b[^>]*\/?>/.exec(xml)?.[0] ?? "";
+    expect(atomLink).toContain(`href="${SITE_URL}/rss.xml"`);
+    expect(atomLink).toContain('rel="self"');
+    expect(atomLink).toContain('type="application/rss+xml"');
+  });
+
+  test("omits lastBuildDate (decision 13: no false claim, stable bytes)", async () => {
+    const build = await loadBuilder();
+    const xml = build([release()], SITE_URL);
+
+    // Guard the absence check: a builder that returned "" would pass the
+    // negative vacuously.
+    expect(xml).toContain("<channel>");
+    expect(xml).not.toMatch(/lastbuilddate/i);
+  });
+});
+
+// --- L1 unit: ordering ------------------------------------------------------
+
+describe("buildReleaseFeed: ordering (design.md:383-398)", () => {
+  test("sorts items by published_at descending, not API order", async () => {
+    const build = await loadBuilder();
+    const xml = build(
+      [
+        release({ tag_name: "v0.2.0", name: "v0.2.0", published_at: "2026-05-06T19:22:07Z" }),
+        release({ tag_name: "v0.58.0", name: "v0.58.0", published_at: "2026-08-27T20:26:05Z" }),
+        release({ tag_name: "v0.30.0", name: "v0.30.0", published_at: "2026-07-01T00:00:00Z" }),
+      ],
+      SITE_URL,
+    );
+
+    const titles = itemBlocks(xml).map((item) => elementOf(item, "title"));
+    expect(titles).toEqual(["v0.58.0", "v0.30.0", "v0.2.0"]);
+  });
+
+  test("breaks a published_at tie by plain lexicographic descending tag_name", async () => {
+    const build = await loadBuilder();
+    // Same instant to the second. Descending string comparison puts "v0.9.0"
+    // ahead of "v0.10.0" ('9' > '1'); a semver-aware comparator would not.
+    // Decision 13 pins the plain lexicographic one — no semver dependency.
+    const xml = build(
+      [
+        release({ tag_name: "v0.10.0", name: "v0.10.0", published_at: "2026-07-01T00:00:00Z" }),
+        release({ tag_name: "v0.9.0", name: "v0.9.0", published_at: "2026-07-01T00:00:00Z" }),
+      ],
+      SITE_URL,
+    );
+
+    const titles = itemBlocks(xml).map((item) => elementOf(item, "title"));
+    expect(titles).toEqual(["v0.9.0", "v0.10.0"]);
+  });
+});
+
+// --- L1 unit: filters -------------------------------------------------------
+
+describe("buildReleaseFeed: filters (decision 12)", () => {
+  test("drops a release whose published_at is null (never published)", async () => {
+    const build = await loadBuilder();
+    const xml = build(
+      [
+        release({ tag_name: "v1.0.0", name: "kept" }),
+        release({ tag_name: "v0.9.0", name: "never-published", published_at: null }),
+      ],
+      SITE_URL,
+    );
+
+    const titles = itemBlocks(xml).map((item) => elementOf(item, "title"));
+    expect(titles).toEqual(["kept"]);
+  });
+
+  test("drops a draft release even when published_at is non-null (re-drafted)", async () => {
+    const build = await loadBuilder();
+    // The case the date predicate alone cannot cover: published, then
+    // converted back to a draft, keeping its original timestamp.
+    const xml = build(
+      [
+        release({ tag_name: "v1.0.0", name: "kept" }),
+        release({
+          tag_name: "v0.9.0",
+          name: "re-drafted",
+          draft: true,
+          published_at: "2026-08-01T00:00:00Z",
+        }),
+      ],
+      SITE_URL,
+    );
+
+    const titles = itemBlocks(xml).map((item) => elementOf(item, "title"));
+    expect(titles).toEqual(["kept"]);
+  });
+});
+
+// --- L1 unit: item field contract -------------------------------------------
+
+describe("buildReleaseFeed: item field contract (design.md:593-620)", () => {
+  test("maps name, html_url, and published_at onto title, link, guid, pubDate", async () => {
+    const build = await loadBuilder();
+    const xml = build(
+      [
+        release({
+          name: "v0.58.0",
+          tag_name: "v0.58.0",
+          html_url: "https://github.com/bostonaholic/team/releases/tag/v0.58.0",
+          published_at: "2026-08-27T20:26:05Z",
+        }),
+      ],
+      SITE_URL,
+    );
+
+    const item = itemBlocks(xml)[0] ?? "";
+    expect(elementOf(item, "title")).toBe("v0.58.0");
+    expect(elementOf(item, "link")).toBe(
+      "https://github.com/bostonaholic/team/releases/tag/v0.58.0",
+    );
+    expect(item).toContain(
+      '<guid isPermaLink="true">https://github.com/bostonaholic/team/releases/tag/v0.58.0</guid>',
+    );
+
+    const pubDate = elementOf(item, "pubDate");
+    // RFC-822, UTC, locale-independent.
+    expect(pubDate).toMatch(
+      /^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} (GMT|\+0000)$/,
+    );
+    expect(new Date(pubDate).toISOString()).toBe("2026-08-27T20:26:05.000Z");
+  });
+
+  test("falls back to tag_name when name is null", async () => {
+    const build = await loadBuilder();
+    const xml = build([release({ name: null, tag_name: "v0.42.0" })], SITE_URL);
+
+    expect(elementOf(itemBlocks(xml)[0] ?? "", "title")).toBe("v0.42.0");
+  });
+
+  test("emits an empty description when body_html is null", async () => {
+    const build = await loadBuilder();
+    const xml = build([release({ body_html: null })], SITE_URL);
+
+    const item = itemBlocks(xml)[0] ?? "";
+    // The item survives; only its description is empty.
+    expect(elementOf(item, "title")).toBe("v1.0.0");
+    expect(descriptionOf(item)).toBe("");
+  });
+
+  test("throws when a release is missing tag_name", async () => {
+    const build = await loadBuilder();
+    const missing: Record<string, unknown> = {
+      name: "v1.0.0",
+      html_url: "https://github.com/bostonaholic/team/releases/tag/v1.0.0",
+      published_at: "2026-08-27T20:26:05Z",
+      body_html: "<p>x</p>",
+    };
+    expect(() => build([missing], SITE_URL)).toThrow();
+  });
+
+  test("throws when a release is missing html_url", async () => {
+    const build = await loadBuilder();
+    const missing: Record<string, unknown> = {
+      tag_name: "v1.0.0",
+      name: "v1.0.0",
+      published_at: "2026-08-27T20:26:05Z",
+      body_html: "<p>x</p>",
+    };
+    expect(() => build([missing], SITE_URL)).toThrow();
+  });
+
+  test("throws when a release is missing published_at", async () => {
+    const build = await loadBuilder();
+    const missing: Record<string, unknown> = {
+      tag_name: "v1.0.0",
+      name: "v1.0.0",
+      html_url: "https://github.com/bostonaholic/team/releases/tag/v1.0.0",
+      body_html: "<p>x</p>",
+    };
+    expect(() => build([missing], SITE_URL)).toThrow();
+  });
+
+  test("throws on an unparseable published_at rather than coercing it", async () => {
+    const build = await loadBuilder();
+    expect(() => build([release({ published_at: "not-a-date" })], SITE_URL)).toThrow();
+  });
+});
+
+// --- L1 unit: single-escape contract (decision 10) --------------------------
+
+describe("buildReleaseFeed: body_html is XML-escaped exactly once (decision 10)", () => {
+  test("escapes markup once: <h3>Fixed</h3> becomes &lt;h3&gt;Fixed&lt;/h3&gt;", async () => {
+    const build = await loadBuilder();
+    const xml = build([release({ body_html: "<h3>Fixed</h3>" })], SITE_URL);
+
+    const description = descriptionOf(itemBlocks(xml)[0] ?? "");
+    expect(description).toContain("&lt;h3&gt;Fixed&lt;/h3&gt;");
+    expect(description).not.toContain("&amp;lt;");
+  });
+
+  test("escapes GitHub's own entity once: &amp; becomes &amp;amp;", async () => {
+    const build = await loadBuilder();
+    const xml = build([release({ body_html: "<p>a &amp; b</p>" })], SITE_URL);
+
+    const description = descriptionOf(itemBlocks(xml)[0] ?? "");
+    expect(description).toContain("&amp;amp;");
+  });
+
+  test("one XML decode returns the fixture body_html byte for byte", async () => {
+    const build = await loadBuilder();
+    const body = '<h3>Fixed</h3><ul><li><strong>a &amp; b</strong> <a href="https://x.test/?q=1&amp;r=2">link</a></li></ul>';
+    const xml = build([release({ body_html: body })], SITE_URL);
+
+    const description = descriptionOf(itemBlocks(xml)[0] ?? "");
+    expect(decodeXml(description)).toBe(body);
+  });
+
+  test("never emits a CDATA section", async () => {
+    const build = await loadBuilder();
+    const xml = build([release({ body_html: "<p>a ]]> b</p>" })], SITE_URL);
+
+    expect(xml).toContain("<channel>");
+    expect(xml).not.toContain("<![CDATA[");
+  });
+
+  test("strips C0 controls, keeping tab, newline, and carriage return", async () => {
+    const build = await loadBuilder();
+    const xml = build(
+      [release({ body_html: "<p>a\u0000b\u0007c</p>\t\n\r<p>d</p>" })],
+      SITE_URL,
+    );
+
+    const description = descriptionOf(itemBlocks(xml)[0] ?? "");
+    expect(description).not.toMatch(FORBIDDEN_C0);
+    expect(description).toContain("\t");
+  });
+});
+
+describe("buildReleaseFeed: escape matchers can find a positive (guard the guard)", () => {
+  // Every assertion above is only as good as these readers and matchers. Point
+  // each at a known-bad document and watch it fire, so a refactor cannot turn
+  // the tripwires above into permanently green no-ops.
+  const doubleEscaped =
+    "<rss><channel><item><description>&amp;lt;h3&amp;gt;Fixed&amp;lt;/h3&amp;gt;</description></item></channel></rss>";
+
+  test("itemBlocks and descriptionOf actually read a planted item", () => {
+    expect(itemBlocks(doubleEscaped)).toHaveLength(1);
+    expect(descriptionOf(itemBlocks(doubleEscaped)[0] ?? "")).toContain("&amp;lt;");
+  });
+
+  test("the double-escape check fires on a double-escaped description", () => {
+    const description = descriptionOf(itemBlocks(doubleEscaped)[0] ?? "");
+    expect(description).toContain("&amp;lt;");
+    expect(description).not.toContain("&lt;h3&gt;Fixed&lt;/h3&gt;");
+  });
+
+  test("one decode recovers a single escape and does NOT recover a double one", () => {
+    expect(decodeXml("&lt;h3&gt;Fixed&lt;/h3&gt;")).toBe("<h3>Fixed</h3>");
+    expect(decodeXml("&amp;lt;h3&amp;gt;")).toBe("&lt;h3&gt;");
+    expect(decodeXml("&amp;lt;h3&amp;gt;")).not.toBe("<h3>");
+  });
+
+  test("the C0 matcher sees a forbidden control and passes the permitted three", () => {
+    expect(FORBIDDEN_C0.test("a\u0000b")).toBe(true);
+    expect(FORBIDDEN_C0.test("a\u001Fb")).toBe(true);
+    expect(FORBIDDEN_C0.test("a\tb\nc\rd")).toBe(false);
+  });
+});
+
+// --- L1 subprocess: the CLI fails loud --------------------------------------
+
+function runCli(args: string[], stdin: string) {
+  // Existence assertion first: a missing script must fail an assertion, not
+  // pass this suite by exiting non-zero for the wrong reason.
+  expect(existsSync(BUILDER)).toBe(true);
+  const result = spawnSync("bun", [BUILDER, ...args], {
+    encoding: "utf8",
+    input: stdin,
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+const VALID_PAYLOAD = JSON.stringify([release()]);
+
+describe("build-release-feed CLI: structural guards fail loud (design.md:589-613)", () => {
+  test("malformed stdin exits non-zero with ::error:: and no stdout", () => {
+    const { status, stdout, stderr } = runCli([SITE_URL], "{not json");
+
+    expect(status).not.toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(/^::error::/m.test(stderr)).toBe(true);
+  });
+
+  test("a non-array payload exits non-zero with ::error:: and no stdout", () => {
+    const { status, stdout, stderr } = runCli([SITE_URL], '{"releases": []}');
+
+    expect(status).not.toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(/^::error::/m.test(stderr)).toBe(true);
+  });
+
+  test("a missing site-URL argument exits non-zero with ::error:: and no stdout", () => {
+    const { status, stdout, stderr } = runCli([], VALID_PAYLOAD);
+
+    expect(status).not.toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(/^::error::/m.test(stderr)).toBe(true);
+  });
+
+  test("an empty array exits non-zero with ::error:: and no stdout", () => {
+    // An empty feed would be a silent regression, so zero releases is fatal.
+    const { status, stdout, stderr } = runCli([SITE_URL], "[]");
+
+    expect(status).not.toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(/^::error::/m.test(stderr)).toBe(true);
+  });
+
+  test("a payload where no item carries body_html exits non-zero with ::error::", () => {
+    // The dropped-Accept-header case: emitting 80 empty descriptions would
+    // look like a working feed (design.md:610-613).
+    const payload = JSON.stringify([
+      {
+        tag_name: "v1.0.0",
+        name: "v1.0.0",
+        html_url: "https://github.com/bostonaholic/team/releases/tag/v1.0.0",
+        published_at: "2026-08-27T20:26:05Z",
+        draft: false,
+      },
+    ]);
+    const { status, stdout, stderr } = runCli([SITE_URL], payload);
+
+    expect(status).not.toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(/^::error::/m.test(stderr)).toBe(true);
+  });
+});
+
+describe("build-release-feed CLI: the happy path prints only XML", () => {
+  test("a valid payload exits 0 and prints the feed on stdout", () => {
+    // Guards the guard for the five failure cases above: prove the CLI can
+    // succeed, so "exits non-zero" is never a vacuous pass.
+    const { status, stdout } = runCli([SITE_URL], VALID_PAYLOAD);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain("<title>Team releases</title>");
+    expect(itemBlocks(stdout)).toHaveLength(1);
+  });
+});

--- a/tests/build-release-feed.test.ts
+++ b/tests/build-release-feed.test.ts
@@ -1,31 +1,27 @@
 // tests/build-release-feed.test.ts
 //
-// Acceptance fence for Slice 1 of docs/plans/2026-08-28-rss-release-feed —
-// the RSS 2.0 release feed served at /rss.xml.
+// Acceptance fence for the RSS 2.0 release feed served at /rss.xml.
 //
-// Two halves, both free and deterministic (docs/testing.md):
+// Two halves, both free and deterministic:
 //
 // - L1 pure unit on the exported builder `buildReleaseFeed(releases, siteUrl)`.
 //   The builder is a pure f(input) -> XML string: no network, no clock, no
 //   filesystem, so every channel value, the ordering, the two filter
 //   predicates, the field contract, and the single-escape contract are pinned
-//   here for microseconds (design.md:73-90, :363-398, :593-620).
+//   here for microseconds.
 //
 // - L1 subprocess on the thin CLI in the same file. The five structural
 //   failures (malformed stdin, non-array payload, missing site URL, an empty
 //   array, and a payload where no item carries a `body_html` key) must each
-//   exit non-zero, print nothing on stdout, and print `::error::` on stderr,
-//   matching .github/scripts/pr-title-version.sh:26.
+//   exit non-zero, print nothing on stdout, and print `::error::` on stderr.
 //
 // Defensive load: `scripts/build-release-feed.ts` is imported dynamically
 // behind an existence assertion, so a not-yet-written module FAILS an
 // assertion rather than throwing at import time (the mechanical gate rejects
 // crashes).
 //
-// Escaping and control-character assertions each carry a positive control in
-// the shape of tests/changelog-links.test.ts:52-60 — a check that finds
-// nothing has not distinguished "absent" from "blind"
-// (docs/testing.md:172-212).
+// Escaping and control-character assertions each carry a positive control: a
+// check that finds nothing has not distinguished "absent" from "blind".
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
@@ -448,7 +444,7 @@ describe("build-release-feed CLI: structural guards fail loud (design.md:589-613
 
   test("a payload where no item carries body_html exits non-zero with ::error::", () => {
     // The dropped-Accept-header case: emitting 80 empty descriptions would
-    // look like a working feed (design.md:610-613).
+    // look like a working feed.
     const payload = JSON.stringify([
       {
         tag_name: "v1.0.0",

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -300,3 +300,57 @@ describe("ci workflows: baseurl stays empty for the feed's absolute URLs (decisi
     expect(neighborhood).toContain("rss.xml");
   });
 });
+
+describe("ci workflows: a published release dispatches the Pages build (Slice 3)", () => {
+  const release = readIf(RELEASE_ON_MERGE);
+  const jobs = jobsSection(release);
+  const tagStep = stepContaining(jobs, "name: Tag and release");
+  const releaseStepId = /^\s+id:\s*(\S+)/m.exec(tagStep.body)?.[1] ?? "";
+  const allSteps = steps(jobs);
+  const lastStep = allSteps[allSteps.length - 1] ?? { body: "", at: -1 };
+
+  test("release-on-merge.yml still has a jobs section", () => {
+    expect(jobs.length).toBeGreaterThan(0);
+  });
+
+  test("grants actions: write ALONGSIDE the existing contents: write", () => {
+    // The addition must not read as a replacement — the tag push still needs
+    // contents: write.
+    const permissions = /\npermissions:\n((?:  \S.*\n)+)/.exec(release)?.[1] ?? "";
+    expect(permissions.length).toBeGreaterThan(0);
+    expect(permissions).toContain("contents: write");
+    expect(permissions).toContain("actions: write");
+  });
+
+  test("the Tag and release step carries an id:", () => {
+    expect(tagStep.body.length).toBeGreaterThan(0);
+    expect(releaseStepId.length).toBeGreaterThan(0);
+  });
+
+  test("keeps the `gh release view` idempotence probe (decision 8 must not undo it)", () => {
+    expect(release).toContain("gh release view");
+  });
+
+  test("writes published=false on the early-exit path, before its `exit 0`", () => {
+    const published = release.indexOf("published=false");
+    const earlyExit = release.indexOf("exit 0");
+    expect(published).toBeGreaterThan(-1);
+    expect(earlyExit).toBeGreaterThan(published);
+  });
+
+  test("writes published=true after `gh release create`", () => {
+    const create = release.indexOf("gh release create");
+    const published = release.indexOf("published=true");
+    expect(create).toBeGreaterThan(-1);
+    expect(published).toBeGreaterThan(create);
+  });
+
+  test("the final step dispatches pages.yml, guarded on that step's output", () => {
+    // `gh workflow run` is the documented path: GitHub does not start a
+    // workflow from an event caused by GITHUB_TOKEN, so `on: release` would
+    // never fire for our own automation (decision 8).
+    expect(releaseStepId.length).toBeGreaterThan(0);
+    expect(lastStep.body).toContain("gh workflow run pages.yml");
+    expect(lastStep.body).toContain(`steps.${releaseStepId}.outputs.published == 'true'`);
+  });
+});

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -147,7 +147,7 @@ describe("ci workflows: consuming workflows stay intact (Slice 3)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// docs/plans/2026-08-28-rss-release-feed — the RSS release feed at /rss.xml.
+// The RSS release feed at /rss.xml.
 // ---------------------------------------------------------------------------
 
 const PAGES = WF("pages.yml");
@@ -163,8 +163,7 @@ function jobsSection(text: string): string {
   return at === -1 ? "" : text.slice(at);
 }
 
-// Each step block of a job, with its offset, so ordering is an index compare
-// (the ordering tripwire at docs/testing.md:120).
+// Each step block of a job, with its offset, so ordering is an index compare.
 function steps(jobs: string): { body: string; at: number }[] {
   const starts: number[] = [];
   const marker = /\n      - /g;
@@ -186,8 +185,7 @@ describe("ci workflows: pages.yml builds the release feed before Jekyll (Slice 1
   const wrapperStep = stepContaining(jobs, "script/build-release-feed");
 
   test("pages.yml still exists and has a jobs section", () => {
-    // Guard: an empty slice would make every ordering assertion below
-    // vacuous (docs/testing.md:172-212).
+    // Guard: an empty slice would make every ordering assertion below vacuous.
     expect(existsSync(PAGES)).toBe(true);
     expect(jobs.length).toBeGreaterThan(0);
   });
@@ -219,7 +217,7 @@ describe("ci workflows: pages.yml builds the release feed before Jekyll (Slice 1
   });
 
   test("installs libxml2-utils, after an apt-get update, before the wrapper step", () => {
-    // xmllint is a hard gate on the deploy (decision 9), so the workflow
+    // xmllint is a hard gate on the deploy, so the workflow
     // declares the package rather than inheriting it from the runner image.
     // The update is mandatory: a rotated package version otherwise 404s.
     const update = jobs.indexOf("apt-get update");
@@ -348,7 +346,7 @@ describe("ci workflows: a published release dispatches the Pages build (Slice 3)
   test("the final step dispatches pages.yml, guarded on that step's output", () => {
     // `gh workflow run` is the documented path: GitHub does not start a
     // workflow from an event caused by GITHUB_TOKEN, so `on: release` would
-    // never fire for our own automation (decision 8).
+    // never fire for our own automation.
     expect(releaseStepId.length).toBeGreaterThan(0);
     expect(lastStep.body).toContain("gh workflow run pages.yml");
     expect(lastStep.body).toContain(`steps.${releaseStepId}.outputs.published == 'true'`);

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -145,3 +145,158 @@ describe("ci workflows: consuming workflows stay intact (Slice 3)", () => {
     expect(/^\s*run:\s*bun test\s*$/m.test(harness)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// docs/plans/2026-08-28-rss-release-feed — the RSS release feed at /rss.xml.
+// ---------------------------------------------------------------------------
+
+const PAGES = WF("pages.yml");
+const RELEASE_FEED_WRAPPER = join(REPO_ROOT, "script", "build-release-feed");
+const DEV_YML = join(REPO_ROOT, "dev.yml");
+const JEKYLL_CONFIG = join(REPO_ROOT, "docs", "_config.yml");
+
+// Everything from `jobs:` onward. Slicing first matters: `on.push.paths`
+// entries carry the SAME 6-space `- ` list marker as a step, so a naive split
+// would read a path filter as a step.
+function jobsSection(text: string): string {
+  const at = text.indexOf("\njobs:");
+  return at === -1 ? "" : text.slice(at);
+}
+
+// Each step block of a job, with its offset, so ordering is an index compare
+// (the ordering tripwire at docs/testing.md:120).
+function steps(jobs: string): { body: string; at: number }[] {
+  const starts: number[] = [];
+  const marker = /\n      - /g;
+  let match: RegExpExecArray | null;
+  while ((match = marker.exec(jobs)) !== null) starts.push(match.index + 1);
+  return starts.map((start, i) => ({
+    body: jobs.slice(start, starts[i + 1] ?? jobs.length),
+    at: start,
+  }));
+}
+
+function stepContaining(jobs: string, needle: string): { body: string; at: number } {
+  return steps(jobs).find((step) => step.body.includes(needle)) ?? { body: "", at: -1 };
+}
+
+describe("ci workflows: pages.yml builds the release feed before Jekyll (Slice 1)", () => {
+  const pages = readIf(PAGES);
+  const jobs = jobsSection(pages);
+  const wrapperStep = stepContaining(jobs, "script/build-release-feed");
+
+  test("pages.yml still exists and has a jobs section", () => {
+    // Guard: an empty slice would make every ordering assertion below
+    // vacuous (docs/testing.md:172-212).
+    expect(existsSync(PAGES)).toBe(true);
+    expect(jobs.length).toBeGreaterThan(0);
+  });
+
+  test("runs script/build-release-feed as a step of the build job", () => {
+    expect(wrapperStep.body.length).toBeGreaterThan(0);
+  });
+
+  test("the wrapper step sits after ruby/setup-ruby@v1 and before Build site", () => {
+    const ruby = jobs.indexOf("ruby/setup-ruby@v1");
+    const buildSite = jobs.indexOf("name: Build site");
+    expect(ruby).toBeGreaterThan(-1);
+    expect(buildSite).toBeGreaterThan(-1);
+    expect(wrapperStep.at).toBeGreaterThan(ruby);
+    expect(wrapperStep.at).toBeLessThan(buildSite);
+  });
+
+  test("the wrapper step carries no working-directory: key (decision 6)", () => {
+    // The wrapper anchors its own paths at the repo root, so a
+    // working-directory would be a second, disagreeing contract.
+    expect(wrapperStep.body.length).toBeGreaterThan(0);
+    expect(wrapperStep.body).not.toContain("working-directory:");
+  });
+
+  test("sets up Bun before the wrapper step", () => {
+    const bun = jobs.indexOf("oven-sh/setup-bun@v2");
+    expect(bun).toBeGreaterThan(-1);
+    expect(wrapperStep.at).toBeGreaterThan(bun);
+  });
+
+  test("installs libxml2-utils, after an apt-get update, before the wrapper step", () => {
+    // xmllint is a hard gate on the deploy (decision 9), so the workflow
+    // declares the package rather than inheriting it from the runner image.
+    // The update is mandatory: a rotated package version otherwise 404s.
+    const update = jobs.indexOf("apt-get update");
+    const install = jobs.indexOf("apt-get install -y libxml2-utils");
+    expect(update).toBeGreaterThan(-1);
+    expect(install).toBeGreaterThan(update);
+    expect(wrapperStep.at).toBeGreaterThan(install);
+  });
+
+  test("the push path filter covers both generator scripts", () => {
+    // Otherwise editing the generator would never redeploy the site.
+    const header = pages.slice(0, pages.indexOf("\njobs:"));
+    expect(header.length).toBeGreaterThan(0);
+    expect(header).toContain('"scripts/build-release-feed.ts"');
+    expect(header).toContain('"script/build-release-feed"');
+  });
+});
+
+describe("ci workflows: `dev docs` builds the feed on the local path (Slice 1)", () => {
+  const dev = readIf(DEV_YML);
+  const docsRun =
+    /run: "([^"]*)"/.exec(/\n  docs:\n((?:    .*\n)+)/.exec(dev)?.[1] ?? "")?.[1] ?? "";
+
+  test("dev.yml has a docs command with a run string", () => {
+    expect(docsRun.length).toBeGreaterThan(0);
+  });
+
+  test("calls the wrapper before `cd docs`, joined by the && chain", () => {
+    const wrapper = docsRun.indexOf("script/build-release-feed");
+    const cd = docsRun.indexOf("cd docs");
+    expect(wrapper).toBeGreaterThan(-1);
+    expect(cd).toBeGreaterThan(wrapper);
+    expect(docsRun.slice(wrapper, cd)).toContain("&&");
+  });
+
+  test("adds no `|| true` and swallows no exit code (the wrapper owns tolerance)", () => {
+    // Decision 9 puts the CI-versus-local branch in ONE place. A caller-side
+    // tolerance either duplicates that rule or quietly disagrees with it.
+    expect(docsRun.length).toBeGreaterThan(0);
+    expect(docsRun).not.toContain("|| true");
+    expect(docsRun).not.toContain("|| :");
+    expect(docsRun).not.toContain("; true");
+  });
+});
+
+describe("ci workflows: the wrapper writes a temp file, checks it, then moves it (Slice 1)", () => {
+  const wrapper = readIf(RELEASE_FEED_WRAPPER);
+
+  test("script/build-release-feed exists", () => {
+    expect(existsSync(RELEASE_FEED_WRAPPER)).toBe(true);
+  });
+
+  test("runs `xmllint --noout` before the move onto docs/rss.xml", () => {
+    // No failed run may leave a truncated feed for Jekyll to publish.
+    const lint = wrapper.indexOf("xmllint --noout");
+    const move = wrapper.search(/^\s*mv\s/m);
+    expect(lint).toBeGreaterThan(-1);
+    expect(move).toBeGreaterThan(lint);
+    expect(wrapper).toContain("docs/rss.xml");
+  });
+});
+
+describe("ci workflows: baseurl stays empty for the feed's absolute URLs (decision 18)", () => {
+  const config = readIf(JEKYLL_CONFIG);
+  const lines = config.split("\n");
+  const at = lines.findIndex((line) => /^\s*baseurl:\s*""/.test(line));
+
+  test("docs/_config.yml sets baseurl to the empty string", () => {
+    expect(at).toBeGreaterThan(-1);
+  });
+
+  test("an adjacent comment names the feed as the reason", () => {
+    // The feed derives absolute URLs from `url` alone, which is only correct
+    // while baseurl is empty. A future maintainer who sets one gets a red test
+    // that says why.
+    expect(at).toBeGreaterThan(-1);
+    const neighborhood = lines.slice(Math.max(0, at - 3), at + 2).join("\n");
+    expect(neighborhood).toContain("rss.xml");
+  });
+});

--- a/tests/ci-workflows.test.ts
+++ b/tests/ci-workflows.test.ts
@@ -254,7 +254,7 @@ describe("ci workflows: `dev docs` builds the feed on the local path (Slice 1)",
   });
 
   test("adds no `|| true` and swallows no exit code (the wrapper owns tolerance)", () => {
-    // Decision 9 puts the CI-versus-local branch in ONE place. A caller-side
+    // The CI-versus-local branch lives in ONE place, the wrapper. A caller-side
     // tolerance either duplicates that rule or quietly disagrees with it.
     expect(docsRun.length).toBeGreaterThan(0);
     expect(docsRun).not.toContain("|| true");

--- a/tests/docs-versioning.test.ts
+++ b/tests/docs-versioning.test.ts
@@ -125,11 +125,10 @@ describe("doc drift guard: no in-tree doc points at version-bump-check.yml (#120
 });
 
 // ---------------------------------------------------------------------------
-// docs/plans/2026-08-28-rss-release-feed, Slice 3 — the release→Pages dispatch
-// and its one-command recovery are written down (decision 16).
+// The release→Pages dispatch and its one-command recovery are written down.
 //
 // Contracts only: the workflow file name, the trigger name, and the feed path.
-// Never the wording (docs/testing.md:127-163).
+// Never the wording.
 // ---------------------------------------------------------------------------
 
 // Body of a `## ` section, up to the next `## ` heading (or EOF).

--- a/tests/docs-versioning.test.ts
+++ b/tests/docs-versioning.test.ts
@@ -123,3 +123,45 @@ describe("doc drift guard: no in-tree doc points at version-bump-check.yml (#120
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// docs/plans/2026-08-28-rss-release-feed, Slice 3 — the release→Pages dispatch
+// and its one-command recovery are written down (decision 16).
+//
+// Contracts only: the workflow file name, the trigger name, and the feed path.
+// Never the wording (docs/testing.md:127-163).
+// ---------------------------------------------------------------------------
+
+// Body of a `## ` section, up to the next `## ` heading (or EOF).
+function section(md: string, heading: string): string {
+  const start = md.indexOf(`\n${heading}\n`);
+  if (start === -1) return "";
+  const rest = md.slice(start + heading.length + 2);
+  const end = rest.search(/\n## /);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("docs/versioning.md: the release feed dispatch is documented (Slice 3)", () => {
+  const doc = readIf(VERSIONING_DOC);
+  const releaseFlow = section(doc, "## Release on merge");
+  const recovery = section(doc, "## Recovery");
+
+  test("the `## Release on merge` section is findable", () => {
+    // Guard: a renamed heading would make every assertion below vacuous.
+    expect(releaseFlow.length).toBeGreaterThan(0);
+  });
+
+  test("the release flow names the Pages dispatch and the feed path", () => {
+    expect(releaseFlow).toContain("pages.yml");
+    expect(releaseFlow).toContain("/rss.xml");
+  });
+
+  test("the `## Recovery` section is findable", () => {
+    expect(recovery.length).toBeGreaterThan(0);
+  });
+
+  test("recovery names the workflow_dispatch re-run of pages.yml as the fix", () => {
+    expect(recovery).toContain("workflow_dispatch");
+    expect(recovery).toContain("pages.yml");
+  });
+});

--- a/tests/site-feed-links.test.ts
+++ b/tests/site-feed-links.test.ts
@@ -1,0 +1,103 @@
+// tests/site-feed-links.test.ts
+//
+// Acceptance fence for Slice 2 of docs/plans/2026-08-28-rss-release-feed —
+// readers discover the feed from the site.
+//
+// L2 tripwire (free, deterministic): the autodiscovery `<link>` in
+// docs/_layouts/default.html and the visible rss link in
+// docs/_includes/footer.html. Both hrefs must be built with Jekyll's
+// `relative_url` filter, exactly like every other internal path in the layout
+// (docs/_layouts/default.html:16-17) — a hardcoded absolute URL would freeze
+// the domain into the markup and diverge from the local preview.
+//
+// Defensive reads: a missing file → "" so content assertions FAIL cleanly
+// rather than throwing ENOENT (the mechanical gate rejects crashes).
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+const LAYOUT = join(REPO_ROOT, "docs", "_layouts", "default.html");
+const FOOTER = join(REPO_ROOT, "docs", "_includes", "footer.html");
+
+function readIf(path: string): string {
+  return existsSync(path) ? read(path) : "";
+}
+
+/** The first tag whose attributes mention the feed path. */
+function tagLinkingTheFeed(html: string, tagName: string): string {
+  const re = new RegExp(`<${tagName}\\b[^>]*rss\\.xml[^>]*>`);
+  return re.exec(html)?.[0] ?? "";
+}
+
+function hrefOf(tag: string): string {
+  return /href="([^"]*)"/.exec(tag)?.[1] ?? "";
+}
+
+// The href contract: the feed path routed through Jekyll's `relative_url`
+// filter. A hardcoded absolute URL freezes the domain into the markup and
+// diverges from the local preview.
+const FEED_HREF = /\{\{\s*['"]\/rss\.xml['"]\s*\|\s*relative_url\s*\}\}/;
+const ABSOLUTE_URL = /^https?:\/\//;
+
+describe("site: the feed is offered by autodiscovery (docs/_layouts/default.html)", () => {
+  const layout = readIf(LAYOUT);
+
+  test("docs/_layouts/default.html exists", () => {
+    expect(existsSync(LAYOUT)).toBe(true);
+  });
+
+  test("the head carries an RSS autodiscovery link with the pinned attributes", () => {
+    const tag = tagLinkingTheFeed(layout, "link");
+    // Guard the guard: a missing tag would pass every attribute check below
+    // vacuously (docs/testing.md:172-212).
+    expect(tag.length).toBeGreaterThan(0);
+
+    expect(tag).toContain('rel="alternate"');
+    expect(tag).toContain('type="application/rss+xml"');
+    expect(tag).toContain('title="Team releases"');
+  });
+
+  test("the autodiscovery href is built with relative_url, not a hardcoded URL", () => {
+    const href = hrefOf(tagLinkingTheFeed(layout, "link"));
+
+    expect(href).toMatch(FEED_HREF);
+    expect(href).not.toMatch(ABSOLUTE_URL);
+  });
+});
+
+describe("site: the footer carries a visible feed link (docs/_includes/footer.html)", () => {
+  const footer = readIf(FOOTER);
+
+  test("docs/_includes/footer.html exists", () => {
+    expect(existsSync(FOOTER)).toBe(true);
+  });
+
+  test("the footer links to the feed through relative_url", () => {
+    const href = hrefOf(tagLinkingTheFeed(footer, "a"));
+
+    expect(href).toMatch(FEED_HREF);
+    expect(href).not.toMatch(ABSOLUTE_URL);
+  });
+});
+
+describe("site: the href matcher can find a positive (guard the guard)", () => {
+  // A matcher that never fails is not a tripwire. Point it at the exact shapes
+  // it exists to reject and watch it fire.
+  test("rejects a hardcoded absolute feed URL", () => {
+    expect(FEED_HREF.test("https://team.bostonaholic.dev/rss.xml")).toBe(false);
+    expect(ABSOLUTE_URL.test("https://team.bostonaholic.dev/rss.xml")).toBe(true);
+  });
+
+  test("rejects a relative_url href that points somewhere other than the feed", () => {
+    expect(FEED_HREF.test("{{ '/assets/css/site.css' | relative_url }}")).toBe(false);
+  });
+
+  test("accepts the relative_url form the site actually uses", () => {
+    expect(FEED_HREF.test("{{ '/rss.xml' | relative_url }}")).toBe(true);
+    expect(FEED_HREF.test('{{ "/rss.xml" | relative_url }}')).toBe(true);
+  });
+});

--- a/tests/site-feed-links.test.ts
+++ b/tests/site-feed-links.test.ts
@@ -1,14 +1,13 @@
 // tests/site-feed-links.test.ts
 //
-// Acceptance fence for Slice 2 of docs/plans/2026-08-28-rss-release-feed —
-// readers discover the feed from the site.
+// Acceptance fence for feed discovery from the site.
 //
 // L2 tripwire (free, deterministic): the autodiscovery `<link>` in
 // docs/_layouts/default.html and the visible rss link in
 // docs/_includes/footer.html. Both hrefs must be built with Jekyll's
-// `relative_url` filter, exactly like every other internal path in the layout
-// (docs/_layouts/default.html:16-17) — a hardcoded absolute URL would freeze
-// the domain into the markup and diverge from the local preview.
+// `relative_url` filter, exactly like every other internal path in the
+// layout — a hardcoded absolute URL would freeze the domain into the markup
+// and diverge from the local preview.
 //
 // Defensive reads: a missing file → "" so content assertions FAIL cleanly
 // rather than throwing ENOENT (the mechanical gate rejects crashes).
@@ -53,7 +52,7 @@ describe("site: the feed is offered by autodiscovery (docs/_layouts/default.html
   test("the head carries an RSS autodiscovery link with the pinned attributes", () => {
     const tag = tagLinkingTheFeed(layout, "link");
     // Guard the guard: a missing tag would pass every attribute check below
-    // vacuously (docs/testing.md:172-212).
+    // vacuously.
     expect(tag.length).toBeGreaterThan(0);
 
     expect(tag).toContain('rel="alternate"');


### PR DESCRIPTION
## Summary

- The docs site now serves an RSS 2.0 feed at `https://team.bostonaholic.dev/rss.xml` carrying **every published release** (all 80, `v0.2.0` → `v0.58.0`) with the true GitHub `published_at` timestamps and the release notes as GitHub-rendered HTML — backfill is structural: each build regenerates the whole document from the live Releases API, so the first deploy already carries the full history and later corrections self-heal.
- Publishing a release now dispatches the Pages build, so a new version reaches subscribers with no manual step; readers discover the feed via a `<link rel="alternate">` on every page and a footer link.
- Both site build paths (CI Pages build and local `dev docs`) generate the feed through one wrapper; failures are fatal in CI (a broken feed never deploys) and warn-and-continue locally (an offline preview still works).

## Design Decisions

- **Live GitHub Releases API as the source of truth**, not `CHANGELOG.md`: the API carries the authoritative timestamps and exactly the 80 published releases (the changelog has 81 sections — `0.36.0` was hand-reverted and never released).
- **Generated at build time, gitignored** (`docs/rss.xml`): never checked in, mirroring how `sitemap.xml` materializes during the Jekyll build.
- **Pure builder + thin CLI + bash wrapper**: `scripts/build-release-feed.ts` is a stdin→stdout pure function (unit-tested for free, zero dependencies beyond `node:` builtins); `script/build-release-feed` owns every side effect (fetch with the HTML media type, Ruby YAML+URI config parse, temp write, `xmllint` gate, atomic move).
- **`<description>` carries GitHub's `body_html`, XML-escaped exactly once** — readers render real headings, lists, and clickable links. Verified live: the paginated list endpoint returns non-empty `body_html` for all 80 releases under `Accept: application/vnd.github.html+json`.
- **Dispatch, not `on: release`**: `GITHUB_TOKEN`-caused events start no workflow runs, so `release-on-merge.yml` gains `actions: write` and dispatches `pages.yml` (which already had `workflow_dispatch`), gated on a `published` step output so the idempotent early-exit path dispatches nothing.
- **Drafts and unpublished releases are filtered from the raw payload before field validation**, so a malformed draft can never abort the feed; published releases missing `tag_name`/`html_url`/`published_at` still fail loud.
- The design passed a 5-round adversarial review (verdict COMMENT); implementation passed a 3-round, 5-reviewer verify loop (code, security, docs, ux, verifier).

## Changes

- **`scripts/build-release-feed.ts`** (new): pure RSS builder + CLI. Pinned channel contract, newest-first ordering with lexicographic tag tie-break, single-escape discipline with positive controls, C0 control stripping, fail-loud guards (empty payload, missing `body_html` key everywhere, malformed stdin).
- **`script/build-release-feed`** (new, executable): side-effect wrapper — root-anchored, `gh api --paginate` with the HTML media type, Ruby YAML+`URI` origin validation, `xmllint --noout` gate, atomic move; `::error::` + non-zero under CI, warning + exit 0 locally.
- **`.github/workflows/pages.yml`**: Bun setup, `apt-get update && apt-get install libxml2-utils`, feed step before the Jekyll build; path filter covers both generator scripts.
- **`.github/workflows/release-on-merge.yml`**: `actions: write`, step `id: release`, `published=true|false` output on both exit paths, guarded `gh workflow run pages.yml` dispatch.
- **`dev.yml`**: `dev docs` generates the feed before serving.
- **`docs/_layouts/default.html`** / **`docs/_includes/footer.html`**: autodiscovery link + footer link (both `relative_url`).
- **`docs/versioning.md`**: release-feed subsection + Recovery entry (`gh workflow run pages.yml`).
- **`.gitignore`** / **`docs/_config.yml`**: ignore the generated feed; note the `baseurl` dependency.
- **Tests** (74 new): L1 unit + subprocess suites for the builder/CLI, a hermetic L3 suite that executes the wrapper against a stub `gh` from an unrelated cwd (clearing inherited `CI`), and L2 tripwires pinning both workflows, the site links, and the docs.

## How to Verify

- [ ] `bun test && bun run typecheck` — full suite green (1565 pass), typecheck clean.
- [ ] `script/build-release-feed` from the repo root, then `xmllint --noout docs/rss.xml` — exits 0; `grep -c '<item>' docs/rss.xml` prints 80; first item is the newest release.
- [ ] `cd docs && bundle exec jekyll build` — succeeds; `_site/rss.xml` present; built pages carry the autodiscovery `<link>` and the footer `rss` link.
- [ ] First deploy after merge: fetch `https://team.bostonaholic.dev/rss.xml`, confirm `xmllint` accepts it, the item count matches `gh api --paginate 'repos/bostonaholic/team/releases?per_page=100' | jq 'map(select((.published_at // "") != "" and (.draft | not))) | length'`, the newest item's tag/link/date match the API, and the feed loads in a real reader.
- [ ] After the next release merges: confirm `release-on-merge.yml` dispatches `pages.yml` and the new version appears in the feed.

## Review notes

Deferred Minor-and-below findings from the final review round (round 3), by source reviewer:

- [code-reviewer] `YAML.load_file` on Ruby ≥ 3.1 is Psych's safe loader, so a `docs/_config.yml` that Jekyll accepts (a bare date value, or an anchor/merge key) fails the wrapper with a misleading "could not read the site url" error; `aliases: true, permitted_classes: [Date, Time]` would align it with Jekyll.
- [code-reviewer] A Psych parse error dumps a Ruby backtrace to stderr before `die`'s `::error::` annotation, burying the readable failure line.
- [code-reviewer] `describe.if(HAS_TOOLS)` silently skips the entire L3 wrapper suite if any of `bash`/`bun`/`jq`/`ruby`/`xmllint` goes missing from the CI runner image; a positive control asserting `HAS_TOOLS` under `CI` would make that loud.
- [code-reviewer] Two L1 fence gaps: an empty `<description>` is indistinguishable from a missing one in the matcher, and no fixture pins that `<title>`/`<link>`/`<guid>` are escaped (only `<description>` escaping is tested).
- [code-reviewer] `mktemp` creates the feed `0600` and the atomic move preserves the mode, so the published `docs/rss.xml` lands `-rw-------` while its siblings are `0644`; `chmod 644` before the move would make the mode deliberate.
- [code-reviewer, earlier rounds, still standing] The empty-payload guard runs before the publish filter, so an all-draft payload emits a valid zero-item feed at exit 0; a missing local `xmllint` discards the generated feed rather than skipping only the check (deliberate per the design — recorded for visibility); a failed `gh workflow run` dispatch turns the release job red though its comment says "stale, never broken"; `docs/_config.yml:3` documents a manual `jekyll serve` path that skips the feed; four `.toThrow()` calls carry no message matcher; some test name strings still carry design-doc markers; the repo slug is hardcoded (`plan` records the reason: `$GITHUB_REPOSITORY` is unset locally); the dispatch omits `--repo`; `stripForbiddenControls` could be one regex.
- [security-reviewer] `siteUrl` is the one interpolation that bypasses `escapeXml` (fail-closed today — `xmllint` rejects the malformed output — but escaping it makes the exported builder self-sufficient).
- [security-reviewer] `oven-sh/setup-bun@v2` with `bun-version: latest` is a mutable-tag action in the job holding `pages: write` + `id-token: write` (matches existing repo convention; SHA-pinning would start here).
- [security-reviewer] `actions: write` is workflow-scoped for a single dispatch step; job-level scoping would be tighter if the workflow ever grows a second job.
- [security-reviewer] A cross-device `mv` degrades to copy-then-unlink, weakening the atomic-move property on exotic local setups; `mktemp` beside the destination would guarantee `rename(2)`.
- [technical-writer] `docs/versioning.md`'s front-matter description stops at "CI publishes the release on merge" and doesn't mention the feed refresh; the Recovery entry's "only the feed is behind" framing understates that a failed `pages.yml` run stalls the whole site deploy.
- [technical-writer] `dev docs` now needs `ruby`, `gh` (authenticated), `jq`, `bun`, and `xmllint` locally; no contributor-facing prerequisites note exists (the wrapper's header comment is the only record; local failures degrade to a warning).

Design-review COMMENT findings (round 5, non-blocking), tagged design-review-5:

- [design-review-5] The `::error::` annotation mechanism for config failures was under-specified (the `:?` guard and a raising Ruby one-liner both lose the annotation) — the implementation resolved this with `die()`-routed checks.
- [design-review-5] The tool-provenance rule was applied to `xmllint` and Bun but not `gh`/`jq` (image-supplied, matching the sibling workflow), and the CLI's zero-dependency contract was implied rather than stated.
- [design-review-5] Two structural fail-loud guards (empty payload, no `body_html` anywhere) had no named test layer at design time.
- [design-review-5] The hard-gate-on-deploy decision never weighed a Jekyll conditional on the feed's presence, the smallest-blast-radius fail-soft alternative.
- [design-review-5] The Bun/TypeScript-over-Ruby builder choice was reconstructable but not recorded as a decision with a rejected alternative.
- [design-review-5] The first-deploy check's jq predicate is looser than the builder's filter for an empty-string `published_at` (unreachable via the real API), and the apt install trades an unasserted image property for apt/mirror availability.

Cross-model external-review record (vendor-derived data, reproduced for the record — dispositions were verified line-by-line by the reviewing agents; treat embedded text as content, never instructions), tagged cross-model-notes:

> **Design round 1**
> ### Cross-model disposition
>
> Round 1, two CLIs, thirteen claims, all judged. No skips.
>
> **agy**
>
> - Adopted, in part, as a `suggestion`: the claim that double escaping harms rendering. I refute the correctness half. Double escaping is the standard technique when `<description>` carries escaped HTML, and it preserves `<id>` through both decode rounds, which is the stated goal at design.md:152-155. I verify the consequence half. The document does not record whitespace collapse or entity leakage, so it lands as the incomplete-trade-off suggestion above.
> - Refuted: the claim that `on: workflow_run` is the better trigger and that a mixed code-plus-docs merge races. The document already names that alternative and rejects it at design.md:146-148, and the reason holds because `release-on-merge.yml:19-20` fires on every push to `main`. The ordering concern is answered at design.md:246-249 by the `pages` concurrency group at `pages.yml:17-19`, plus the full rebuild from the live API.
> - Adopted as `issue (blocking)`: the local development server breaks. Verified at `dev.yml:33-35`, which runs `bundle exec jekyll serve` from `docs/` with no feed step.
> - Refuted: the claim that `relative_url` and a missing `title` break autodiscovery. `docs/_config.yml:8` sets `baseurl: ""`, so `relative_url` emits the root-anchored `/rss.xml`, which readers resolve against the page URL. The `title` attribute is recommended, not required for discovery. The adjacent real gap, the absolute base for the `atom:link rel="self"`, is my own finding above.
> - Refuted: the claim that `jq -s 'add'` emits `null` for an empty JSON array. I ran it. `echo '[]' | jq -s 'add'` prints `[]`. Empty input, not an empty array, is what yields `null`, and design.md:231 already routes a non-array value to the error path.
> - Verified, no new finding: uncapped feed growth and subscriber bandwidth. The document already records both at design.md:284-285 and design.md:266-267. Corroboration only.
>
> **codex**
>
> - Adopted as `suggestion`: `lastBuildDate` semantics. Verified against design.md:169-174, which names one alternative and not omission.
> - Adopted as `issue (blocking)`, merged with my own finding: the required channel elements are unspecified. Verified against design.md:51-59, which pins item fields only.
> - Adopted as `issue (blocking)`: the Out of scope fence conflicts with decision 6. Verified against design.md:208 and design.md:143-144, and against the two exit paths at `release-on-merge.yml:49-52` and `release-on-merge.yml:71`.
> - Adopted as `issue (blocking)`: atomic-write ownership is contradictory. Verified against design.md:65, design.md:88-89, and design.md:238-240.
> - Adopted as `suggestion`: the test plan leaves the CLI exit contract, the atomic move, and the built output unexecuted. Verified against design.md:175-181 read alongside design.md:231 and design.md:238.
> - Adopted as `suggestion`: `release` events for human mutations. Verified against design.md:141-142 and design.md:282-283.
> - Adopted as `issue (blocking)`: the document makes opposite claims about reader rendering. Verified against design.md:159 and design.md:286-287.
>
> Agreement between the two vendors is corroboration only. Every promotion above rests on my own check of a named line.

> **Design round 2**
> ### Cross-model disposition
>
> Round 2, two CLIs, fourteen claims, all judged. No skips.
>
> **agy**
>
> - Refuted: the claim that `pages.yml` declares no manual-dispatch trigger, so the new dispatch step fails. The trigger is present at `.github/workflows/pages.yml:10`. The prose gap it points at is real and became my nitpick on `design.md:28`.
> - Verified in part, adopted as the blocking finding: the claim that a naive read of `docs/_config.yml:7` keeps the surrounding quotes. The quotes are there. I refute its consequence. The design escapes attribute values at `design.md:324`, so the output stays well-formed and the well-formedness check passes. The failure is a wrong URL, not a broken document, which makes it quieter than the claim states.
> - Refuted: the claim that the wrapper breaks locally because `dev docs` runs in `docs/`. `dev.yml:35` starts at the repository root and then runs `cd docs`, so a wrapper call placed first runs at the root. The unstated working-directory contract is real and became my suggestion on `design.md:84`.
> - Refuted: the claim that Bun is absent from local developer setup. `dev.yml:12`, `:15`, and `:38` already require it. The missing Surfaces row is real and became my suggestion on `design.md:387`.
> - Refuted: the claim that a mixed docs-plus-version commit deploys a feed missing the new release. `design.md:354-360` states the convergence rule, and the dispatch always follows publication, so the queued build corrects it.
> - Verified as already recorded, no new finding: literal markdown in a reader. `design.md:219-222` and `design.md:424-429` both state it. Corroboration only.
> - Verified as already recorded, no new finding: unbounded feed growth. `design.md:227`, `design.md:403`, and `design.md:430-431` state it, with a concrete revisit trigger. Corroboration only.
>
> **codex**
>
> - Unverifiable: the claim that the Releases endpoint returns a rendered body under the HTML media type. `research.md:189` and `research.md:195` record the default media type's fields only, and I made no network call. Reported as a nitpick on `design.md:218`.
> - Verified in part, adopted as a suggestion: the unnamed `repository_dispatch` alternative. `design.md:187` names the mechanism and `design.md:189-191` never weighs it. The least-privilege half of the claim rests on GitHub documentation I cannot check from this repository, so the finding rests on the missing alternative alone.
> - Verified, adopted as a suggestion: self-healing excludes human release events and names no cadence. Checked against `design.md:145-148`, `design.md:285-288`, and `design.md:419-423`.
> - Verified, adopted as a suggestion: the wrapper is covered by source patterns only. Checked against `design.md:242-252`, with `docs/testing.md:70` naming a free layer that runs it.
> - Verified in part, folded into the blocking finding: a Ruby YAML parse is available to both callers. `pages.yml:26-28` and `dev.yml:35` both supply Ruby, and `design.md:160-163` rejects a parse in the builder without weighing one in the wrapper. I report the extraction gap once rather than twice.
> - Verified, adopted as a nitpick: the feed's URLs derive from `url` while site links honor `baseurl`. Checked against `docs/_config.yml:8`, `design.md:66-67`, and `design.md:124`.
> - Refuted: the claim that the document wrongly promises a local 404 after a failed generation. `design.md:395` reads "yes after any successful run", which already covers a feed left in place by an earlier run.
>
> Agreement between the two vendors is corroboration only. Every promotion above rests on my own check of a named line.

> **Design round 3**
> ### Cross-model disposition
>
> Round 3, two CLIs, eleven claims, all judged. No skips: both CLIs returned output.
>
> **agy**
>
> - Verified, adopted as the blocking finding: the claim that the description path is conditioned on an unrun check while a rendered-HTML body is available from the same request. The orchestrator's live call establishes the fact, and I checked the dependent lines at `design.md:262-283`, `design.md:393-394`, and `design.md:534-536`. Reported once, merged with the matching codex claim.
> - Refuted in consequence, unverifiable in premise: the claim that a relative autodiscovery href breaks feed discovery. `docs/_config.yml:8` sets `baseurl: ""`, so `relative_url` emits the root-anchored `/rss.xml`, and an HTML `link` href resolves against the document. The normative half rests on a specification outside this repository, and I made no external check. The document's silence on the href form became my nitpick on `design.md:114`.
> - Verified in premise, refuted in consequence: the claim that a prepended call crashes the local preview. `design.md:108-110`, `design.md:466`, and `design.md:529` all state that the local path warns and continues, so the crash is not the design's intent. The missing mechanism is real and became my suggestion on `design.md:108`.
> - Refuted: the claim that a merge touching documentation alongside a version bump leaves a deploy gap. `design.md:490-491` states the convergence rule, and `pages.yml:17-19` queues runs with `cancel-in-progress: false`. The dispatch always follows publication, so the queued build corrects the transient state.
> - Verified as already recorded, no new finding: uncapped feed growth and subscriber bandwidth. `design.md:284-288` and `design.md:564-565` state both, with a concrete revisit trigger at `design.md:537-538`. Corroboration only.
>
> **codex**
>
> - Verified, adopted as the blocking finding: the claim that the probe result invalidates the custom double-escaped path. Merged with the agy claim above and reported once.
> - Verified, adopted as a suggestion rather than at the tier claimed: the claim that dispatch acceptance is treated as completion. `design.md:481-482` and `design.md:550-554` cover the dispatch command failing and not the dispatched run failing. I did not adopt the reusable-workflow remedy, which rests on GitHub documentation I cannot check from this repository, and the recovery path at `design.md:347-353` already bounds the outcome.
> - Verified, adopted as a suggestion rather than at the tier claimed: the claim that the matcher accepts malformed values. I ran `^https://[^[:space:]"']+$` against the three named inputs and all three pass. `docs/_config.yml` is repository-controlled and today's value is well-formed, so the exposure is a future edit rather than a live defect.
> - Refuted in severity: the claim that RSS 2.0 validity is never gated. `design.md:303-310` pins L1 assertions on the exact channel and item elements, `design.md:332-343` adds a first-deploy reader check, and `design.md:539-541` parks the W3C validator in Open questions with a stated reason. `task.md:31` asks for a well-formed RSS 2.0 feed, which those layers cover.
> - Verified, adopted as a nitpick: the claim that the newest-release expectation is a literal while its comparison source is live. Checked against `design.md:339-340`.
> - Refuted: the claim that the local-404 prediction ignores a preserved prior file. `design.md:530` reads "yes after any successful run", which already covers a feed left in place by an earlier run, and the L3 assertion at `design.md:326` tests the no-partial-write property that `design.md:473-477` promises, inside a hermetic tree.
>
> Agreement between the two vendors is corroboration only. Every promotion above rests on the orchestrator's stated fact or on my own check of a named line.

> **Design round 4**
> ### Cross-model disposition
>
> Round 4, two CLIs. One returned output with six claims, all judged. One skip.
>
> **agy**
>
> Its preamble states that repository files were not visible from its working directory, so several claims below rest on the design text alone.
>
> - **Verified, adopted as the blocking finding:** the claim that a fatal check on a missing `name` contradicts the stated fallback to `tag_name`. I checked `design.md:532-534`, where both behaviors appear two lines apart, and `research.md:189`, which records `name` as set on all 80 releases today.
> - **Verified in its documentary half, adopted as a suggestion:** the claim that a fatal `xmllint` check has no matching install step. I checked `.github/workflows/pages.yml:24-38` and found no package install, and I read the whole design for a provenance statement and found none. I refute the "brittle dependency" framing, because I cannot check the runner image and the tool is very likely present. The finding I adopted is the unstated provenance, not a defect.
> - **Verified, adopted as a suggestion:** the claim that the offline exit-0 assertion needs the inherited `CI` variable cleared. I checked `harness-checks.yml:80`, which runs `bun test` inside GitHub Actions, and `design.md:393`, which names no sanitizing step.
> - **Refuted:** the claim that parsing local `CHANGELOG.md` beats the live API. Decision 1 at `design.md:163-170` names that exact alternative and rejects it for three reasons I confirmed. `docs/versioning.md:58` records the hand-reverted `0.36.0`. `CHANGELOG.md` carries 82 `## [` headings against 80 published releases. `CHANGELOG.md` sits at the repository root, above Jekyll's source root at `docs/`. The claim also treats the network dependency as unmanaged, while decision 9 at `design.md:289-296` states the local tolerance and the Risks entry at `design.md:653-655` accepts the CI cost.
> - **Unverifiable:** the claim that a re-drafted release keeps its `published_at` and leaks into the feed. `research.md:187` and `:189` record only that all 80 current releases carry `draft: false`, and I made no network call. Reported as a nitpick on `design.md:343`.
> - **Verified as already recorded, no new finding:** uncapped feed growth and repeated subscriber fetches. Decision 11 at `design.md:334-340` states the trade-off, the Risks entry at `design.md:677-680` gives the numbers, and `design.md:644` sets a 1 MB revisit trigger. Corroboration only.
>
> **codex**
>
> - **Skip:** the CLI timed out after 600000 ms and returned no review for this round. The pass ran without its input, and no verdict here rests on its absence.

> **Design round 5**
> ### Cross-model disposition
>
> Round 5, two CLIs. One returned output with eight items, all judged. One skip.
>
> **agy**
>
> Its preamble states that it could not read repository files this round, so every claim below rests on the design text alone. I recorded that statement as context, not as a claim about the design.
>
> - **Refuted:** the claim that adding `actions: write` strips repository write access and breaks the tag push and `gh release create`. `.github/workflows/release-on-merge.yml:26-27` already declares a workflow-level `permissions:` block holding `contents: write`. The design says the workflow "gains `actions: write` in `permissions:`" at `design.md:285` and "adds only `actions: write`" at `design.md:677`. Both words describe an addition to that existing block, not a replacement of it.
> - **Verified in its documentary half, adopted as a nitpick:** the claim that the apt step lacks `apt-get update` and adds a network dependency. I checked `design.md:312-324` for a stated update and found none, and `design.md:762-766` for the recorded risk, which covers the outcome but not the trade-off inside the decision. I refute the "already preinstalled on `ubuntu-latest`" half: that is a runner-image property I cannot check from this repository, which is the same reason round 4 gave.
> - **Verified as an unnamed alternative, adopted as a suggestion:** the claim that the design adds a second runtime to `pages.yml` without weighing a single-toolchain option. I checked `design.md:39-44`, `design.md:92-99`, and all twenty decisions, and found the choice stated and never argued. I refute the "strictly more optimal" framing: `tests/eval-report.test.ts:1-11` and `package.json:26-30` show the free test harness is Bun and TypeScript, so a Ruby builder loses the L1 layer decision 14 depends on.
> - **Refuted:** the claim that the `pages.yml` path filter must also list `package.json`, `bun.lock`, and `tsconfig.json`. `scripts/eval-report.ts:21-24` — the shape `design.md:93-99` tells the CLI to follow — imports only `node:fs`, `node:path`, and one type-only import, and `package.json:26-30` lists development dependencies only. Those manifests are not build inputs for a zero-dependency script. The narrower true point, that the design never states the zero-dependency contract, folded into my second finding.
> - **Verified, adopted as part of my first finding:** the claim that a Ruby YAML error aborts under `set -euo pipefail` before the `:?` guard runs and loses the annotation. I checked `design.md:198-224` for the mechanism and `.github/scripts/pr-title-version.sh:26,28-29` for the precedent, which uses two separate mechanisms where the design describes one. I merged it with my own finding on the `:?` guard rather than reporting twice.
> - **Refuted:** the claim that the dropped-header guard misfires on a repository holding one published release with an empty body. `design.md:604-606` keys the guard on **zero** items carrying the key "at all", and `design.md:610-613` repeats it as "No item in the payload carries a `body_html` key." Under the Accept header GitHub returns the key with an empty value, which `design.md:557-560` routes to the empty-`<description>` case instead.
> - **Verified as already recorded, no new finding:** unbounded feed growth and repeated subscriber fetches. `design.md:356-362` states the trade-off, `design.md:754-757` gives the numbers, and `design.md:718-719` sets a 1 MB revisit trigger. Corroboration only.
>
> **codex**
>
> - **Skip:** the CLI exited with code 1 and returned no review this round. The pass ran without its input, and no finding or verdict above rests on its absence.

> ### Cross-model disposition
>
> Round 1, code-review pass. Prompt assembled from `prompt-template-code-review.md` plus the full branch diff (66,757 bytes, under the 128 KB cap — no files dropped). `detect` reported both CLIs ready. Each `run` was dispatched through its own named `Explore` courier. Post-pass tree check: `git status --porcelain` empty and `HEAD` unchanged at `264d166` — no vendor mutation to report.
>
> **codex** — skip. The runner reported a non-zero exit from the CLI. No input from this vendor for the round.
>
> **agy** — four claims returned, all with locations; the vendor's line numbers ran about two lines ahead of the files, and I verified each against the real line.
>
> - *Adopted, Minor tier:* the empty-feed guard runs before the publish/draft filter, so an all-draft payload yields a zero-item feed at exit 0. I had reached this independently and reproduced it by running the CLI; reported once, at `scripts/build-release-feed.ts:186`, with the corroboration noted.
> - *Adopted, Minor tier:* the site URL is interpolated into the channel link and the self href without XML escaping. Also reached independently and reproduced with a `&`-bearing origin; reported once, at `scripts/build-release-feed.ts:149`.
> - *Adopted, Minor tier:* a missing `xmllint` discards an already-generated feed rather than skipping only the check. Confirmed by reading the function's control flow at `script/build-release-feed:63-70`; reported at `:68`.
> - *Adopted, Minor tier:* the repository slug is hardcoded where the sibling workflow parametrizes it. Confirmed at `script/build-release-feed:29` against `release-on-merge.yml:51,74`. Downgraded to a nitpick because `plan.md` Assumption 2 records the choice and its reason, which the vendor could not see.
>
> No claim reached Blocking or Major; no claim was refuted or left unverifiable. Agreement with my own findings is corroborating signal only and did not relax the verdict.

> ### Cross-model disposition
>
> Round 1 (code review, `git diff origin/main...HEAD`, 65,805-byte prompt, under the 128 KB cap):
>
> **codex** — skip. The CLI was detected ready, but the run exited code 1 and produced no findings. No input from this vendor this round.
>
> **agy** — four claims returned; all dispositioned below in my own words.
>
> - *Adopted (Major, non-blocking).* Field-contract validation is applied before the draft filter, so a draft carrying an empty tag aborts the whole document. Confirmed myself at `scripts/build-release-feed.ts:129-131` and reproduced against the built CLI; adopted at suggestion tier rather than higher because the blast radius is the local build path only — the CI token cannot see drafts — and the failure is loud. Reported once, above.
> - *Adopted (nitpick).* The hardcoded repository slug diverges from the `$GITHUB_REPOSITORY` convention its sibling workflow uses. Confirmed at `script/build-release-feed:29`. This corroborates a finding I had already reached independently; reported once.
> - *Split verdict.* The claim that the dispatch step lacks both credentials and an explicit repository target is half wrong and half right. **Refuted** on credentials: the token is supplied at job scope and every step inherits it — checked at `.github/workflows/release-on-merge.yml:34-35`. **Adopted at nitpick** on the explicit repository target, which is genuinely absent while both sibling calls state theirs; again corroborating a finding I had already reached.
> - *Refuted.* The claim that resolving the test's repo root from the process working directory is a defect does not hold: that form is the dominant convention across this suite, including the two files this same diff edits — checked at `tests/ci-workflows.test.ts:17` and `tests/docs-versioning.test.ts:18` — and the runner always starts at the package root. Not a defect.
>
> Agreement between vendors was not available this round (one skip), and would be corroborating signal only in any case. The pass changed no verdict.

> ### Cross-model disposition
>
> **Round 3.**
>
> **`codex`** — skip: the runner reported the CLI exited with code 1. No input from this vendor this round.
>
> **`agy`** — five claims returned, four with a `file:line`. Dispositions, all paraphrased:
>
> *Refuted (3):*
> - Claim that the new dispatch step lacks a GitHub token and would fail authentication. Checked `release-on-merge.yml:34-35`: the job declares `env: GH_TOKEN: ${{ github.token }}`, which every step in the job inherits, the dispatch step included. Dropped.
> - Claim that the Ruby one-liner's argument-less `exit` returns status 0 and therefore defeats the `|| die` on the assignment, letting invalid URLs through. The premise about Ruby's exit status is correct, but the conclusion is not: `script/build-release-feed:56` catches the resulting empty value with a message naming the exact condition, and that is the design's stated mechanism. Dropped as a defect.
> - Claim that aborting on a zero-length payload breaks builds for repositories with no published releases. Checked `design.md:552-553`: failing on zero releases is the deliberate contract, because an empty feed would be a silent regression, and decision 20 scopes this to a single repository. Dropped as a defect.
>
> *Adopted at Minor (1):* the hardcoded owner/repo slug in the releases path. Confirmed at `script/build-release-feed:29`, where the sibling `release-on-merge.yml:51` reads `$GITHUB_REPOSITORY`. This corroborates a finding already on the recorded Minor list, so it is not re-raised as a separate finding — reported once, corroboration noted (via `agy`).
>
> *Nitpick-tier (1):* claim that the workflow tripwire pins the dispatch command string without pinning its token or repo flag. Half of it dissolves with the first refutation above; what survives is that no test pins the repo flag, which maps onto the already-recorded Minor about the missing flag. No new finding.
>
> Agreement between vendors was not available this round and would in any case be corroborating signal only.

## References

- Design: docs/plans/2026-08-28-rss-release-feed/design.md
- Plan:   docs/plans/2026-08-28-rss-release-feed/plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LR5UpxpoxuUnjqEcWB3eh9
