### PR TITLE
v0.67.0 fix(pr-rebase): drop nonexistent baseRepository probe

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.66.0"
+    "version": "0.67.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/pr-rebase` step 0 no longer errors resolving the base repository.** The documented probe requested a `baseRepository` field that `gh pr view` does not expose, so the command failed on every run. A pull request lives in its base repository, so the step now uses the repository already resolved in step 0 — same fork-aware remote matching, one fewer network call, and the probe actually works. **What this asks of you:** nothing.
+
 ## [0.66.0] - 2026-09-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.67.0] - 2026-09-01
+
 ### Fixed
 
 - **`/pr-rebase` step 0 no longer errors resolving the base repository.** The documented probe requested a `baseRepository` field that `gh pr view` does not expose, so the command failed on every run. A pull request lives in its base repository, so the step now uses the repository already resolved in step 0 — same fork-aware remote matching, one fewer network call, and the probe actually works. **What this asks of you:** nothing.
@@ -654,7 +656,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.66.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.67.0...HEAD
+[0.67.0]: https://github.com/bostonaholic/team/compare/v0.66.0...v0.67.0
 [0.66.0]: https://github.com/bostonaholic/team/compare/v0.65.0...v0.66.0
 [0.65.0]: https://github.com/bostonaholic/team/compare/v0.64.0...v0.65.0
 [0.64.0]: https://github.com/bostonaholic/team/compare/v0.63.0...v0.64.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -219,8 +219,9 @@ onto it replays your work on old history and produces a diff full of
 changes you did not make:
 
 ```sh
-BASE_OWNER="$(gh pr view ${PR:+"$PR"} --repo "$REPO" --json baseRepository \
-  --jq '.baseRepository.owner.login + "/" + .baseRepository.name' 2>/dev/null)"
+# gh pr view exposes no baseRepository field; a PR lives in its base
+# repository, so $REPO (step 0) already names the base owner/name.
+BASE_OWNER="$REPO"
 # Pick the remote whose URL names that repository.
 BASE_REMOTE="$(git remote | while read -r r; do
   case "$(git remote get-url "$r")" in *"$BASE_OWNER"*) echo "$r"; break ;; esac

--- a/tests/pr-rebase-skill.test.ts
+++ b/tests/pr-rebase-skill.test.ts
@@ -175,7 +175,7 @@ describe("pr-rebase skill: the two remotes are resolved separately", () => {
     // base branch is stale — rebasing onto it replays your work on old
     // history.
     const lines = fencedLines().join("\n");
-    expect(lines).toContain("baseRepository");
+    expect(lines).toContain('BASE_OWNER="$REPO"');
     expect(lines).toContain("git remote get-url");
   });
 


### PR DESCRIPTION
## Summary

`/pr-rebase`'s step 0 documents a base-remote probe built on `gh pr view --json baseRepository` — a field `gh` does not expose (its schema offers `headRepository`/`headRepositoryOwner`, but nothing for the base repo). The documented command therefore errors on every run; it did exactly that during the live rebase of #284, where it had to be reworked mid-run.

The fix uses what step 0 already has: a pull request lives in its base repository, so `$REPO` (resolved at the top of step 0) is the base owner/name. `BASE_OWNER="$REPO"` replaces the two-line `gh`/`jq` probe. The fork-aware remote-matching loop, the `origin` fallback, and the empty-`$REPO` offline degradation are all unchanged — and it's one fewer network call.

Also updates the L2 tripwire in `tests/pr-rebase-skill.test.ts` to pin the new assignment instead of the dead field name, and adds an `[Unreleased]` changelog bullet.

Found by `/reflect` mining this session's transcript (tooling lens).

Runtime change — version bump happens at land time per docs/versioning.md, so the `version-bump-required` check stays red until then by design.

## Test plan

- [x] `bun test` full free gate green in the worktree (1809 tests, 0 fail, 55 files)
- [x] Tripwire updated at the same layer: `pr-rebase skill: the base remote is resolved from the PR, not fixed to origin` now pins `BASE_OWNER="$REPO"` + `git remote get-url`
- [x] Real-world repro: the old probe's schema error and the working substitute both occurred in the #284 rebase session

🤖 Generated with [Claude Code](https://claude.com/claude-code)