### PR TITLE
test(gate): parse-check .github/workflows/*.yml at the free static gate

### DIFF
--- a/tests/workflow-yaml.test.ts
+++ b/tests/workflow-yaml.test.ts
@@ -1,0 +1,36 @@
+// tests/workflow-yaml.test.ts
+//
+// L2 tripwire (free, deterministic): every file under .github/workflows/
+// must parse as YAML. The other workflow tripwires read these files as raw
+// text and regex-match contract phrases, so a syntax error would otherwise
+// pass the free gate and surface only when the workflow next triggers — for
+// schedule-only workflows that is the next cron, and an unparseable
+// workflow's own failure-reporting job can never fire (#271).
+//
+// Parse-only on purpose: Actions schema/semantic validation is a heavier
+// tool than the silent-window failure requires.
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WORKFLOWS_DIR = join(process.cwd(), ".github", "workflows");
+
+const workflowFiles = readdirSync(WORKFLOWS_DIR)
+  .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+  .sort();
+
+describe("workflow yaml: every .github/workflows file parses", () => {
+  test("the workflows directory is not empty", () => {
+    // Guard: an empty haystack must fail, not vacuously pass the per-file
+    // checks below (a moved directory would otherwise go permanently green).
+    expect(workflowFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const name of workflowFiles) {
+    test(`${name} parses as YAML`, () => {
+      const text = readFileSync(join(WORKFLOWS_DIR, name), "utf8");
+      expect(() => Bun.YAML.parse(text)).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
## Problem

No layer of the test harness parses the workflow files under `.github/workflows/` as YAML. The existing tripwires (`tests/static-gate.test.ts`, `tests/ci-workflows.test.ts`) read the files as raw text and regex-match contract phrases, so a YAML syntax error passes the free gate untouched. That bites hardest on schedule-only workflows: `periodic-evals.yml` triggers on cron and manual dispatch only, so a merged syntax error surfaces at the next weekly cron at the earliest — and an unparseable workflow cannot run at all, so its own failure-reporting job (#270) never fires either.

## Change

One new L2 tripwire, `tests/workflow-yaml.test.ts`: parse every `.github/workflows/*.yml` (and `.yaml`) with `Bun.YAML.parse` and fail on a syntax error, with one test per file so a failure names the broken workflow. A non-empty-directory guard keeps the check from going vacuously green if the directory moves.

Notes against the issue:

- **No devDependency needed.** The issue anticipated adding a YAML parser, but Bun ≥ 1.2 ships `Bun.YAML.parse` built in — zero-dep is simpler and keeps the free suite lean.
- **Parse-only**, as scoped: no Actions schema/semantic validation.
- Single `test:` commit rather than the usual test+fix pair — the defect is an absent check, so the test is the fix.

## Verification

- [x] A deliberate syntax error in any `.github/workflows/*.yml` fails `bun test` — verified red on `periodic-evals.yml` and `harness-checks.yml` (assertion failure naming the file, not a crash)
- [x] All current workflow files pass; full suite green (1617 tests, 0 fail) and `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UQRkDmhFBZbtsxbhRtAQB

Closes #271
