### PR TITLE
ci(evals): open an issue when the periodic evals run fails

### DIFF
--- a/.github/workflows/periodic-evals.yml
+++ b/.github/workflows/periodic-evals.yml
@@ -113,3 +113,49 @@ jobs:
           name: periodic-evals-${{ matrix.suite.name }}-${{ github.run_id }}
           path: evals/results/
           retention-days: 90
+
+  # A scheduled run has no PR to redden, so a failure is invisible unless
+  # someone subscribes to workflow notifications. Surface it as an issue.
+  # `failure()` covers any failed matrix leg and stays false when the run is
+  # cancelled (e.g. by the concurrency group).
+  report-failure:
+    name: Open failure issue
+    needs: periodic-evals
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      actions: read  # gh run view: list this run's jobs to find the failed ones
+    steps:
+      - name: Create issue linking the failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          # This job is still in_progress (conclusion empty), so the filter
+          # can only match the completed matrix legs.
+          failed_jobs=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs \
+            --jq '.jobs[] | select(.conclusion == "failure") | "- [\(.name)](\(.url))"')
+          {
+            echo "The [periodic evals run]($RUN_URL) failed."
+            echo
+            echo "**Failed jobs:**"
+            echo "$failed_jobs"
+            echo
+            echo "**Context:**"
+            echo "- Trigger: \`$EVENT_NAME\`"
+            echo "- Commit: $SHA"
+            echo "- Per-suite eval results are attached to the run as artifacts (90-day retention)."
+            echo "- Suites run live agents against a live model, so first rule out a transient"
+            echo "  (API outage, rate limit) by re-running the failed jobs before treating this"
+            echo "  as a behavioral regression."
+          } > "$RUNNER_TEMP/issue-body.md"
+          gh issue create --repo "$REPO" \
+            --title "Periodic evals failed ($(date -u +%F))" \
+            --label bug --label tests \
+            --body-file "$RUNNER_TEMP/issue-body.md"


### PR DESCRIPTION
## Summary

A scheduled run has no PR to redden, so a failed weekly eval run is invisible unless someone subscribes to workflow notifications. This adds a `report-failure` job to `periodic-evals.yml` that files a GitHub issue only when the run fails.

- Fires on `if: failure()` after the matrix (`needs: periodic-evals`) — silent on success and on cancellation.
- Issue body links the run and each failed job directly (via `gh run view --json jobs` filtered to `conclusion == "failure"`), plus trigger event, commit SHA, a pointer to the uploaded eval-result artifacts, and a transient-vs-regression triage note.
- Issue is labeled `bug` + `tests`. Job permissions are minimal: `issues: write`, `actions: read`.

Dev-only change (CI): no version bump, per the runtime-vs-development split.

## Test plan

- [x] `bun test tests/static-gate.test.ts tests/ci-workflows.test.ts` passes (93 tests — no tripwire pins broken: no new triggers, trust gate untouched)
- [x] Workflow YAML parses

**Note:** the failure path (issue actually filed, linking the failed jobs) is only verifiable live at the next failed run; the success path files nothing. Worst case matches today's status quo (silent failure), so this does not gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UQRkDmhFBZbtsxbhRtAQB

