### PR TITLE
feat(dev): add /nuke-team-plugin reversible instruction-surface reset

### DIFF
--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -189,6 +189,13 @@ run this skill at all. Everything the run *produced* is downstream of it.
 
 ## Execution
 
+**Unlike restore, the nuke steps are not one Bash invocation.** Each numbered
+step is its own Bash call that re-derives `$PRIMARY_ROOT`, `$WORKTREE` and
+`$ARCHIVE_SHA` from scratch behind a standalone `${VAR:?}` guard (Hard Rule 3),
+carrying forward only the `$DATE` literal step 0 printed. So a `${VAR:?}` guard
+here proves a value was re-derived in *this* invocation, never that one crossed
+a Bash boundary it should not have — the guards are the discipline, not a defect.
+
 ### Step 0 — resolve and validate $PRIMARY_ROOT, then derive the worktree
 
 The whole resolve-validate-derive sequence is one runnable block. A failure
@@ -225,9 +232,15 @@ already pushed.
 
 ### Step 1 — fetch, detect the default branch, capture the archive SHA
 
+**The fetch is a gate, so its exit status is checked** (Hard Rule 4). A failed
+fetch — offline, or no read access — leaves the previous run's refs in place,
+and every later gate would then prove its claim against stale data while Hard
+Rule 5 reads as satisfied:
+
 ```sh
 : "${PRIMARY_ROOT:?}"
-git -C "$PRIMARY_ROOT" fetch origin --tags
+git -C "$PRIMARY_ROOT" fetch origin --tags ||
+  { echo "refusing: 'git fetch origin --tags' failed — offline or no read access to origin, and every gate after this would read stale refs; restore access to origin and re-run, or fetch by hand and re-run once it succeeds" >&2; exit 1; }
 DEFAULT="$(git -C "$PRIMARY_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed -n 's#^origin/##p')"
 [ -n "$DEFAULT" ] || { echo "refusing: cannot detect the default branch — run 'git remote set-head origin --auto' and re-run" >&2; exit 1; }
 ARCHIVE_SHA="$(git -C "$PRIMARY_ROOT" rev-parse "origin/${DEFAULT}")"
@@ -263,7 +276,7 @@ for p in AGENTS.md CLAUDE.md skills agents hooks .claude/hooks; do
   git -C "$PRIMARY_ROOT" cat-file -e "${ARCHIVE_SHA}:${p}" 2>/dev/null && PRESENT=1
 done
 OTHER_SKILLS="$(git -C "$PRIMARY_ROOT" ls-tree -z --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
-  tr '\0' '\n' | grep -vxF '.claude/skills/nuke-team-plugin' || true)"
+  tr '\0' '\n' | grep -vixF '.claude/skills/nuke-team-plugin' || true)"
 [ -z "$OTHER_SKILLS" ] || PRESENT=1
 [ "$PRESENT" = 1 ] ||
   { echo "already nuked: every deletion-set path is absent at ${ARCHIVE_SHA} — nothing was created"; exit 0; }
@@ -289,14 +302,18 @@ maintainer to clean up.
 `refs/tags/<name>` row and the commit it points at on the `refs/tags/<name>^{}`
 row. A **lightweight** remote tag has no `^{}` row at all, so comparing only
 the peeled row is vacuous against exactly the case that must refuse. Read both
-rows:
+rows, and **check the read's own exit status before either comparison**: a
+failed `ls-remote` yields no rows either, so an unguarded pre-flight would read
+"origin carries nothing" off a network error and fall through to `tag -a -s`
+having proved nothing (Hard Rule 4):
 
 ```sh
 : "${PRIMARY_ROOT:?}"
 : "${ARCHIVE_SHA:?}"
 DATE="<the literal value step 0 printed>"
 ROWS="$(git -C "$PRIMARY_ROOT" ls-remote --tags origin \
-  "refs/tags/nuke-baseline/${DATE}" "refs/tags/nuke-baseline/${DATE}^{}")"
+  "refs/tags/nuke-baseline/${DATE}" "refs/tags/nuke-baseline/${DATE}^{}")" ||
+  { echo "refusing: 'git ls-remote --tags origin' failed — offline or no read access to origin, so the pre-flight cannot prove origin carries no nuke-baseline/${DATE}; restore access to origin and re-run, or read the remote tag by hand and re-run once it succeeds" >&2; exit 1; }
 UNPEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}" | grep -vF '^{}' | cut -f1)"
 PEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}^{}" | cut -f1)"
 if [ -n "$UNPEELED_ROW" ] && [ -z "$PEELED_ROW" ]; then
@@ -383,7 +400,8 @@ done
 git -C "$WORKTREE" ls-tree -z --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
   tr '\0' '\n' |
   while IFS= read -r entry; do
-    case "$entry" in
+    entry_lc="$(printf '%s' "$entry" | tr 'A-Z' 'a-z')"
+    case "$entry_lc" in
       ''|.claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*) continue ;;
     esac
     git -C "$WORKTREE" rm -r -q -- "$entry"
@@ -391,7 +409,12 @@ git -C "$WORKTREE" ls-tree -z --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
 ```
 
 The `.claude/skills/` sweep needs no presence guard: every entry it removes came
-from `ls-tree` at the same SHA, so each one exists by construction.
+from `ls-tree` at the same SHA, so each one exists by construction. It **folds
+each entry to lower case before the own-directory exclusion**, exactly as
+`check_path` and R4 do: macOS is case-insensitive by default, so a case-variant
+archive path like `.claude/skills/Nuke-Team-Plugin` names this skill's own
+directory, and an exact-case exclusion would let it fall through to `git rm -r`
+and delete the very directory the exclusion protects.
 
 Then strip the `hooks` key from the two manifests, leaving every other key —
 `.claude-plugin/plugin.json` also carries `name` and `version`, without which
@@ -499,7 +522,8 @@ done)"
 # `exit 1` aborts the whole run. Every loop that accumulates a value or refuses
 # is fed the same way.
 while IFS= read -r ENTRY; do
-  case "$ENTRY" in ''|.claude/skills/nuke-team-plugin) continue ;; esac
+  ENTRY_LC="$(printf '%s' "$ENTRY" | tr 'A-Z' 'a-z')"
+  case "$ENTRY_LC" in ''|.claude/skills/nuke-team-plugin) continue ;; esac
   # Round-trip proof: every entry came from ls-tree at this SHA, so one that
   # no longer resolves means the NUL-to-newline split cut a path in half.
   TYPE="$(git -C "$WORKTREE" cat-file -t "${ARCHIVE_SHA}:${ENTRY}" 2>/dev/null)" ||
@@ -654,7 +678,7 @@ esac
 # its last whitespace-separated field. Reading it with sed keeps any `$(...)`
 # planted in NUKE.md inert — command substitution never re-evaluates captured
 # bytes.
-RECORDED_ENTRY="$(grep -E '^ln -sfn ' "${WORKTREE}/NUKE.md" | head -1 | sed -E 's/^ln -sfn .* //')"
+RECORDED_ENTRY="$(sed -n '/^### The cache undo$/,/^### /p' "${WORKTREE}/NUKE.md" | grep -E '^ln -sfn ' | head -1 | sed -E 's/^ln -sfn .* //')"
 case "$RECORDED_ENTRY" in
   *..*|*[!A-Za-z0-9._/-]*|'')
     echo "refusing the repoint: NUKE.md's undo entry '${RECORDED_ENTRY}' fails the syntax check" >&2; exit 1 ;;
@@ -856,8 +880,9 @@ case "$SCRATCH_DIR" in
   *) echo "refusing: the scratch path '$SCRATCH_DIR' is not absolute" >&2; exit 1 ;;
 esac
 [ -f "${SCRATCH_DIR}/item" ] && [ ! -L "${SCRATCH_DIR}/item" ] ||
-  { echo "refusing: ${SCRATCH_DIR}/item is not a regular file — write the argument there first" >&2; exit 1; }
-[ "$(wc -l < "${SCRATCH_DIR}/item")" -le 1 ] ||
+  { rm -f "${SCRATCH_DIR}/item"; rmdir "$SCRATCH_DIR" 2>/dev/null
+    echo "refusing: ${SCRATCH_DIR}/item is not a regular file — write the argument there first" >&2; exit 1; }
+[ -z "$(sed -n '2,$p' "${SCRATCH_DIR}/item")" ] ||
   { rm -f "${SCRATCH_DIR}/item"; rmdir "$SCRATCH_DIR"
     echo "refusing: the item argument spans more than one line — an item id never does" >&2; exit 1; }
 IFS= read -r ITEM < "${SCRATCH_DIR}/item"
@@ -873,6 +898,14 @@ first line and silently drop the rest, so a multi-line argument would restore a
 real item while the maintainer never saw what else was sent; refusing names it
 instead. The scratch file is removed on both paths, so untrusted bytes never
 outlive the block that read them.
+
+**The cap asks whether a second line exists, never how many newlines the file
+holds.** `wc -l` counts newline *characters*, and the Write tool appends no
+trailing newline — so a two-line argument written as `a\nb` counts as one and
+sails through the cap, after which `read` takes `a` and drops `b` silently:
+exactly the case the cap exists to name. `sed -n '2,$p'` prints every line past
+the first whether or not the last one is terminated, so any second line makes
+the substitution non-empty and the run refuses.
 
 ### R2 — location, branch, and containment
 
@@ -982,6 +1015,8 @@ Then extract **the item's own line** by an exact match on field 1 — pipe-free,
 so it never depends on `$ITEM` being regex-safe — for R4 through R7 to read:
 
 ```sh
+: "${MANIFEST_LINES:?}"
+: "${ITEM:?}"
 MANIFEST_LINE=""
 while IFS= read -r ml; do
   [ -n "$ml" ] || continue
@@ -1095,6 +1130,7 @@ carries `git -C "$TOPLEVEL"` behind a standalone guard (Hard Rule 1):
 ```sh
 export LC_ALL=C
 : "${TOPLEVEL:?}"
+: "${RECORDED_BRANCH:?}"
 RECORDED_TAG="$(sed -n 's/^- Baseline tag: //p' "${TOPLEVEL}/NUKE.md" | head -1)"
 RECORDED_ARCHIVE_SHA="$(sed -n 's/^- Archive SHA: //p' "${TOPLEVEL}/NUKE.md" | head -1)"
 case "$RECORDED_TAG" in
@@ -1431,10 +1467,10 @@ Steps 1 to 3 preserve this experiment's output; steps 5 and 6 remove it.
    `git -C <primary root> ls-remote --tags origin "refs/tags/nuke-result/<date>^{}" | cut -f1`
 
    When the push in step 2 was refused, prove the local tag instead with
-   `git -C <primary root> rev-parse "nuke-result/<date>^{}"`. Either way, the
-   second half is the branch tip:
+   `git -C <primary root> rev-parse "refs/tags/nuke-result/<date>^{}"`. Either
+   way, the second half is the branch tip:
 
-   `git -C <primary root> rev-parse experiment/nuke-<date>`
+   `git -C <primary root> rev-parse refs/heads/experiment/nuke-<date>`
 
    Four steps separate the tag from step 6, and a commit made in between would
    otherwise be reflog-only while the first line still passed.

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -60,12 +60,13 @@ The whole argument is at most two words.
    run at `$PRIMARY_ROOT` would stage the deletions on the default branch in
    the maintainer's own checkout. **Restore has no `$WORKTREE`**: it runs
    inside the experiment tree and binds to `$TOPLEVEL`, the value R2 derives
-   and proves. **Restore's whole proof-and-write path — R2 through R7 — runs as
-   one Bash invocation**, so `$TOPLEVEL` (proved in R2) and `$ARCHIVE` (proved
-   in R5) are the exact values R6's gate and R7's checkout write against: the
-   value proved is the value used because no Bash boundary sits between the
-   proof and the write. The re-restore escape is its own single invocation that
-   re-establishes both proofs before it writes. Every restore read and every
+   and proves. **Restore's whole proof-and-write path — R1 through R7 — runs as
+   one Bash invocation**, so `$ITEM` (bound in R1), `$TOPLEVEL` (proved in R2)
+   and `$ARCHIVE` (proved in R5) are the exact values R6's gate and R7's
+   checkout write against: the value proved is the value used because no Bash
+   boundary sits between the proof and the write. The re-restore escape is its
+   own single invocation that re-establishes every one of those bindings before
+   it writes. Every restore read and every
    restore write — R6's state gate, R7's checkout, and the re-restore escape —
    carries `git -C "$TOPLEVEL"` and resolves its path against `"$TOPLEVEL/"`, so
    no restore command is bound by the caller's working directory alone.
@@ -84,10 +85,13 @@ The whole argument is at most two words.
    0 printed, never re-derived.** A run that starts before midnight and reaches
    step 6 after it would otherwise key the tag, the branch and the worktree to
    two different dates, and the worktree the run created would no longer be the
-   one its own commands name. Restore is the other exception: R2 through R7 are
-   one invocation (Hard Rule 1), so `$TOPLEVEL` and `$ARCHIVE` are proved once
-   and persist to every later block without re-derivation, and the re-restore
-   escape re-proves both from scratch.
+   one its own commands name. Restore is the other exception: R1 through R7 are
+   one invocation (Hard Rule 1), so `$ITEM`, `$TOPLEVEL`, `$MANIFEST_LINE`,
+   `$TRIPLES` and `$ARCHIVE` are bound once and persist to every later block
+   without re-derivation, and the re-restore escape re-runs R1 through R5 to
+   re-establish all five from scratch. `$SCRATCH_DIR` is a third exception: R0
+   creates it in its own invocation and R1 transcribes the literal path R0
+   printed, because the Write that fills it has to land between the two.
 4. **Refuse first.** Every gate is a positive proof, never the absence of an
    objection. A gate that cannot prove its claim refuses the run and prints the
    two ways forward; it never repairs, normalizes, or retries around what it
@@ -125,13 +129,19 @@ The whole argument is at most two words.
     that originates in `NUKE.md` or the user `<item>` argument may appear as
     literal text inside any shell command. Retyping it as `VAR="<value>"`
     executes any embedded `$(...)` or backtick at assignment, before a single
-    gate runs (this is the injection round 2's CRITICAL named). Every such value
+    gate runs — the file is read by the very command the retyping would run it
+    in. Every such value
     is bound by a command that *reads it* — a file-reading command substitution
     for `NUKE.md` fields (`sed`/`grep`/`cut` against `"${TOPLEVEL}/NUKE.md"`),
     a `cut`/`read` split for the manifest triples in `$MANIFEST_LINES`, and a
-    single-quoted here-doc for the `<item>` argument that has no file — and then
-    shape-checked before it reaches any command. Command substitution does not
-    re-evaluate the bytes it captures, so `$(...)` in the file lands in the
+    redirect from R0's scratch file for the `<item>` argument — and then
+    shape-checked before it reaches any command. **The argument's bytes never
+    enter the script text at all.** Any in-script quoting the argument is pasted
+    into is a string the argument itself can close — a here-doc delimiter
+    included, since a line equal to the delimiter ends the here-doc and every
+    byte after it parses as shell. A redirect has no such closing sequence.
+    Command substitution and `read` do not
+    re-evaluate the bytes they capture, so `$(...)` in the file lands in the
     variable as inert text. The `$DATE` literal-transcription idiom is only ever
     for values step 0 *printed* (from `date`, from `git`), never for anything
     that came out of `NUKE.md` or the argument.
@@ -308,8 +318,8 @@ before any deletion, because one dated label must not name two baselines.
 : "${ARCHIVE_SHA:?}"
 DATE="<the literal value step 0 printed>"
 if git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/tags/nuke-baseline/${DATE}"; then
-  PEELED="$(git -C "$PRIMARY_ROOT" rev-parse "nuke-baseline/${DATE}^{}")"
-  KIND="$(git -C "$PRIMARY_ROOT" cat-file -t "nuke-baseline/${DATE}")"
+  PEELED="$(git -C "$PRIMARY_ROOT" rev-parse "refs/tags/nuke-baseline/${DATE}^{}")"
+  KIND="$(git -C "$PRIMARY_ROOT" cat-file -t "refs/tags/nuke-baseline/${DATE}")"
   [ "$PEELED" = "$ARCHIVE_SHA" ] && [ "$KIND" = tag ] &&
     git -C "$PRIMARY_ROOT" tag -v "nuke-baseline/${DATE}" ||
     { echo "refusing: nuke-baseline/${DATE} already exists at ${PEELED} (kind ${KIND}) and is not a verified annotated tag at ${ARCHIVE_SHA} — retire that tag deliberately, or run on another date" >&2; exit 1; }
@@ -423,6 +433,12 @@ gone from the worktree, so `git hash-object` against it errors.
 These helpers read named variables rather than positional parameters, because
 Hard Rule 9 bans a `$` followed by a digit anywhere in this file.
 
+`check_path` folds the path to lower case before the own-directory exclusion,
+exactly as R4 does. macOS is case-insensitive by default, so
+`.claude/Skills/Nuke-Team-Plugin/SKILL.md` names this skill's own file while
+matching neither the exclusion nor, without the fold, anything that would stop
+it being written to the manifest.
+
 ```sh
 export LC_ALL=C
 : "${WORKTREE:?}"
@@ -434,7 +450,8 @@ check_path() {   # reads P — syntax, own-directory exclusion, then containment
     ''|/*|*..*|*[!A-Za-z0-9._/-]*)
       echo "refusing: path '$P' fails the syntax check" >&2; exit 1 ;;
   esac
-  case "$P" in
+  P_LC="$(printf '%s' "$P" | tr 'A-Z' 'a-z')"
+  case "$P_LC" in
     .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*)
       echo "refusing: path '$P' is inside this skill's own directory" >&2; exit 1 ;;
   esac
@@ -479,8 +496,8 @@ done)"
 # unquoted expansion, so that form would run once over the whole blob. The
 # here-doc feeds the loop in
 # the current shell (never a pipe), so MANIFEST keeps accumulating and a refusal
-# `exit 1` aborts the whole run. The two other enumeration loops use the same
-# idiom.
+# `exit 1` aborts the whole run. Every loop that accumulates a value or refuses
+# is fed the same way.
 while IFS= read -r ENTRY; do
   case "$ENTRY" in ''|.claude/skills/nuke-team-plugin) continue ;; esac
   # Round-trip proof: every entry came from ls-tree at this SHA, so one that
@@ -523,9 +540,10 @@ set. That entry path is therefore needed *while `NUKE.md` is being written*,
 which is here — not in step 7. This scan is read-only: it moves nothing, so
 running it before the commit costs nothing and keeps the run at one commit.
 
-Run the discovery block from `### Step 7 — repoint the plugin cache` now,
-unchanged, and keep the entries whose `readlink` target equals `$PRIMARY_ROOT`
-byte for byte. Then:
+Run step 7's **read-only scan block** — the first of its two, the one that only
+`printf`s each entry with its kind and target — now, unchanged, and keep the
+entries whose `readlink` target equals `$PRIMARY_ROOT` byte for byte. Never run
+step 7's second block here: it moves the link. Then:
 
 - **Exactly one match** — write its literal path into `NUKE.md`'s
   `### The cache undo` section.
@@ -598,16 +616,40 @@ explicit confirmation — this changes what every Claude Code session on the
 machine loads. Name the entry, its current target, and the worktree it will
 point at. Only after the user agrees:
 
-`$CACHE_ENTRY` is the single discovered match, bound from the scan above — a
-trusted filesystem path. `$RECORDED_ENTRY` comes out of the committed `NUKE.md`,
-so it is **read from the file, never retyped** (Hard Rule 12), and shape-checked
-before the equality gate:
+**This block re-runs the match itself, so `$CACHE_ENTRY` is bound by the command
+that finds it.** The scan above is a report for the human to confirm against; its
+output does not survive into this invocation (Hard Rule 3), and transcribing the
+matched path by hand would make a machine-local filesystem value into literal
+script text — the shape Hard Rule 12 rules out. The `find` below filters to
+symlinks and compares each `readlink` target itself, so the value repointed is
+the value proved, and the count is proved here too rather than carried over from
+the human's reading of the report.
+
+`$RECORDED_ENTRY` comes out of the committed `NUKE.md`, so it is **read from the
+file, never retyped** (Hard Rule 12). Both paths are shape-checked and proved to
+sit under the cache directory before the equality gate:
 
 ```sh
+export LC_ALL=C
 : "${PRIMARY_ROOT:?}"
 : "${WORKTREE:?}"
-: "${CACHE_ENTRY:?}"
 CACHE_DIR="${HOME}/.claude/plugins/cache/team-dev/team"
+CACHE_ENTRY="$(find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -type l -print |
+  while IFS= read -r entry; do
+    [ "$(readlink "$entry")" = "$PRIMARY_ROOT" ] && printf '%s\n' "$entry"
+  done)"
+[ -n "$CACHE_ENTRY" ] ||
+  { echo "refusing the repoint: no symlink under ${CACHE_DIR} targets ${PRIMARY_ROOT} — the cache changed since the scan; re-read the scan and start step 7 again" >&2; exit 1; }
+[ "$(printf '%s\n' "$CACHE_ENTRY" | grep -c .)" = 1 ] ||
+  { echo "refusing the repoint: several symlinks under ${CACHE_DIR} target ${PRIMARY_ROOT} — retire the duplicates by hand, then re-run" >&2; exit 1; }
+case "$CACHE_ENTRY" in
+  *..*|*[!A-Za-z0-9._/-]*|'')
+    echo "refusing the repoint: the live entry '${CACHE_ENTRY}' fails the syntax check" >&2; exit 1 ;;
+esac
+case "$CACHE_ENTRY" in
+  "${CACHE_DIR}/"*) : ;;
+  *) echo "refusing the repoint: the live entry '${CACHE_ENTRY}' is not under ${CACHE_DIR}" >&2; exit 1 ;;
+esac
 # The undo line is `ln -sfn <primary root> <cache entry>`; the recorded entry is
 # its last whitespace-separated field. Reading it with sed keeps any `$(...)`
 # planted in NUKE.md inert — command substitution never re-evaluates captured
@@ -725,18 +767,22 @@ every claim below before it writes anything; a failed proof refuses, names what
 failed, and writes nothing. The steps run in order, and none is skipped when an
 earlier one already looks convincing.
 
-**R2 through R7 are one Bash invocation.** Run them as a single script, in
-order, in one shell — `$TOPLEVEL` (proved in R2) and `$ARCHIVE` (proved in R5)
-must be the exact values R6's gate and R7's checkout write against, and shell
+**R1 through R7 are one Bash invocation.** Run them as a single script, in
+order, in one shell — `$ITEM` (bound in R1), `$TOPLEVEL` (proved in R2),
+`$MANIFEST_LINE` (R3), `$TRIPLES` (R4) and `$ARCHIVE` (proved in R5) must be the
+exact values R6's gate and R7's checkout write against, and shell
 state does not survive a Bash boundary (Hard Rule 3). Splitting the blocks
-across separate Bash calls loses both bindings, so the value proved is no longer
-the value used. The re-restore escape is a separate, deliberate invocation that
-re-establishes both proofs from scratch before it writes.
+across separate Bash calls loses those bindings, so the value proved is no longer
+the value used. R0 is the one block outside the span, because the Write that
+fills its scratch file has to land between R0 and R1. The re-restore escape is a
+separate, deliberate invocation that re-runs R1 through R5 from scratch before
+it writes.
 
 **Every value read from `NUKE.md` is bound by a file-reading command
-substitution, and the `<item>` argument by a quoted here-doc — never retyped**
-(Hard Rule 12). Retyping a NUKE.md value or the argument into `VAR="<value>"`
-would execute any embedded `$(...)` at assignment, before a single gate runs.
+substitution, and the `<item>` argument by a redirect from R0's scratch file —
+never retyped** (Hard Rule 12). Retyping a NUKE.md value or the argument into
+`VAR="<value>"` would execute any embedded `$(...)` at assignment, before a
+single gate runs.
 The manifest triples are split out of `$MANIFEST_LINES` with parameter
 expansion, never read off the line by eye.
 
@@ -751,7 +797,7 @@ Checking out an edited manifest whole is equivalent to returning its `hooks`
 key, because the recorded hash proves the file is byte-for-byte what the nuke
 wrote, so the checkout changes that key and nothing else.
 
-### R1 — the argument
+### R0 and R1 — the argument
 
 Any first word other than `restore` prints the usage line and stops; the skill
 never guesses a mode. With no item id, print the manifest and stop. An item id
@@ -762,22 +808,71 @@ branch above has already been taken and returned. An empty `$ITEM` reaching it
 therefore means the mode dispatch was skipped, which is a refusal and not a
 second spelling of bare restore — hence the `''` case.
 
-`<item>` is untrusted and has no file to read it from, so it is bound with a
-**single-quoted here-doc** (`<<'RESTORE_ITEM'`), whose body is never expanded:
-a `$(...)` in the argument lands in `$ITEM` as inert text instead of running at
-assignment (Hard Rule 12). The shape check then runs before `$ITEM` reaches any
-command. Paste the raw argument on the line between the markers, nothing else:
+`<item>` is untrusted, so **it is given a file to be read from rather than
+pasted into the script** (Hard Rule 12). R0 makes that file; R1 reads it.
+
+Pasting the argument anywhere inside the script text is unsafe no matter how it
+is quoted, because every in-script quoting has a closing sequence the argument
+itself can supply. A single-quoted here-doc is the trap worth naming: its body
+is never expanded, but a line of the argument equal to the delimiter *ends* the
+here-doc, and every byte after that line parses as ordinary shell — at parse
+time, before the shape check below has run. A redirect from a file has no
+closing sequence, so the argument's bytes are data from beginning to end.
+
+#### R0 — make the scratch file
+
+Its own invocation, and the only block outside the R1-through-R7 span: the
+Write that fills the file has to land between this block and R1. `mktemp -d`
+creates an unpredictable directory with owner-only permissions, so the file
+R1 reads cannot be pre-planted or swapped by another user on the machine:
+
+```sh
+SCRATCH_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nuke-team-plugin.XXXXXXXX")"
+[ -d "$SCRATCH_DIR" ] ||
+  { echo "refusing: could not create the scratch directory for the item argument" >&2; exit 1; }
+printf 'SCRATCH_DIR=%s\n' "$SCRATCH_DIR"
+```
+
+Then, with the **Write tool** (never a shell command — a shell command would put
+the argument's bytes back into script text, which is the whole thing this
+avoids), write the raw `<item>` argument, verbatim and alone, to
+`<the SCRATCH_DIR path just printed>/item`. No quotes around it, no edits, no
+trailing commentary. The Write tool carries its content as data, so nothing in
+the argument is ever parsed as shell.
+
+#### R1 — read it back and shape-check it
+
+`$SCRATCH_DIR` is transcribed as the literal path R0 *printed* — the `$DATE`
+idiom of Hard Rule 3, for a value `mktemp` generated and no untrusted source
+can influence — and it is shape-checked anyway. The file is read with a
+redirect, capped at one line, and deleted immediately; the shape check then
+runs before `$ITEM` reaches any command:
 
 ```sh
 export LC_ALL=C
-IFS= read -r ITEM <<'RESTORE_ITEM'
-<the item argument, pasted here verbatim — no surrounding quotes, no edits>
-RESTORE_ITEM
+SCRATCH_DIR="<the literal path R0 printed>"
+case "$SCRATCH_DIR" in
+  /*) : ;;
+  *) echo "refusing: the scratch path '$SCRATCH_DIR' is not absolute" >&2; exit 1 ;;
+esac
+[ -f "${SCRATCH_DIR}/item" ] && [ ! -L "${SCRATCH_DIR}/item" ] ||
+  { echo "refusing: ${SCRATCH_DIR}/item is not a regular file — write the argument there first" >&2; exit 1; }
+[ "$(wc -l < "${SCRATCH_DIR}/item")" -le 1 ] ||
+  { rm -f "${SCRATCH_DIR}/item"; rmdir "$SCRATCH_DIR"
+    echo "refusing: the item argument spans more than one line — an item id never does" >&2; exit 1; }
+IFS= read -r ITEM < "${SCRATCH_DIR}/item"
+rm -f "${SCRATCH_DIR}/item"; rmdir "$SCRATCH_DIR"
 case "$ITEM" in
   ''|/*|*..*|*[!A-Za-z0-9._/-]*)
     echo "refusing: '$ITEM' is not a valid item id — printing the manifest, nothing was written" >&2; exit 1 ;;
 esac
 ```
+
+The one-line cap is not redundant with the shape check. `read` would take the
+first line and silently drop the rest, so a multi-line argument would restore a
+real item while the maintainer never saw what else was sent; refusing names it
+instead. The scratch file is removed on both paths, so untrusted bytes never
+outlive the block that read them.
 
 ### R2 — location, branch, and containment
 
@@ -851,6 +946,12 @@ fence that still runs the range on is caught by the grammar assertion below:
 every extracted line must be a whole `<id> <kind> <path> <baseline> <state>`
 record, and the extracted count must equal the count that matches the grammar.
 
+**`$ITEM` is guarded here, never re-bound.** R1 is inside this invocation, so
+the value is already in the shell; the standalone `: "${ITEM:?}"` proves it
+arrived. An empty `$ITEM` means the span was split across Bash calls — re-run
+R0 and R1, and never repair it by retyping the argument, which is the one
+assignment Hard Rule 12 exists to stop.
+
 **The variable is `MANIFEST_LINES`, never `LINES`.** `LINES` is a zsh special
 integer parameter (the terminal's line count); the Bash tool runs zsh, and
 assigning a manifest string to `LINES` makes zsh arithmetic-evaluate it on the
@@ -860,6 +961,7 @@ written. The name is load-bearing.
 ```sh
 export LC_ALL=C
 : "${TOPLEVEL:?}"
+: "${ITEM:?}"
 NUKE_MD="${TOPLEVEL}/NUKE.md"
 OPENERS="$(grep -c '^[`]\{3\}nuke-manifest[[:space:]]*$' "$NUKE_MD")"
 [ "$OPENERS" = 1 ] ||
@@ -977,6 +1079,13 @@ the tag is signed, so the tag name must match
 **the trusted commit is the peeled `^{}` value**; the recorded `ARCHIVE_SHA` is
 a cross-check that never reaches a command.
 
+**Every revision naming a tag is fully qualified as `refs/tags/<name>`**, here
+and in step 3. A bare `<name>` is resolved through git's revision search order,
+which tries `refs/<name>` before `refs/tags/<name>` — so a ref planted at
+`refs/nuke-baseline/<date>` would be the object peeled and checked out while
+`tag -v` verified the real tag under `refs/tags/`, and the object proved would
+not be the object used.
+
 **The tag is bound to THIS experiment, not merely to a valid signature.** The
 date is derived once from the proved `$TOPLEVEL` worktree name and must key both
 the recorded tag and the recorded branch — otherwise an edited `NUKE.md` could
@@ -1010,7 +1119,7 @@ git -C "$TOPLEVEL" rev-parse --verify --quiet "refs/tags/${RECORDED_TAG}" >/dev/
   { echo "refusing: ${RECORDED_TAG} is missing locally — run 'git fetch origin tag ${RECORDED_TAG}' and re-run" >&2; exit 1; }
 git -C "$TOPLEVEL" tag -v "$RECORDED_TAG" ||
   { echo "refusing: ${RECORDED_TAG} does not verify" >&2; exit 1; }
-ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "${RECORDED_TAG}^{}")"
+ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "refs/tags/${RECORDED_TAG}^{}")"
 [ "$ARCHIVE" = "$RECORDED_ARCHIVE_SHA" ] ||
   { echo "refusing: ${RECORDED_TAG} peels to ${ARCHIVE}, but NUKE.md records ${RECORDED_ARCHIVE_SHA} — the file was edited" >&2; exit 1; }
 ```
@@ -1035,43 +1144,70 @@ the maintainer may commit freely in the worktree.
 
 ### R7 — check out every present path, then report
 
-**One loop over `$TRIPLES` — R4's normalized `<path> <baseline> <state>` per
-line — applies R6's gate and then the checkout to each `present` path.** An
-`absent` path is skipped and named; the item refuses only when *every* path was
-absent, so nothing silently restores a partial item and nothing silently
-restores nothing. Both the gate and the write carry `git -C "$TOPLEVEL"`, so
-they land in the tree R2 proved and nowhere else:
+**Two loops over `$TRIPLES` — R4's normalized `<path> <baseline> <state>` per
+line — and every gate runs in the first one, before the second one writes
+anything.** One loop that gated and wrote per iteration would break the
+"a failed proof writes nothing" contract on any multi-path item: a `pair` whose
+first path passes and whose second fails would leave the first path already
+checked out when the refusal fires, half-restoring the item and wedging the
+re-run on the path that is now present. Gating the whole item first makes the
+refusal total.
+
+An `absent` path is skipped and named; the item refuses only when *every* path
+is absent, so nothing silently restores a partial item and nothing silently
+restores nothing. Every gate and every write carries `git -C "$TOPLEVEL"`, so
+they read and land in the tree R2 proved and nowhere else.
+
+First pass — R6's gate over every `present` path on the item, writing nothing:
 
 ```sh
 : "${TOPLEVEL:?}"
 : "${ARCHIVE:?}"
 : "${TRIPLES:?}"
-WROTE=0
+: "${ITEM:?}"
+PRESENT_COUNT=0
+while IFS=' ' read -r ITEM_PATH BASELINE STATE; do
+  [ -n "$ITEM_PATH" ] || continue
+  [ "$BASELINE" = absent ] && continue
+  PRESENT_COUNT=$((PRESENT_COUNT + 1))
+  if [ "$STATE" = "-" ]; then
+    { [ ! -e "${TOPLEVEL}/${ITEM_PATH}" ] && [ ! -L "${TOPLEVEL}/${ITEM_PATH}" ] &&
+      [ -z "$(git -C "$TOPLEVEL" ls-files -- "$ITEM_PATH")" ]; } ||
+      { echo "refusing: ${ITEM_PATH} is recorded removed but exists in the tree or the index — nothing was written" >&2; exit 1; }
+  else
+    [ "$(git -C "$TOPLEVEL" hash-object -- "${TOPLEVEL}/${ITEM_PATH}")" = "$STATE" ] &&
+    [ "$(git -C "$TOPLEVEL" rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
+      { echo "refusing: ${ITEM_PATH} no longer matches its recorded state ${STATE} — nothing was written" >&2; exit 1; }
+  fi
+done <<ITEM_TRIPLES
+$TRIPLES
+ITEM_TRIPLES
+[ "$PRESENT_COUNT" -ge 1 ] ||
+  { echo "refusing: every path on '$ITEM' is recorded absent — nothing to restore" >&2; exit 1; }
+```
+
+Second pass — every path on the item is now proved, so the checkouts run:
+
+```sh
+: "${TOPLEVEL:?}"
+: "${ARCHIVE:?}"
+: "${TRIPLES:?}"
 while IFS=' ' read -r ITEM_PATH BASELINE STATE; do
   [ -n "$ITEM_PATH" ] || continue
   if [ "$BASELINE" = absent ]; then
     printf 'skipping %s — recorded absent at the archive, nothing to restore\n' "$ITEM_PATH"
     continue
   fi
-  # R6 recorded-state gate for this present path, working tree AND index.
-  if [ "$STATE" = "-" ]; then
-    { [ ! -e "${TOPLEVEL}/${ITEM_PATH}" ] && [ ! -L "${TOPLEVEL}/${ITEM_PATH}" ] &&
-      [ -z "$(git -C "$TOPLEVEL" ls-files -- "$ITEM_PATH")" ]; } ||
-      { echo "refusing: ${ITEM_PATH} is recorded removed but exists in the tree or the index" >&2; exit 1; }
-  else
-    [ "$(git -C "$TOPLEVEL" hash-object -- "${TOPLEVEL}/${ITEM_PATH}")" = "$STATE" ] &&
-    [ "$(git -C "$TOPLEVEL" rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
-      { echo "refusing: ${ITEM_PATH} no longer matches its recorded state ${STATE}" >&2; exit 1; }
-  fi
-  git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH"
+  git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH" ||
+    { echo "refusing: checking out ${ITEM_PATH} from ${ARCHIVE} failed — the item is partly restored; re-run after reading 'git status'" >&2; exit 1; }
   printf 'restored %s\n' "$ITEM_PATH"
-  WROTE=$((WROTE + 1))
 done <<ITEM_TRIPLES
 $TRIPLES
 ITEM_TRIPLES
-[ "$WROTE" -ge 1 ] ||
-  { echo "refusing: every path on '$ITEM' is recorded absent — nothing to restore" >&2; exit 1; }
 ```
+
+Both loops are fed by a here-doc rather than a pipe, so `$PRESENT_COUNT`
+accumulates in the current shell and a refusal's `exit 1` ends the run.
 
 The `-L` half of the `-` gate is not decoration: `-e` follows a link, so a
 dangling symlink would otherwise read as absent. Report every path written,
@@ -1088,9 +1224,23 @@ survives and R6 checks the index too. The escape therefore goes through git.
 rather than trusting a variable from the main path** (Hard Rule 3): shell state
 does not survive a Bash boundary, and a bare `${VAR:?}` guard would only prove a
 value is non-empty, not that it was ever proved. Before it writes, the escape
-**re-runs R2's containment proof and R5's tag verification from scratch** — the
-same blocks, in the same invocation as the writes below — to re-derive
-`$TOPLEVEL`, `$ARCHIVE`, and the item's `$TRIPLES`. Only then:
+**re-runs R1 through R5 from scratch** — the same blocks, in the same
+invocation as the writes below — because each binding it needs is made by a
+different one of them and none can be skipped:
+
+| Binding | The block that makes it |
+|---------|-------------------------|
+| `$ITEM` | R1, from a fresh R0 scratch file |
+| `$TOPLEVEL` | R2's containment proof |
+| `$MANIFEST_LINE` | R3's fence, grammar and membership gates |
+| `$TRIPLES` | R4's per-triple validation |
+| `$ARCHIVE` | R5's tag verification |
+
+R2 and R5 alone are not enough: `$TRIPLES` is R4's output, R4 reads R3's
+`$MANIFEST_LINE`, and R3 reads R1's `$ITEM`. An escape that ran only R2 and R5
+would reach `: "${TRIPLES:?}"` unbound, and the obvious repair — retyping the
+manifest triples as literals immediately before a `git rm -r -f` — is exactly
+the assignment Hard Rule 12 forbids. Only once all five are re-bound:
 
 The nuke commit is derived, never read: `NUKE.md` sits inside that commit and
 cannot record its own SHA. It records `ARCHIVE_SHA`, and the nuke commit is the
@@ -1101,6 +1251,7 @@ is the current branch:
 : "${TOPLEVEL:?}"
 : "${ARCHIVE:?}"
 : "${TRIPLES:?}"
+: "${ITEM:?}"
 NUKE_COMMIT="$(git -C "$TOPLEVEL" rev-list --ancestry-path --reverse "${ARCHIVE}..HEAD" | head -1)"
 [ -n "$NUKE_COMMIT" ] ||
   { echo "refusing: cannot derive the nuke commit from ${ARCHIVE}..HEAD" >&2; exit 1; }
@@ -1110,9 +1261,11 @@ while IFS=' ' read -r ITEM_PATH BASELINE STATE; do
   [ -n "$ITEM_PATH" ] || continue
   [ "$BASELINE" = absent ] && continue
   if [ "$STATE" = "-" ]; then
-    git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH"
+    git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH" ||
+      { echo "refusing: could not clear ${ITEM_PATH} from the tree and index" >&2; exit 1; }
   else
-    git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH"
+    git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH" ||
+      { echo "refusing: could not return ${ITEM_PATH} to the state the nuke left" >&2; exit 1; }
   fi
 done <<ITEM_TRIPLES
 $TRIPLES
@@ -1125,6 +1278,11 @@ with `git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH"`, which clears the working
 tree and the index together; a recorded hash is returned with
 `git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH"`, restoring the exact
 bytes the nuke wrote so the recorded hash matches again.
+
+Each write's exit status is checked and refuses the escape (Hard Rule 4).
+`git rm` exits non-zero on a pathspec that matches nothing, and an unchecked
+loop would carry on to the next path and report success while the recorded
+state it was meant to clear is still there.
 
 For a manifest the maintainer edited on purpose, the alternative is a hand
 merge from `git show <ARCHIVE_SHA>:<path>`, which writes nothing.
@@ -1339,6 +1497,25 @@ a decision the maintainer makes by hand, long after this run.
   step 7, which would need a second commit to record it.
 - **Treating the tag push as a gate.** It is best-effort; a maintainer with no
   push access must not be stranded.
+- **Retyping a `NUKE.md` value or the `<item>` argument as `VAR="<value>"`.**
+  The shell expands a double-quoted assignment, so an embedded `$(...)` or
+  backtick runs at assignment — before the gate that was going to reject the
+  value ever executes. Bind every such value with a command that reads it
+  (Hard Rule 12), and reach for that binding rather than a retype when a
+  variable turns up unset: an unset variable means the invocation span was
+  split, and the repair is to re-run the span.
+- **Pasting the `<item>` argument into the script under any quoting.** Every
+  in-script quoting has a closing sequence the argument can supply — a
+  single-quoted here-doc ends at a line equal to its delimiter, and the bytes
+  after it parse as shell at parse time, ahead of every gate. The argument
+  reaches the shell only through R0's scratch file.
+- **Gating and writing in one loop over a multi-path item.** A `pair` or
+  `group` whose second path fails its gate would already have had its first
+  path checked out, so "a failed proof writes nothing" would be false and the
+  re-run would wedge on the path that is now present. Gate every triple first.
+- **Naming a tag as a bare revision.** `rev-parse <name>^{}` searches
+  `refs/<name>` before `refs/tags/<name>`, so the object verified and the
+  object used can differ. Qualify every tag revision as `refs/tags/<name>`.
 - **Repairing the nuked worktree's test suite.** It is red by construction —
   `tests/` survives while its targets do not. Repairing it is contamination.
 

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -329,6 +329,101 @@ git -C "$WORKTREE" commit -S -m "experiment: nuke Team's instruction surface (${
 If signing fails, stop here, print the command and its verbatim error, and
 print the recovery line from `## NUKE.md template`. Never commit unsigned.
 
+### Step 7 — repoint the plugin cache
+
+The deletions are inert until this step: Team's skills, agents and hooks are
+live in a session because the plugin is *installed*, not because files sit in a
+checkout. The dev install is a symlink under `~/.claude/plugins/cache/team-dev/team/`
+pointing at the primary clone; repointing it at the experiment worktree is what
+makes the nuke real.
+
+**Find the entry by proof, never by arithmetic.** The live entry was named by
+whichever checkout last ran the installer, so a directory name computed today
+can name a path that does not exist while the real link sits beside it. Match
+on the link target instead:
+
+```sh
+: "${PRIMARY_ROOT:?}"
+CACHE_DIR="${HOME}/.claude/plugins/cache/team-dev/team"
+for entry in "$CACHE_DIR"/*; do
+  [ -e "$entry" ] || [ -L "$entry" ] || continue
+  printf '%s\t%s\t%s\n' "$entry" "$([ -L "$entry" ] && echo symlink || echo directory)" "$(readlink "$entry" || true)"
+done
+```
+
+Keep the entries that are symlinks whose `readlink` target equals
+`$PRIMARY_ROOT` byte for byte. Then branch on how many there are.
+
+**Exactly one match.** Ask for an explicit confirmation first — this changes
+what every Claude Code session on the machine loads. Name the entry, its
+current target, and the worktree it will point at. Only after the user agrees:
+
+```sh
+: "${PRIMARY_ROOT:?}"
+: "${WORKTREE:?}"
+: "${CACHE_ENTRY:?}"
+ln -sfn "$WORKTREE" "$CACHE_ENTRY"
+readlink "$CACHE_ENTRY"
+```
+
+`ln -sfn` replaces the link in place. Never append a trailing slash to a
+symlink path in a removal command: BSD `rm -rf link/` follows the link and
+empties the checkout behind it.
+
+**Two or more matches.** Refuse the repoint, keep the commit, and list every
+entry with its `readlink` target so the maintainer can retire the duplicates by
+hand.
+
+**Zero matches.** Refuse the repoint, keep the commit, and give the remediation
+for the case actually found — a blanket "run the installer" is a no-op in two
+of the four, because the dev installer short-circuits on a link that already
+points at its own checkout and skips any path that is already a symlink:
+
+- *No entry at all under the cache directory* — Team was never dev-installed
+  here. Run `script/dev-install claude` from `$PRIMARY_ROOT`.
+- *A symlink pointing at a `team-nuke-<date>` worktree of this same clone* — an
+  earlier experiment is still live. This is this skill's own doing, not a stale
+  foreign link. Name the date it carries and give both ways forward: finish
+  that experiment through its `NUKE.md` teardown, or undo its cache link
+  (relink the entry at `$PRIMARY_ROOT`) and re-run.
+- *A symlink pointing anywhere else* (another clone, or a linked worktree that
+  ran the installer) — the installer skips an existing symlink, so it does
+  nothing here. Print the entry path and its `readlink` target, and say to
+  `rm <entry>` first, then run `script/dev-install claude` from
+  `$PRIMARY_ROOT`.
+- *A real directory* — a plain, non-dev install. Run `script/dev-install claude`
+  from `$PRIMARY_ROOT`, which does relink that shape.
+
+Print the remediation; never run it. Removing another checkout's install is a
+machine-wide change, and this skill asks before every one of those.
+
+**A declined or failed repoint is not a failure of the run.** The commit
+stands. Print the exact command that would complete it and say the experiment
+is inert until it runs. Never roll a commit back to fix a machine-local step.
+
+## Final report
+
+Report all of this, every run:
+
+- **The repoint is machine-wide.** While the link points at the worktree, every
+  Claude Code session on this machine, in every repo, loads a Team with no
+  skills, no agents and no hooks. Live sessions keep whatever they loaded at
+  start; the change lands on their next restart.
+- **The one-line undo**, ready to paste:
+  `ln -sfn <primary root> <cache entry>`. It is idempotent and loses nothing.
+- **Known contamination.** The experiment is not a clean room. These survive
+  and are reported, never deleted: `~/.claude/CLAUDE.md`, `~/.claude/skills/`,
+  and any `CLAUDE.md` in an ancestor directory of the worktree path. The run
+  measures "Team removed", not "no instructions".
+- **The primary checkout is partially nuked from a session's point of view.**
+  It keeps its own `AGENTS.md` and `.claude/`, but loses every runtime skill
+  while the link is moved. Work in the worktree.
+- **The worktree's test suite is red by construction** — `tests/` survives
+  while its targets do not. **Do not repair them.** Repairing them is
+  contamination of the experiment.
+- Anything the run warned about: a dirty or ahead primary checkout, a rejected
+  tag push, a declined or failed repoint.
+
 ## NUKE.md template
 
 Step 6 writes `NUKE.md` at the worktree root. **Every value is written
@@ -364,6 +459,19 @@ agents/implementer file agents/implementer.md present -
 runtime-hooks group hooks/ present - .claude-plugin/plugin.json present 3b5d0c1a7f4e29806b5a4c3d2e1f0a9b8c7d6e5f
 dev-hooks group .claude/hooks/ present - .claude/settings.json present 8a4c2e6019bd7f35c4b3a2918070f6e5d4c3b2a1
 ```
+
+### The cache undo
+
+Idempotent, and it loses nothing: it points the dev install back at the primary
+clone, so the next session loads Team as it was. Written with the run's literal
+entry path and primary root, never a variable:
+
+```
+ln -sfn /Users/<you>/code/bostonaholic/team /Users/<you>/.claude/plugins/cache/team-dev/team/0.59.0
+```
+
+Running it does not end the experiment: the branch, the worktree and the
+archive all stay exactly as they were.
 
 ### Read-only inspection
 
@@ -419,7 +527,6 @@ the archive — but the experiment's own output is.
 
 ## Completion
 
-Report, in this order: the archive SHA and the branch it came from; the
-baseline tag and whether the push succeeded; the worktree path and the commit
-SHA; anything the run warned about (a dirty or ahead primary checkout, a
-rejected push); and the recovery line above.
+State the facts of the run — the archive SHA and the branch it came from, the
+baseline tag and whether its push succeeded, the worktree path and the commit
+SHA, and the recovery line above — then everything `## Final report` lists.

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -424,6 +424,188 @@ Report all of this, every run:
 - Anything the run warned about: a dirty or ahead primary checkout, a rejected
   tag push, a declined or failed repoint.
 
+## Restore mode
+
+`/nuke-team-plugin restore [<item>]` runs **from inside the experiment
+worktree**. Bare, it prints the manifest and stops. With an item id it proves
+every claim below before it writes anything; a failed proof refuses, names what
+failed, and writes nothing. The steps run in order, and none is skipped when an
+earlier one already looks convincing.
+
+**The write scope, stated once.** Restore checks out **every path on the item's
+line whose baseline is `present`** — including the whole-file checkout of a
+path whose recorded state is a hash, which is what makes `runtime-hooks` and
+`dev-hooks` restorable at all, since their manifests were edited rather than
+removed. A path whose baseline is `absent` is skipped, and each skip is named
+in the output. An item refuses only when *every* path on its line is `absent`.
+
+Checking out an edited manifest whole is equivalent to returning its `hooks`
+key, because the recorded hash proves the file is byte-for-byte what the nuke
+wrote, so the checkout changes that key and nothing else.
+
+### R1 — the argument
+
+Any first word other than `restore` prints the usage line and stops; the skill
+never guesses a mode. With no item id, print the manifest and stop. An item id
+is checked before it reaches anything:
+
+```sh
+LC_ALL=C
+case "$ITEM" in
+  ''|/*|*..*|*[!A-Za-z0-9._/-]*)
+    echo "refusing: '$ITEM' is not a valid item id — printing the manifest, nothing was written" >&2; exit 1 ;;
+esac
+```
+
+### R2 — location, branch, and containment
+
+`NUKE.md` must sit at the toplevel of the tree being restored into, and the
+current branch must equal the branch recorded in it. Neither is a proof — the
+file under test supplies the value it is compared against — so both are cheap
+consistency checks that catch the honest mistake with a clear message.
+
+The containment check is the one that matters: **refuse when the toplevel is
+the primary clone**. A path recorded with a hash is restorable in a tree that
+was never nuked, so "every recorded state is `-`" is not by itself a proof of
+where this is running.
+
+```sh
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+[ -f "${TOPLEVEL}/NUKE.md" ] ||
+  { echo "refusing: no NUKE.md at ${TOPLEVEL} — run this from inside the experiment worktree" >&2; exit 1; }
+COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+PRIMARY_ROOT="$(dirname "$COMMON_DIR")"
+[ "$TOPLEVEL" != "$PRIMARY_ROOT" ] ||
+  { echo "refusing: ${TOPLEVEL} is the primary clone, not an experiment worktree — restore never writes there" >&2; exit 1; }
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "$RECORDED_BRANCH" ] ||
+  { echo "refusing: on ${BRANCH}, but NUKE.md records ${RECORDED_BRANCH} — run 'git switch ${RECORDED_BRANCH}' and re-run" >&2; exit 1; }
+```
+
+### R3 — the manifest block and membership
+
+`NUKE.md` must carry exactly one fenced block whose info string is
+`nuke-manifest`. Zero or several is a refusal; the skill never picks one.
+Membership is an exact match on field 1, read with the digit-free
+`cut -d' ' -f1` and proved with `grep -qxF` — never a substring or a pattern
+match, either of which would let `skills/pr` open `skills/pr-cleanup`:
+
+```sh
+LC_ALL=C
+: "${TOPLEVEL:?}"
+OPENERS="$(grep -c '^[`]\{3\}nuke-manifest[[:space:]]*$' "${TOPLEVEL}/NUKE.md")"
+[ "$OPENERS" = 1 ] ||
+  { echo "refusing: NUKE.md carries ${OPENERS} nuke-manifest blocks, not exactly one" >&2; exit 1; }
+LINES="$(sed -n '/^[`]\{3\}nuke-manifest/,/^[`]\{3\}[[:space:]]*$/p' "${TOPLEVEL}/NUKE.md" | sed '1d;$d')"
+printf '%s\n' "$LINES" | cut -d' ' -f1 | grep -qxF -- "$ITEM" ||
+  { echo "refusing: '$ITEM' is not an item in the manifest" >&2; exit 1; }
+[ "$(printf '%s\n' "$LINES" | cut -d' ' -f1 | grep -cxF -- "$ITEM")" = 1 ] ||
+  { echo "refusing: duplicate manifest id '$ITEM'" >&2; exit 1; }
+```
+
+### R4 — validate the item's line
+
+A line that fails any check below is **refused, never repaired**:
+
+- Fewer than five fields, or fields from 3 onward that do not divide into whole
+  `<path> <baseline> <state>` triples.
+- A `<kind>` (field 2) outside `pair|tree|file|group`. It labels the report
+  only; no gate branches on it.
+- A `<baseline>` outside `present|absent`.
+- A `<state>` that is neither `-` nor 40 lowercase hex.
+- The combination `absent` with a hash, which is a contradiction.
+- A path that fails the R1 syntax check under `LC_ALL=C`, or that sits outside
+  the deletion-set roots hard-coded in Hard Rule 10, or that sits under
+  `.claude/skills/nuke-team-plugin/`.
+
+### R5 — prove the archive ref
+
+The recorded `ARCHIVE_SHA` and the recorded tag name come out of the same
+untrusted file, but only the tag is signed. So the tag name must match
+`^nuke-baseline/[0-9]{4}-[0-9]{2}-[0-9]{2}$`, `git tag -v` must verify it, and
+**the trusted commit is the peeled `^{}` value**. The recorded `ARCHIVE_SHA` is
+a cross-check that never reaches a command:
+
+```sh
+LC_ALL=C
+case "$RECORDED_TAG" in
+  nuke-baseline/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
+  *) echo "refusing: '$RECORDED_TAG' is not a dated nuke-baseline tag name" >&2; exit 1 ;;
+esac
+git rev-parse --verify --quiet "refs/tags/${RECORDED_TAG}" >/dev/null ||
+  { echo "refusing: ${RECORDED_TAG} is missing locally — run 'git fetch origin tag ${RECORDED_TAG}' and re-run" >&2; exit 1; }
+git tag -v "$RECORDED_TAG" ||
+  { echo "refusing: ${RECORDED_TAG} does not verify" >&2; exit 1; }
+ARCHIVE="$(git rev-parse "${RECORDED_TAG}^{}")"
+[ "$ARCHIVE" = "$RECORDED_ARCHIVE_SHA" ] ||
+  { echo "refusing: ${RECORDED_TAG} peels to ${ARCHIVE}, but NUKE.md records ${RECORDED_ARCHIVE_SHA} — the file was edited" >&2; exit 1; }
+```
+
+### R6 — the recorded-state gate
+
+`git checkout <sha> -- <path>` overwrites the working tree **and** the index,
+so both are checked for every `present` path. A state of `-` requires the path
+to be absent from each; the `-L` half is not decoration, because `-e` follows a
+link and a dangling symlink would otherwise read as absent. A hash requires the
+working file and the staged blob to both equal it, and a path missing from the
+index counts as a mismatch:
+
+```sh
+: "${TOPLEVEL:?}"
+if [ "$STATE" = "-" ]; then
+  { [ ! -e "$ITEM_PATH" ] && [ ! -L "$ITEM_PATH" ] && [ -z "$(git ls-files -- "$ITEM_PATH")" ]; } ||
+    { echo "refusing: ${ITEM_PATH} is recorded absent but exists in the tree or the index" >&2; exit 1; }
+else
+  [ "$(git hash-object -- "$ITEM_PATH")" = "$STATE" ] &&
+  [ "$(git rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
+    { echo "refusing: ${ITEM_PATH} no longer matches its recorded state ${STATE}" >&2; exit 1; }
+fi
+```
+
+This gate reads only present state, so the maintainer may commit freely in the
+worktree. Any mismatch refuses and names the offending path.
+
+### R7 — check out, then report
+
+```sh
+: "${ARCHIVE:?}"
+git checkout "$ARCHIVE" -- "$ITEM_PATH"
+```
+
+Report every path written, every `absent` path skipped and why, and that the
+restored files are live in a session only after a restart.
+
+### The re-restore escape
+
+Restoring the same item twice is refused by R6 — that is the idempotent
+outcome. A filesystem `rm` does **not** clear it, because the index entry
+survives and R6 checks the index too. The escape therefore goes through git.
+
+The nuke commit is derived, never read: `NUKE.md` sits inside that commit and
+cannot record its own SHA. It records `ARCHIVE_SHA`, and the nuke commit is the
+archive's only child on the experiment branch, which R2 has already established
+is the current branch:
+
+```sh
+: "${ARCHIVE:?}"
+NUKE_COMMIT="$(git rev-list --ancestry-path --reverse "${ARCHIVE}..HEAD" | head -1)"
+[ -n "$NUKE_COMMIT" ] ||
+  { echo "refusing: cannot derive the nuke commit from ${ARCHIVE}..HEAD" >&2; exit 1; }
+[ "$(git rev-parse "${NUKE_COMMIT}^")" = "$ARCHIVE" ] ||
+  { echo "refusing: the derived commit's parent is not the verified archive commit" >&2; exit 1; }
+```
+
+Then, per path on the item's line:
+
+- Recorded state `-` — return it with `git rm -r -f -- "$ITEM_PATH"`, which
+  clears the working tree and the index together.
+- Recorded state a hash — return it with
+  `git checkout "$NUKE_COMMIT" -- "$ITEM_PATH"`, restoring the exact bytes the
+  nuke wrote so the recorded hash matches again.
+
+For a manifest the maintainer edited on purpose, the alternative is a hand
+merge from `git show <ARCHIVE_SHA>:<path>`, which writes nothing.
+
 ## NUKE.md template
 
 Step 6 writes `NUKE.md` at the worktree root. **Every value is written
@@ -483,7 +665,24 @@ git log --oneline experiment/nuke-2026-08-28
 ```
 
 `git show <ARCHIVE_SHA>:AGENTS.md` prints the whole router, so a single section
-can be copied back by hand.
+can be copied back by hand. Written with the run's literal SHA:
+
+```
+git show 4f9a1c0b7d2e8f36a5b4c3d2e1f0a9b8c7d6e5f4:AGENTS.md
+```
+
+### The restore command
+
+The gated skill is the **only** write path into this tree. `NUKE.md` carries no
+raw checkout line, so nothing in it can write an arbitrary ref over an
+arbitrary path:
+
+```
+/nuke-team-plugin restore skills/pr-cleanup
+```
+
+Bare `/nuke-team-plugin restore` prints the manifest. Every id in the
+`nuke-manifest` block above is a valid argument.
 
 ### Recovery
 

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -60,10 +60,15 @@ The whole argument is at most two words.
    run at `$PRIMARY_ROOT` would stage the deletions on the default branch in
    the maintainer's own checkout. **Restore has no `$WORKTREE`**: it runs
    inside the experiment tree and binds to `$TOPLEVEL`, the value R2 derives
-   and proves. Every restore read and every restore write — R6's state gate,
-   R7's checkout, and the re-restore escape — carries `git -C "$TOPLEVEL"`
-   and resolves its path against `"$TOPLEVEL/"`, so no restore command is
-   bound by the caller's working directory alone.
+   and proves. **Restore's whole proof-and-write path — R2 through R7 — runs as
+   one Bash invocation**, so `$TOPLEVEL` (proved in R2) and `$ARCHIVE` (proved
+   in R5) are the exact values R6's gate and R7's checkout write against: the
+   value proved is the value used because no Bash boundary sits between the
+   proof and the write. The re-restore escape is its own single invocation that
+   re-establishes both proofs before it writes. Every restore read and every
+   restore write — R6's state gate, R7's checkout, and the re-restore escape —
+   carries `git -C "$TOPLEVEL"` and resolves its path against `"$TOPLEVEL/"`, so
+   no restore command is bound by the caller's working directory alone.
 2. **`$PRIMARY_ROOT` is detected, never assumed.** Step 0 derives it from
    `--git-common-dir` and validates it three ways, including against
    `worktree list --porcelain`. This repo carries linked worktrees, so being
@@ -79,7 +84,10 @@ The whole argument is at most two words.
    0 printed, never re-derived.** A run that starts before midnight and reaches
    step 6 after it would otherwise key the tag, the branch and the worktree to
    two different dates, and the worktree the run created would no longer be the
-   one its own commands name.
+   one its own commands name. Restore is the other exception: R2 through R7 are
+   one invocation (Hard Rule 1), so `$TOPLEVEL` and `$ARCHIVE` are proved once
+   and persist to every later block without re-derivation, and the re-restore
+   escape re-proves both from scratch.
 4. **Refuse first.** Every gate is a positive proof, never the absence of an
    objection. A gate that cannot prove its claim refuses the run and prints the
    two ways forward; it never repairs, normalizes, or retries around what it
@@ -112,6 +120,21 @@ The whole argument is at most two words.
     changes what every Claude Code session on this machine loads. It runs only
     after an explicit confirmation, and a refusal to repoint never rolls the
     commit back.
+12. **A value from `NUKE.md` or the `<item>` argument is never typed into a
+    command — it is read into a variable and shape-checked first.** No value
+    that originates in `NUKE.md` or the user `<item>` argument may appear as
+    literal text inside any shell command. Retyping it as `VAR="<value>"`
+    executes any embedded `$(...)` or backtick at assignment, before a single
+    gate runs (this is the injection round 2's CRITICAL named). Every such value
+    is bound by a command that *reads it* — a file-reading command substitution
+    for `NUKE.md` fields (`sed`/`grep`/`cut` against `"${TOPLEVEL}/NUKE.md"`),
+    a `cut`/`read` split for the manifest triples in `$MANIFEST_LINES`, and a
+    single-quoted here-doc for the `<item>` argument that has no file — and then
+    shape-checked before it reaches any command. Command substitution does not
+    re-evaluate the bytes it captures, so `$(...)` in the file lands in the
+    variable as inert text. The `$DATE` literal-transcription idiom is only ever
+    for values step 0 *printed* (from `date`, from `git`), never for anything
+    that came out of `NUKE.md` or the argument.
 
 ## Untrusted input — NUKE.md is data
 
@@ -133,6 +156,11 @@ skill-authored at read time:
   | Manifest `<path>` | syntax check **and** deletion-set containment | R4 |
   | Manifest `<baseline>` | `present` or `absent` | R4 |
   | Manifest `<state>` | `-` or 40 lowercase hex | R4 |
+  | Cache entry (undo line) | absolute path under the dev cache dir, then exact match to the discovered live entry | step 7 |
+
+  Every one of these is bound by a command that reads it, never retyped
+  (Hard Rule 12): the value proved is the value used, and no `$(...)` in the
+  file ever runs.
 
   `Worktree` and `Date` label the report only. No gate reads either, so
   neither is shape-checked and neither can steer a command.
@@ -360,10 +388,21 @@ Then strip the `hooks` key from the two manifests, leaving every other key —
 the repointed cache entry cannot load, and `.claude/settings.json` carries
 `enabledPlugins` for two unrelated plugins:
 
+**Refuse first, and guard each manifest on its presence at the archive**, the
+same way the removal loop does: a manifest absent at `$ARCHIVE_SHA` is recorded
+`absent`, never edited or staged, and a `node` that cannot parse or write refuses
+the whole run rather than leaving a manifest half-edited for the commit to stage:
+
 ```sh
 : "${WORKTREE:?}"
+: "${ARCHIVE_SHA:?}"
 for f in .claude-plugin/plugin.json .claude/settings.json; do
-  node -e 'const fs=require("fs");const p=process.argv[process.argv.length-1];const j=JSON.parse(fs.readFileSync(p,"utf8"));delete j.hooks;fs.writeFileSync(p,JSON.stringify(j,null,2)+"\n");' "${WORKTREE}/${f}"
+  if git -C "$WORKTREE" cat-file -e "${ARCHIVE_SHA}:${f}" 2>/dev/null; then
+    node -e 'const fs=require("fs");const p=process.argv[process.argv.length-1];const j=JSON.parse(fs.readFileSync(p,"utf8"));delete j.hooks;fs.writeFileSync(p,JSON.stringify(j,null,2)+"\n");' "${WORKTREE}/${f}" ||
+      { echo "refusing: could not strip the hooks key from ${f} — its JSON did not parse or the write failed" >&2; exit 1; }
+  else
+    printf 'absent at %s, will be recorded absent in the manifest: %s\n' "$ARCHIVE_SHA" "$f"
+  fi
 done
 ```
 
@@ -435,9 +474,14 @@ emit_item
 ENTRIES="$(for ROOT in skills agents .claude/skills; do
   git -C "$WORKTREE" ls-tree -z --name-only "$ARCHIVE_SHA" -- "${ROOT}/" | tr '\0' '\n'
 done)"
-OLD_IFS="$IFS"; IFS='
-'
-for ENTRY in $ENTRIES; do
+# Iterate with `while IFS= read -r`, never a bare for-in over an unquoted
+# expansion: the Bash tool's shell is zsh, which does NOT word-split an
+# unquoted expansion, so that form would run once over the whole blob. The
+# here-doc feeds the loop in
+# the current shell (never a pipe), so MANIFEST keeps accumulating and a refusal
+# `exit 1` aborts the whole run. The two other enumeration loops use the same
+# idiom.
+while IFS= read -r ENTRY; do
   case "$ENTRY" in ''|.claude/skills/nuke-team-plugin) continue ;; esac
   # Round-trip proof: every entry came from ls-tree at this SHA, so one that
   # no longer resolves means the NUL-to-newline split cut a path in half.
@@ -451,8 +495,9 @@ for ENTRY in $ENTRIES; do
   esac
   K=removed; add_triple
   emit_item
-done
-IFS="$OLD_IFS"
+done <<ENUMERATED
+$ENTRIES
+ENUMERATED
 
 FIELDS=; ID=runtime-hooks; KIND=group
 P=hooks/; K=removed; add_triple
@@ -492,10 +537,20 @@ byte for byte. Then:
 Write `NUKE.md` at the worktree root from `## NUKE.md template`, then stage and
 commit — signed, with no unsigned fallback:
 
+Stage `NUKE.md` always, and each edited manifest only when it was present at the
+archive — the mirror of the presence guard on the `node` edit above, so a run
+that nuked a partial surface never fails on a `git add` of a manifest that never
+existed:
+
 ```sh
 : "${WORKTREE:?}"
+: "${ARCHIVE_SHA:?}"
 DATE="<the literal value step 0 printed>"
-git -C "$WORKTREE" add -- NUKE.md .claude-plugin/plugin.json .claude/settings.json
+git -C "$WORKTREE" add -- NUKE.md
+for f in .claude-plugin/plugin.json .claude/settings.json; do
+  git -C "$WORKTREE" cat-file -e "${ARCHIVE_SHA}:${f}" 2>/dev/null &&
+    git -C "$WORKTREE" add -- "$f"
+done
 git -C "$WORKTREE" commit -S -m "experiment: nuke Team's instruction surface (${DATE})"
 ```
 
@@ -528,7 +583,10 @@ CACHE_DIR="${HOME}/.claude/plugins/cache/team-dev/team"
   { echo "no cache entry at all: ${CACHE_DIR} does not exist — Team was never dev-installed on this machine" >&2; exit 1; }
 find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -print |
   while IFS= read -r entry; do
-    printf '%s\t%s\t%s\n' "$entry" "$([ -L "$entry" ] && echo symlink || echo directory)" "$(readlink "$entry" || true)"
+    if [ -L "$entry" ]; then kind=symlink
+    elif [ -d "$entry" ]; then kind=directory
+    else kind=file; fi
+    printf '%s\t%s\t%s\n' "$entry" "$kind" "$(readlink "$entry" || true)"
   done
 ```
 
@@ -540,11 +598,29 @@ explicit confirmation — this changes what every Claude Code session on the
 machine loads. Name the entry, its current target, and the worktree it will
 point at. Only after the user agrees:
 
+`$CACHE_ENTRY` is the single discovered match, bound from the scan above — a
+trusted filesystem path. `$RECORDED_ENTRY` comes out of the committed `NUKE.md`,
+so it is **read from the file, never retyped** (Hard Rule 12), and shape-checked
+before the equality gate:
+
 ```sh
 : "${PRIMARY_ROOT:?}"
 : "${WORKTREE:?}"
 : "${CACHE_ENTRY:?}"
-: "${RECORDED_ENTRY:?}"
+CACHE_DIR="${HOME}/.claude/plugins/cache/team-dev/team"
+# The undo line is `ln -sfn <primary root> <cache entry>`; the recorded entry is
+# its last whitespace-separated field. Reading it with sed keeps any `$(...)`
+# planted in NUKE.md inert — command substitution never re-evaluates captured
+# bytes.
+RECORDED_ENTRY="$(grep -E '^ln -sfn ' "${WORKTREE}/NUKE.md" | head -1 | sed -E 's/^ln -sfn .* //')"
+case "$RECORDED_ENTRY" in
+  *..*|*[!A-Za-z0-9._/-]*|'')
+    echo "refusing the repoint: NUKE.md's undo entry '${RECORDED_ENTRY}' fails the syntax check" >&2; exit 1 ;;
+esac
+case "$RECORDED_ENTRY" in
+  "${CACHE_DIR}/"*) : ;;
+  *) echo "refusing the repoint: NUKE.md's undo entry '${RECORDED_ENTRY}' is not under ${CACHE_DIR} — correct NUKE.md by hand, then re-run" >&2; exit 1 ;;
+esac
 [ "$CACHE_ENTRY" = "$RECORDED_ENTRY" ] ||
   { echo "refusing the repoint: the live entry is ${CACHE_ENTRY}, but NUKE.md's undo line names ${RECORDED_ENTRY} — the cache changed since the commit; correct NUKE.md by hand, then re-run" >&2; exit 1; }
 ln -sfn "$WORKTREE" "$CACHE_ENTRY"
@@ -649,6 +725,21 @@ every claim below before it writes anything; a failed proof refuses, names what
 failed, and writes nothing. The steps run in order, and none is skipped when an
 earlier one already looks convincing.
 
+**R2 through R7 are one Bash invocation.** Run them as a single script, in
+order, in one shell — `$TOPLEVEL` (proved in R2) and `$ARCHIVE` (proved in R5)
+must be the exact values R6's gate and R7's checkout write against, and shell
+state does not survive a Bash boundary (Hard Rule 3). Splitting the blocks
+across separate Bash calls loses both bindings, so the value proved is no longer
+the value used. The re-restore escape is a separate, deliberate invocation that
+re-establishes both proofs from scratch before it writes.
+
+**Every value read from `NUKE.md` is bound by a file-reading command
+substitution, and the `<item>` argument by a quoted here-doc — never retyped**
+(Hard Rule 12). Retyping a NUKE.md value or the argument into `VAR="<value>"`
+would execute any embedded `$(...)` at assignment, before a single gate runs.
+The manifest triples are split out of `$MANIFEST_LINES` with parameter
+expansion, never read off the line by eye.
+
 **The write scope, stated once.** Restore checks out **every path on the item's
 line whose baseline is `present`** — including the whole-file checkout of a
 path whose recorded state is a hash, which is what makes `runtime-hooks` and
@@ -669,10 +760,19 @@ is checked before it reaches anything.
 The block below runs **only on the with-an-item path**, after the bare-restore
 branch above has already been taken and returned. An empty `$ITEM` reaching it
 therefore means the mode dispatch was skipped, which is a refusal and not a
-second spelling of bare restore — hence the `''` case:
+second spelling of bare restore — hence the `''` case.
+
+`<item>` is untrusted and has no file to read it from, so it is bound with a
+**single-quoted here-doc** (`<<'RESTORE_ITEM'`), whose body is never expanded:
+a `$(...)` in the argument lands in `$ITEM` as inert text instead of running at
+assignment (Hard Rule 12). The shape check then runs before `$ITEM` reaches any
+command. Paste the raw argument on the line between the markers, nothing else:
 
 ```sh
 export LC_ALL=C
+IFS= read -r ITEM <<'RESTORE_ITEM'
+<the item argument, pasted here verbatim — no surrounding quotes, no edits>
+RESTORE_ITEM
 case "$ITEM" in
   ''|/*|*..*|*[!A-Za-z0-9._/-]*)
     echo "refusing: '$ITEM' is not a valid item id — printing the manifest, nothing was written" >&2; exit 1 ;;
@@ -716,16 +816,23 @@ case "$TOPLEVEL" in
 esac
 git -C "$PRIMARY_ROOT" worktree list --porcelain | grep -qxF "worktree ${TOPLEVEL}" ||
   { echo "refusing: ${TOPLEVEL} is not a registered worktree of ${PRIMARY_ROOT}" >&2; exit 1; }
+RECORDED_BRANCH="$(sed -n 's/^- Branch: //p' "${TOPLEVEL}/NUKE.md" | head -1)"
 case "$RECORDED_BRANCH" in
   experiment/nuke-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
   *) echo "refusing: NUKE.md records branch '$RECORDED_BRANCH', which is not a dated experiment/nuke name" >&2; exit 1 ;;
 esac
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+BRANCH="$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)"
 [ "$BRANCH" = "$RECORDED_BRANCH" ] ||
   { echo "refusing: on ${BRANCH}, but NUKE.md records ${RECORDED_BRANCH} — run 'git switch ${RECORDED_BRANCH}' and re-run" >&2; exit 1; }
 ```
 
-### R3 — the manifest block and membership
+`$RECORDED_BRANCH` is read from the `- Branch:` header line of `NUKE.md` by a
+command substitution over `sed`, never retyped (Hard Rule 12), and shape-checked
+before the comparison. `git rev-parse --show-toplevel` and `--git-common-dir`
+stay bare — they establish *where this is running* from the caller's directory —
+but every read after `$TOPLEVEL` is proved carries `git -C "$TOPLEVEL"`.
+
+### R3 — the manifest block, membership, and the item's line
 
 `NUKE.md` must carry exactly one fenced block whose info string is
 `nuke-manifest`. Zero or several is a refusal; the skill never picks one.
@@ -733,92 +840,177 @@ Membership is an exact match on field 1, read with the digit-free
 `cut -d' ' -f1` and proved with `grep -qxF` — never a substring or a pattern
 match, either of which would let `skills/pr` open `skills/pr-cleanup`:
 
-**The counter and the extractor use one identical, end-anchored regex.** Two
-spellings of "the opener" is a parser differential: an end-anchored `grep -c`
-paired with an unanchored `sed` counts one block but extracts from a
-`nuke-manifestX` decoy fence that the count never saw. The anchored form
-`^```nuke-manifest[[:space:]]*$` appears in both, character for character:
+**The opener is one anchored regex** in both the counter and the range start:
+an end-anchored `grep -c` paired with an unanchored `sed` counts one block but
+extracts from a `nuke-manifestX` decoy fence that the count never saw. The
+anchored form `^```nuke-manifest[[:space:]]*$` appears in both, character for
+character. **The closer matches a CommonMark closing fence** — up to three
+leading spaces, then three *or more* backticks — so a `````` line inside the
+block closes the range instead of being swallowed. An unclosed or mis-nested
+fence that still runs the range on is caught by the grammar assertion below:
+every extracted line must be a whole `<id> <kind> <path> <baseline> <state>`
+record, and the extracted count must equal the count that matches the grammar.
+
+**The variable is `MANIFEST_LINES`, never `LINES`.** `LINES` is a zsh special
+integer parameter (the terminal's line count); the Bash tool runs zsh, and
+assigning a manifest string to `LINES` makes zsh arithmetic-evaluate it on the
+next use — `bad math expression` — aborting the run after nothing has been
+written. The name is load-bearing.
 
 ```sh
 export LC_ALL=C
 : "${TOPLEVEL:?}"
-OPENERS="$(grep -c '^[`]\{3\}nuke-manifest[[:space:]]*$' "${TOPLEVEL}/NUKE.md")"
+NUKE_MD="${TOPLEVEL}/NUKE.md"
+OPENERS="$(grep -c '^[`]\{3\}nuke-manifest[[:space:]]*$' "$NUKE_MD")"
 [ "$OPENERS" = 1 ] ||
   { echo "refusing: NUKE.md carries ${OPENERS} nuke-manifest blocks, not exactly one" >&2; exit 1; }
-LINES="$(sed -n '/^[`]\{3\}nuke-manifest[[:space:]]*$/,/^[`]\{3\}[[:space:]]*$/p' "${TOPLEVEL}/NUKE.md" | sed '1d;$d')"
-printf '%s\n' "$LINES" | cut -d' ' -f1 | grep -qxF -- "$ITEM" ||
+MANIFEST_LINES="$(sed -n '/^[`]\{3\}nuke-manifest[[:space:]]*$/,/^ \{0,3\}[`]\{3,\}[[:space:]]*$/p' "$NUKE_MD" | sed '1d;$d')"
+MANIFEST_GRAMMAR='^[A-Za-z0-9._/-]+ (pair|tree|file|group)( [A-Za-z0-9._/-]+ (present|absent) (-|[0-9a-f]{40}))+$'
+TOTAL="$(printf '%s\n' "$MANIFEST_LINES" | grep -c .)"
+GOOD="$(printf '%s\n' "$MANIFEST_LINES" | grep -Ec "$MANIFEST_GRAMMAR")"
+[ "$TOTAL" = "$GOOD" ] ||
+  { echo "refusing: the nuke-manifest block has ${TOTAL} lines but ${GOOD} match the <id> <kind> <path> <baseline> <state> grammar — the fence is malformed or the block was edited" >&2; exit 1; }
+printf '%s\n' "$MANIFEST_LINES" | cut -d' ' -f1 | grep -qxF -- "$ITEM" ||
   { echo "refusing: '$ITEM' is not an item in the manifest" >&2; exit 1; }
-[ "$(printf '%s\n' "$LINES" | cut -d' ' -f1 | grep -cxF -- "$ITEM")" = 1 ] ||
+[ "$(printf '%s\n' "$MANIFEST_LINES" | cut -d' ' -f1 | grep -cxF -- "$ITEM")" = 1 ] ||
   { echo "refusing: duplicate manifest id '$ITEM'" >&2; exit 1; }
 ```
 
-### R4 — validate the item's line
+Then extract **the item's own line** by an exact match on field 1 — pipe-free,
+so it never depends on `$ITEM` being regex-safe — for R4 through R7 to read:
 
-A line that fails any check below is **refused, never repaired**:
+```sh
+MANIFEST_LINE=""
+while IFS= read -r ml; do
+  [ -n "$ml" ] || continue
+  id="${ml%% *}"
+  [ "$id" = "$ITEM" ] && MANIFEST_LINE="$ml"
+done <<MANIFEST_RECORDS
+$MANIFEST_LINES
+MANIFEST_RECORDS
+[ -n "$MANIFEST_LINE" ] ||
+  { echo "refusing: could not extract the manifest line for '$ITEM'" >&2; exit 1; }
+```
 
-- Fewer than five fields, or fields from 3 onward that do not divide into whole
-  `<path> <baseline> <state>` triples.
-- A `<kind>` (field 2) outside `pair|tree|file|group`. It labels the report
-  only; no gate branches on it.
-- A `<baseline>` outside `present|absent`.
-- A `<state>` that is neither `-` nor 40 lowercase hex.
-- The combination `absent` with a hash, which is a contradiction.
-- A path that fails the syntax check under `LC_ALL=C`, or that sits outside the
-  deletion-set roots hard-coded in Hard Rule 10, or that sits under
-  `.claude/skills/nuke-team-plugin/`.
+### R4 — validate every triple on the line
 
-**The path check is a runnable block, not a description.** `$ITEM_PATH` comes
-out of an untrusted file and goes on to reach `hash-object`, `ls-files`,
-`checkout` and `git rm -r -f`; nothing else stands between it and them. Run
-this against **every** path on the line, before any of those:
+**One runnable gate, run over every `<path> <baseline> <state>` triple on the
+line — not a prose description.** `$ITEM_PATH` comes out of an untrusted file
+and goes on to reach `hash-object`, `ls-files`, `checkout` and `git rm -r -f`;
+nothing else stands between it and them. The block folds all six checks the
+review named into one loop: field count / triple divisibility, the `<kind>`
+enum, the `<baseline>` enum, the `<state>` format, the `absent`-with-a-hash
+contradiction, and the path's syntax / own-directory exclusion / deletion-set
+containment. It also builds the normalized `$TRIPLES` that R6 and R7 re-read, so
+the fields are split **once**, with parameter expansion, and never re-read off
+the line by eye:
 
 ```sh
 export LC_ALL=C
-case "$ITEM_PATH" in
-  ''|/*|*..*|*[!A-Za-z0-9._/-]*)
-    echo "refusing: manifest path '$ITEM_PATH' fails the syntax check" >&2; exit 1 ;;
+: "${MANIFEST_LINE:?}"
+KIND="${MANIFEST_LINE#* }"; KIND="${KIND%% *}"
+case "$KIND" in
+  pair|tree|file|group) ;;
+  *) echo "refusing: item kind '$KIND' is not pair|tree|file|group" >&2; exit 1 ;;
 esac
-case "$ITEM_PATH" in
-  .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*)
-    echo "refusing: manifest path '$ITEM_PATH' is inside this skill's own directory, which the nuke never removed" >&2; exit 1 ;;
-esac
-case "$ITEM_PATH" in
-  AGENTS.md|CLAUDE.md|skills/*|agents/*|hooks/*|.claude/hooks/*|.claude/skills/*|.claude-plugin/plugin.json|.claude/settings.json) ;;
-  *) echo "refusing: manifest path '$ITEM_PATH' sits outside the deletion-set roots of Hard Rule 10" >&2; exit 1 ;;
-esac
+REST="${MANIFEST_LINE#* }"; REST="${REST#* }"   # drop <id> and <kind>
+TRIPLES=""
+n=0; ITEM_PATH=""; BASELINE=""; STATE=""
+while [ -n "$REST" ]; do
+  tok="${REST%% *}"
+  case "$REST" in *' '*) REST="${REST#* }" ;; *) REST="" ;; esac
+  [ -n "$tok" ] || continue
+  n=$((n + 1))
+  case "$n" in
+    1) ITEM_PATH="$tok" ;;
+    2) BASELINE="$tok" ;;
+    3)
+      STATE="$tok"; n=0
+      case "$ITEM_PATH" in
+        ''|/*|*..*|*[!A-Za-z0-9._/-]*)
+          echo "refusing: manifest path '$ITEM_PATH' fails the syntax check" >&2; exit 1 ;;
+      esac
+      ITEM_PATH_LC="$(printf '%s' "$ITEM_PATH" | tr 'A-Z' 'a-z')"
+      case "$ITEM_PATH_LC" in
+        .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*)
+          echo "refusing: manifest path '$ITEM_PATH' is inside this skill's own directory, which the nuke never removed" >&2; exit 1 ;;
+      esac
+      case "$ITEM_PATH" in
+        AGENTS.md|CLAUDE.md|skills/*|agents/*|hooks/*|.claude/hooks/*|.claude/skills/*|.claude-plugin/plugin.json|.claude/settings.json) ;;
+        *) echo "refusing: manifest path '$ITEM_PATH' sits outside the deletion-set roots of Hard Rule 10" >&2; exit 1 ;;
+      esac
+      case "$BASELINE" in
+        present|absent) ;;
+        *) echo "refusing: baseline '$BASELINE' for '$ITEM_PATH' is not present|absent" >&2; exit 1 ;;
+      esac
+      case "$STATE" in
+        -) ;;
+        *[!0-9a-f]*) echo "refusing: state for '$ITEM_PATH' is neither '-' nor lowercase hex" >&2; exit 1 ;;
+        *) [ "${#STATE}" = 40 ] || { echo "refusing: state for '$ITEM_PATH' is ${#STATE} hex chars, not 40" >&2; exit 1; } ;;
+      esac
+      { [ "$BASELINE" = absent ] && [ "$STATE" != - ]; } &&
+        { echo "refusing: '$ITEM_PATH' is recorded absent but carries a hash state — a contradiction" >&2; exit 1; }
+      TRIPLES="${TRIPLES}${ITEM_PATH} ${BASELINE} ${STATE}
+"
+      ;;
+  esac
+done
+[ "$n" = 0 ] ||
+  { echo "refusing: the item line does not divide into whole <path> <baseline> <state> triples" >&2; exit 1; }
+[ -n "$TRIPLES" ] ||
+  { echo "refusing: the item line carries no paths" >&2; exit 1; }
 ```
 
 The exclusion case is tested **before** the containment case, on purpose:
 `.claude/skills/nuke-team-plugin/SKILL.md` matches `.claude/skills/*`, so
 ordering them the other way would admit the one path the nuke must never write.
-This is the same `check_path` the generator runs in step 6 — both ends of the
+These are the same checks `check_path` runs in step 6 — both ends of the
 manifest are checked, so a hand-edited `NUKE.md` gains nothing a generated one
 could not already say.
 
 ### R5 — prove the archive ref
 
-The recorded `ARCHIVE_SHA` and the recorded tag name come out of the same
-untrusted file, but only the tag is signed. So the tag name must match
+The recorded tag name and `ARCHIVE_SHA` come out of the same untrusted file, so
+both are **read from `NUKE.md` by `sed`, never retyped** (Hard Rule 12). Only
+the tag is signed, so the tag name must match
 `^nuke-baseline/[0-9]{4}-[0-9]{2}-[0-9]{2}$`, `git tag -v` must verify it, and
-**the trusted commit is the peeled `^{}` value**. The recorded `ARCHIVE_SHA` is
-a cross-check that never reaches a command:
+**the trusted commit is the peeled `^{}` value**; the recorded `ARCHIVE_SHA` is
+a cross-check that never reaches a command.
+
+**The tag is bound to THIS experiment, not merely to a valid signature.** The
+date is derived once from the proved `$TOPLEVEL` worktree name and must key both
+the recorded tag and the recorded branch — otherwise an edited `NUKE.md` could
+name any other date's verified `nuke-baseline/<other-date>`. Every git read
+carries `git -C "$TOPLEVEL"` behind a standalone guard (Hard Rule 1):
 
 ```sh
 export LC_ALL=C
+: "${TOPLEVEL:?}"
+RECORDED_TAG="$(sed -n 's/^- Baseline tag: //p' "${TOPLEVEL}/NUKE.md" | head -1)"
+RECORDED_ARCHIVE_SHA="$(sed -n 's/^- Archive SHA: //p' "${TOPLEVEL}/NUKE.md" | head -1)"
 case "$RECORDED_TAG" in
   nuke-baseline/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
   *) echo "refusing: '$RECORDED_TAG' is not a dated nuke-baseline tag name" >&2; exit 1 ;;
 esac
+NUKE_DATE="${TOPLEVEL##*/team-nuke-}"
+case "$NUKE_DATE" in
+  [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
+  *) echo "refusing: cannot read a dated worktree name from ${TOPLEVEL}" >&2; exit 1 ;;
+esac
+[ "$RECORDED_TAG" = "nuke-baseline/${NUKE_DATE}" ] ||
+  { echo "refusing: NUKE.md names tag ${RECORDED_TAG}, not nuke-baseline/${NUKE_DATE} for this worktree — the file was edited" >&2; exit 1; }
+[ "$RECORDED_BRANCH" = "experiment/nuke-${NUKE_DATE}" ] ||
+  { echo "refusing: NUKE.md names branch ${RECORDED_BRANCH}, not experiment/nuke-${NUKE_DATE} for this worktree — the file was edited" >&2; exit 1; }
 case "$RECORDED_ARCHIVE_SHA" in
   *[!0-9a-f]*|'') echo "refusing: NUKE.md's archive SHA is not lowercase hex" >&2; exit 1 ;;
 esac
 [ "${#RECORDED_ARCHIVE_SHA}" = 40 ] ||
   { echo "refusing: NUKE.md's archive SHA is ${#RECORDED_ARCHIVE_SHA} characters, not 40" >&2; exit 1; }
-git rev-parse --verify --quiet "refs/tags/${RECORDED_TAG}" >/dev/null ||
+git -C "$TOPLEVEL" rev-parse --verify --quiet "refs/tags/${RECORDED_TAG}" >/dev/null ||
   { echo "refusing: ${RECORDED_TAG} is missing locally — run 'git fetch origin tag ${RECORDED_TAG}' and re-run" >&2; exit 1; }
-git tag -v "$RECORDED_TAG" ||
+git -C "$TOPLEVEL" tag -v "$RECORDED_TAG" ||
   { echo "refusing: ${RECORDED_TAG} does not verify" >&2; exit 1; }
-ARCHIVE="$(git rev-parse "${RECORDED_TAG}^{}")"
+ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "${RECORDED_TAG}^{}")"
 [ "$ARCHIVE" = "$RECORDED_ARCHIVE_SHA" ] ||
   { echo "refusing: ${RECORDED_TAG} peels to ${ARCHIVE}, but NUKE.md records ${RECORDED_ARCHIVE_SHA} — the file was edited" >&2; exit 1; }
 ```
@@ -833,44 +1025,72 @@ working file and the staged blob to both equal it, and a path missing from the
 index counts as a mismatch:
 
 **Every command here binds to `$TOPLEVEL`.** The `git -C "$TOPLEVEL"` prefix
-and the `"${TOPLEVEL}/${ITEM_PATH}"` resolution are what make the guard above
-them load-bearing: with bare `git` and a relative path, this gate would check
-one tree while R7 wrote into whichever tree the caller happened to `cd` into.
+and the `"${TOPLEVEL}/${ITEM_PATH}"` resolution are what make the guard
+load-bearing: with bare `git` and a relative path, this gate would check one
+tree while R7 wrote into whichever tree the caller happened to `cd` into. R7's
+loop applies this gate to each `present` triple before it checks that path out,
+so multi-path items (`pair`, `group`) are gated and restored path by path
+rather than as a single unchecked write. The gate reads only present state, so
+the maintainer may commit freely in the worktree.
 
-```sh
-: "${TOPLEVEL:?}"
-if [ "$STATE" = "-" ]; then
-  { [ ! -e "${TOPLEVEL}/${ITEM_PATH}" ] && [ ! -L "${TOPLEVEL}/${ITEM_PATH}" ] &&
-    [ -z "$(git -C "$TOPLEVEL" ls-files -- "$ITEM_PATH")" ]; } ||
-    { echo "refusing: ${ITEM_PATH} is recorded absent but exists in the tree or the index" >&2; exit 1; }
-else
-  [ "$(git -C "$TOPLEVEL" hash-object -- "${TOPLEVEL}/${ITEM_PATH}")" = "$STATE" ] &&
-  [ "$(git -C "$TOPLEVEL" rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
-    { echo "refusing: ${ITEM_PATH} no longer matches its recorded state ${STATE}" >&2; exit 1; }
-fi
-```
+### R7 — check out every present path, then report
 
-This gate reads only present state, so the maintainer may commit freely in the
-worktree. Any mismatch refuses and names the offending path.
-
-### R7 — check out, then report
+**One loop over `$TRIPLES` — R4's normalized `<path> <baseline> <state>` per
+line — applies R6's gate and then the checkout to each `present` path.** An
+`absent` path is skipped and named; the item refuses only when *every* path was
+absent, so nothing silently restores a partial item and nothing silently
+restores nothing. Both the gate and the write carry `git -C "$TOPLEVEL"`, so
+they land in the tree R2 proved and nowhere else:
 
 ```sh
 : "${TOPLEVEL:?}"
 : "${ARCHIVE:?}"
-git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH"
+: "${TRIPLES:?}"
+WROTE=0
+while IFS=' ' read -r ITEM_PATH BASELINE STATE; do
+  [ -n "$ITEM_PATH" ] || continue
+  if [ "$BASELINE" = absent ]; then
+    printf 'skipping %s — recorded absent at the archive, nothing to restore\n' "$ITEM_PATH"
+    continue
+  fi
+  # R6 recorded-state gate for this present path, working tree AND index.
+  if [ "$STATE" = "-" ]; then
+    { [ ! -e "${TOPLEVEL}/${ITEM_PATH}" ] && [ ! -L "${TOPLEVEL}/${ITEM_PATH}" ] &&
+      [ -z "$(git -C "$TOPLEVEL" ls-files -- "$ITEM_PATH")" ]; } ||
+      { echo "refusing: ${ITEM_PATH} is recorded removed but exists in the tree or the index" >&2; exit 1; }
+  else
+    [ "$(git -C "$TOPLEVEL" hash-object -- "${TOPLEVEL}/${ITEM_PATH}")" = "$STATE" ] &&
+    [ "$(git -C "$TOPLEVEL" rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
+      { echo "refusing: ${ITEM_PATH} no longer matches its recorded state ${STATE}" >&2; exit 1; }
+  fi
+  git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH"
+  printf 'restored %s\n' "$ITEM_PATH"
+  WROTE=$((WROTE + 1))
+done <<ITEM_TRIPLES
+$TRIPLES
+ITEM_TRIPLES
+[ "$WROTE" -ge 1 ] ||
+  { echo "refusing: every path on '$ITEM' is recorded absent — nothing to restore" >&2; exit 1; }
 ```
 
-The only write in this mode carries `git -C "$TOPLEVEL"`, so it lands in the
-tree R2 proved and nowhere else. Report every path written, every `absent` path
-skipped and why, and that the restored files are live in a session only after a
-restart.
+The `-L` half of the `-` gate is not decoration: `-e` follows a link, so a
+dangling symlink would otherwise read as absent. Report every path written,
+every `absent` path skipped and why, and that the restored files are live in a
+session only after a restart.
 
 ### The re-restore escape
 
 Restoring the same item twice is refused by R6 — that is the idempotent
 outcome. A filesystem `rm` does **not** clear it, because the index entry
 survives and R6 checks the index too. The escape therefore goes through git.
+
+**The escape is its own separate invocation, so it re-proves what it needs
+rather than trusting a variable from the main path** (Hard Rule 3): shell state
+does not survive a Bash boundary, and a bare `${VAR:?}` guard would only prove a
+value is non-empty, not that it was ever proved. Before it writes, the escape
+**re-runs R2's containment proof and R5's tag verification from scratch** — the
+same blocks, in the same invocation as the writes below — to re-derive
+`$TOPLEVEL`, `$ARCHIVE`, and the item's `$TRIPLES`. Only then:
 
 The nuke commit is derived, never read: `NUKE.md` sits inside that commit and
 cannot record its own SHA. It records `ARCHIVE_SHA`, and the nuke commit is the
@@ -880,27 +1100,44 @@ is the current branch:
 ```sh
 : "${TOPLEVEL:?}"
 : "${ARCHIVE:?}"
+: "${TRIPLES:?}"
 NUKE_COMMIT="$(git -C "$TOPLEVEL" rev-list --ancestry-path --reverse "${ARCHIVE}..HEAD" | head -1)"
 [ -n "$NUKE_COMMIT" ] ||
   { echo "refusing: cannot derive the nuke commit from ${ARCHIVE}..HEAD" >&2; exit 1; }
 [ "$(git -C "$TOPLEVEL" rev-parse "${NUKE_COMMIT}^")" = "$ARCHIVE" ] ||
   { echo "refusing: the derived commit's parent is not the verified archive commit" >&2; exit 1; }
+while IFS=' ' read -r ITEM_PATH BASELINE STATE; do
+  [ -n "$ITEM_PATH" ] || continue
+  [ "$BASELINE" = absent ] && continue
+  if [ "$STATE" = "-" ]; then
+    git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH"
+  else
+    git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH"
+  fi
+done <<ITEM_TRIPLES
+$TRIPLES
+ITEM_TRIPLES
 ```
 
-Then, per path on the item's line — both destructive, and both bound to
-`$TOPLEVEL` like every other restore write:
-
-- Recorded state `-` — return it with
-  `git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH"`, which clears the working tree
-  and the index together.
-- Recorded state a hash — return it with
-  `git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH"`, restoring the
-  exact bytes the nuke wrote so the recorded hash matches again.
+Per path on the item's line, both writes are destructive and both bound to
+`$TOPLEVEL` like every other restore write: a recorded state `-` is returned
+with `git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH"`, which clears the working
+tree and the index together; a recorded hash is returned with
+`git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH"`, restoring the exact
+bytes the nuke wrote so the recorded hash matches again.
 
 For a manifest the maintainer edited on purpose, the alternative is a hand
 merge from `git show <ARCHIVE_SHA>:<path>`, which writes nothing.
 
 ## NUKE.md template
+
+> **`NUKE.md` is a tracked, model-writable file, not a trusted script.** It is
+> written into a tree the observed model can also edit. Every destructive line
+> below — the teardown sequence, the `reset --hard`, the cache undo — is a
+> **paste-ready template a human reads and runs by hand**, never something this
+> skill sources or trusts. When the skill itself reads a value back out of
+> `NUKE.md` (restore's R2/R3/R5, step 7's undo entry) it re-derives and
+> shape-checks it (Hard Rule 12); it never trusts the recorded value on sight.
 
 Step 6 writes `NUKE.md` at the worktree root. **Every value is written
 literally** — the run's real SHA, tag name, branch, worktree path and date —
@@ -984,7 +1221,11 @@ arbitrary path:
 ```
 
 Bare `/nuke-team-plugin restore` prints the manifest. Every id in the
-`nuke-manifest` block above is a valid argument.
+`nuke-manifest` block above is a valid argument. **Run it from inside this
+experiment worktree** — restore derives its target tree from
+`git rev-parse --show-toplevel` and refuses anywhere that is not this
+`team-nuke-<date>` worktree, so a restore invoked from the primary clone or
+another checkout writes nothing.
 
 ### Recovery
 

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -424,6 +424,33 @@ Report all of this, every run:
 - Anything the run warned about: a dirty or ahead primary checkout, a rejected
   tag push, a declined or failed repoint.
 
+### Which recovery lines to print
+
+Print, least destructive first, only the lines that apply: the cache undo when
+the repoint already happened (it loses nothing), then the whole-tree rollback,
+then the ending sequence from `NUKE.md`. Every one of them is printed with the
+label saying what it discards.
+
+The ending sequence is conditional. Before printing it, ask whether anything
+has been authored in the worktree yet — using only values `NUKE.md` can hold.
+The check cannot compare against the nuke commit's own SHA, because `NUKE.md`
+is inside that commit and cannot name it; its parent, `ARCHIVE_SHA`, is
+recorded, and one commit past the archive is exactly the untouched state:
+
+```sh
+: "${WORKTREE:?}"
+: "${ARCHIVE_SHA:?}"
+git -C "$WORKTREE" rev-list --count "${ARCHIVE_SHA}..HEAD"
+git -C "$WORKTREE" status --porcelain
+```
+
+A count of exactly 1 **and** an empty status means nothing has been authored:
+print the sequence as it stands. Otherwise lead with the preservation lines
+(steps 1 to 3) and name what steps 5 and 6 would discard without them. When
+signing is unavailable the sequence stops at step 1, before anything is
+removed, so an unsignable machine costs the maintainer the ending, never the
+experiment.
+
 ## Restore mode
 
 `/nuke-team-plugin restore [<item>]` runs **from inside the experiment
@@ -697,6 +724,68 @@ It **returns the worktree to the archived tree and discards the nuke commit,
 every commit made after it, and every uncommitted change.** Nothing that
 existed before the run is at risk — `main` is untouched and the baseline tag is
 the archive — but the experiment's own output is.
+
+### Teardown — one ordered sequence, never a bare pair
+
+Run these **in order**, with the run's literal paths and dates as written.
+Steps 1 to 3 preserve this experiment's output; steps 5 and 6 remove it.
+
+1. Tag the branch tip, annotated and signed, with an explicit message — a tag
+   command with no `-m` opens an editor a Claude Code Bash call cannot answer:
+
+   `git -C <primary root> tag -a -s -m "nuke experiment <date>" nuke-result/<date> experiment/nuke-<date>`
+
+   If git says that name is already used — a second experiment on the same date
+   — take the next free suffix and carry it through steps 2 and 3:
+
+   `git -C <primary root> tag -a -s -m "nuke experiment <date>" nuke-result/<date>.2 experiment/nuke-<date>`
+
+   then `.3`, counting up to the first free one. **Never `-f`**: the tag
+   standing in the way is the other run's only durable copy, and step 1 exists
+   precisely so that nothing overwrites it.
+
+2. Push it. Best-effort, like the baseline tag: a refusal leaves the local tag
+   holding every commit on the branch.
+
+   `git -C <primary root> push origin nuke-result/<date>`
+
+3. Prove it. Both lines must print, and print the **same** commit SHA, before
+   step 4 is run. Take the SHA at the start of the `ls-remote` line — an
+   annotated tag's own object SHA is not the commit's, so the ref is read
+   peeled:
+
+   `git -C <primary root> ls-remote --tags origin "refs/tags/nuke-result/<date>^{}" | cut -f1`
+
+   When the push in step 2 was refused, prove the local tag instead with
+   `git -C <primary root> rev-parse "nuke-result/<date>^{}"`. Either way, the
+   second half is the branch tip:
+
+   `git -C <primary root> rev-parse experiment/nuke-<date>`
+
+   Four steps separate the tag from step 6, and a commit made in between would
+   otherwise be reflog-only while the first line still passed.
+
+4. Undo the cache link — the one-line command under `### The cache undo`.
+
+5. `git -C <primary root> worktree remove <worktree>`
+
+6. `git -C <primary root> branch -D experiment/nuke-<date>`
+
+Step 5 carries no `--force`, on purpose: an uncommitted restore or a scratch
+file then stops the removal and shows itself instead of vanishing. Adding
+`--force` discards exactly that, so add it only after reading what step 5
+refused to remove.
+
+Steps 5 and 6 run on their own leave the reflog as the only copy of this
+experiment's commits, restores, and notes. A reflog is not a copy: it expires,
+it is machine-local, and nothing here treats it as a backup. That is what steps
+1 to 3 exist to prevent.
+
+Neither tag is ever removed by this file. `nuke-baseline/<date>` is the archive
+of everything the nuke deleted, and `nuke-result/<date>` is this experiment's
+own record. Removing either one, locally or on the remote, destroys it — so no
+command that would do so appears anywhere here, deliberately. Retiring a tag is
+a decision the maintainer makes by hand, long after this run.
 
 ## Success Criteria
 

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -1,0 +1,425 @@
+---
+name: nuke-team-plugin
+description: |
+  Run Team's instruction-surface nuke experiment (DEV-internal, never
+  distributed): archive the remote default branch as a signed
+  `nuke-baseline/<date>` tag, build a `team-nuke-<date>` worktree on
+  `experiment/nuke-<date>` with Team's own skills, agents, hooks and guidance
+  files removed, repoint the Claude Code dev plugin cache at that worktree so
+  the experiment is live, and pull removed items back one at a time from the
+  archive (`/nuke-team-plugin restore <item>`). Invoke ONLY on explicit nuke or
+  restore intent — the user says "nuke the team plugin", "run the nuke
+  experiment", "restore <item> from the nuke", or runs `/nuke-team-plugin`.
+  Nuking deletes Team's own instruction surface and changes what every Claude
+  Code session on this machine loads until it is undone: never infer that
+  intent from a conversation about skills, plugins, or cleanup.
+disable-model-invocation: true
+argument-hint: "[restore [<item>]]"
+---
+
+# nuke-team-plugin — archive, remove, and selectively restore Team's instruction surface
+
+> This procedure has more than two steps — seed one todo item per numbered step
+> below before starting, and mark each complete as you go. The ledger is inlined
+> here rather than delegated, on purpose: every other instruction file in this
+> repo is inside the deletion set, so this skill may not point at one and expect
+> it to exist.
+
+Two modes, one frontmatter:
+
+- **Nuke** (no argument). Archive, isolate, remove, then make the experiment
+  live. Steps 0 through 7 below.
+- **Restore** (`restore [<item>]`). Print the manifest, or pull one item back
+  out of the archive. See `## Restore mode`.
+
+This skill is deliberately self-contained. It loads no other instruction file
+and reads nothing under `skills/` or `agents/` at run time, because the nuke
+deletes both. Its own directory, `.claude/skills/nuke-team-plugin/`, is
+excluded from the deletion set so that the undo survives the experiment.
+
+## Input
+
+The whole argument is at most two words.
+
+- Empty → nuke mode.
+- `restore` → print the manifest and stop.
+- `restore <item>` → restore that manifest item.
+- Any other first word → print the usage line
+  (`/nuke-team-plugin [restore [<item>]]`) and stop. Never guess a mode.
+
+`<item>` is untrusted (see `## Untrusted input`). It must match
+`^[A-Za-z0-9._/-]+$` under `LC_ALL=C`, contain no `..`, and not start with `/`.
+
+## Hard Rules
+
+1. **Two scopes, and mixing them up is the one mistake that can hurt the
+   primary checkout.** Repo-level operations — `fetch`, `rev-parse`,
+   `ls-remote`, `tag`, `branch`, `worktree add`, `worktree remove` — run as
+   `git -C "$PRIMARY_ROOT"`. Everything that touches the experiment's own tree
+   — step 6's `rm`, `add` and `commit`, and every restore checkout — runs as
+   `git -C "$WORKTREE"`. Step 6 run at `$PRIMARY_ROOT` would stage the
+   deletions on the default branch in the maintainer's own checkout.
+2. **`$PRIMARY_ROOT` is detected, never assumed.** Step 0 derives it from
+   `--git-common-dir` and validates it three ways, including against
+   `worktree list --porcelain`. This repo carries linked worktrees, so being
+   invoked from one is the normal case.
+3. **No command relies on a variable set in an earlier Bash invocation.**
+   Shell state does not persist. Re-derive `$PRIMARY_ROOT`, `$WORKTREE`,
+   `$ARCHIVE_SHA` and `$DATE` in the same invocation that uses them, and guard
+   every value consumed inside a command substitution with a standalone
+   `: "${PRIMARY_ROOT:?}"` or `: "${WORKTREE:?}"` statement ahead of it. Inside
+   `$( )` the `${VAR:?}` form kills only the subshell and the parent continues
+   with an empty value, which is why the guard is its own statement.
+4. **Refuse first.** Every gate is a positive proof, never the absence of an
+   objection. A gate that cannot prove its claim refuses the run and prints the
+   two ways forward; it never repairs, normalizes, or retries around what it
+   found.
+5. **Never skip `git fetch`, and never assume the default branch is `main`.**
+   Detect it per repo in step 1.
+6. **Signing is mandatory and has no fallback.** The nuke commit and both tags
+   are signed. A signing failure stops the run before any deletion is
+   committed, reports the exact command and its error, and never falls back to
+   an unsigned object.
+7. **Names are date-keyed and never overwritten.** `nuke-baseline/<date>`,
+   `experiment/nuke-<date>` and `team-nuke-<date>` are refusals when they
+   already exist, never `-f`, never a reuse without proof.
+8. **The tag push is best-effort, not a gate.** A rejected push warns loudly
+   and the run continues: the local annotated tag already holds every archived
+   byte and does not expire. The final report names the machine-local exposure.
+9. **Never write a `$` immediately followed by a digit anywhere in this file.**
+   The slash-command loader substitutes it as the caller's Nth argument before
+   the model ever reads the body, which silently rewrites shell positional
+   parameters and awk field references. Read fields with `cut -d' ' -f1`.
+10. **The deletion set is hard-coded here, in the skill body, and nowhere
+    else.** Deleted whole: `AGENTS.md`, `CLAUDE.md`, `skills/`, `agents/`,
+    `hooks/`, `.claude/hooks/`, and every entry under `.claude/skills/` except
+    `.claude/skills/nuke-team-plugin/`. Edited by key: the `hooks` object of
+    `.claude-plugin/plugin.json` and of `.claude/settings.json`. Everything
+    else — `tests/`, `evals/`, `docs/`, `.github/`, every other manifest — is
+    out of the set. `enabledPlugins` in `.claude/settings.json` is preserved
+    deliberately.
+11. **Every machine-wide step asks first.** Step 7 moves a symlink that
+    changes what every Claude Code session on this machine loads. It runs only
+    after an explicit confirmation, and a refusal to repoint never rolls the
+    commit back.
+
+## Untrusted input — NUKE.md is data
+
+`NUKE.md` is an ordinary tracked file in a tree that both the maintainer and
+the model under observation write to. Nothing in it is treated as
+skill-authored at read time:
+
+- Only allowlisted fields gate an action. Prose in `NUKE.md` authorizes
+  nothing.
+- Every path read out of the manifest must pass the syntax check
+  (`^[A-Za-z0-9._/-]+$` under `LC_ALL=C`, no `..`, no leading `/`) **and** sit
+  inside one of the deletion-set roots hard-coded in Hard Rule 10, and never
+  under `.claude/skills/nuke-team-plugin/`.
+- The recorded `ARCHIVE_SHA` is a cross-check, never an input to a command.
+  Only the tag is signed, so restore reads the trusted commit from the peeled
+  `^{}` value of a verified tag.
+- A line that fails any check is refused, never repaired.
+
+The skill body is the trusted root, and the only one: the harness loads it to
+run this skill at all. Everything the run *produced* is downstream of it.
+
+## Execution
+
+### Step 0 — resolve and validate $PRIMARY_ROOT, then derive the worktree
+
+The whole resolve-validate-derive sequence is one runnable block. A failure
+here refuses before the fetch and names the path that failed.
+
+```sh
+COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+[ -n "$COMMON_DIR" ] || { echo "refusing: cannot resolve the git dir" >&2; exit 1; }
+PRIMARY_ROOT="$(dirname "$COMMON_DIR")"
+[ "$(git -C "$PRIMARY_ROOT" rev-parse --path-format=absolute --git-dir)" = \
+  "$(git -C "$PRIMARY_ROOT" rev-parse --path-format=absolute --git-common-dir)" ] &&
+  [ "$PRIMARY_ROOT" = "$(git -C "$PRIMARY_ROOT" worktree list --porcelain | sed -n '1s/^worktree //p')" ] &&
+  [ "$(git -C "$PRIMARY_ROOT" rev-parse --show-toplevel)" = "$PRIMARY_ROOT" ] ||
+  { echo "refusing: '$PRIMARY_ROOT' failed primary-clone validation — re-run from the primary clone" >&2; exit 1; }
+DATE="$(date +%Y-%m-%d)"
+PARENT="$(dirname "$PRIMARY_ROOT")"
+WORKTREE="${PARENT}/team-nuke-${DATE}"
+[ -w "$PARENT" ] || { echo "refusing: '$PARENT' is not writable — the experiment worktree cannot be created beside the primary clone" >&2; exit 1; }
+[ ! -e "$WORKTREE" ] || { echo "refusing: '$WORKTREE' already exists — finish or tear down that experiment, or run on another date" >&2; exit 1; }
+git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/heads/experiment/nuke-${DATE}" &&
+  { echo "refusing: branch experiment/nuke-${DATE} already exists — finish or tear down that experiment, or run on another date" >&2; exit 1; }
+printf 'PRIMARY_ROOT=%s\nWORKTREE=%s\nDATE=%s\n' "$PRIMARY_ROOT" "$WORKTREE" "$DATE"
+```
+
+The worktree sits **beside** the primary clone, not under
+`<repo>/.claude/worktrees/`: Claude Code reads `CLAUDE.md` from every ancestor
+directory, so a nested worktree would inherit the guidance the experiment just
+deleted.
+
+### Step 1 — fetch, detect the default branch, capture the archive SHA
+
+```sh
+: "${PRIMARY_ROOT:?}"
+git -C "$PRIMARY_ROOT" fetch origin --tags
+DEFAULT="$(git -C "$PRIMARY_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed -n 's#^origin/##p')"
+[ -n "$DEFAULT" ] || { echo "refusing: cannot detect the default branch — run 'git remote set-head origin --auto' and re-run" >&2; exit 1; }
+ARCHIVE_SHA="$(git -C "$PRIMARY_ROOT" rev-parse "origin/${DEFAULT}")"
+git -C "$PRIMARY_ROOT" status --porcelain
+git -C "$PRIMARY_ROOT" rev-list --count "${ARCHIVE_SHA}..HEAD"
+```
+
+The last two lines are a **warning**, never a refusal. A dirty or ahead primary
+checkout means the experiment measures the remote's Team, not the maintainer's
+working state. Say so in the report and continue.
+
+### Step 2 — the already-nuked stop
+
+This check runs after `ARCHIVE_SHA` exists and **before** the tag is created,
+so a run with nothing to remove stops with nothing to dispose of: no tag, no
+branch, no worktree, no commit, no `NUKE.md`.
+
+```sh
+: "${PRIMARY_ROOT:?}"
+: "${ARCHIVE_SHA:?}"
+PRESENT=0
+for p in AGENTS.md CLAUDE.md skills agents hooks .claude/hooks .claude/skills; do
+  git -C "$PRIMARY_ROOT" cat-file -e "${ARCHIVE_SHA}:${p}" 2>/dev/null && PRESENT=1
+done
+[ "$PRESENT" = 1 ] ||
+  { echo "already nuked: every deletion-set path is absent at ${ARCHIVE_SHA} — nothing was created"; exit 0; }
+```
+
+### Step 3 — prove or create the baseline tag
+
+The archive is one signed annotated tag at `$ARCHIVE_SHA`. **Every SHA
+comparison peels first**: a bare `git rev-parse <annotated-tag>` returns the
+tag object's own SHA, never the commit's, so an unpeeled comparison reads every
+correctly created baseline as a second baseline for the same date.
+
+An existing local tag is reused only on three positive proofs: the peeled
+`^{}` SHA equals `$ARCHIVE_SHA`, `cat-file -t` reports `tag` (annotated, not
+lightweight), and `git tag -v` verifies the signature. Any one failing refuses
+the whole run, before any deletion, because one dated label must not name two
+baselines.
+
+```sh
+: "${PRIMARY_ROOT:?}"
+: "${ARCHIVE_SHA:?}"
+DATE="$(date +%Y-%m-%d)"
+if git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/tags/nuke-baseline/${DATE}"; then
+  PEELED="$(git -C "$PRIMARY_ROOT" rev-parse "nuke-baseline/${DATE}^{}")"
+  KIND="$(git -C "$PRIMARY_ROOT" cat-file -t "nuke-baseline/${DATE}")"
+  [ "$PEELED" = "$ARCHIVE_SHA" ] && [ "$KIND" = tag ] &&
+    git -C "$PRIMARY_ROOT" tag -v "nuke-baseline/${DATE}" ||
+    { echo "refusing: nuke-baseline/${DATE} already exists at ${PEELED} (kind ${KIND}) and is not a verified annotated tag at ${ARCHIVE_SHA} — retire that tag deliberately, or run on another date" >&2; exit 1; }
+else
+  git -C "$PRIMARY_ROOT" tag -a -s -m "Team instruction surface archived ${DATE}" "nuke-baseline/${DATE}" "$ARCHIVE_SHA"
+fi
+```
+
+The explicit `-m` is not optional: `git tag -a` with no message opens
+`$EDITOR`, which a Claude Code Bash call cannot answer.
+
+**Remote pre-flight.** `git ls-remote --tags` lists an annotated tag's own
+object SHA on the `refs/tags/<name>` row and the commit it points at on the
+`refs/tags/<name>^{}` row. A **lightweight** remote tag has no `^{}` row at
+all, so comparing only the peeled row is vacuous against exactly the case that
+must refuse. Read both rows:
+
+```sh
+: "${PRIMARY_ROOT:?}"
+: "${ARCHIVE_SHA:?}"
+DATE="$(date +%Y-%m-%d)"
+ROWS="$(git -C "$PRIMARY_ROOT" ls-remote --tags origin \
+  "refs/tags/nuke-baseline/${DATE}" "refs/tags/nuke-baseline/${DATE}^{}")"
+UNPEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}" | grep -vF '^{}' | cut -f1)"
+PEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}^{}" | cut -f1)"
+if [ -n "$UNPEELED_ROW" ] && [ -z "$PEELED_ROW" ]; then
+  echo "refusing: origin carries a LIGHTWEIGHT tag nuke-baseline/${DATE} at ${UNPEELED_ROW} (no ^{} companion row) — retire that tag deliberately, or run on another date" >&2; exit 1
+fi
+if [ -n "$PEELED_ROW" ] && [ "$PEELED_ROW" != "$ARCHIVE_SHA" ]; then
+  echo "refusing: origin's nuke-baseline/${DATE} peels to ${PEELED_ROW}, not ${ARCHIVE_SHA} — retire that tag deliberately, or run on another date" >&2; exit 1
+fi
+```
+
+### Step 4 — push the baseline tag, before anything is deleted
+
+```sh
+: "${PRIMARY_ROOT:?}"
+DATE="$(date +%Y-%m-%d)"
+git -C "$PRIMARY_ROOT" push origin "nuke-baseline/${DATE}"
+```
+
+A rejected push (no write access, offline) **warns loudly and continues**. The
+local annotated tag already holds every archived byte, `main` is untouched, and
+the tag does not expire the way a reflog entry does. Record the exposure — the
+archive is machine-local only — in the final report.
+
+### Step 5 — create the experiment worktree
+
+```sh
+: "${PRIMARY_ROOT:?}"
+: "${WORKTREE:?}"
+: "${ARCHIVE_SHA:?}"
+DATE="$(date +%Y-%m-%d)"
+git -C "$PRIMARY_ROOT" worktree add "$WORKTREE" -b "experiment/nuke-${DATE}" "$ARCHIVE_SHA"
+```
+
+The branch stays local. It is never pushed and never opens a PR: it holds only
+deletions plus `NUKE.md`, and the tag already preserves every removed byte.
+
+### Step 6 — remove the surface in the worktree, then commit
+
+**Every command in this step carries `git -C "$WORKTREE"`.** The same three
+commands run at `$PRIMARY_ROOT` would stage the deletions on the default branch
+in the maintainer's own checkout.
+
+```sh
+: "${WORKTREE:?}"
+: "${ARCHIVE_SHA:?}"
+git -C "$WORKTREE" rm -r -q -- AGENTS.md CLAUDE.md skills/ agents/ hooks/ .claude/hooks/
+git -C "$WORKTREE" ls-tree --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
+  while IFS= read -r entry; do
+    case "$entry" in
+      .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*) continue ;;
+    esac
+    git -C "$WORKTREE" rm -r -q -- "$entry"
+  done
+```
+
+Then strip the `hooks` key from the two manifests, leaving every other key —
+`.claude-plugin/plugin.json` also carries `name` and `version`, without which
+the repointed cache entry cannot load, and `.claude/settings.json` carries
+`enabledPlugins` for two unrelated plugins:
+
+```sh
+: "${WORKTREE:?}"
+for f in .claude-plugin/plugin.json .claude/settings.json; do
+  node -e 'const fs=require("fs");const p=process.argv[process.argv.length-1];const j=JSON.parse(fs.readFileSync(p,"utf8"));delete j.hooks;fs.writeFileSync(p,JSON.stringify(j,null,2)+"\n");' "${WORKTREE}/${f}"
+done
+```
+
+**Generate the manifest, never type it.** Enumerate the deletion-set roots at
+`$ARCHIVE_SHA` and write one line per entry found, so an item added after this
+skill shipped still gets a line and stays restorable. Each generated id is
+checked before it is written, and the `<state>` of an edited manifest is its
+`git hash-object` value as the nuke wrote it:
+
+```sh
+LC_ALL=C
+: "${WORKTREE:?}"
+case "$ITEM_ID" in
+  ''|/*|*..*|*[!A-Za-z0-9._/-]*)
+    echo "refusing: generated item id '$ITEM_ID' fails the syntax check" >&2; exit 1 ;;
+esac
+printf '%s\n' "$LINES_SO_FAR" | cut -d' ' -f1 | grep -qxF -- "$ITEM_ID" &&
+  { echo "refusing: duplicate manifest item id '$ITEM_ID'" >&2; exit 1; }
+STATE="$(git -C "$WORKTREE" hash-object -- "$ITEM_PATH")"
+printf '%s %s %s %s %s\n' "$ITEM_ID" "$ITEM_KIND" "$ITEM_PATH" "$BASELINE" "$STATE"
+```
+
+Write `NUKE.md` at the worktree root from `## NUKE.md template`, then stage and
+commit — signed, with no unsigned fallback:
+
+```sh
+: "${WORKTREE:?}"
+DATE="$(date +%Y-%m-%d)"
+git -C "$WORKTREE" add -- NUKE.md .claude-plugin/plugin.json .claude/settings.json
+git -C "$WORKTREE" commit -S -m "experiment: nuke Team's instruction surface (${DATE})"
+```
+
+If signing fails, stop here, print the command and its verbatim error, and
+print the recovery line from `## NUKE.md template`. Never commit unsigned.
+
+## NUKE.md template
+
+Step 6 writes `NUKE.md` at the worktree root. **Every value is written
+literally** — the run's real SHA, tag name, branch, worktree path and date —
+because a reader's shell has none of this skill's variables set.
+
+### Header fields
+
+```md
+# NUKE.md — Team instruction-surface experiment
+
+- Archive SHA: 4f9a1c0b7d2e8f36a5b4c3d2e1f0a9b8c7d6e5f4
+- Baseline tag: nuke-baseline/2026-08-28
+- Branch: experiment/nuke-2026-08-28
+- Worktree: /Users/<you>/code/bostonaholic/team-nuke-2026-08-28
+- Date: 2026-08-28
+```
+
+### The nuke-manifest block
+
+Exactly one fenced block, info string `nuke-manifest`, one generated line per
+item, in the format `<id> <kind> <path> <baseline> <state> [...]`. `<kind>` is
+one of `pair`, `tree`, `file`, `group` and labels the report only. `<baseline>`
+is what the path was at the archive SHA (`present` or `absent`). `<state>` is
+what the nuke left there: `-` for a removed path, or the 40-lowercase-hex
+`git hash-object` value for an edited manifest.
+
+```nuke-manifest
+guidance pair AGENTS.md present - CLAUDE.md present -
+skills/pr-cleanup tree skills/pr-cleanup/ present -
+agents/implementer file agents/implementer.md present -
+.claude/skills/version-bump tree .claude/skills/version-bump/ present -
+runtime-hooks group hooks/ present - .claude-plugin/plugin.json present 3b5d0c1a7f4e29806b5a4c3d2e1f0a9b8c7d6e5f
+dev-hooks group .claude/hooks/ present - .claude/settings.json present 8a4c2e6019bd7f35c4b3a2918070f6e5d4c3b2a1
+```
+
+### Read-only inspection
+
+Never a write. Both lines are safe to run anywhere:
+
+```
+git show 4f9a1c0b7d2e8f36a5b4c3d2e1f0a9b8c7d6e5f4:skills/pr-cleanup/SKILL.md
+git log --oneline experiment/nuke-2026-08-28
+```
+
+`git show <ARCHIVE_SHA>:AGENTS.md` prints the whole router, so a single section
+can be copied back by hand.
+
+### Recovery
+
+The whole-tree rollback is a `git reset --hard` to the archive SHA, written for
+the reader as:
+
+```
+git -C /Users/<you>/code/bostonaholic/team-nuke-2026-08-28 reset --hard 4f9a1c0b7d2e8f36a5b4c3d2e1f0a9b8c7d6e5f4
+```
+
+It **returns the worktree to the archived tree and discards the nuke commit,
+every commit made after it, and every uncommitted change.** Nothing that
+existed before the run is at risk — `main` is untouched and the baseline tag is
+the archive — but the experiment's own output is.
+
+## Success Criteria
+
+- `main`, the primary checkout, and `docs/skills.md` are byte-for-byte
+  unchanged; `git status` in the primary checkout reads the same before and
+  after.
+- `nuke-baseline/<date>` exists as a verified, signed, annotated tag at the
+  archive SHA, and its push was attempted before the first deletion.
+- One signed commit sits on `experiment/nuke-<date>` in `team-nuke-<date>`,
+  carrying the deletions, the two edited manifests, and `NUKE.md`.
+- `NUKE.md` carries exactly one `nuke-manifest` block, with one line per
+  removed or edited item.
+
+## Pitfalls
+
+- **Running step 6 at `$PRIMARY_ROOT`.** It stages the deletions on the default
+  branch in the maintainer's own checkout. Re-read Hard Rule 1.
+- **Comparing an unpeeled tag SHA.** Every correctly created baseline then
+  reads as a different baseline, and the fail-closed refusal fires on the one
+  path that should succeed.
+- **Assuming a remote tag row exists in pairs.** A lightweight remote tag has
+  no `^{}` row, which is why step 3 reads both.
+- **Treating the tag push as a gate.** It is best-effort; a maintainer with no
+  push access must not be stranded.
+- **Repairing the nuked worktree's test suite.** It is red by construction —
+  `tests/` survives while its targets do not. Repairing it is contamination.
+
+## Completion
+
+Report, in this order: the archive SHA and the branch it came from; the
+baseline tag and whether the push succeeded; the worktree path and the commit
+SHA; anything the run warned about (a dirty or ahead primary checkout, a
+rejected push); and the recovery line above.

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -345,6 +345,9 @@ on the link target instead:
 ```sh
 : "${PRIMARY_ROOT:?}"
 CACHE_DIR="${HOME}/.claude/plugins/cache/team-dev/team"
+# Test the directory first: an unmatched glob aborts under zsh.
+[ -d "$CACHE_DIR" ] ||
+  { echo "no cache entry at all: ${CACHE_DIR} does not exist — Team was never dev-installed on this machine" >&2; exit 1; }
 for entry in "$CACHE_DIR"/*; do
   [ -e "$entry" ] || [ -L "$entry" ] || continue
   printf '%s\t%s\t%s\n' "$entry" "$([ -L "$entry" ] && echo symlink || echo directory)" "$(readlink "$entry" || true)"

--- a/.claude/skills/nuke-team-plugin/SKILL.md
+++ b/.claude/skills/nuke-team-plugin/SKILL.md
@@ -56,20 +56,30 @@ The whole argument is at most two words.
    primary checkout.** Repo-level operations — `fetch`, `rev-parse`,
    `ls-remote`, `tag`, `branch`, `worktree add`, `worktree remove` — run as
    `git -C "$PRIMARY_ROOT"`. Everything that touches the experiment's own tree
-   — step 6's `rm`, `add` and `commit`, and every restore checkout — runs as
-   `git -C "$WORKTREE"`. Step 6 run at `$PRIMARY_ROOT` would stage the
-   deletions on the default branch in the maintainer's own checkout.
+   — step 6's `rm`, `add` and `commit` — runs as `git -C "$WORKTREE"`. Step 6
+   run at `$PRIMARY_ROOT` would stage the deletions on the default branch in
+   the maintainer's own checkout. **Restore has no `$WORKTREE`**: it runs
+   inside the experiment tree and binds to `$TOPLEVEL`, the value R2 derives
+   and proves. Every restore read and every restore write — R6's state gate,
+   R7's checkout, and the re-restore escape — carries `git -C "$TOPLEVEL"`
+   and resolves its path against `"$TOPLEVEL/"`, so no restore command is
+   bound by the caller's working directory alone.
 2. **`$PRIMARY_ROOT` is detected, never assumed.** Step 0 derives it from
    `--git-common-dir` and validates it three ways, including against
    `worktree list --porcelain`. This repo carries linked worktrees, so being
    invoked from one is the normal case.
 3. **No command relies on a variable set in an earlier Bash invocation.**
-   Shell state does not persist. Re-derive `$PRIMARY_ROOT`, `$WORKTREE`,
-   `$ARCHIVE_SHA` and `$DATE` in the same invocation that uses them, and guard
-   every value consumed inside a command substitution with a standalone
+   Shell state does not persist. Re-derive `$PRIMARY_ROOT`, `$WORKTREE` and
+   `$ARCHIVE_SHA` in the same invocation that uses them, and guard every value
+   consumed inside a command substitution with a standalone
    `: "${PRIMARY_ROOT:?}"` or `: "${WORKTREE:?}"` statement ahead of it. Inside
    `$( )` the `${VAR:?}` form kills only the subshell and the parent continues
    with an empty value, which is why the guard is its own statement.
+   **`$DATE` is the exception: it is carried forward as the literal value step
+   0 printed, never re-derived.** A run that starts before midnight and reaches
+   step 6 after it would otherwise key the tag, the branch and the worktree to
+   two different dates, and the worktree the run created would no longer be the
+   one its own commands name.
 4. **Refuse first.** Every gate is a positive proof, never the absence of an
    objection. A gate that cannot prove its claim refuses the run and prints the
    two ways forward; it never repairs, normalizes, or retries around what it
@@ -111,10 +121,26 @@ skill-authored at read time:
 
 - Only allowlisted fields gate an action. Prose in `NUKE.md` authorizes
   nothing.
+- **Every allowlisted field is shape-checked before it reaches anything**, and
+  the list is closed. Nothing outside it is read at all:
+
+  | Field | Shape it must match | Where it is checked |
+  |-------|--------------------|---------------------|
+  | Branch | `experiment/nuke-<YYYY-MM-DD>`, no suffix | R2 |
+  | Baseline tag | `nuke-baseline/<YYYY-MM-DD>` | R5 |
+  | Archive SHA | exactly 40 lowercase hex | R5 |
+  | Manifest `<id>` | `^[A-Za-z0-9._/-]+$`, unique in the block | R3 |
+  | Manifest `<path>` | syntax check **and** deletion-set containment | R4 |
+  | Manifest `<baseline>` | `present` or `absent` | R4 |
+  | Manifest `<state>` | `-` or 40 lowercase hex | R4 |
+
+  `Worktree` and `Date` label the report only. No gate reads either, so
+  neither is shape-checked and neither can steer a command.
 - Every path read out of the manifest must pass the syntax check
   (`^[A-Za-z0-9._/-]+$` under `LC_ALL=C`, no `..`, no leading `/`) **and** sit
   inside one of the deletion-set roots hard-coded in Hard Rule 10, and never
-  under `.claude/skills/nuke-team-plugin/`.
+  under `.claude/skills/nuke-team-plugin/`. R4 runs that check as a fenced
+  block, before `$ITEM_PATH` reaches any command.
 - The recorded `ARCHIVE_SHA` is a cross-check, never an input to a command.
   Only the tag is signed, so restore reads the trusted commit from the peeled
   `^{}` value of a verified tag.
@@ -143,7 +169,7 @@ DATE="$(date +%Y-%m-%d)"
 PARENT="$(dirname "$PRIMARY_ROOT")"
 WORKTREE="${PARENT}/team-nuke-${DATE}"
 [ -w "$PARENT" ] || { echo "refusing: '$PARENT' is not writable — the experiment worktree cannot be created beside the primary clone" >&2; exit 1; }
-[ ! -e "$WORKTREE" ] || { echo "refusing: '$WORKTREE' already exists — finish or tear down that experiment, or run on another date" >&2; exit 1; }
+{ [ ! -e "$WORKTREE" ] && [ ! -L "$WORKTREE" ]; } || { echo "refusing: '$WORKTREE' already exists — finish or tear down that experiment, or run on another date" >&2; exit 1; }
 git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/heads/experiment/nuke-${DATE}" &&
   { echo "refusing: branch experiment/nuke-${DATE} already exists — finish or tear down that experiment, or run on another date" >&2; exit 1; }
 printf 'PRIMARY_ROOT=%s\nWORKTREE=%s\nDATE=%s\n' "$PRIMARY_ROOT" "$WORKTREE" "$DATE"
@@ -153,6 +179,11 @@ The worktree sits **beside** the primary clone, not under
 `<repo>/.claude/worktrees/`: Claude Code reads `CLAUDE.md` from every ancestor
 directory, so a nested worktree would inherit the guidance the experiment just
 deleted.
+
+The collision check tests `-L` as well as `-e`, because `-e` follows the link
+and a **dangling** symlink at that path would otherwise read as "nothing is
+there" — and then `git worktree add` fails on it anyway, after the tag was
+already pushed.
 
 ### Step 1 — fetch, detect the default branch, capture the archive SHA
 
@@ -176,13 +207,26 @@ This check runs after `ARCHIVE_SHA` exists and **before** the tag is created,
 so a run with nothing to remove stops with nothing to dispose of: no tag, no
 branch, no worktree, no commit, no `NUKE.md`.
 
+The stop is an **OR over the deletion set** — one surviving path is enough
+work to justify the run — and step 6 is written to match it: step 6 removes
+each path only if it is present, so a partially-nuked archive is the normal
+case on both sides rather than a fatal pathspec error.
+
+**`.claude/skills` is never tested as a whole.** This skill's own directory
+lives under it and is excluded from the deletion set, so that path is present
+at every SHA and testing it would pin `PRESENT=1` forever, turning the stop
+into dead code. What counts is whether any *other* entry survives under it:
+
 ```sh
 : "${PRIMARY_ROOT:?}"
 : "${ARCHIVE_SHA:?}"
 PRESENT=0
-for p in AGENTS.md CLAUDE.md skills agents hooks .claude/hooks .claude/skills; do
+for p in AGENTS.md CLAUDE.md skills agents hooks .claude/hooks; do
   git -C "$PRIMARY_ROOT" cat-file -e "${ARCHIVE_SHA}:${p}" 2>/dev/null && PRESENT=1
 done
+OTHER_SKILLS="$(git -C "$PRIMARY_ROOT" ls-tree -z --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
+  tr '\0' '\n' | grep -vxF '.claude/skills/nuke-team-plugin' || true)"
+[ -z "$OTHER_SKILLS" ] || PRESENT=1
 [ "$PRESENT" = 1 ] ||
   { echo "already nuked: every deletion-set path is absent at ${ARCHIVE_SHA} — nothing was created"; exit 0; }
 ```
@@ -194,16 +238,47 @@ comparison peels first**: a bare `git rev-parse <annotated-tag>` returns the
 tag object's own SHA, never the commit's, so an unpeeled comparison reads every
 correctly created baseline as a second baseline for the same date.
 
-An existing local tag is reused only on three positive proofs: the peeled
-`^{}` SHA equals `$ARCHIVE_SHA`, `cat-file -t` reports `tag` (annotated, not
-lightweight), and `git tag -v` verifies the signature. Any one failing refuses
-the whole run, before any deletion, because one dated label must not name two
-baselines.
+`DATE` in this step and every step after it is the **literal value step 0
+printed**, pasted in. Never `date +%Y-%m-%d` again: a run that crosses midnight
+would key the tag to one date and the branch to the next (Hard Rule 3).
+
+**The remote pre-flight runs first**, before the local tag is created. Both
+blocks are read-only up to `tag -a -s`, so ordering them this way costs
+nothing and means a refusal leaves no stray local tag behind for the
+maintainer to clean up.
+
+`git ls-remote --tags` lists an annotated tag's own object SHA on the
+`refs/tags/<name>` row and the commit it points at on the `refs/tags/<name>^{}`
+row. A **lightweight** remote tag has no `^{}` row at all, so comparing only
+the peeled row is vacuous against exactly the case that must refuse. Read both
+rows:
 
 ```sh
 : "${PRIMARY_ROOT:?}"
 : "${ARCHIVE_SHA:?}"
-DATE="$(date +%Y-%m-%d)"
+DATE="<the literal value step 0 printed>"
+ROWS="$(git -C "$PRIMARY_ROOT" ls-remote --tags origin \
+  "refs/tags/nuke-baseline/${DATE}" "refs/tags/nuke-baseline/${DATE}^{}")"
+UNPEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}" | grep -vF '^{}' | cut -f1)"
+PEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}^{}" | cut -f1)"
+if [ -n "$UNPEELED_ROW" ] && [ -z "$PEELED_ROW" ]; then
+  echo "refusing: origin carries a LIGHTWEIGHT tag nuke-baseline/${DATE} at ${UNPEELED_ROW} (no ^{} companion row) — retire that tag deliberately, or run on another date" >&2; exit 1
+fi
+if [ -n "$PEELED_ROW" ] && [ "$PEELED_ROW" != "$ARCHIVE_SHA" ]; then
+  echo "refusing: origin's nuke-baseline/${DATE} peels to ${PEELED_ROW}, not ${ARCHIVE_SHA} — retire that tag deliberately, or run on another date" >&2; exit 1
+fi
+```
+
+Only once the remote is clear, prove or create the local tag. An existing local
+tag is reused only on three positive proofs: the peeled `^{}` SHA equals
+`$ARCHIVE_SHA`, `cat-file -t` reports `tag` (annotated, not lightweight), and
+`git tag -v` verifies the signature. Any one failing refuses the whole run,
+before any deletion, because one dated label must not name two baselines.
+
+```sh
+: "${PRIMARY_ROOT:?}"
+: "${ARCHIVE_SHA:?}"
+DATE="<the literal value step 0 printed>"
 if git -C "$PRIMARY_ROOT" show-ref --verify --quiet "refs/tags/nuke-baseline/${DATE}"; then
   PEELED="$(git -C "$PRIMARY_ROOT" rev-parse "nuke-baseline/${DATE}^{}")"
   KIND="$(git -C "$PRIMARY_ROOT" cat-file -t "nuke-baseline/${DATE}")"
@@ -218,33 +293,11 @@ fi
 The explicit `-m` is not optional: `git tag -a` with no message opens
 `$EDITOR`, which a Claude Code Bash call cannot answer.
 
-**Remote pre-flight.** `git ls-remote --tags` lists an annotated tag's own
-object SHA on the `refs/tags/<name>` row and the commit it points at on the
-`refs/tags/<name>^{}` row. A **lightweight** remote tag has no `^{}` row at
-all, so comparing only the peeled row is vacuous against exactly the case that
-must refuse. Read both rows:
-
-```sh
-: "${PRIMARY_ROOT:?}"
-: "${ARCHIVE_SHA:?}"
-DATE="$(date +%Y-%m-%d)"
-ROWS="$(git -C "$PRIMARY_ROOT" ls-remote --tags origin \
-  "refs/tags/nuke-baseline/${DATE}" "refs/tags/nuke-baseline/${DATE}^{}")"
-UNPEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}" | grep -vF '^{}' | cut -f1)"
-PEELED_ROW="$(printf '%s\n' "$ROWS" | grep -F "refs/tags/nuke-baseline/${DATE}^{}" | cut -f1)"
-if [ -n "$UNPEELED_ROW" ] && [ -z "$PEELED_ROW" ]; then
-  echo "refusing: origin carries a LIGHTWEIGHT tag nuke-baseline/${DATE} at ${UNPEELED_ROW} (no ^{} companion row) — retire that tag deliberately, or run on another date" >&2; exit 1
-fi
-if [ -n "$PEELED_ROW" ] && [ "$PEELED_ROW" != "$ARCHIVE_SHA" ]; then
-  echo "refusing: origin's nuke-baseline/${DATE} peels to ${PEELED_ROW}, not ${ARCHIVE_SHA} — retire that tag deliberately, or run on another date" >&2; exit 1
-fi
-```
-
 ### Step 4 — push the baseline tag, before anything is deleted
 
 ```sh
 : "${PRIMARY_ROOT:?}"
-DATE="$(date +%Y-%m-%d)"
+DATE="<the literal value step 0 printed>"
 git -C "$PRIMARY_ROOT" push origin "nuke-baseline/${DATE}"
 ```
 
@@ -259,7 +312,7 @@ archive is machine-local only — in the final report.
 : "${PRIMARY_ROOT:?}"
 : "${WORKTREE:?}"
 : "${ARCHIVE_SHA:?}"
-DATE="$(date +%Y-%m-%d)"
+DATE="<the literal value step 0 printed>"
 git -C "$PRIMARY_ROOT" worktree add "$WORKTREE" -b "experiment/nuke-${DATE}" "$ARCHIVE_SHA"
 ```
 
@@ -268,22 +321,39 @@ deletions plus `NUKE.md`, and the tag already preserves every removed byte.
 
 ### Step 6 — remove the surface in the worktree, then commit
 
-**Every command in this step carries `git -C "$WORKTREE"`.** The same three
-commands run at `$PRIMARY_ROOT` would stage the deletions on the default branch
-in the maintainer's own checkout.
+**Every command in this step carries `git -C "$WORKTREE"`.** The same commands
+run at `$PRIMARY_ROOT` would stage the deletions on the default branch in the
+maintainer's own checkout.
+
+**Remove per path, never in one pathspec list.** A single
+`git rm -- a b c d e f` is fatal on the *first* unmatched pathspec and removes
+nothing, so it contradicts step 2, whose stop is an OR: step 2 lets a run
+proceed when even one deletion-set path survives. Guard each path on its own
+presence at the archive, and record the absent ones — the manifest carries them
+as `absent`, which is what makes them reportable rather than silent:
 
 ```sh
 : "${WORKTREE:?}"
 : "${ARCHIVE_SHA:?}"
-git -C "$WORKTREE" rm -r -q -- AGENTS.md CLAUDE.md skills/ agents/ hooks/ .claude/hooks/
-git -C "$WORKTREE" ls-tree --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
+for p in AGENTS.md CLAUDE.md skills agents hooks .claude/hooks; do
+  if git -C "$WORKTREE" cat-file -e "${ARCHIVE_SHA}:${p}" 2>/dev/null; then
+    git -C "$WORKTREE" rm -r -q -- "$p"
+  else
+    printf 'absent at %s, will be recorded absent in the manifest: %s\n' "$ARCHIVE_SHA" "$p"
+  fi
+done
+git -C "$WORKTREE" ls-tree -z --name-only "$ARCHIVE_SHA" -- .claude/skills/ |
+  tr '\0' '\n' |
   while IFS= read -r entry; do
     case "$entry" in
-      .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*) continue ;;
+      ''|.claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*) continue ;;
     esac
     git -C "$WORKTREE" rm -r -q -- "$entry"
   done
 ```
+
+The `.claude/skills/` sweep needs no presence guard: every entry it removes came
+from `ls-tree` at the same SHA, so each one exists by construction.
 
 Then strip the `hooks` key from the two manifests, leaving every other key —
 `.claude-plugin/plugin.json` also carries `name` and `version`, without which
@@ -298,30 +368,133 @@ done
 ```
 
 **Generate the manifest, never type it.** Enumerate the deletion-set roots at
-`$ARCHIVE_SHA` and write one line per entry found, so an item added after this
-skill shipped still gets a line and stays restorable. Each generated id is
-checked before it is written, and the `<state>` of an edited manifest is its
-`git hash-object` value as the nuke wrote it:
+`$ARCHIVE_SHA` and write one line per item found, so an item added after this
+skill shipped still gets a line and stays restorable.
+
+A line is `<id> <kind> <path> <baseline> <state> [<path> <baseline> <state> …]`
+— **one whole triple per path**, and an item may carry more than one. A `pair`
+carries two, and `runtime-hooks` and `dev-hooks` each carry a removed tree plus
+an edited manifest. So the generator emits triples, then joins them; it never
+emits one fixed-width line.
+
+`<state>` is `-` for every path the nuke *removed*, and only the two edited
+manifests are hashed. Hashing is not conditional decoration: a removed path is
+gone from the worktree, so `git hash-object` against it errors.
+
+These helpers read named variables rather than positional parameters, because
+Hard Rule 9 bans a `$` followed by a digit anywhere in this file.
 
 ```sh
-LC_ALL=C
+export LC_ALL=C
 : "${WORKTREE:?}"
-case "$ITEM_ID" in
-  ''|/*|*..*|*[!A-Za-z0-9._/-]*)
-    echo "refusing: generated item id '$ITEM_ID' fails the syntax check" >&2; exit 1 ;;
-esac
-printf '%s\n' "$LINES_SO_FAR" | cut -d' ' -f1 | grep -qxF -- "$ITEM_ID" &&
-  { echo "refusing: duplicate manifest item id '$ITEM_ID'" >&2; exit 1; }
-STATE="$(git -C "$WORKTREE" hash-object -- "$ITEM_PATH")"
-printf '%s %s %s %s %s\n' "$ITEM_ID" "$ITEM_KIND" "$ITEM_PATH" "$BASELINE" "$STATE"
+: "${ARCHIVE_SHA:?}"
+MANIFEST=""
+
+check_path() {   # reads P — syntax, own-directory exclusion, then containment
+  case "$P" in
+    ''|/*|*..*|*[!A-Za-z0-9._/-]*)
+      echo "refusing: path '$P' fails the syntax check" >&2; exit 1 ;;
+  esac
+  case "$P" in
+    .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*)
+      echo "refusing: path '$P' is inside this skill's own directory" >&2; exit 1 ;;
+  esac
+  case "$P" in
+    AGENTS.md|CLAUDE.md|skills/*|agents/*|hooks/*|.claude/hooks/*|.claude/skills/*|.claude-plugin/plugin.json|.claude/settings.json) ;;
+    *) echo "refusing: path '$P' sits outside the deletion-set roots of Hard Rule 10" >&2; exit 1 ;;
+  esac
+}
+
+add_triple() {   # reads P and K (removed|edited); appends one triple to FIELDS
+  check_path
+  if git -C "$WORKTREE" cat-file -e "${ARCHIVE_SHA}:${P%/}" 2>/dev/null
+  then BASE=present; else BASE=absent; fi
+  STATE=-
+  if [ "$K" = edited ] && [ "$BASE" = present ]; then
+    STATE="$(git -C "$WORKTREE" hash-object -- "${WORKTREE}/${P}")"
+  fi
+  FIELDS="${FIELDS}${FIELDS:+ }${P} ${BASE} ${STATE}"
+}
+
+emit_item() {   # reads ID, KIND, FIELDS
+  case "$ID" in
+    ''|/*|*..*|*[!A-Za-z0-9._/-]*)
+      echo "refusing: generated item id '$ID' fails the syntax check" >&2; exit 1 ;;
+  esac
+  printf '%s\n' "$MANIFEST" | cut -d' ' -f1 | grep -qxF -- "$ID" &&
+    { echo "refusing: duplicate manifest item id '$ID'" >&2; exit 1; }
+  MANIFEST="${MANIFEST}${ID} ${KIND} ${FIELDS}
+"
+}
+
+FIELDS=; ID=guidance; KIND=pair
+P=AGENTS.md; K=removed; add_triple
+P=CLAUDE.md; K=removed; add_triple
+emit_item
+
+ENTRIES="$(for ROOT in skills agents .claude/skills; do
+  git -C "$WORKTREE" ls-tree -z --name-only "$ARCHIVE_SHA" -- "${ROOT}/" | tr '\0' '\n'
+done)"
+OLD_IFS="$IFS"; IFS='
+'
+for ENTRY in $ENTRIES; do
+  case "$ENTRY" in ''|.claude/skills/nuke-team-plugin) continue ;; esac
+  # Round-trip proof: every entry came from ls-tree at this SHA, so one that
+  # no longer resolves means the NUL-to-newline split cut a path in half.
+  TYPE="$(git -C "$WORKTREE" cat-file -t "${ARCHIVE_SHA}:${ENTRY}" 2>/dev/null)" ||
+    { echo "refusing: listed entry '$ENTRY' does not resolve at ${ARCHIVE_SHA}" >&2; exit 1; }
+  FIELDS=
+  case "$TYPE" in
+    tree) ID="$ENTRY"; KIND=tree; P="${ENTRY}/" ;;
+    blob) ID="${ENTRY%.md}"; KIND=file; P="$ENTRY" ;;
+    *) echo "refusing: unexpected object type '$TYPE' for '$ENTRY'" >&2; exit 1 ;;
+  esac
+  K=removed; add_triple
+  emit_item
+done
+IFS="$OLD_IFS"
+
+FIELDS=; ID=runtime-hooks; KIND=group
+P=hooks/; K=removed; add_triple
+P=.claude-plugin/plugin.json; K=edited; add_triple
+emit_item
+FIELDS=; ID=dev-hooks; KIND=group
+P=.claude/hooks/; K=removed; add_triple
+P=.claude/settings.json; K=edited; add_triple
+emit_item
+
+printf '%s' "$MANIFEST"
 ```
+
+The two `group` items run **after** the `node` edit above, so their recorded
+hash is the byte-for-byte state the nuke left, which is exactly what R6 later
+compares against.
+
+#### Locate the cache entry — read-only, and before the commit
+
+`NUKE.md` carries the cache undo as a **literal** `ln -sfn <primary root>
+<cache entry>` line, and a reader's shell has none of this skill's variables
+set. That entry path is therefore needed *while `NUKE.md` is being written*,
+which is here — not in step 7. This scan is read-only: it moves nothing, so
+running it before the commit costs nothing and keeps the run at one commit.
+
+Run the discovery block from `### Step 7 — repoint the plugin cache` now,
+unchanged, and keep the entries whose `readlink` target equals `$PRIMARY_ROOT`
+byte for byte. Then:
+
+- **Exactly one match** — write its literal path into `NUKE.md`'s
+  `### The cache undo` section.
+- **Zero or two-or-more matches** — step 7 will refuse the repoint, so there is
+  no link to undo. Write the matching zero- or multi-match remediation from
+  step 7 into that section instead of an undo line, and say the experiment is
+  inert. Never invent an entry path to fill the template.
 
 Write `NUKE.md` at the worktree root from `## NUKE.md template`, then stage and
 commit — signed, with no unsigned fallback:
 
 ```sh
 : "${WORKTREE:?}"
-DATE="$(date +%Y-%m-%d)"
+DATE="<the literal value step 0 printed>"
 git -C "$WORKTREE" add -- NUKE.md .claude-plugin/plugin.json .claude/settings.json
 git -C "$WORKTREE" commit -S -m "experiment: nuke Team's instruction surface (${DATE})"
 ```
@@ -342,32 +515,46 @@ whichever checkout last ran the installer, so a directory name computed today
 can name a path that does not exist while the real link sits beside it. Match
 on the link target instead:
 
+This is the same read-only discovery step 6 already ran to write the undo line
+into `NUKE.md`. It is re-run here rather than remembered, because shell state
+does not survive a Bash invocation (Hard Rule 3).
+
 ```sh
 : "${PRIMARY_ROOT:?}"
 CACHE_DIR="${HOME}/.claude/plugins/cache/team-dev/team"
-# Test the directory first: an unmatched glob aborts under zsh.
+# Enumerate with find, never a glob: `-d` says the directory exists, not that
+# it has entries, and zsh aborts the whole command on a glob that matches none.
 [ -d "$CACHE_DIR" ] ||
   { echo "no cache entry at all: ${CACHE_DIR} does not exist — Team was never dev-installed on this machine" >&2; exit 1; }
-for entry in "$CACHE_DIR"/*; do
-  [ -e "$entry" ] || [ -L "$entry" ] || continue
-  printf '%s\t%s\t%s\n' "$entry" "$([ -L "$entry" ] && echo symlink || echo directory)" "$(readlink "$entry" || true)"
-done
+find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -print |
+  while IFS= read -r entry; do
+    printf '%s\t%s\t%s\n' "$entry" "$([ -L "$entry" ] && echo symlink || echo directory)" "$(readlink "$entry" || true)"
+  done
 ```
 
 Keep the entries that are symlinks whose `readlink` target equals
 `$PRIMARY_ROOT` byte for byte. Then branch on how many there are.
 
-**Exactly one match.** Ask for an explicit confirmation first — this changes
-what every Claude Code session on the machine loads. Name the entry, its
-current target, and the worktree it will point at. Only after the user agrees:
+**Exactly one match.** Prove it is the entry `NUKE.md` names, then ask for an
+explicit confirmation — this changes what every Claude Code session on the
+machine loads. Name the entry, its current target, and the worktree it will
+point at. Only after the user agrees:
 
 ```sh
 : "${PRIMARY_ROOT:?}"
 : "${WORKTREE:?}"
 : "${CACHE_ENTRY:?}"
+: "${RECORDED_ENTRY:?}"
+[ "$CACHE_ENTRY" = "$RECORDED_ENTRY" ] ||
+  { echo "refusing the repoint: the live entry is ${CACHE_ENTRY}, but NUKE.md's undo line names ${RECORDED_ENTRY} — the cache changed since the commit; correct NUKE.md by hand, then re-run" >&2; exit 1; }
 ln -sfn "$WORKTREE" "$CACHE_ENTRY"
 readlink "$CACHE_ENTRY"
 ```
+
+`$RECORDED_ENTRY` is the second path on the undo line step 6 wrote. A mismatch
+means the machine's cache moved between the commit and now, so the undo line in
+the committed `NUKE.md` would not undo the link this step is about to move —
+which is exactly the state that must refuse rather than repoint.
 
 `ln -sfn` replaces the link in place. Never append a trailing slash to a
 symlink path in a removal command: BSD `rm -rf link/` follows the link and
@@ -477,10 +664,15 @@ wrote, so the checkout changes that key and nothing else.
 
 Any first word other than `restore` prints the usage line and stops; the skill
 never guesses a mode. With no item id, print the manifest and stop. An item id
-is checked before it reaches anything:
+is checked before it reaches anything.
+
+The block below runs **only on the with-an-item path**, after the bare-restore
+branch above has already been taken and returned. An empty `$ITEM` reaching it
+therefore means the mode dispatch was skipped, which is a refusal and not a
+second spelling of bare restore — hence the `''` case:
 
 ```sh
-LC_ALL=C
+export LC_ALL=C
 case "$ITEM" in
   ''|/*|*..*|*[!A-Za-z0-9._/-]*)
     echo "refusing: '$ITEM' is not a valid item id — printing the manifest, nothing was written" >&2; exit 1 ;;
@@ -492,14 +684,25 @@ esac
 `NUKE.md` must sit at the toplevel of the tree being restored into, and the
 current branch must equal the branch recorded in it. Neither is a proof — the
 file under test supplies the value it is compared against — so both are cheap
-consistency checks that catch the honest mistake with a clear message.
+consistency checks that catch the honest mistake with a clear message. The
+branch value is still shape-checked before it is compared, because everything
+in `NUKE.md` is data (see `## Untrusted input`).
 
-The containment check is the one that matters: **refuse when the toplevel is
-the primary clone**. A path recorded with a hash is restorable in a tree that
+**`$TOPLEVEL` is the binding this whole mode runs against.** R6, R7 and the
+re-restore escape all carry `git -C "$TOPLEVEL"` and resolve their paths
+against `"$TOPLEVEL/"`, so the value proved here is the value every later write
+uses — never the caller's working directory.
+
+The containment proof is the one that matters, and it is **positive, not just
+"is not the primary clone"**: refusing the primary root alone leaves every
+other checkout on the machine acceptable. Prove instead that this toplevel
+carries the `team-nuke-<date>` shape *and* is a registered worktree of the
+derived primary root. A path recorded with a hash is restorable in a tree that
 was never nuked, so "every recorded state is `-`" is not by itself a proof of
 where this is running.
 
 ```sh
+export LC_ALL=C
 TOPLEVEL="$(git rev-parse --show-toplevel)"
 [ -f "${TOPLEVEL}/NUKE.md" ] ||
   { echo "refusing: no NUKE.md at ${TOPLEVEL} — run this from inside the experiment worktree" >&2; exit 1; }
@@ -507,6 +710,16 @@ COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
 PRIMARY_ROOT="$(dirname "$COMMON_DIR")"
 [ "$TOPLEVEL" != "$PRIMARY_ROOT" ] ||
   { echo "refusing: ${TOPLEVEL} is the primary clone, not an experiment worktree — restore never writes there" >&2; exit 1; }
+case "$TOPLEVEL" in
+  */team-nuke-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+  *) echo "refusing: ${TOPLEVEL} does not carry the team-nuke-<date> shape — restore only ever writes into an experiment worktree" >&2; exit 1 ;;
+esac
+git -C "$PRIMARY_ROOT" worktree list --porcelain | grep -qxF "worktree ${TOPLEVEL}" ||
+  { echo "refusing: ${TOPLEVEL} is not a registered worktree of ${PRIMARY_ROOT}" >&2; exit 1; }
+case "$RECORDED_BRANCH" in
+  experiment/nuke-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+  *) echo "refusing: NUKE.md records branch '$RECORDED_BRANCH', which is not a dated experiment/nuke name" >&2; exit 1 ;;
+esac
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$BRANCH" = "$RECORDED_BRANCH" ] ||
   { echo "refusing: on ${BRANCH}, but NUKE.md records ${RECORDED_BRANCH} — run 'git switch ${RECORDED_BRANCH}' and re-run" >&2; exit 1; }
@@ -520,13 +733,19 @@ Membership is an exact match on field 1, read with the digit-free
 `cut -d' ' -f1` and proved with `grep -qxF` — never a substring or a pattern
 match, either of which would let `skills/pr` open `skills/pr-cleanup`:
 
+**The counter and the extractor use one identical, end-anchored regex.** Two
+spellings of "the opener" is a parser differential: an end-anchored `grep -c`
+paired with an unanchored `sed` counts one block but extracts from a
+`nuke-manifestX` decoy fence that the count never saw. The anchored form
+`^```nuke-manifest[[:space:]]*$` appears in both, character for character:
+
 ```sh
-LC_ALL=C
+export LC_ALL=C
 : "${TOPLEVEL:?}"
 OPENERS="$(grep -c '^[`]\{3\}nuke-manifest[[:space:]]*$' "${TOPLEVEL}/NUKE.md")"
 [ "$OPENERS" = 1 ] ||
   { echo "refusing: NUKE.md carries ${OPENERS} nuke-manifest blocks, not exactly one" >&2; exit 1; }
-LINES="$(sed -n '/^[`]\{3\}nuke-manifest/,/^[`]\{3\}[[:space:]]*$/p' "${TOPLEVEL}/NUKE.md" | sed '1d;$d')"
+LINES="$(sed -n '/^[`]\{3\}nuke-manifest[[:space:]]*$/,/^[`]\{3\}[[:space:]]*$/p' "${TOPLEVEL}/NUKE.md" | sed '1d;$d')"
 printf '%s\n' "$LINES" | cut -d' ' -f1 | grep -qxF -- "$ITEM" ||
   { echo "refusing: '$ITEM' is not an item in the manifest" >&2; exit 1; }
 [ "$(printf '%s\n' "$LINES" | cut -d' ' -f1 | grep -cxF -- "$ITEM")" = 1 ] ||
@@ -544,9 +763,37 @@ A line that fails any check below is **refused, never repaired**:
 - A `<baseline>` outside `present|absent`.
 - A `<state>` that is neither `-` nor 40 lowercase hex.
 - The combination `absent` with a hash, which is a contradiction.
-- A path that fails the R1 syntax check under `LC_ALL=C`, or that sits outside
-  the deletion-set roots hard-coded in Hard Rule 10, or that sits under
+- A path that fails the syntax check under `LC_ALL=C`, or that sits outside the
+  deletion-set roots hard-coded in Hard Rule 10, or that sits under
   `.claude/skills/nuke-team-plugin/`.
+
+**The path check is a runnable block, not a description.** `$ITEM_PATH` comes
+out of an untrusted file and goes on to reach `hash-object`, `ls-files`,
+`checkout` and `git rm -r -f`; nothing else stands between it and them. Run
+this against **every** path on the line, before any of those:
+
+```sh
+export LC_ALL=C
+case "$ITEM_PATH" in
+  ''|/*|*..*|*[!A-Za-z0-9._/-]*)
+    echo "refusing: manifest path '$ITEM_PATH' fails the syntax check" >&2; exit 1 ;;
+esac
+case "$ITEM_PATH" in
+  .claude/skills/nuke-team-plugin|.claude/skills/nuke-team-plugin/*)
+    echo "refusing: manifest path '$ITEM_PATH' is inside this skill's own directory, which the nuke never removed" >&2; exit 1 ;;
+esac
+case "$ITEM_PATH" in
+  AGENTS.md|CLAUDE.md|skills/*|agents/*|hooks/*|.claude/hooks/*|.claude/skills/*|.claude-plugin/plugin.json|.claude/settings.json) ;;
+  *) echo "refusing: manifest path '$ITEM_PATH' sits outside the deletion-set roots of Hard Rule 10" >&2; exit 1 ;;
+esac
+```
+
+The exclusion case is tested **before** the containment case, on purpose:
+`.claude/skills/nuke-team-plugin/SKILL.md` matches `.claude/skills/*`, so
+ordering them the other way would admit the one path the nuke must never write.
+This is the same `check_path` the generator runs in step 6 — both ends of the
+manifest are checked, so a hand-edited `NUKE.md` gains nothing a generated one
+could not already say.
 
 ### R5 — prove the archive ref
 
@@ -557,11 +804,16 @@ untrusted file, but only the tag is signed. So the tag name must match
 a cross-check that never reaches a command:
 
 ```sh
-LC_ALL=C
+export LC_ALL=C
 case "$RECORDED_TAG" in
   nuke-baseline/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
   *) echo "refusing: '$RECORDED_TAG' is not a dated nuke-baseline tag name" >&2; exit 1 ;;
 esac
+case "$RECORDED_ARCHIVE_SHA" in
+  *[!0-9a-f]*|'') echo "refusing: NUKE.md's archive SHA is not lowercase hex" >&2; exit 1 ;;
+esac
+[ "${#RECORDED_ARCHIVE_SHA}" = 40 ] ||
+  { echo "refusing: NUKE.md's archive SHA is ${#RECORDED_ARCHIVE_SHA} characters, not 40" >&2; exit 1; }
 git rev-parse --verify --quiet "refs/tags/${RECORDED_TAG}" >/dev/null ||
   { echo "refusing: ${RECORDED_TAG} is missing locally — run 'git fetch origin tag ${RECORDED_TAG}' and re-run" >&2; exit 1; }
 git tag -v "$RECORDED_TAG" ||
@@ -580,14 +832,20 @@ link and a dangling symlink would otherwise read as absent. A hash requires the
 working file and the staged blob to both equal it, and a path missing from the
 index counts as a mismatch:
 
+**Every command here binds to `$TOPLEVEL`.** The `git -C "$TOPLEVEL"` prefix
+and the `"${TOPLEVEL}/${ITEM_PATH}"` resolution are what make the guard above
+them load-bearing: with bare `git` and a relative path, this gate would check
+one tree while R7 wrote into whichever tree the caller happened to `cd` into.
+
 ```sh
 : "${TOPLEVEL:?}"
 if [ "$STATE" = "-" ]; then
-  { [ ! -e "$ITEM_PATH" ] && [ ! -L "$ITEM_PATH" ] && [ -z "$(git ls-files -- "$ITEM_PATH")" ]; } ||
+  { [ ! -e "${TOPLEVEL}/${ITEM_PATH}" ] && [ ! -L "${TOPLEVEL}/${ITEM_PATH}" ] &&
+    [ -z "$(git -C "$TOPLEVEL" ls-files -- "$ITEM_PATH")" ]; } ||
     { echo "refusing: ${ITEM_PATH} is recorded absent but exists in the tree or the index" >&2; exit 1; }
 else
-  [ "$(git hash-object -- "$ITEM_PATH")" = "$STATE" ] &&
-  [ "$(git rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
+  [ "$(git -C "$TOPLEVEL" hash-object -- "${TOPLEVEL}/${ITEM_PATH}")" = "$STATE" ] &&
+  [ "$(git -C "$TOPLEVEL" rev-parse ":${ITEM_PATH}")" = "$STATE" ] ||
     { echo "refusing: ${ITEM_PATH} no longer matches its recorded state ${STATE}" >&2; exit 1; }
 fi
 ```
@@ -598,12 +856,15 @@ worktree. Any mismatch refuses and names the offending path.
 ### R7 — check out, then report
 
 ```sh
+: "${TOPLEVEL:?}"
 : "${ARCHIVE:?}"
-git checkout "$ARCHIVE" -- "$ITEM_PATH"
+git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH"
 ```
 
-Report every path written, every `absent` path skipped and why, and that the
-restored files are live in a session only after a restart.
+The only write in this mode carries `git -C "$TOPLEVEL"`, so it lands in the
+tree R2 proved and nowhere else. Report every path written, every `absent` path
+skipped and why, and that the restored files are live in a session only after a
+restart.
 
 ### The re-restore escape
 
@@ -617,21 +878,24 @@ archive's only child on the experiment branch, which R2 has already established
 is the current branch:
 
 ```sh
+: "${TOPLEVEL:?}"
 : "${ARCHIVE:?}"
-NUKE_COMMIT="$(git rev-list --ancestry-path --reverse "${ARCHIVE}..HEAD" | head -1)"
+NUKE_COMMIT="$(git -C "$TOPLEVEL" rev-list --ancestry-path --reverse "${ARCHIVE}..HEAD" | head -1)"
 [ -n "$NUKE_COMMIT" ] ||
   { echo "refusing: cannot derive the nuke commit from ${ARCHIVE}..HEAD" >&2; exit 1; }
-[ "$(git rev-parse "${NUKE_COMMIT}^")" = "$ARCHIVE" ] ||
+[ "$(git -C "$TOPLEVEL" rev-parse "${NUKE_COMMIT}^")" = "$ARCHIVE" ] ||
   { echo "refusing: the derived commit's parent is not the verified archive commit" >&2; exit 1; }
 ```
 
-Then, per path on the item's line:
+Then, per path on the item's line — both destructive, and both bound to
+`$TOPLEVEL` like every other restore write:
 
-- Recorded state `-` — return it with `git rm -r -f -- "$ITEM_PATH"`, which
-  clears the working tree and the index together.
+- Recorded state `-` — return it with
+  `git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH"`, which clears the working tree
+  and the index together.
 - Recorded state a hash — return it with
-  `git checkout "$NUKE_COMMIT" -- "$ITEM_PATH"`, restoring the exact bytes the
-  nuke wrote so the recorded hash matches again.
+  `git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH"`, restoring the
+  exact bytes the nuke wrote so the recorded hash matches again.
 
 For a manifest the maintainer edited on purpose, the alternative is a hand
 merge from `git show <ARCHIVE_SHA>:<path>`, which writes nothing.
@@ -676,7 +940,8 @@ dev-hooks group .claude/hooks/ present - .claude/settings.json present 8a4c2e601
 
 Idempotent, and it loses nothing: it points the dev install back at the primary
 clone, so the next session loads Team as it was. Written with the run's literal
-entry path and primary root, never a variable:
+entry path and primary root, never a variable — which is why step 6 runs the
+read-only cache scan **before** it writes this file:
 
 ```
 ln -sfn /Users/<you>/code/bostonaholic/team /Users/<you>/.claude/plugins/cache/team-dev/team/0.59.0
@@ -684,6 +949,13 @@ ln -sfn /Users/<you>/code/bostonaholic/team /Users/<you>/.claude/plugins/cache/t
 
 Running it does not end the experiment: the branch, the worktree and the
 archive all stay exactly as they were.
+
+When that scan found **zero or several** matching entries, there is no entry
+path to write and no link that will be moved. Write step 7's remediation for
+the case actually found in place of the line above, under the sentence "no
+cache entry was repointed; the experiment is inert until one is." Never write a
+guessed path here: a wrong undo line is worse than none, because it is the line
+a maintainer pastes without reading.
 
 ### Read-only inspection
 
@@ -797,10 +1069,14 @@ a decision the maintainer makes by hand, long after this run.
   after.
 - `nuke-baseline/<date>` exists as a verified, signed, annotated tag at the
   archive SHA, and its push was attempted before the first deletion.
-- One signed commit sits on `experiment/nuke-<date>` in `team-nuke-<date>`,
-  carrying the deletions, the two edited manifests, and `NUKE.md`.
+- **Exactly one** signed commit sits on `experiment/nuke-<date>` in
+  `team-nuke-<date>`, carrying the deletions, the two edited manifests, and
+  `NUKE.md`. Step 6's cache-entry scan is read-only and runs before it, so the
+  literal undo line is inside that one commit and nothing is amended after
+  step 7.
 - `NUKE.md` carries exactly one `nuke-manifest` block, with one line per
-  removed or edited item.
+  removed or edited item, and every deletion-set path absent at the archive
+  appears on it as `absent` rather than being silently omitted.
 
 ## Pitfalls
 
@@ -811,6 +1087,15 @@ a decision the maintainer makes by hand, long after this run.
   path that should succeed.
 - **Assuming a remote tag row exists in pairs.** A lightweight remote tag has
   no `^{}` row, which is why step 3 reads both.
+- **One `git rm` over the whole deletion set.** It is fatal on the first
+  unmatched pathspec and removes nothing, which contradicts step 2's OR: step 2
+  lets a partially-nuked archive through, so step 6 must remove per path.
+- **Testing `.claude/skills` as a whole in step 2.** This skill lives under it,
+  so that path is present at every SHA and the already-nuked stop becomes dead
+  code. Test the entries *other than* `nuke-team-plugin`.
+- **Writing `NUKE.md` before the cache entry is known.** The undo line is
+  literal, so the read-only scan runs in step 6, ahead of the commit — not in
+  step 7, which would need a second commit to record it.
 - **Treating the tag push as a gate.** It is best-effort; a maintainer with no
   push access must not be stranded.
 - **Repairing the nuked worktree's test suite.** It is red by construction —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This project produces a **distributed plugin**. Two contexts exist:
 | Behavioral regression harness | `tests/`, `evals/` | Plugin developers |
 | Versioning & release automation | [docs/versioning.md](docs/versioning.md), `.claude/skills/version-bump/`, `.claude/scripts/next-version.sh`, `.github/workflows/` | Plugin developers |
 | Dev install, per harness | `script/dev-install`/`dev-uninstall` (dispatch), `dev-install-<harness>` | Plugin developers |
+| Instruction-surface nuke experiment | `.claude/skills/nuke-team-plugin/` | Plugin developers |
 
 **Rule of thumb:** If it validates that the plugin is *built correctly*, it is a dev concern (`.claude/`). If it runs *as part of the plugin's functionality*, it is runtime (`hooks/`).
 

--- a/tests/nuke-team-plugin-skill.test.ts
+++ b/tests/nuke-team-plugin-skill.test.ts
@@ -1,21 +1,18 @@
 // tests/nuke-team-plugin-skill.test.ts
 //
-// L2 tripwire (free, deterministic): fences the DEV `nuke-team-plugin` skill
-// (.claude/skills/nuke-team-plugin/SKILL.md) — Team's instruction-surface nuke
-// experiment (docs/plans/2026-08-28-nuke-team-plugin). It archives, removes,
-// and selectively restores Team's own skills/agents/hooks on a throwaway
+// Free, deterministic tripwire over the DEV `nuke-team-plugin` skill
+// (.claude/skills/nuke-team-plugin/SKILL.md), which archives, removes, and
+// selectively restores Team's own skills/agents/hooks on a throwaway
 // experiment branch, then repoints the plugin cache so the experiment is live.
 //
-// What this file pins, per docs/testing.md §L2: frontmatter keys and values,
-// the commands and template strings the body tells the model to emit, the
-// hard-coded deletion-set roots, section headings, and the order of two
-// headings. Never a wording, never a proximity span, never a file length.
-// Every absence assertion carries a length guard plus a positive control, so a
-// renamed heading fails loudly instead of turning the sweep into a green no-op.
+// What this file pins: frontmatter keys and values, the commands and template
+// strings the body tells the model to emit, the hard-coded deletion-set roots,
+// section headings, and the order of two headings. Never a wording, never a
+// proximity span, never a file length. Every absence assertion carries a
+// length guard plus a positive control, so a renamed heading fails loudly
+// instead of turning the sweep into a green no-op.
 //
-// Describe blocks are named with the acceptance criteria verbatim from
-// docs/plans/2026-08-28-nuke-team-plugin/structure.md, one describe per named
-// criterion, grouped by slice so a slice's fence can be run in isolation:
+// Describe blocks are grouped so one group's fence can be run in isolation:
 //   bun test tests/nuke-team-plugin-skill.test.ts -t "Slice 3"
 //
 // Defensive reads: a missing file → "" and a missing section → "", so every
@@ -53,19 +50,41 @@ function agents(): string {
   return readIf(AGENTS_MD);
 }
 
+// Mark every line that sits inside a fenced code block, fence lines included.
+// A shell comment (`# ...`) inside a block otherwise reads as a level-1
+// heading, which would end a section early and leave the sweeps below scanning
+// a stub that passes every absence check vacuously.
+function fencedLines(lines: string[]): boolean[] {
+  const FENCE = /^\s{0,3}(?:`{3,}|~{3,})/;
+  const marks: boolean[] = [];
+  let fenced = false;
+  for (const line of lines) {
+    if (FENCE.test(line)) {
+      marks.push(true);
+      fenced = !fenced;
+      continue;
+    }
+    marks.push(fenced);
+  }
+  return marks;
+}
+
 // Slice the body from the heading matching `re` to the next heading at the
 // same or a shallower level. A heading that does not exist yields "" — the
 // length guard on each dependent assertion then fails rather than passing
-// vacuously (docs/testing.md, "Prove a negative check can find a positive").
+// vacuously.
 function sectionFrom(re: RegExp): string {
   const lines = body().split("\n");
-  const start = lines.findIndex((line) => re.test(line));
+  const fenced = fencedLines(lines);
+  const start = lines.findIndex((line, i) => !fenced[i] && re.test(line));
   if (start < 0) return "";
   const hashes = lines[start]!.match(/^#+/);
   const level = hashes ? hashes[0].length : 6;
   const boundary = new RegExp(`^#{1,${level}}\\s`);
   for (let i = start + 1; i < lines.length; i++) {
-    if (boundary.test(lines[i]!)) return lines.slice(start, i).join("\n");
+    if (!fenced[i] && boundary.test(lines[i]!)) {
+      return lines.slice(start, i).join("\n");
+    }
   }
   return lines.slice(start).join("\n");
 }
@@ -74,7 +93,7 @@ function lineIndex(text: string, re: RegExp): number {
   return text.split("\n").findIndex((line) => re.test(line));
 }
 
-// The three sections the later slices assert against, each pinned by its
+// The three sections the later groups assert against, each pinned by its
 // heading — a rename is a real contract change and must fail the build.
 const RESTORE_HEADING = /^##\s+Restore mode\b/;
 const CACHE_STEP_HEADING = /^#{2,4}\s*Step\s+\d+\b.*cache/i;
@@ -103,18 +122,18 @@ function tableAfter(text: string, header: string): string {
 
 // --- Matchers used by the negative sweeps, each with a positive control ------
 
-// The self-containment ban of Decision 7: no directive telling the model to
-// read another instruction file, since every other one is deleted by the nuke.
-// Non-global so `.test()` carries no lastIndex between calls.
+// The self-containment ban: no directive telling the model to read another
+// instruction file, since every other one is deleted by the nuke. Non-global
+// so `.test()` carries no lastIndex between calls.
 const LOAD_DIRECTIVE = /^\s*>?\s*(Load|Follow)\b.*SKILL\.md/m;
 
-// Version arithmetic on the cache entry (Decision 5's rejected alternative):
-// the live entry was named by whichever checkout last ran the installer, so a
-// version read today can name a directory that does not exist.
+// Version arithmetic on the cache entry: the live entry was named by whichever
+// checkout last ran the installer, so a version read today can name a
+// directory that does not exist while the real link sits beside it.
 const VERSION_ARITHMETIC = /PLUGIN_VERSION|\.claude-plugin\/plugin\.json/;
 
 // A `rm -rf` whose target ends in `/`. BSD `rm -rf link/` follows the symlink
-// and deletes the checkout it points at (design-review-5.md:59).
+// and deletes the checkout it points at.
 const RM_RF_TRAILING_SLASH =
   /rm -rf\s+(?:"[^"]*"|'[^']*'|[^\s"']+)\/(?:\s|$)/;
 
@@ -123,12 +142,12 @@ const RM_RF_TRAILING_SLASH =
 const POSITIONAL = /\$[0-9]/;
 
 // awk positional field extraction, which is how the `$<digit>` token would get
-// into the body (design.md:346 spells the membership gate that way).
+// into the body.
 const AWK_POSITIONAL = /awk\s+'\{\s*print/;
 
-// The two narrower write-scope phrasings the review Major (design.md:806)
-// rejected. Reproducing either builds a restore that cannot restore
-// `runtime-hooks` or `dev-hooks`, whose manifest state is a hash, not `-`.
+// The two narrower write-scope phrasings. Either one builds a restore that
+// cannot restore `runtime-hooks` or `dev-hooks`, whose manifest state is a
+// hash, not `-`.
 const NARROW_WRITE_SCOPE = [
   "the paths the nuke actually removed",
   "only writes recorded-absent paths",
@@ -140,8 +159,8 @@ const NARROW_WRITE_SCOPE = [
 // lastIndex between calls.
 const TAG_DELETION = /\btag -d\b|\bpush --delete\b/;
 
-// Decision 13's hard-coded scope check: every manifest path must sit inside one
-// of these roots, and the roots live in the skill body, never in NUKE.md.
+// Every manifest path must sit inside one of these roots, and the roots live
+// in the skill body, never in NUKE.md.
 const DELETION_SET_ROOTS = [
   "AGENTS.md",
   "CLAUDE.md",
@@ -190,7 +209,7 @@ describe("Slice 1: frontmatter carries name + disable-model-invocation: true, no
     expect(squash(fm())).toContain("Invoke ONLY on explicit");
   });
 
-  test("frontmatter carries no skills: key (Decision 7 self-containment)", () => {
+  test("frontmatter carries no skills: key (the skill loads no other instruction file)", () => {
     // Guard: empty frontmatter must fail, not vacuously pass the absence check.
     expect(fm().length).toBeGreaterThan(0);
     expect(/^skills:/m.test(fm())).toBe(false);
@@ -284,13 +303,19 @@ describe('Slice 1: nuke steps split the two scopes — repo-level commands run a
   test("the recovery line is a whole-tree git reset --hard to the archive SHA", () => {
     expect(body()).toContain("git reset --hard");
   });
+
+  test("the manifest generator folds case before excluding the skill's own directory", () => {
+    // Mutant target: drop the fold and `.claude/Skills/Nuke-Team-Plugin/…`
+    // reaches the manifest on a case-insensitive filesystem.
+    expect(body()).toContain(`P_LC="$(printf '%s' "$P" | tr 'A-Z' 'a-z')"`);
+  });
 });
 
 describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote tag (an unpeeled refs/tags row with no ^{} companion), not only a differing peeled SHA", () => {
   // The pre-flight reads `git ls-remote --tags origin`, which lists an
   // annotated tag's own object SHA on `refs/tags/<name>` and the commit on
   // `refs/tags/<name>^{}`. A lightweight remote tag has NO `^{}` row at all,
-  // so a peeled-row-only comparison is vacuous against it (design.md:714).
+  // so a peeled-row-only comparison is vacuous against it.
   function lsRemoteBlock(): string {
     const blocks = [...body().matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map(
       (m) => m[1]!,
@@ -321,7 +346,7 @@ describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote t
 
   test('an unpeeled row with NO peeled companion is the refused condition', () => {
     // Reading both rows is not the correction; refusing on
-    // "present unpeeled AND absent peeled" is (design.md:714).
+    // "present unpeeled AND absent peeled" is.
     expect(squash(lsRemoteBlock())).toContain(
       `[ -n "$UNPEELED_ROW" ] && [ -z "$PEELED_ROW" ]`,
     );
@@ -339,13 +364,25 @@ describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote t
   });
 
   test("the pre-flight is read-only, so it never creates the local tag it may refuse", () => {
-    // Ordering correction: the remote pre-flight runs before `tag -a -s`, so a
-    // refusal leaves no stray local tag behind.
+    // The remote pre-flight runs before `tag -a -s`, so a refusal leaves no
+    // stray local tag behind.
     const preflight = lineIndex(body(), /ls-remote --tags origin/);
     const create = lineIndex(body(), /tag -a -s -m "Team instruction surface/);
     expect(preflight).toBeGreaterThanOrEqual(0);
     expect(create).toBeGreaterThan(preflight);
     expect(lsRemoteBlock()).not.toContain("tag -a -s");
+  });
+
+  test("the baseline-tag reuse gate peels a fully qualified refs/tags/ revision", () => {
+    // Mutant target: a bare `<name>^{}` resolves through git's search order,
+    // which tries `refs/<name>` before `refs/tags/<name>`, so the object
+    // verified and the object used can differ.
+    expect(body()).toContain(
+      `PEELED="$(git -C "$PRIMARY_ROOT" rev-parse "refs/tags/nuke-baseline/${"${DATE}"}^{}")"`,
+    );
+    expect(body()).toContain(
+      `KIND="$(git -C "$PRIMARY_ROOT" cat-file -t "refs/tags/nuke-baseline/${"${DATE}"}")"`,
+    );
   });
 });
 
@@ -372,7 +409,7 @@ describe('Slice 2: the cache entry is identified by readlink equality with "$PRI
 
   test("the foreign-symlink case says to remove the stale link first", () => {
     // `script/dev-install claude` is a no-op here — the installer skips an
-    // existing symlink (script/dev-install-claude:14,27).
+    // existing symlink.
     expect(body()).toContain("rm <entry>");
   });
 
@@ -388,6 +425,58 @@ describe('Slice 2: the cache entry is identified by readlink equality with "$PRI
   test("the cache section derives no entry path from a version string", () => {
     expect(cacheSection().length).toBeGreaterThan(0);
     expect(VERSION_ARITHMETIC.test(cacheSection())).toBe(false);
+  });
+});
+
+describe("Slice 2: the repoint block binds CACHE_ENTRY with the command that finds it, shape-checks it, and only then moves the link", () => {
+  test("CACHE_ENTRY is assigned by a find over the cache directory, never transcribed", () => {
+    // Mutant target: consuming `$CACHE_ENTRY` without assigning it leaves the
+    // repoint dead on `: "${CACHE_ENTRY:?}"`, and the only way to revive it is
+    // to type a machine-local path in as literal script text.
+    expect(cacheSection()).toContain(
+      `CACHE_ENTRY="$(find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -type l -print |`,
+    );
+  });
+
+  test("the find filters candidates by readlink equality with the primary root", () => {
+    expect(squash(cacheSection())).toContain(
+      `[ "$(readlink "$entry")" = "$PRIMARY_ROOT" ]`,
+    );
+  });
+
+  test("an empty match set refuses the repoint", () => {
+    expect(squash(cacheSection())).toContain(`[ -n "$CACHE_ENTRY" ]`);
+  });
+
+  test("more than one match refuses the repoint, counted in the same block", () => {
+    expect(squash(cacheSection())).toContain(
+      `[ "$(printf '%s\\n' "$CACHE_ENTRY" | grep -c .)" = 1 ]`,
+    );
+  });
+
+  test("the discovered entry gets the same syntax check the recorded entry gets", () => {
+    const checks = cacheSection()
+      .split("\n")
+      .filter((line) => line.includes(`*..*|*[!A-Za-z0-9._/-]*|''`));
+    expect(checks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("the discovered entry is proved to sit under the cache directory", () => {
+    const contained = cacheSection()
+      .split("\n")
+      .filter((line) => line.includes(`"${"${CACHE_DIR}"}/"*`));
+    expect(contained.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("the repoint block runs its shape checks under LC_ALL=C", () => {
+    expect(cacheSection()).toContain("export LC_ALL=C");
+  });
+
+  test("the link is only moved after the discovered and recorded entries agree", () => {
+    const equality = lineIndex(cacheSection(), /\[ "\$CACHE_ENTRY" = "\$RECORDED_ENTRY" \]/);
+    const link = lineIndex(cacheSection(), /^ln -sfn "\$WORKTREE" "\$CACHE_ENTRY"/);
+    expect(equality).toBeGreaterThanOrEqual(0);
+    expect(link).toBeGreaterThan(equality);
   });
 });
 
@@ -421,7 +510,7 @@ describe("Slice 2: the repoint target carries no trailing slash (or uses ln -sfn
 
   test("no rm -rf line in the body ends its target with a trailing slash", () => {
     // BSD `rm -rf link/` follows the symlink and empties the checkout behind
-    // it (design-review-5.md:59).
+    // it.
     expect(body().length).toBeGreaterThan(0);
     const offenders = body()
       .split("\n")
@@ -469,13 +558,13 @@ describe("Slice 3: restore proves before it writes: exactly one nuke-manifest bl
   test("the trusted archive commit comes from the peeled <tag>^{} SHA", () => {
     // The recorded ARCHIVE_SHA is untrusted (NUKE.md is a tracked file anyone
     // can edit); only the tag is signed, so the checkout runs against the
-    // peeled value and the recorded field is a cross-check (Decision 13).
+    // peeled value and the recorded field is a cross-check.
     expect(restoreSection()).toContain("^{}");
   });
 
   test("the recorded-state gate checks the index, not only the working tree", () => {
-    // Bound to $TOPLEVEL, not to the caller's cwd: R6 and R7 must read and
-    // write the same tree, which is the one R2 proved.
+    // Bound to $TOPLEVEL, not to the caller's cwd: the gate and the write must
+    // read and write the same tree, which is the one R2 proved.
     expect(restoreSection()).toContain(`git -C "$TOPLEVEL" ls-files`);
   });
 
@@ -526,8 +615,7 @@ describe("Slice 3: restore's write scope is stated one way: every present path o
 
   test("the body never says restore writes only the paths the nuke removed", () => {
     // Either narrower phrasing builds a restore that silently cannot return
-    // runtime-hooks or dev-hooks, whose state is a hash, not `-`
-    // (review Major, design.md:806).
+    // runtime-hooks or dev-hooks, whose state is a hash, not `-`.
     expect(body().length).toBeGreaterThan(0);
     expect(squash(body())).not.toContain(NARROW_WRITE_SCOPE[0]!);
   });
@@ -545,7 +633,7 @@ describe("Slice 3: restore refuses when the worktree toplevel equals the derived
 
   test("restore derives the primary root so it can refuse a toplevel that equals it", () => {
     // The `present <hash>` branch is reachable in a non-nuked tree, so the
-    // `-`-only state argument is not the containment proof (design.md:437).
+    // `-`-only state argument is not the containment proof.
     expect(restoreSection()).toContain("--git-common-dir");
   });
 
@@ -589,13 +677,25 @@ describe("Slice 3: restore refuses when the worktree toplevel equals the derived
 
   test("a `-` state path is cleared from tree AND index with git rm -r -f", () => {
     // A filesystem `rm` leaves the index entry, so the stated escape would
-    // never clear the recorded-state gate (design.md:426).
+    // never clear the recorded-state gate.
     expect(restoreSection()).toContain(`git -C "$TOPLEVEL" rm -r -f --`);
   });
 
   test("a hashed manifest is returned by checking out the nuke commit, restoring the exact bytes the nuke wrote", () => {
     expect(restoreSection()).toContain(
       `git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" --`,
+    );
+  });
+
+  test("both escape writes refuse on a non-zero exit status", () => {
+    // Mutant target: `git rm` exits non-zero on a pathspec that matches
+    // nothing, and an unchecked loop reports success while the recorded state
+    // it was meant to clear is still there.
+    expect(restoreSection()).toContain(
+      `git -C "$TOPLEVEL" rm -r -f -- "$ITEM_PATH" ||`,
+    );
+    expect(restoreSection()).toContain(
+      `git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" -- "$ITEM_PATH" ||`,
     );
   });
 });
@@ -618,7 +718,7 @@ describe("Slice 4: in the NUKE.md teardown template the nuke-result/ tag line pr
 
   test("the nuke-result/ tag line comes BEFORE the worktree remove line", () => {
     // Preservation first: four steps separate the tag from the branch -D, and
-    // the tag is what keeps every commit reachable afterwards (Decision 17).
+    // the tag is what keeps every commit reachable afterwards.
     const tag = lineIndex(teardownSection(), /tag -a -s -m/);
     const remove = lineIndex(teardownSection(), /worktree remove/);
     expect(tag).toBeGreaterThanOrEqual(0);
@@ -656,8 +756,8 @@ describe("Slice 4: teardown carries no tag-deletion command anywhere, no --force
   });
 
   test("no worktree remove line carries --force", () => {
-    // Mirrors skills/pr-cleanup/SKILL.md:388-391 — an uncommitted restore
-    // stops the removal and shows itself instead of vanishing.
+    // An uncommitted restore stops the removal and shows itself instead of
+    // vanishing.
     expect(teardownSection().length).toBeGreaterThan(0);
     const forced = teardownSection()
       .split("\n")
@@ -706,7 +806,7 @@ describe("Slice 4: the tip-equality proof names git -C <primary root> on both ha
 });
 
 // ===========================================================================
-// Cross-slice concerns (structure.md ## Cross-slice concerns)
+// Cross-slice concerns
 // ===========================================================================
 
 describe("Cross-slice: no $<digit> the slash-command loader would substitute, and fields are read with cut", () => {
@@ -770,11 +870,8 @@ describe("Cross-slice: AGENTS.md registers the skill as a development concern on
 });
 
 // ===========================================================================
-// Round-2 review-fix tripwires (docs/plans/2026-08-28-nuke-team-plugin,
-// design-review-5.md). Each pins a mechanic the round-2 gate found missing:
-// untrusted NUKE.md values reaching the shell as literals (security CRITICAL),
-// the zsh-hostile generator loop (code B1), restore bindings that never re-prove
-// (code B2), and the manifest-fence / R4 / R5 hardening (security MEDIUM).
+// Injection and binding discipline: every untrusted value reaches the shell
+// through a command that reads it, and never as script text.
 // ===========================================================================
 
 // A bare `LINES=` assignment — the zsh special integer parameter (terminal
@@ -784,15 +881,16 @@ describe("Cross-slice: AGENTS.md registers the skill as a development concern on
 const BARE_LINES_ASSIGN = /(^|[^A-Za-z0-9_])LINES=/m;
 
 // A `for X in $VAR` loop over an unquoted expansion — zsh does not word-split
-// it, so the loop runs once over the whole blob (code B1). Literal-list loops
+// it, so the loop runs once over the whole blob. Literal-list loops
 // (`for p in AGENTS.md ...`) carry no `$` and never match.
 const FOR_IN_UNQUOTED = /for\s+\w+\s+in\s+\$/;
 
-describe("Round 2: untrusted NUKE.md values are bound by file-reading command substitution, never retyped (security CRITICAL S-C1)", () => {
-  test("the item argument is bound by a single-quoted here-doc, so $(...) in it is inert", () => {
-    expect(restoreSection()).toContain(`IFS= read -r ITEM <<'RESTORE_ITEM'`);
-  });
+// A here-doc used to carry the untrusted `<item>` argument. A line of the
+// argument equal to the delimiter ends the here-doc, and every byte after it
+// parses as shell at parse time — before any shape check runs.
+const ITEM_HEREDOC = /<<'?RESTORE_ITEM'?/;
 
+describe("Untrusted NUKE.md values are bound by file-reading command substitution, never retyped", () => {
   test("the recorded branch is read from NUKE.md by sed, not retyped", () => {
     expect(restoreSection()).toContain(
       `RECORDED_BRANCH="$(sed -n 's/^- Branch: //p'`,
@@ -811,11 +909,11 @@ describe("Round 2: untrusted NUKE.md values are bound by file-reading command su
     );
   });
 
-  test("the cache-undo entry is read from NUKE.md by grep/sed before the equality gate (step 7)", () => {
+  test("the cache-undo entry is read from NUKE.md by grep/sed before the equality gate", () => {
     expect(body()).toContain(`RECORDED_ENTRY="$(grep -E '^ln -sfn '`);
   });
 
-  test("step 7 refuses unless the recorded entry equals the discovered live entry", () => {
+  test("the repoint refuses unless the recorded entry equals the discovered live entry", () => {
     // Mutant target: delete this equality and the undo line can name any path.
     expect(body()).toContain(`[ "$CACHE_ENTRY" = "$RECORDED_ENTRY" ]`);
   });
@@ -832,7 +930,58 @@ describe("Round 2: untrusted NUKE.md values are bound by file-reading command su
   });
 });
 
-describe("Round 2: the manifest variable is MANIFEST_LINES, never the zsh special LINES (code B1 / restore)", () => {
+describe("The item argument reaches the shell only through a scratch file, never as script text", () => {
+  test("the here-doc matcher fires on the binding it replaced", () => {
+    expect(ITEM_HEREDOC.test(`IFS= read -r ITEM <<'RESTORE_ITEM'`)).toBe(true);
+  });
+
+  test("no here-doc carries the item argument into the script", () => {
+    // Mutant target: a single-quoted here-doc keeps `$(...)` inert but cannot
+    // stop a line equal to its own delimiter from closing it, which hands the
+    // remaining bytes to the shell as commands.
+    expect(body().length).toBeGreaterThan(0);
+    expect(ITEM_HEREDOC.test(body())).toBe(false);
+  });
+
+  test("the scratch directory is created with mktemp -d, so it cannot be pre-planted", () => {
+    expect(restoreSection()).toContain(
+      `SCRATCH_DIR="$(mktemp -d "${"${TMPDIR:-/tmp}"}/nuke-team-plugin.XXXXXXXX")"`,
+    );
+  });
+
+  test("the argument is bound by a redirect from that scratch file", () => {
+    expect(restoreSection()).toContain(
+      `IFS= read -r ITEM < "${"${SCRATCH_DIR}"}/item"`,
+    );
+  });
+
+  test("the scratch file must be a regular file, never a symlink", () => {
+    expect(squash(restoreSection())).toContain(
+      `[ -f "${"${SCRATCH_DIR}"}/item" ] && [ ! -L "${"${SCRATCH_DIR}"}/item" ]`,
+    );
+  });
+
+  test("an argument spanning more than one line is refused, not silently truncated", () => {
+    // Mutant target: `read` takes the first line and drops the rest, so a
+    // multi-line argument would restore a real item while the maintainer never
+    // saw what else was sent.
+    expect(restoreSection()).toContain(
+      `[ "$(wc -l < "${"${SCRATCH_DIR}"}/item")" -le 1 ]`,
+    );
+  });
+
+  test("the shape check still runs before $ITEM reaches any command", () => {
+    expect(restoreSection()).toContain(`''|/*|*..*|*[!A-Za-z0-9._/-]*)`);
+  });
+
+  test("the scratch file is removed once it has been read", () => {
+    expect(restoreSection()).toContain(
+      `rm -f "${"${SCRATCH_DIR}"}/item"; rmdir "$SCRATCH_DIR"`,
+    );
+  });
+});
+
+describe("The manifest variable is MANIFEST_LINES, never the zsh special LINES", () => {
   test("the bare-LINES matcher fires on a planted assignment", () => {
     expect(BARE_LINES_ASSIGN.test('\nLINES="$(sed -n ...)"')).toBe(true);
     expect(BARE_LINES_ASSIGN.test('\nMANIFEST_LINES="$(sed ...)"')).toBe(false);
@@ -848,7 +997,7 @@ describe("Round 2: the manifest variable is MANIFEST_LINES, never the zsh specia
   });
 });
 
-describe("Round 2: the generator enumerates per entry with while-read, not a zsh-hostile for-in (code B1)", () => {
+describe("The generator enumerates per entry with while-read, not a zsh-hostile for-in", () => {
   test("the for-in matcher fires on a planted unquoted loop", () => {
     expect(FOR_IN_UNQUOTED.test("for ENTRY in $ENTRIES; do")).toBe(true);
     expect(FOR_IN_UNQUOTED.test("for p in AGENTS.md CLAUDE.md; do")).toBe(false);
@@ -875,16 +1024,25 @@ describe("Round 2: the generator enumerates per entry with while-read, not a zsh
   });
 });
 
-describe("Round 2: restore proves within one invocation and re-proves in the escape (code B2)", () => {
-  test("restore states R2 through R7 run as one Bash invocation", () => {
+describe("Restore binds and proves within one invocation, and re-proves in the escape", () => {
+  test("restore states R1 through R7 run as one Bash invocation", () => {
+    // The span must start at R1: it is the block that binds $ITEM, which R3
+    // and R7 read. Excluding it leaves them unbound, and the obvious repair is
+    // the retype Hard Rule 12 forbids.
     expect(squash(restoreSection())).toContain(
-      "R2 through R7 are one Bash invocation",
+      "R1 through R7 are one Bash invocation",
     );
   });
 
-  test("the re-restore escape re-establishes both proofs from scratch", () => {
+  test("R3 guards $ITEM rather than re-binding it", () => {
+    expect(restoreSection()).toContain(`: "\${ITEM:?}"`);
+  });
+
+  test("the re-restore escape re-runs every block that makes a binding it uses", () => {
+    // Mutant target: naming only R2 and R5 leaves $TRIPLES (R4), which reads
+    // $MANIFEST_LINE (R3), which reads $ITEM (R1), unbound at the write.
     expect(squash(restoreSection())).toContain(
-      "re-runs R2's containment proof and R5's tag verification from scratch",
+      "re-runs R1 through R5 from scratch",
     );
   });
 
@@ -894,22 +1052,58 @@ describe("Round 2: restore proves within one invocation and re-proves in the esc
   });
 
   test("R7 refuses only when every path on the item is absent, never on a partial", () => {
-    expect(restoreSection()).toContain(`[ "$WROTE" -ge 1 ]`);
+    expect(restoreSection()).toContain(`[ "$PRESENT_COUNT" -ge 1 ]`);
   });
 });
 
-describe("Round 2: the manifest fence and R4/R5 gates are hardened (security MEDIUM S-M1..M4)", () => {
-  test("the closer matches a CommonMark 3-or-more-backtick fence (S-M1)", () => {
+describe("R7 gates every path on an item before it writes any of them", () => {
+  test("the gate pass counts present paths without writing", () => {
+    expect(restoreSection()).toContain("PRESENT_COUNT=0");
+    expect(restoreSection()).toContain(`PRESENT_COUNT=$((PRESENT_COUNT + 1))`);
+  });
+
+  test("the recorded-state gate runs BEFORE the first checkout", () => {
+    // Mutant target: gating and writing in one loop leaves a `pair` whose
+    // first path passes and whose second fails half-restored, which both
+    // breaks the "a failed proof writes nothing" contract and wedges the
+    // re-run on the path that is now present.
+    const gate = lineIndex(restoreSection(), /git -C "\$TOPLEVEL" hash-object -- /);
+    const allGatesPassed = lineIndex(restoreSection(), /\[ "\$PRESENT_COUNT" -ge 1 \]/);
+    const write = lineIndex(
+      restoreSection(),
+      /git -C "\$TOPLEVEL" checkout "\$ARCHIVE" -- "\$ITEM_PATH"/,
+    );
+    expect(gate).toBeGreaterThanOrEqual(0);
+    expect(allGatesPassed).toBeGreaterThan(gate);
+    expect(write).toBeGreaterThan(allGatesPassed);
+  });
+
+  test("both refusals in the gate pass say nothing was written", () => {
+    const refusals = restoreSection()
+      .split("\n")
+      .filter((line) => line.includes("nothing was written"));
+    expect(refusals.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("a failed checkout in the write pass refuses rather than reporting success", () => {
+    expect(restoreSection()).toContain(
+      `git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH" ||`,
+    );
+  });
+});
+
+describe("The manifest fence and the R4/R5 gates are hardened", () => {
+  test("the closer matches a CommonMark 3-or-more-backtick fence", () => {
     // Mutant target: exactly-three closer lets a 4-backtick line run the range on.
     expect(restoreSection()).toContain(`^ \\{0,3\\}[\`]\\{3,\\}[[:space:]]*$`);
   });
 
-  test("every extracted manifest line must match the record grammar, counted (S-M1)", () => {
+  test("every extracted manifest line must match the record grammar, counted", () => {
     expect(restoreSection()).toContain("(pair|tree|file|group)");
     expect(restoreSection()).toContain(`[ "$TOTAL" = "$GOOD" ]`);
   });
 
-  test("R4 is one runnable gate: baseline enum, state format, and the absent+hash contradiction (S-M4)", () => {
+  test("R4 is one runnable gate: baseline enum, state format, and the absent+hash contradiction", () => {
     // Mutant target: any of these deleted and a forged line reaches checkout.
     expect(restoreSection()).toContain("present|absent) ;;");
     expect(restoreSection()).toContain(`[ "${"${#STATE}"}" = 40 ]`);
@@ -918,11 +1112,11 @@ describe("Round 2: the manifest fence and R4/R5 gates are hardened (security MED
     );
   });
 
-  test("R4 excludes the skill's own directory case-insensitively (security LOW)", () => {
+  test("R4 excludes the skill's own directory case-insensitively", () => {
     expect(restoreSection()).toContain(`tr 'A-Z' 'a-z'`);
   });
 
-  test("R5 binds the tag and branch to the date derived from the proved worktree (S-M2)", () => {
+  test("R5 binds the tag and branch to the date derived from the proved worktree", () => {
     // Mutant target: the two equalities, not just the interpolated strings —
     // an edited NUKE.md must not name another date's verified baseline.
     expect(restoreSection()).toContain(`NUKE_DATE="${"${TOPLEVEL##*/team-nuke-}"}"`);
@@ -934,10 +1128,17 @@ describe("Round 2: the manifest fence and R4/R5 gates are hardened (security MED
     );
   });
 
-  test("R5's git reads are scoped to $TOPLEVEL behind a guard (S-M3)", () => {
+  test("R5's git reads are scoped to $TOPLEVEL behind a guard", () => {
     expect(restoreSection()).toContain(`git -C "$TOPLEVEL" tag -v "$RECORDED_TAG"`);
     expect(restoreSection()).toContain(
-      `ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "${"${RECORDED_TAG}"}^{}")"`,
+      `ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "refs/tags/${"${RECORDED_TAG}"}^{}")"`,
     );
+  });
+
+  test("R5 peels a fully qualified refs/tags/ revision, never a bare tag name", () => {
+    // Mutant target: git's revision search order tries `refs/<name>` before
+    // `refs/tags/<name>`, so a planted ref would be peeled and checked out
+    // while `tag -v` verified the real tag.
+    expect(restoreSection()).toContain(`rev-parse "refs/tags/${"${RECORDED_TAG}"}^{}"`);
   });
 });

--- a/tests/nuke-team-plugin-skill.test.ts
+++ b/tests/nuke-team-plugin-skill.test.ts
@@ -768,3 +768,176 @@ describe("Cross-slice: AGENTS.md registers the skill as a development concern on
     expect(entryPoints).not.toContain("nuke-team-plugin");
   });
 });
+
+// ===========================================================================
+// Round-2 review-fix tripwires (docs/plans/2026-08-28-nuke-team-plugin,
+// design-review-5.md). Each pins a mechanic the round-2 gate found missing:
+// untrusted NUKE.md values reaching the shell as literals (security CRITICAL),
+// the zsh-hostile generator loop (code B1), restore bindings that never re-prove
+// (code B2), and the manifest-fence / R4 / R5 hardening (security MEDIUM).
+// ===========================================================================
+
+// A bare `LINES=` assignment — the zsh special integer parameter (terminal
+// height). Assigning a manifest string to it makes zsh arithmetic-evaluate the
+// value on next use and abort. `MANIFEST_LINES` is the safe name; this matcher
+// must NOT fire on it, so it is anchored to a non-name character before LINES.
+const BARE_LINES_ASSIGN = /(^|[^A-Za-z0-9_])LINES=/m;
+
+// A `for X in $VAR` loop over an unquoted expansion — zsh does not word-split
+// it, so the loop runs once over the whole blob (code B1). Literal-list loops
+// (`for p in AGENTS.md ...`) carry no `$` and never match.
+const FOR_IN_UNQUOTED = /for\s+\w+\s+in\s+\$/;
+
+describe("Round 2: untrusted NUKE.md values are bound by file-reading command substitution, never retyped (security CRITICAL S-C1)", () => {
+  test("the item argument is bound by a single-quoted here-doc, so $(...) in it is inert", () => {
+    expect(restoreSection()).toContain(`IFS= read -r ITEM <<'RESTORE_ITEM'`);
+  });
+
+  test("the recorded branch is read from NUKE.md by sed, not retyped", () => {
+    expect(restoreSection()).toContain(
+      `RECORDED_BRANCH="$(sed -n 's/^- Branch: //p'`,
+    );
+  });
+
+  test("the recorded baseline tag is read from NUKE.md by sed, not retyped", () => {
+    expect(restoreSection()).toContain(
+      `RECORDED_TAG="$(sed -n 's/^- Baseline tag: //p'`,
+    );
+  });
+
+  test("the recorded archive SHA is read from NUKE.md by sed, not retyped", () => {
+    expect(restoreSection()).toContain(
+      `RECORDED_ARCHIVE_SHA="$(sed -n 's/^- Archive SHA: //p'`,
+    );
+  });
+
+  test("the cache-undo entry is read from NUKE.md by grep/sed before the equality gate (step 7)", () => {
+    expect(body()).toContain(`RECORDED_ENTRY="$(grep -E '^ln -sfn '`);
+  });
+
+  test("step 7 refuses unless the recorded entry equals the discovered live entry", () => {
+    // Mutant target: delete this equality and the undo line can name any path.
+    expect(body()).toContain(`[ "$CACHE_ENTRY" = "$RECORDED_ENTRY" ]`);
+  });
+
+  test("Hard Rule 12 bans a NUKE.md/argument value as literal text in a command", () => {
+    expect(squash(body())).toContain(
+      "A value from `NUKE.md` or the `<item>` argument is never typed into a command",
+    );
+  });
+
+  test("manifest triples are split with parameter expansion, never read by eye", () => {
+    // ${REST%% *} peels one whitespace-delimited field with no subshell.
+    expect(restoreSection()).toContain(`tok="${"${REST%% *}"}"`);
+  });
+});
+
+describe("Round 2: the manifest variable is MANIFEST_LINES, never the zsh special LINES (code B1 / restore)", () => {
+  test("the bare-LINES matcher fires on a planted assignment", () => {
+    expect(BARE_LINES_ASSIGN.test('\nLINES="$(sed -n ...)"')).toBe(true);
+    expect(BARE_LINES_ASSIGN.test('\nMANIFEST_LINES="$(sed ...)"')).toBe(false);
+  });
+
+  test("restore assigns MANIFEST_LINES", () => {
+    expect(restoreSection()).toContain(`MANIFEST_LINES="$(sed -n`);
+  });
+
+  test("no block assigns the zsh special integer parameter LINES", () => {
+    expect(body().length).toBeGreaterThan(0);
+    expect(BARE_LINES_ASSIGN.test(body())).toBe(false);
+  });
+});
+
+describe("Round 2: the generator enumerates per entry with while-read, not a zsh-hostile for-in (code B1)", () => {
+  test("the for-in matcher fires on a planted unquoted loop", () => {
+    expect(FOR_IN_UNQUOTED.test("for ENTRY in $ENTRIES; do")).toBe(true);
+    expect(FOR_IN_UNQUOTED.test("for p in AGENTS.md CLAUDE.md; do")).toBe(false);
+  });
+
+  test("the manifest generator iterates entries with while IFS= read -r", () => {
+    // Mutant target: revert to `for ENTRY in $ENTRIES` and zsh runs one blob
+    // iteration after the tag push — a stranded tag and no commit.
+    expect(body()).toContain("while IFS= read -r ENTRY");
+  });
+
+  test("no loop iterates an unquoted variable expansion with for-in", () => {
+    expect(body().length).toBeGreaterThan(0);
+    const offenders = body()
+      .split("\n")
+      .filter((line) => FOR_IN_UNQUOTED.test(line))
+      .map((line) => line.trim());
+    expect(offenders).toEqual([]);
+  });
+
+  test("the per-path removal loop deletes each surviving path on its own presence", () => {
+    // Mutant target: the presence-guarded per-path `git rm`, not one pathspec.
+    expect(body()).toContain(`git -C "$WORKTREE" rm -r -q -- "$p"`);
+  });
+});
+
+describe("Round 2: restore proves within one invocation and re-proves in the escape (code B2)", () => {
+  test("restore states R2 through R7 run as one Bash invocation", () => {
+    expect(squash(restoreSection())).toContain(
+      "R2 through R7 are one Bash invocation",
+    );
+  });
+
+  test("the re-restore escape re-establishes both proofs from scratch", () => {
+    expect(squash(restoreSection())).toContain(
+      "re-runs R2's containment proof and R5's tag verification from scratch",
+    );
+  });
+
+  test("R7 loops over the proved TRIPLES, gating and writing each present path", () => {
+    expect(restoreSection()).toContain(`while IFS=' ' read -r ITEM_PATH BASELINE STATE`);
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" checkout "$ARCHIVE" -- "$ITEM_PATH"`);
+  });
+
+  test("R7 refuses only when every path on the item is absent, never on a partial", () => {
+    expect(restoreSection()).toContain(`[ "$WROTE" -ge 1 ]`);
+  });
+});
+
+describe("Round 2: the manifest fence and R4/R5 gates are hardened (security MEDIUM S-M1..M4)", () => {
+  test("the closer matches a CommonMark 3-or-more-backtick fence (S-M1)", () => {
+    // Mutant target: exactly-three closer lets a 4-backtick line run the range on.
+    expect(restoreSection()).toContain(`^ \\{0,3\\}[\`]\\{3,\\}[[:space:]]*$`);
+  });
+
+  test("every extracted manifest line must match the record grammar, counted (S-M1)", () => {
+    expect(restoreSection()).toContain("(pair|tree|file|group)");
+    expect(restoreSection()).toContain(`[ "$TOTAL" = "$GOOD" ]`);
+  });
+
+  test("R4 is one runnable gate: baseline enum, state format, and the absent+hash contradiction (S-M4)", () => {
+    // Mutant target: any of these deleted and a forged line reaches checkout.
+    expect(restoreSection()).toContain("present|absent) ;;");
+    expect(restoreSection()).toContain(`[ "${"${#STATE}"}" = 40 ]`);
+    expect(squash(restoreSection())).toContain(
+      `[ "$BASELINE" = absent ] && [ "$STATE" != - ]`,
+    );
+  });
+
+  test("R4 excludes the skill's own directory case-insensitively (security LOW)", () => {
+    expect(restoreSection()).toContain(`tr 'A-Z' 'a-z'`);
+  });
+
+  test("R5 binds the tag and branch to the date derived from the proved worktree (S-M2)", () => {
+    // Mutant target: the two equalities, not just the interpolated strings —
+    // an edited NUKE.md must not name another date's verified baseline.
+    expect(restoreSection()).toContain(`NUKE_DATE="${"${TOPLEVEL##*/team-nuke-}"}"`);
+    expect(restoreSection()).toContain(
+      `[ "$RECORDED_TAG" = "nuke-baseline/${"${NUKE_DATE}"}" ]`,
+    );
+    expect(restoreSection()).toContain(
+      `[ "$RECORDED_BRANCH" = "experiment/nuke-${"${NUKE_DATE}"}" ]`,
+    );
+  });
+
+  test("R5's git reads are scoped to $TOPLEVEL behind a guard (S-M3)", () => {
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" tag -v "$RECORDED_TAG"`);
+    expect(restoreSection()).toContain(
+      `ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "${"${RECORDED_TAG}"}^{}")"`,
+    );
+  });
+});

--- a/tests/nuke-team-plugin-skill.test.ts
+++ b/tests/nuke-team-plugin-skill.test.ts
@@ -134,6 +134,12 @@ const NARROW_WRITE_SCOPE = [
   "only writes recorded-absent paths",
 ];
 
+// Either half of a tag deletion. Neither tag is ever removed by the skill:
+// `nuke-baseline/<date>` is the archive, `nuke-result/<date>` is the
+// experiment's only durable record. Non-global, so `.test()` carries no
+// lastIndex between calls.
+const TAG_DELETION = /\btag -d\b|\bpush --delete\b/;
+
 // Decision 13's hard-coded scope check: every manifest path must sit inside one
 // of these roots, and the roots live in the skill body, never in NUKE.md.
 const DELETION_SET_ROOTS = [
@@ -302,6 +308,44 @@ describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote t
 
   test("that block also reads the row's ^{} companion, so a missing companion is detectable", () => {
     expect(lsRemoteBlock()).toContain("^{}");
+  });
+
+  // The three above only pin the argv, which a body that reads both rows and
+  // then ignores the lightweight case would still satisfy. These pin the
+  // refusal itself: the two rows are bound to named variables, compared, and
+  // the comparison ends in a refusal.
+  test("the two rows are bound to named variables, so they can be compared at all", () => {
+    expect(lsRemoteBlock()).toContain("UNPEELED_ROW=");
+    expect(lsRemoteBlock()).toContain("PEELED_ROW=");
+  });
+
+  test('an unpeeled row with NO peeled companion is the refused condition', () => {
+    // Reading both rows is not the correction; refusing on
+    // "present unpeeled AND absent peeled" is (design.md:714).
+    expect(squash(lsRemoteBlock())).toContain(
+      `[ -n "$UNPEELED_ROW" ] && [ -z "$PEELED_ROW" ]`,
+    );
+  });
+
+  test("that condition refuses, naming the lightweight tag", () => {
+    expect(lsRemoteBlock()).toContain("refusing:");
+    expect(lsRemoteBlock()).toContain("LIGHTWEIGHT");
+  });
+
+  test("a peeled row that differs from the archive SHA is refused separately", () => {
+    expect(squash(lsRemoteBlock())).toContain(
+      `[ "$PEELED_ROW" != "$ARCHIVE_SHA" ]`,
+    );
+  });
+
+  test("the pre-flight is read-only, so it never creates the local tag it may refuse", () => {
+    // Ordering correction: the remote pre-flight runs before `tag -a -s`, so a
+    // refusal leaves no stray local tag behind.
+    const preflight = lineIndex(body(), /ls-remote --tags origin/);
+    const create = lineIndex(body(), /tag -a -s -m "Team instruction surface/);
+    expect(preflight).toBeGreaterThanOrEqual(0);
+    expect(create).toBeGreaterThan(preflight);
+    expect(lsRemoteBlock()).not.toContain("tag -a -s");
   });
 });
 
@@ -505,6 +549,35 @@ describe("Slice 3: restore refuses when the worktree toplevel equals the derived
     expect(restoreSection()).toContain("--git-common-dir");
   });
 
+  // Deriving both values is not the correction; comparing them and refusing on
+  // equality is. These three pin the comparison, its refusal, and the positive
+  // containment proof that a bare "not the primary clone" leaves out.
+  test("the derived toplevel is COMPARED with the derived primary root", () => {
+    expect(squash(restoreSection())).toContain(
+      `[ "$TOPLEVEL" != "$PRIMARY_ROOT" ]`,
+    );
+  });
+
+  test("that comparison refuses, saying the toplevel is the primary clone", () => {
+    expect(restoreSection()).toContain("refusing:");
+    expect(squash(restoreSection())).toContain("is the primary clone");
+  });
+
+  test("containment is proved positively, not only by excluding the primary clone", () => {
+    // "Not the primary clone" admits every other checkout on the machine. The
+    // toplevel must carry the team-nuke-<date> shape AND be a registered
+    // worktree of the derived primary root.
+    expect(restoreSection()).toContain("team-nuke-[0-9]");
+    expect(squash(restoreSection())).toContain(
+      `git -C "$PRIMARY_ROOT" worktree list --porcelain | grep -qxF "worktree ${"${TOPLEVEL}"}"`,
+    );
+  });
+
+  test("the recorded branch is shape-checked before it is compared", () => {
+    // NUKE.md is data: every allowlisted field it holds carries a shape check.
+    expect(restoreSection()).toContain("experiment/nuke-[0-9]");
+  });
+
   test("the nuke commit is derived, never read from NUKE.md, with rev-list --ancestry-path", () => {
     // NUKE.md sits inside the nuke commit and cannot record its own SHA.
     expect(restoreSection()).toContain("rev-list --ancestry-path");
@@ -562,20 +635,24 @@ describe("Slice 4: in the NUKE.md teardown template the nuke-result/ tag line pr
 
 describe("Slice 4: teardown carries no tag-deletion command anywhere, no --force on worktree remove, both tags created with an explicit -m, and the .2 collision line written literally beneath step 1", () => {
   test("the tag-deletion matcher fires on planted local and remote deletions", () => {
-    expect("git tag -d nuke-result/2026-08-28").toContain("tag -d");
-    expect("git push --delete origin nuke-result/2026-08-28").toContain(
-      "push --delete",
+    // Controls the matcher the absence sweeps below actually use — asserting a
+    // literal contains its own substring would prove nothing about them.
+    expect(TAG_DELETION.test("git tag -d nuke-result/2026-08-28")).toBe(true);
+    expect(
+      TAG_DELETION.test("git push --delete origin nuke-result/2026-08-28"),
+    ).toBe(true);
+    expect(TAG_DELETION.test("git tag -a -s -m msg nuke-result/<date>")).toBe(
+      false,
     );
   });
 
-  test("the teardown section carries no local tag deletion", () => {
+  test("the teardown section carries no local or remote tag deletion", () => {
     expect(teardownSection().length).toBeGreaterThan(0);
-    expect(teardownSection()).not.toContain("tag -d");
-  });
-
-  test("the teardown section carries no remote tag deletion", () => {
-    expect(teardownSection().length).toBeGreaterThan(0);
-    expect(teardownSection()).not.toContain("push --delete");
+    const offenders = teardownSection()
+      .split("\n")
+      .filter((line) => TAG_DELETION.test(line))
+      .map((line) => line.trim());
+    expect(offenders).toEqual([]);
   });
 
   test("no worktree remove line carries --force", () => {

--- a/tests/nuke-team-plugin-skill.test.ts
+++ b/tests/nuke-team-plugin-skill.test.ts
@@ -12,8 +12,8 @@
 // length guard plus a positive control, so a renamed heading fails loudly
 // instead of turning the sweep into a green no-op.
 //
-// Describe blocks are grouped so one group's fence can be run in isolation:
-//   bun test tests/nuke-team-plugin-skill.test.ts -t "Slice 3"
+// Describe blocks are grouped by mode so one group can be run in isolation:
+//   bun test tests/nuke-team-plugin-skill.test.ts -t "Restore"
 //
 // Defensive reads: a missing file → "" and a missing section → "", so every
 // content assertion FAILS cleanly rather than throwing ENOENT. The mechanical
@@ -69,7 +69,7 @@ function fencedLines(lines: string[]): boolean[] {
   return marks;
 }
 
-// Slice the body from the heading matching `re` to the next heading at the
+// Extract the body from the heading matching `re` to the next heading at the
 // same or a shallower level. A heading that does not exist yields "" — the
 // length guard on each dependent assertion then fails rather than passing
 // vacuously.
@@ -174,10 +174,10 @@ const DELETION_SET_ROOTS = [
 ];
 
 // ===========================================================================
-// Slice 1: Nuke mode — archive, isolate, remove
+// Nuke mode — archive, isolate, remove
 // ===========================================================================
 
-describe("Slice 1: frontmatter carries name + disable-model-invocation: true, no skills: key, and no Load/Follow …SKILL.md directive", () => {
+describe("Nuke mode: frontmatter carries name + disable-model-invocation: true, no skills: key, and no Load/Follow …SKILL.md directive", () => {
   test("the skill file lives under .claude/skills (dev-only, never distributed)", () => {
     expect(existsSync(SKILL)).toBe(true);
   });
@@ -239,7 +239,7 @@ describe("Slice 1: frontmatter carries name + disable-model-invocation: true, no
   });
 });
 
-describe('Slice 1: nuke steps split the two scopes — repo-level commands run at "$PRIMARY_ROOT", tree mutations run at "$WORKTREE" — and baseline-tag reuse requires peeled ^{} equality + cat-file -t tag + tag -v', () => {
+describe('Nuke mode: nuke steps split the two scopes — repo-level commands run at "$PRIMARY_ROOT", tree mutations run at "$WORKTREE" — and baseline-tag reuse requires peeled ^{} equality + cat-file -t tag + tag -v', () => {
   test("repo-level git commands are scoped to the derived primary root", () => {
     expect(body()).toContain(`git -C "$PRIMARY_ROOT"`);
   });
@@ -262,6 +262,12 @@ describe('Slice 1: nuke steps split the two scopes — repo-level commands run a
 
   test("WORKTREE is re-derived behind a standalone ${VAR:?} guard", () => {
     expect(body()).toContain(`: "\${WORKTREE:?}"`);
+  });
+
+  test("the fetch refuses on a non-zero exit status, never proceeding on stale refs", () => {
+    // Mutant target: an unguarded fetch fails silently offline, and every gate
+    // after it then proves its claim against the previous run's refs.
+    expect(body()).toContain(`git -C "$PRIMARY_ROOT" fetch origin --tags ||`);
   });
 
   test("baseline-tag reuse compares the peeled ^{} SHA, never the tag object's own", () => {
@@ -311,7 +317,7 @@ describe('Slice 1: nuke steps split the two scopes — repo-level commands run a
   });
 });
 
-describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote tag (an unpeeled refs/tags row with no ^{} companion), not only a differing peeled SHA", () => {
+describe("Nuke mode: the remote baseline pre-flight refuses a lightweight remote tag (an unpeeled refs/tags row with no ^{} companion), not only a differing peeled SHA", () => {
   // The pre-flight reads `git ls-remote --tags origin`, which lists an
   // annotated tag's own object SHA on `refs/tags/<name>` and the commit on
   // `refs/tags/<name>^{}`. A lightweight remote tag has NO `^{}` row at all,
@@ -357,6 +363,13 @@ describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote t
     expect(lsRemoteBlock()).toContain("LIGHTWEIGHT");
   });
 
+  test("the ROWS read is gated on its own exit status before either comparison", () => {
+    // Mutant target: a failed `ls-remote` yields no rows either, so an
+    // unguarded read fires neither refusal below and falls through to
+    // `tag -a -s` having proved nothing.
+    expect(lsRemoteBlock()).toContain(`^{}")" ||`);
+  });
+
   test("a peeled row that differs from the archive SHA is refused separately", () => {
     expect(squash(lsRemoteBlock())).toContain(
       `[ "$PEELED_ROW" != "$ARCHIVE_SHA" ]`,
@@ -370,6 +383,9 @@ describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote t
     const create = lineIndex(body(), /tag -a -s -m "Team instruction surface/);
     expect(preflight).toBeGreaterThanOrEqual(0);
     expect(create).toBeGreaterThan(preflight);
+    // Length guard so a renamed heading or vanished block fails loudly rather
+    // than passing the `.not.toContain` sweep vacuously.
+    expect(lsRemoteBlock().length).toBeGreaterThan(0);
     expect(lsRemoteBlock()).not.toContain("tag -a -s");
   });
 
@@ -387,10 +403,10 @@ describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote t
 });
 
 // ===========================================================================
-// Slice 2: Liveness — repoint the plugin cache
+// Liveness — repoint the plugin cache
 // ===========================================================================
 
-describe('Slice 2: the cache entry is identified by readlink equality with "$PRIMARY_ROOT" and never by version arithmetic, and each of the four zero-match cases carries its own remediation', () => {
+describe('Liveness: the cache entry is identified by readlink equality with "$PRIMARY_ROOT" and never by version arithmetic, and each of the four zero-match cases carries its own remediation', () => {
   test("a cache-repoint step section exists", () => {
     expect(cacheSection().length).toBeGreaterThan(0);
   });
@@ -428,7 +444,7 @@ describe('Slice 2: the cache entry is identified by readlink equality with "$PRI
   });
 });
 
-describe("Slice 2: the repoint block binds CACHE_ENTRY with the command that finds it, shape-checks it, and only then moves the link", () => {
+describe("Liveness: the repoint block binds CACHE_ENTRY with the command that finds it, shape-checks it, and only then moves the link", () => {
   test("CACHE_ENTRY is assigned by a find over the cache directory, never transcribed", () => {
     // Mutant target: consuming `$CACHE_ENTRY` without assigning it leaves the
     // repoint dead on `: "${CACHE_ENTRY:?}"`, and the only way to revive it is
@@ -480,7 +496,7 @@ describe("Slice 2: the repoint block binds CACHE_ENTRY with the command that fin
   });
 });
 
-describe("Slice 2: the cache-repoint step heading appears after the commit step heading", () => {
+describe("Liveness: the cache-repoint step heading appears after the commit step heading", () => {
   test("a commit step heading is present", () => {
     expect(lineIndex(body(), COMMIT_STEP_HEADING)).toBeGreaterThanOrEqual(0);
   });
@@ -499,7 +515,7 @@ describe("Slice 2: the cache-repoint step heading appears after the commit step 
   });
 });
 
-describe("Slice 2: the repoint target carries no trailing slash (or uses ln -sfn)", () => {
+describe("Liveness: the repoint target carries no trailing slash (or uses ln -sfn)", () => {
   test("the trailing-slash matcher fires on a planted rm -rf target", () => {
     expect(RM_RF_TRAILING_SLASH.test(`rm -rf "$ENTRY"/`)).toBe(true);
   });
@@ -521,10 +537,10 @@ describe("Slice 2: the repoint target carries no trailing slash (or uses ln -sfn
 });
 
 // ===========================================================================
-// Slice 3: Selective restore
+// Restore — selective, proof-gated
 // ===========================================================================
 
-describe("Slice 3: restore proves before it writes: exactly one nuke-manifest block, exact-match membership, LC_ALL=C path syntax plus containment in the hard-coded deletion set, tag shape + git tag -v, and the checkout runs against the peeled <tag>^{} SHA and never against the recorded string", () => {
+describe("Restore: restore proves before it writes: exactly one nuke-manifest block, exact-match membership, LC_ALL=C path syntax plus containment in the hard-coded deletion set, tag shape + git tag -v, and the checkout runs against the peeled <tag>^{} SHA and never against the recorded string", () => {
   test("a Restore mode section exists", () => {
     expect(restoreSection().length).toBeGreaterThan(0);
   });
@@ -558,8 +574,11 @@ describe("Slice 3: restore proves before it writes: exactly one nuke-manifest bl
   test("the trusted archive commit comes from the peeled <tag>^{} SHA", () => {
     // The recorded ARCHIVE_SHA is untrusted (NUKE.md is a tracked file anyone
     // can edit); only the tag is signed, so the checkout runs against the
-    // peeled value and the recorded field is a cross-check.
-    expect(restoreSection()).toContain("^{}");
+    // peeled value and the recorded field is a cross-check. Pinned to the R5
+    // derivation itself, not a bare "^{}" that any prose could satisfy.
+    expect(restoreSection()).toContain(
+      `ARCHIVE="$(git -C "$TOPLEVEL" rev-parse "refs/tags/${"${RECORDED_TAG}"}^{}")"`,
+    );
   });
 
   test("the recorded-state gate checks the index, not only the working tree", () => {
@@ -591,7 +610,7 @@ describe("Slice 3: restore proves before it writes: exactly one nuke-manifest bl
   });
 });
 
-describe("Slice 3: restore's write scope is stated one way: every present path on the item's line, including whole-file checkout of a present-with-hash manifest; absent paths are skipped and named", () => {
+describe("Restore: restore's write scope is stated one way: every present path on the item's line, including whole-file checkout of a present-with-hash manifest; absent paths are skipped and named", () => {
   test("the write scope distinguishes present paths", () => {
     expect(restoreSection()).toContain("present");
   });
@@ -626,7 +645,7 @@ describe("Slice 3: restore's write scope is stated one way: every present path o
   });
 });
 
-describe("Slice 3: restore refuses when the worktree toplevel equals the derived primary root, and the re-restore escape clears the index (git rm -f / a checkout of the nuke commit), not only the file", () => {
+describe("Restore: restore refuses when the worktree toplevel equals the derived primary root, and the re-restore escape clears the index (git rm -f / a checkout of the nuke commit), not only the file", () => {
   test("restore derives the toplevel with rev-parse --show-toplevel", () => {
     expect(restoreSection()).toContain("--show-toplevel");
   });
@@ -701,10 +720,10 @@ describe("Slice 3: restore refuses when the worktree toplevel equals the derived
 });
 
 // ===========================================================================
-// Slice 4: Teardown that preserves the experiment
+// Teardown — preserves the experiment
 // ===========================================================================
 
-describe("Slice 4: in the NUKE.md teardown template the nuke-result/ tag line precedes the worktree remove line and branch -D is last", () => {
+describe("Teardown: in the NUKE.md teardown template the nuke-result/ tag line precedes the worktree remove line and branch -D is last", () => {
   test("a teardown section exists in the NUKE.md template", () => {
     expect(teardownSection().length).toBeGreaterThan(0);
   });
@@ -733,7 +752,7 @@ describe("Slice 4: in the NUKE.md teardown template the nuke-result/ tag line pr
   });
 });
 
-describe("Slice 4: teardown carries no tag-deletion command anywhere, no --force on worktree remove, both tags created with an explicit -m, and the .2 collision line written literally beneath step 1", () => {
+describe("Teardown: teardown carries no tag-deletion command anywhere, no --force on worktree remove, both tags created with an explicit -m, and the .2 collision line written literally beneath step 1", () => {
   test("the tag-deletion matcher fires on planted local and remote deletions", () => {
     // Controls the matcher the absence sweeps below actually use — asserting a
     // literal contains its own substring would prove nothing about them.
@@ -781,7 +800,7 @@ describe("Slice 4: teardown carries no tag-deletion command anywhere, no --force
   });
 });
 
-describe("Slice 4: the tip-equality proof names git -C <primary root> on both halves and compares the SHA at the start of the ls-remote line", () => {
+describe("Teardown: the tip-equality proof names git -C <primary root> on both halves and compares the SHA at the start of the ls-remote line", () => {
   test("the ls-remote proof line is scoped with git -C <primary root>", () => {
     const line = teardownSection()
       .split("\n")
@@ -789,15 +808,24 @@ describe("Slice 4: the tip-equality proof names git -C <primary root> on both ha
     expect(line ?? "").toContain("git -C <primary root>");
   });
 
-  test("the branch-tip rev-parse proof line is scoped with git -C <primary root>", () => {
+  test("the branch-tip rev-parse proof line is scoped with git -C <primary root> and fully qualifies the branch", () => {
+    // The branch is qualified as refs/heads/ so a planted lightweight tag named
+    // experiment/nuke-<date> cannot satisfy git's revision search order and let
+    // the tip-equality proof pass against the wrong object.
     const line = teardownSection()
       .split("\n")
-      .find((l) => /rev-parse experiment\/nuke-/.test(l));
+      .find((l) => /rev-parse refs\/heads\/experiment\/nuke-/.test(l));
     expect(line ?? "").toContain("git -C <primary root>");
   });
 
-  test("the ls-remote proof reads the peeled refs/tags/nuke-result ref", () => {
+  test("the ls-remote proof reads the peeled, fully qualified refs/tags/nuke-result ref", () => {
     expect(teardownSection()).toContain("refs/tags/nuke-result/<date>^{}");
+  });
+
+  test("the local-tag fallback rev-parse fully qualifies the tag as refs/tags/", () => {
+    // A bare nuke-result/<date>^{} resolves through refs/<name> before
+    // refs/tags/<name>, so a planted ref could be proved instead of the tag.
+    expect(teardownSection()).toContain(`rev-parse "refs/tags/nuke-result/<date>^{}"`);
   });
 
   test("the ls-remote proof takes the SHA at the start of the line with a digit-free cut -f1", () => {
@@ -806,10 +834,10 @@ describe("Slice 4: the tip-equality proof names git -C <primary root> on both ha
 });
 
 // ===========================================================================
-// Cross-slice concerns
+// Cross-cutting concerns
 // ===========================================================================
 
-describe("Cross-slice: no $<digit> the slash-command loader would substitute, and fields are read with cut", () => {
+describe("Cross-cutting: no $<digit> the slash-command loader would substitute, and fields are read with cut", () => {
   test("the positional matcher fires on a planted awk field reference", () => {
     const planted = `awk '{print $1}'`;
     expect(POSITIONAL.test(planted)).toBe(true);
@@ -836,7 +864,7 @@ describe("Cross-slice: no $<digit> the slash-command loader would substitute, an
   });
 });
 
-describe("Cross-slice: AGENTS.md registers the skill as a development concern only", () => {
+describe("Cross-cutting: AGENTS.md registers the skill as a development concern only", () => {
   const DEV_TABLE_HEADER = "| Concern | Where it lives | Who runs it |";
   const ENTRY_POINTS_HEADER = "| Command | Phase |";
 
@@ -909,8 +937,12 @@ describe("Untrusted NUKE.md values are bound by file-reading command substitutio
     );
   });
 
-  test("the cache-undo entry is read from NUKE.md by grep/sed before the equality gate", () => {
-    expect(body()).toContain(`RECORDED_ENTRY="$(grep -E '^ln -sfn '`);
+  test("the cache-undo entry is read from NUKE.md by section-scoped grep/sed before the equality gate", () => {
+    // Scoped to the `### The cache undo` section, so an `ln -sfn` line planted
+    // in any other NUKE.md section cannot be read as the recorded undo entry.
+    expect(body()).toContain(
+      `RECORDED_ENTRY="$(sed -n '/^### The cache undo$/,/^### /p' "${"${WORKTREE}"}/NUKE.md" | grep -E '^ln -sfn '`,
+    );
   });
 
   test("the repoint refuses unless the recorded entry equals the discovered live entry", () => {
@@ -966,8 +998,20 @@ describe("The item argument reaches the shell only through a scratch file, never
     // multi-line argument would restore a real item while the maintainer never
     // saw what else was sent.
     expect(restoreSection()).toContain(
-      `[ "$(wc -l < "${"${SCRATCH_DIR}"}/item")" -le 1 ]`,
+      `[ -z "$(sed -n '2,$p' "${"${SCRATCH_DIR}"}/item")" ]`,
     );
+  });
+
+  test("no runnable block caps the argument by counting newlines", () => {
+    // Mutant target: `wc -l` counts newline characters and the Write tool
+    // appends no trailing newline, so `a\nb` counts as one line and its second
+    // line is dropped in silence. Scoped to fenced blocks, so the prose may
+    // still name the rejected form.
+    const fenced = [...restoreSection().matchAll(/```[a-z]*\n([\s\S]*?)```/g)]
+      .map((m) => m[1]!)
+      .join("\n");
+    expect(fenced.length).toBeGreaterThan(0);
+    expect(fenced).not.toContain("wc -l");
   });
 
   test("the shape check still runs before $ITEM reaches any command", () => {
@@ -1021,6 +1065,23 @@ describe("The generator enumerates per entry with while-read, not a zsh-hostile 
   test("the per-path removal loop deletes each surviving path on its own presence", () => {
     // Mutant target: the presence-guarded per-path `git rm`, not one pathspec.
     expect(body()).toContain(`git -C "$WORKTREE" rm -r -q -- "$p"`);
+  });
+
+  test("the step-6 .claude/skills sweep folds case before the own-directory exclusion", () => {
+    // Mutant target: drop the fold and a case-variant archive path like
+    // `.claude/skills/Nuke-Team-Plugin` misses the exact-case exclusion and
+    // `git rm -r` deletes this skill's own directory on case-insensitive macOS.
+    expect(body()).toContain(`entry_lc="$(printf '%s' "$entry" | tr 'A-Z' 'a-z')"`);
+  });
+
+  test("the manifest generator sweep folds case before the own-directory exclusion", () => {
+    expect(body()).toContain(`ENTRY_LC="$(printf '%s' "$ENTRY" | tr 'A-Z' 'a-z')"`);
+  });
+
+  test("step 2's already-nuked survivor scan excludes the skill's own dir case-insensitively", () => {
+    // `grep -vixF` folds case, matching check_path; `grep -vxF` would let a
+    // case-variant of the own directory read as a surviving other-skill.
+    expect(body()).toContain(`grep -vixF '.claude/skills/nuke-team-plugin'`);
   });
 });
 

--- a/tests/nuke-team-plugin-skill.test.ts
+++ b/tests/nuke-team-plugin-skill.test.ts
@@ -1,0 +1,685 @@
+// tests/nuke-team-plugin-skill.test.ts
+//
+// L2 tripwire (free, deterministic): fences the DEV `nuke-team-plugin` skill
+// (.claude/skills/nuke-team-plugin/SKILL.md) — Team's instruction-surface nuke
+// experiment (docs/plans/2026-08-28-nuke-team-plugin). It archives, removes,
+// and selectively restores Team's own skills/agents/hooks on a throwaway
+// experiment branch, then repoints the plugin cache so the experiment is live.
+//
+// What this file pins, per docs/testing.md §L2: frontmatter keys and values,
+// the commands and template strings the body tells the model to emit, the
+// hard-coded deletion-set roots, section headings, and the order of two
+// headings. Never a wording, never a proximity span, never a file length.
+// Every absence assertion carries a length guard plus a positive control, so a
+// renamed heading fails loudly instead of turning the sweep into a green no-op.
+//
+// Describe blocks are named with the acceptance criteria verbatim from
+// docs/plans/2026-08-28-nuke-team-plugin/structure.md, one describe per named
+// criterion, grouped by slice so a slice's fence can be run in isolation:
+//   bun test tests/nuke-team-plugin-skill.test.ts -t "Slice 3"
+//
+// Defensive reads: a missing file → "" and a missing section → "", so every
+// content assertion FAILS cleanly rather than throwing ENOENT. The mechanical
+// gate rejects crashes, not clean assertion failures.
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { frontmatter, read, squash } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+// nuke-team-plugin is a DEV skill — it lives under .claude/ (not distributed),
+// which is why it costs no version bump and no docs/skills.md entry.
+const SKILL = join(
+  REPO_ROOT,
+  ".claude",
+  "skills",
+  "nuke-team-plugin",
+  "SKILL.md",
+);
+const AGENTS_MD = join(REPO_ROOT, "AGENTS.md");
+
+function readIf(path: string): string {
+  return existsSync(path) ? read(path) : "";
+}
+function body(): string {
+  return readIf(SKILL);
+}
+function fm(): string {
+  return frontmatter(readIf(SKILL));
+}
+function agents(): string {
+  return readIf(AGENTS_MD);
+}
+
+// Slice the body from the heading matching `re` to the next heading at the
+// same or a shallower level. A heading that does not exist yields "" — the
+// length guard on each dependent assertion then fails rather than passing
+// vacuously (docs/testing.md, "Prove a negative check can find a positive").
+function sectionFrom(re: RegExp): string {
+  const lines = body().split("\n");
+  const start = lines.findIndex((line) => re.test(line));
+  if (start < 0) return "";
+  const hashes = lines[start]!.match(/^#+/);
+  const level = hashes ? hashes[0].length : 6;
+  const boundary = new RegExp(`^#{1,${level}}\\s`);
+  for (let i = start + 1; i < lines.length; i++) {
+    if (boundary.test(lines[i]!)) return lines.slice(start, i).join("\n");
+  }
+  return lines.slice(start).join("\n");
+}
+
+function lineIndex(text: string, re: RegExp): number {
+  return text.split("\n").findIndex((line) => re.test(line));
+}
+
+// The three sections the later slices assert against, each pinned by its
+// heading — a rename is a real contract change and must fail the build.
+const RESTORE_HEADING = /^##\s+Restore mode\b/;
+const CACHE_STEP_HEADING = /^#{2,4}\s*Step\s+\d+\b.*cache/i;
+const COMMIT_STEP_HEADING = /^#{2,4}\s*Step\s+\d+\b.*commit/i;
+const TEARDOWN_HEADING = /^#{2,6}\s.*teardown/i;
+
+function restoreSection(): string {
+  return sectionFrom(RESTORE_HEADING);
+}
+function cacheSection(): string {
+  return sectionFrom(CACHE_STEP_HEADING);
+}
+function teardownSection(): string {
+  return sectionFrom(TEARDOWN_HEADING);
+}
+
+// Extract the markdown table that starts with `header`, up to the first blank
+// line. "" when the header row is absent.
+function tableAfter(text: string, header: string): string {
+  const start = text.indexOf(header);
+  if (start < 0) return "";
+  const rest = text.slice(start);
+  const end = rest.indexOf("\n\n");
+  return end >= 0 ? rest.slice(0, end) : rest;
+}
+
+// --- Matchers used by the negative sweeps, each with a positive control ------
+
+// The self-containment ban of Decision 7: no directive telling the model to
+// read another instruction file, since every other one is deleted by the nuke.
+// Non-global so `.test()` carries no lastIndex between calls.
+const LOAD_DIRECTIVE = /^\s*>?\s*(Load|Follow)\b.*SKILL\.md/m;
+
+// Version arithmetic on the cache entry (Decision 5's rejected alternative):
+// the live entry was named by whichever checkout last ran the installer, so a
+// version read today can name a directory that does not exist.
+const VERSION_ARITHMETIC = /PLUGIN_VERSION|\.claude-plugin\/plugin\.json/;
+
+// A `rm -rf` whose target ends in `/`. BSD `rm -rf link/` follows the symlink
+// and deletes the checkout it points at (design-review-5.md:59).
+const RM_RF_TRAILING_SLASH =
+  /rm -rf\s+(?:"[^"]*"|'[^']*'|[^\s"']+)\/(?:\s|$)/;
+
+// `$` followed by a digit — the slash-command loader substitutes it as
+// `$ARGUMENTS[N]` before the model reads the body.
+const POSITIONAL = /\$[0-9]/;
+
+// awk positional field extraction, which is how the `$<digit>` token would get
+// into the body (design.md:346 spells the membership gate that way).
+const AWK_POSITIONAL = /awk\s+'\{\s*print/;
+
+// The two narrower write-scope phrasings the review Major (design.md:806)
+// rejected. Reproducing either builds a restore that cannot restore
+// `runtime-hooks` or `dev-hooks`, whose manifest state is a hash, not `-`.
+const NARROW_WRITE_SCOPE = [
+  "the paths the nuke actually removed",
+  "only writes recorded-absent paths",
+];
+
+// Decision 13's hard-coded scope check: every manifest path must sit inside one
+// of these roots, and the roots live in the skill body, never in NUKE.md.
+const DELETION_SET_ROOTS = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "skills/",
+  "agents/",
+  "hooks/",
+  ".claude/hooks/",
+  ".claude/skills/",
+  ".claude-plugin/plugin.json",
+  ".claude/settings.json",
+];
+
+// ===========================================================================
+// Slice 1: Nuke mode — archive, isolate, remove
+// ===========================================================================
+
+describe("Slice 1: frontmatter carries name + disable-model-invocation: true, no skills: key, and no Load/Follow …SKILL.md directive", () => {
+  test("the skill file lives under .claude/skills (dev-only, never distributed)", () => {
+    expect(existsSync(SKILL)).toBe(true);
+  });
+
+  test("frontmatter declares name: nuke-team-plugin", () => {
+    expect(/^name:\s*nuke-team-plugin\s*$/m.test(fm())).toBe(true);
+  });
+
+  test("frontmatter declares disable-model-invocation: true (anything that deletes is user-invocable only)", () => {
+    expect(/^disable-model-invocation:\s*true\s*$/m.test(fm())).toBe(true);
+  });
+
+  test("frontmatter carries an argument-hint naming the restore mode", () => {
+    expect(/^argument-hint:/m.test(fm())).toBe(true);
+    expect(fm()).toContain("restore");
+  });
+
+  test("description is a block scalar", () => {
+    expect(/^description:\s*\|\s*$/m.test(fm())).toBe(true);
+  });
+
+  test("description names the /nuke-team-plugin command", () => {
+    expect(squash(fm())).toContain("/nuke-team-plugin");
+  });
+
+  test("description carries the shipit-style explicit-intent guard", () => {
+    // The shared literal both `shipit` and `version-bump` use to fence an
+    // irreversible action behind stated user intent.
+    expect(squash(fm())).toContain("Invoke ONLY on explicit");
+  });
+
+  test("frontmatter carries no skills: key (Decision 7 self-containment)", () => {
+    // Guard: empty frontmatter must fail, not vacuously pass the absence check.
+    expect(fm().length).toBeGreaterThan(0);
+    expect(/^skills:/m.test(fm())).toBe(false);
+  });
+
+  test("frontmatter carries no effort: key (dev skills carry none)", () => {
+    expect(fm().length).toBeGreaterThan(0);
+    expect(/^effort:/m.test(fm())).toBe(false);
+  });
+
+  test("the Load/Follow matcher fires on a planted directive", () => {
+    const planted = "> Follow `skills/progress-tracking/SKILL.md`: seed a todo.";
+    expect(LOAD_DIRECTIVE.test(planted)).toBe(true);
+  });
+
+  test("no body line directs the model to Load or Follow another SKILL.md", () => {
+    expect(body().length).toBeGreaterThan(0);
+    expect(LOAD_DIRECTIVE.test(body())).toBe(false);
+  });
+
+  test("the body names skills/ as a deletion-set path (present, never absent)", () => {
+    expect(body()).toContain("skills/");
+  });
+
+  test("the body names agents/ as a deletion-set path (present, never absent)", () => {
+    expect(body()).toContain("agents/");
+  });
+});
+
+describe('Slice 1: nuke steps split the two scopes — repo-level commands run at "$PRIMARY_ROOT", tree mutations run at "$WORKTREE" — and baseline-tag reuse requires peeled ^{} equality + cat-file -t tag + tag -v', () => {
+  test("repo-level git commands are scoped to the derived primary root", () => {
+    expect(body()).toContain(`git -C "$PRIMARY_ROOT"`);
+  });
+
+  test("tree mutations are scoped to the experiment worktree", () => {
+    expect(body()).toContain(`git -C "$WORKTREE"`);
+  });
+
+  test("the primary root is derived from --git-common-dir, never from the invoking directory", () => {
+    expect(body()).toContain("--git-common-dir");
+  });
+
+  test("the primary root is validated against worktree list --porcelain", () => {
+    expect(body()).toContain("worktree list --porcelain");
+  });
+
+  test("PRIMARY_ROOT is re-derived behind a standalone ${VAR:?} guard", () => {
+    expect(body()).toContain(`: "\${PRIMARY_ROOT:?}"`);
+  });
+
+  test("WORKTREE is re-derived behind a standalone ${VAR:?} guard", () => {
+    expect(body()).toContain(`: "\${WORKTREE:?}"`);
+  });
+
+  test("baseline-tag reuse compares the peeled ^{} SHA, never the tag object's own", () => {
+    expect(body()).toContain("^{}");
+  });
+
+  test("baseline-tag reuse proves the tag is annotated with cat-file -t", () => {
+    expect(body()).toContain("cat-file -t");
+  });
+
+  test("baseline-tag reuse proves the signature with git tag -v", () => {
+    expect(body()).toContain("git tag -v");
+  });
+
+  test("tags are created annotated, signed, and with an explicit -m (a bare git tag opens $EDITOR)", () => {
+    expect(body()).toContain("tag -a -s -m");
+  });
+
+  test("the baseline tag is named in the nuke-baseline/ namespace", () => {
+    expect(body()).toContain("nuke-baseline/");
+  });
+
+  test("the manifest is carried in a fenced block with the nuke-manifest info string", () => {
+    expect(body()).toContain("nuke-manifest");
+  });
+
+  test("the recorded post-nuke state of an edited manifest is a git hash-object value", () => {
+    expect(body()).toContain("git hash-object");
+  });
+
+  test("membership is proved by exact match with grep -qxF", () => {
+    expect(body()).toContain("grep -qxF");
+  });
+
+  test("path syntax is checked under LC_ALL=C", () => {
+    expect(body()).toContain("LC_ALL=C");
+  });
+
+  test("the recovery line is a whole-tree git reset --hard to the archive SHA", () => {
+    expect(body()).toContain("git reset --hard");
+  });
+});
+
+describe("Slice 1: the remote baseline pre-flight refuses a lightweight remote tag (an unpeeled refs/tags row with no ^{} companion), not only a differing peeled SHA", () => {
+  // The pre-flight reads `git ls-remote --tags origin`, which lists an
+  // annotated tag's own object SHA on `refs/tags/<name>` and the commit on
+  // `refs/tags/<name>^{}`. A lightweight remote tag has NO `^{}` row at all,
+  // so a peeled-row-only comparison is vacuous against it (design.md:714).
+  function lsRemoteBlock(): string {
+    const blocks = [...body().matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map(
+      (m) => m[1]!,
+    );
+    return blocks.filter((b) => b.includes("ls-remote --tags")).join("\n");
+  }
+
+  test("a fenced block runs the ls-remote --tags pre-flight", () => {
+    expect(lsRemoteBlock().length).toBeGreaterThan(0);
+  });
+
+  test("that block reads the unpeeled refs/tags/nuke-baseline row", () => {
+    expect(lsRemoteBlock()).toContain("refs/tags/nuke-baseline/");
+  });
+
+  test("that block also reads the row's ^{} companion, so a missing companion is detectable", () => {
+    expect(lsRemoteBlock()).toContain("^{}");
+  });
+});
+
+// ===========================================================================
+// Slice 2: Liveness — repoint the plugin cache
+// ===========================================================================
+
+describe('Slice 2: the cache entry is identified by readlink equality with "$PRIMARY_ROOT" and never by version arithmetic, and each of the four zero-match cases carries its own remediation', () => {
+  test("a cache-repoint step section exists", () => {
+    expect(cacheSection().length).toBeGreaterThan(0);
+  });
+
+  test("the entry is matched by its readlink target", () => {
+    expect(body()).toContain("readlink");
+  });
+
+  test("the search is scoped to the Claude Code dev plugin cache directory", () => {
+    expect(body()).toContain("~/.claude/plugins/cache/team-dev/team");
+  });
+
+  test("the never-installed and real-directory cases route to script/dev-install claude", () => {
+    expect(body()).toContain("script/dev-install claude");
+  });
+
+  test("the foreign-symlink case says to remove the stale link first", () => {
+    // `script/dev-install claude` is a no-op here — the installer skips an
+    // existing symlink (script/dev-install-claude:14,27).
+    expect(body()).toContain("rm <entry>");
+  });
+
+  test("the earlier-experiment case is named by its team-nuke-<date> worktree", () => {
+    expect(body()).toContain("team-nuke-");
+  });
+
+  test("the version-arithmetic matcher fires on a planted derivation", () => {
+    const planted = 'PLUGIN_VERSION="$(jq -r .version .claude-plugin/plugin.json)"';
+    expect(VERSION_ARITHMETIC.test(planted)).toBe(true);
+  });
+
+  test("the cache section derives no entry path from a version string", () => {
+    expect(cacheSection().length).toBeGreaterThan(0);
+    expect(VERSION_ARITHMETIC.test(cacheSection())).toBe(false);
+  });
+});
+
+describe("Slice 2: the cache-repoint step heading appears after the commit step heading", () => {
+  test("a commit step heading is present", () => {
+    expect(lineIndex(body(), COMMIT_STEP_HEADING)).toBeGreaterThanOrEqual(0);
+  });
+
+  test("a cache-repoint step heading is present", () => {
+    expect(lineIndex(body(), CACHE_STEP_HEADING)).toBeGreaterThanOrEqual(0);
+  });
+
+  test("the cache repoint runs AFTER the nuke commit, never before it", () => {
+    // The commit must exist before the machine-wide link moves: a declined or
+    // failed repoint then leaves the commit standing, never a rollback.
+    const commit = lineIndex(body(), COMMIT_STEP_HEADING);
+    const cache = lineIndex(body(), CACHE_STEP_HEADING);
+    expect(commit).toBeGreaterThanOrEqual(0);
+    expect(cache).toBeGreaterThan(commit);
+  });
+});
+
+describe("Slice 2: the repoint target carries no trailing slash (or uses ln -sfn)", () => {
+  test("the trailing-slash matcher fires on a planted rm -rf target", () => {
+    expect(RM_RF_TRAILING_SLASH.test(`rm -rf "$ENTRY"/`)).toBe(true);
+  });
+
+  test("the trailing-slash matcher does not fire on a slash-free target", () => {
+    expect(RM_RF_TRAILING_SLASH.test(`rm -rf "$ENTRY"`)).toBe(false);
+  });
+
+  test("no rm -rf line in the body ends its target with a trailing slash", () => {
+    // BSD `rm -rf link/` follows the symlink and empties the checkout behind
+    // it (design-review-5.md:59).
+    expect(body().length).toBeGreaterThan(0);
+    const offenders = body()
+      .split("\n")
+      .filter((line) => RM_RF_TRAILING_SLASH.test(line))
+      .map((line) => line.trim());
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// Slice 3: Selective restore
+// ===========================================================================
+
+describe("Slice 3: restore proves before it writes: exactly one nuke-manifest block, exact-match membership, LC_ALL=C path syntax plus containment in the hard-coded deletion set, tag shape + git tag -v, and the checkout runs against the peeled <tag>^{} SHA and never against the recorded string", () => {
+  test("a Restore mode section exists", () => {
+    expect(restoreSection().length).toBeGreaterThan(0);
+  });
+
+  test("restore reads the manifest from the nuke-manifest fenced block", () => {
+    expect(restoreSection()).toContain("nuke-manifest");
+  });
+
+  test("the item id is extracted with the digit-free cut -d' ' -f1", () => {
+    expect(restoreSection()).toContain(`cut -d' ' -f1`);
+  });
+
+  test("membership is proved by exact match with grep -qxF", () => {
+    expect(restoreSection()).toContain("grep -qxF");
+  });
+
+  test("the path syntax check runs under LC_ALL=C", () => {
+    expect(restoreSection()).toContain("LC_ALL=C");
+  });
+
+  test("the recorded baseline tag must match the dated nuke-baseline shape", () => {
+    expect(restoreSection()).toContain(
+      "^nuke-baseline/[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+    );
+  });
+
+  test("the baseline tag's signature is verified with git tag -v before any write", () => {
+    expect(restoreSection()).toContain("git tag -v");
+  });
+
+  test("the trusted archive commit comes from the peeled <tag>^{} SHA", () => {
+    // The recorded ARCHIVE_SHA is untrusted (NUKE.md is a tracked file anyone
+    // can edit); only the tag is signed, so the checkout runs against the
+    // peeled value and the recorded field is a cross-check (Decision 13).
+    expect(restoreSection()).toContain("^{}");
+  });
+
+  test("the recorded-state gate checks the index, not only the working tree", () => {
+    expect(restoreSection()).toContain("git ls-files");
+  });
+
+  test("the recorded-state gate compares the staged blob with git rev-parse ':<path>'", () => {
+    expect(restoreSection()).toContain(`git rev-parse ":`);
+  });
+
+  test("the recorded-state gate compares the working file with git hash-object", () => {
+    expect(restoreSection()).toContain("git hash-object");
+  });
+
+  for (const root of DELETION_SET_ROOTS) {
+    test(`the deletion-set root ${root} is hard-coded in the skill body`, () => {
+      expect(body()).toContain(root);
+    });
+  }
+
+  test("the skill's own directory is excluded from the scope check", () => {
+    expect(body()).toContain(".claude/skills/nuke-team-plugin/");
+  });
+});
+
+describe("Slice 3: restore's write scope is stated one way: every present path on the item's line, including whole-file checkout of a present-with-hash manifest; absent paths are skipped and named", () => {
+  test("the write scope distinguishes present paths", () => {
+    expect(restoreSection()).toContain("present");
+  });
+
+  test("the write scope names absent paths as skipped", () => {
+    expect(restoreSection()).toContain("absent");
+  });
+
+  test("the runtime-hooks group item is restorable", () => {
+    expect(body()).toContain("runtime-hooks");
+  });
+
+  test("the dev-hooks group item is restorable", () => {
+    expect(body()).toContain("dev-hooks");
+  });
+
+  test("the narrow-phrasing matcher fires on a planted statement", () => {
+    const planted = "Restore writes the paths the nuke actually removed.";
+    expect(NARROW_WRITE_SCOPE.some((p) => planted.includes(p))).toBe(true);
+  });
+
+  test("the body never says restore writes only the paths the nuke removed", () => {
+    // Either narrower phrasing builds a restore that silently cannot return
+    // runtime-hooks or dev-hooks, whose state is a hash, not `-`
+    // (review Major, design.md:806).
+    expect(body().length).toBeGreaterThan(0);
+    expect(squash(body())).not.toContain(NARROW_WRITE_SCOPE[0]!);
+  });
+
+  test("the body never says restore only writes recorded-absent paths", () => {
+    expect(body().length).toBeGreaterThan(0);
+    expect(squash(body())).not.toContain(NARROW_WRITE_SCOPE[1]!);
+  });
+});
+
+describe("Slice 3: restore refuses when the worktree toplevel equals the derived primary root, and the re-restore escape clears the index (git rm -f / a checkout of the nuke commit), not only the file", () => {
+  test("restore derives the toplevel with rev-parse --show-toplevel", () => {
+    expect(restoreSection()).toContain("--show-toplevel");
+  });
+
+  test("restore derives the primary root so it can refuse a toplevel that equals it", () => {
+    // The `present <hash>` branch is reachable in a non-nuked tree, so the
+    // `-`-only state argument is not the containment proof (design.md:437).
+    expect(restoreSection()).toContain("--git-common-dir");
+  });
+
+  test("the nuke commit is derived, never read from NUKE.md, with rev-list --ancestry-path", () => {
+    // NUKE.md sits inside the nuke commit and cannot record its own SHA.
+    expect(restoreSection()).toContain("rev-list --ancestry-path");
+  });
+
+  test("the derived nuke commit is guarded by proving its parent is the peeled archive SHA", () => {
+    expect(restoreSection()).toContain(`\${NUKE_COMMIT}^`);
+  });
+
+  test("a `-` state path is cleared from tree AND index with git rm -r -f", () => {
+    // A filesystem `rm` leaves the index entry, so the stated escape would
+    // never clear the recorded-state gate (design.md:426).
+    expect(restoreSection()).toContain("git rm -r -f --");
+  });
+
+  test("a hashed manifest is returned by checking out the nuke commit, restoring the exact bytes the nuke wrote", () => {
+    expect(restoreSection()).toContain(`git checkout "$NUKE_COMMIT" --`);
+  });
+});
+
+// ===========================================================================
+// Slice 4: Teardown that preserves the experiment
+// ===========================================================================
+
+describe("Slice 4: in the NUKE.md teardown template the nuke-result/ tag line precedes the worktree remove line and branch -D is last", () => {
+  test("a teardown section exists in the NUKE.md template", () => {
+    expect(teardownSection().length).toBeGreaterThan(0);
+  });
+
+  test("the teardown tag command names the nuke-result/ namespace", () => {
+    const line = teardownSection()
+      .split("\n")
+      .find((l) => /tag -a -s -m/.test(l));
+    expect(line ?? "").toContain("nuke-result/");
+  });
+
+  test("the nuke-result/ tag line comes BEFORE the worktree remove line", () => {
+    // Preservation first: four steps separate the tag from the branch -D, and
+    // the tag is what keeps every commit reachable afterwards (Decision 17).
+    const tag = lineIndex(teardownSection(), /tag -a -s -m/);
+    const remove = lineIndex(teardownSection(), /worktree remove/);
+    expect(tag).toBeGreaterThanOrEqual(0);
+    expect(remove).toBeGreaterThan(tag);
+  });
+
+  test("branch -D comes last, after the worktree remove line", () => {
+    const remove = lineIndex(teardownSection(), /worktree remove/);
+    const branch = lineIndex(teardownSection(), /branch -D/);
+    expect(remove).toBeGreaterThanOrEqual(0);
+    expect(branch).toBeGreaterThan(remove);
+  });
+});
+
+describe("Slice 4: teardown carries no tag-deletion command anywhere, no --force on worktree remove, both tags created with an explicit -m, and the .2 collision line written literally beneath step 1", () => {
+  test("the tag-deletion matcher fires on planted local and remote deletions", () => {
+    expect("git tag -d nuke-result/2026-08-28").toContain("tag -d");
+    expect("git push --delete origin nuke-result/2026-08-28").toContain(
+      "push --delete",
+    );
+  });
+
+  test("the teardown section carries no local tag deletion", () => {
+    expect(teardownSection().length).toBeGreaterThan(0);
+    expect(teardownSection()).not.toContain("tag -d");
+  });
+
+  test("the teardown section carries no remote tag deletion", () => {
+    expect(teardownSection().length).toBeGreaterThan(0);
+    expect(teardownSection()).not.toContain("push --delete");
+  });
+
+  test("no worktree remove line carries --force", () => {
+    // Mirrors skills/pr-cleanup/SKILL.md:388-391 — an uncommitted restore
+    // stops the removal and shows itself instead of vanishing.
+    expect(teardownSection().length).toBeGreaterThan(0);
+    const forced = teardownSection()
+      .split("\n")
+      .filter((line) => /worktree remove/.test(line) && line.includes("--force"))
+      .map((line) => line.trim());
+    expect(forced).toEqual([]);
+  });
+
+  test("the teardown result tag is annotated, signed, and carries an explicit -m", () => {
+    expect(teardownSection()).toContain("tag -a -s -m");
+  });
+
+  test("both tags in the body are created with an explicit -m", () => {
+    const count = (body().match(/tag -a -s -m/g) ?? []).length;
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+
+  test("the .2 collision line is written literally beneath step 1", () => {
+    // Never `-f`: the tag in the way is the other run's only durable copy.
+    expect(teardownSection()).toContain("nuke-result/<date>.2");
+  });
+});
+
+describe("Slice 4: the tip-equality proof names git -C <primary root> on both halves and compares the SHA at the start of the ls-remote line", () => {
+  test("the ls-remote proof line is scoped with git -C <primary root>", () => {
+    const line = teardownSection()
+      .split("\n")
+      .find((l) => l.includes("ls-remote --tags"));
+    expect(line ?? "").toContain("git -C <primary root>");
+  });
+
+  test("the branch-tip rev-parse proof line is scoped with git -C <primary root>", () => {
+    const line = teardownSection()
+      .split("\n")
+      .find((l) => /rev-parse experiment\/nuke-/.test(l));
+    expect(line ?? "").toContain("git -C <primary root>");
+  });
+
+  test("the ls-remote proof reads the peeled refs/tags/nuke-result ref", () => {
+    expect(teardownSection()).toContain("refs/tags/nuke-result/<date>^{}");
+  });
+
+  test("the ls-remote proof takes the SHA at the start of the line with a digit-free cut -f1", () => {
+    expect(teardownSection()).toContain("cut -f1");
+  });
+});
+
+// ===========================================================================
+// Cross-slice concerns (structure.md ## Cross-slice concerns)
+// ===========================================================================
+
+describe("Cross-slice: no $<digit> the slash-command loader would substitute, and fields are read with cut", () => {
+  test("the positional matcher fires on a planted awk field reference", () => {
+    const planted = `awk '{print $1}'`;
+    expect(POSITIONAL.test(planted)).toBe(true);
+    expect(AWK_POSITIONAL.test(planted)).toBe(true);
+  });
+
+  test("the skill body contains no $<digit>", () => {
+    expect(body().length).toBeGreaterThan(0);
+    const offenders = body()
+      .split("\n")
+      .map((line, index) => ({ line: index + 1, text: line }))
+      .filter((entry) => POSITIONAL.test(entry.text))
+      .map((entry) => `SKILL.md:${entry.line}: ${entry.text.trim()}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test("the skill body uses no awk positional field extraction", () => {
+    expect(body().length).toBeGreaterThan(0);
+    expect(AWK_POSITIONAL.test(body())).toBe(false);
+  });
+
+  test("manifest fields are read with the digit-free cut -d' ' -f1", () => {
+    expect(body()).toContain(`cut -d' ' -f1`);
+  });
+});
+
+describe("Cross-slice: AGENTS.md registers the skill as a development concern only", () => {
+  const DEV_TABLE_HEADER = "| Concern | Where it lives | Who runs it |";
+  const ENTRY_POINTS_HEADER = "| Command | Phase |";
+
+  test("the runtime-vs-development table is present in AGENTS.md", () => {
+    expect(tableAfter(agents(), DEV_TABLE_HEADER).length).toBeGreaterThan(0);
+  });
+
+  test("the dev table carries a row pointing at .claude/skills/nuke-team-plugin/", () => {
+    expect(tableAfter(agents(), DEV_TABLE_HEADER)).toContain(
+      "`.claude/skills/nuke-team-plugin/`",
+    );
+  });
+
+  test("that row is owned by Plugin developers", () => {
+    const row = tableAfter(agents(), DEV_TABLE_HEADER)
+      .split("\n")
+      .find((line) => line.includes(".claude/skills/nuke-team-plugin/"));
+    expect(row ?? "").toContain("Plugin developers");
+  });
+
+  test("the Entry points table is present in AGENTS.md", () => {
+    expect(tableAfter(agents(), ENTRY_POINTS_HEADER).length).toBeGreaterThan(0);
+  });
+
+  test("no Entry points row is added — the skill is disable-model-invocation, so it wants no routing-map line", () => {
+    const entryPoints = tableAfter(agents(), ENTRY_POINTS_HEADER);
+    // Guard: a missing table must fail, not vacuously pass the absence check.
+    expect(entryPoints.length).toBeGreaterThan(0);
+    expect(entryPoints).not.toContain("nuke-team-plugin");
+  });
+});

--- a/tests/nuke-team-plugin-skill.test.ts
+++ b/tests/nuke-team-plugin-skill.test.ts
@@ -430,15 +430,21 @@ describe("Slice 3: restore proves before it writes: exactly one nuke-manifest bl
   });
 
   test("the recorded-state gate checks the index, not only the working tree", () => {
-    expect(restoreSection()).toContain("git ls-files");
+    // Bound to $TOPLEVEL, not to the caller's cwd: R6 and R7 must read and
+    // write the same tree, which is the one R2 proved.
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" ls-files`);
   });
 
   test("the recorded-state gate compares the staged blob with git rev-parse ':<path>'", () => {
-    expect(restoreSection()).toContain(`git rev-parse ":`);
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" rev-parse ":`);
   });
 
   test("the recorded-state gate compares the working file with git hash-object", () => {
-    expect(restoreSection()).toContain("git hash-object");
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" hash-object`);
+  });
+
+  test("the only restore write is bound to the proved toplevel, never to the caller's cwd", () => {
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" checkout "$ARCHIVE" --`);
   });
 
   for (const root of DELETION_SET_ROOTS) {
@@ -511,11 +517,13 @@ describe("Slice 3: restore refuses when the worktree toplevel equals the derived
   test("a `-` state path is cleared from tree AND index with git rm -r -f", () => {
     // A filesystem `rm` leaves the index entry, so the stated escape would
     // never clear the recorded-state gate (design.md:426).
-    expect(restoreSection()).toContain("git rm -r -f --");
+    expect(restoreSection()).toContain(`git -C "$TOPLEVEL" rm -r -f --`);
   });
 
   test("a hashed manifest is returned by checking out the nuke commit, restoring the exact bytes the nuke wrote", () => {
-    expect(restoreSection()).toContain(`git checkout "$NUKE_COMMIT" --`);
+    expect(restoreSection()).toContain(
+      `git -C "$TOPLEVEL" checkout "$NUKE_COMMIT" --`,
+    );
   });
 });
 


### PR DESCRIPTION
## What this is

A DEV-only skill — `.claude/skills/nuke-team-plugin/`, invoked `/nuke-team-plugin` (nuke) and `/nuke-team-plugin restore [<item>]` — that runs a **reversible experiment**: strip Team's own instruction surface (`AGENTS.md`/`CLAUDE.md`, `skills/`, `agents/`, `hooks/`, dev hooks/settings, other `.claude/skills/*`), observe the model unaided, then bring pieces back one at a time. Motivated by the Claude Code creator's advice to periodically delete your CLAUDE.md/skills/hooks and "see what the model does."

**`main` is never touched.** The archive is a signed annotated tag `nuke-baseline/<date>` at `origin/main`; the deletion lands as one signed commit on a **local, never-pushed** `experiment/nuke-<date>` branch in a worktree beside the repo; the plugin cache symlink is repointed there so the experiment is actually live. Restore is per-item, gated on a `git tag -v`-verified, date-bound tag's peeled SHA. Teardown preserves the experiment's output under a `nuke-result/<date>` tag before removing anything. `NUKE.md` at the worktree root is a self-contained manifest + recovery/teardown script.

**Dev-only, by design.** It operates on this plugin's own repo (like `version-bump`), so it lives under `.claude/skills/` — not a distributed runtime skill. No version bump, no `docs/skills.md` entry, no `## Skills (56)` change, no changelog cut. The diff is exactly three files: the skill, its L2 tripwire `tests/nuke-team-plugin-skill.test.ts`, and one row in the AGENTS.md runtime-vs-development table.

## How it was built

Full QRSPI pipeline. The design cleared a **5-round adversarial review** (with a cross-vendor codex+agy pass each round) — verdict COMMENT at round 5 after the restore mechanism was rebuilt around named manifest items with per-path blob-hash gates. Implementation cleared the **5-reviewer verify gate over 5 rounds**; round-5 verdicts: code-review APPROVE, security PASS, docs PASS, UX APPROVE, verifier PASS. 1684 tests pass / 0 fail, typecheck clean, 11 signed commits, `version-bump-required.sh` → `runtime_changed=false bumped=false`.

Hardening the untrusted-`NUKE.md` threat model drove most rounds: NUKE.md and the `<item>` argument are model-writable, so every field is bound by a file-reading command substitution (never retyped into a shell assignment), the `<item>` arrives via an `mktemp -d` scratch file, paths are shape-checked + deletion-set-contained under `LC_ALL=C`, restore writes are scope-bound to the proved `team-nuke-<date>` worktree, network reads refuse on non-zero exit, and the shell blocks are zsh-safe (the `LINES` special-parameter and word-splitting footguns were both live bugs, now fixed).

## Test plan

- [x] `bun test` — 1684 pass / 4 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun test tests/nuke-team-plugin-skill.test.ts` — 169 pass / 0 fail (mutant-checked tripwires)
- [x] `.github/scripts/version-bump-required.sh` → `OK: runtime_changed=false bumped=false`
- [x] All commits signed (verified good ED25519)
- [x] Exactly 3 files changed; `docs/skills.md`, `## Skills (56)`, `CHANGELOG.md`, version strings untouched
- [ ] **Live end-to-end nuke+restore not run** — reviewers dry-ran read-only steps 0–2 and exercised the manifest generator + full R0–R7 restore pipeline against synthetic fixtures under zsh; an actual nuke (tag push, worktree create, cache repoint) against this machine's real dev install has not been performed. Worth a first-run check by the maintainer.

## Review notes (non-blocking, carried forward)

- **docs (RECOMMENDED):** add three `## Pitfalls` bullets for the round-5 hardening (unguarded `fetch`/`ls-remote` exit status; `wc -l` vs second-line-existence line cap; case-sensitive `.claude/skills/` comparison on a case-insensitive FS). The mechanics are fixed; only the Pitfalls catalogue lags.
- **security (LOW):** the own-directory exclusion folds ASCII only (`tr 'A-Z' 'a-z'`), not Unicode — unreachable from the threat model since these paths come from `ls-tree` at `origin/main`, not from untrusted input. `SCRATCH_DIR` is checked only for absoluteness (its source is `mktemp -d`, trusted).
- **code-review (deferred test-quality):** a few `toContain` sweeps match own-path substrings and a few pins assert prose wording the header disclaims; the mechanical equivalents already exist elsewhere in the file. Deferred in the final round as churn risk; safe to tighten in a follow-up.
- **UX (cosmetic):** the "already nuked" refusal is terser than the file's own bar; hand-authoring a `NUKE.md` manifest fence is easy to get subtly wrong (R3's grammar/fence check catches the malformed case).

## Key design assumptions (audit here)

These were resolved autonomously during design and marked for PR-review audit:

- **Target is the Team plugin itself, dev-placed.** Read the maintainer's "nuke the team plugin" as this repo's own instruction surface, not an arbitrary invoking repo; placed under `.claude/skills/` like `version-bump`.
- **The experiment branch never merges and is never pushed.** `main` stays instructed; a normal session on `main` still sees Team. The "instruction-free session" is the repointed worktree, not `main` — a deliberate deviation from a literal reading of the request, taken so the product isn't deleted and CI's 56-skill pins aren't gutted. **This is the biggest judgment call — confirm it matches your intent.**
- **`disable-model-invocation: true`** — irreversible/destructive, so user-invoked only.
- **The skill excludes itself from the nuke** so a restore path survives; **user-scope `~/.claude` config is reported, not deleted** (out of the archive's reach), so the experiment is "Team removed," not "no instructions."
- **Restore/teardown scope is single-repo, per-item**; per-hook and per-guidance-section restore are out of scope (hooks restore as a group; guidance restores whole).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
