### PR TITLE
v0.70.0 feat(pr-rebase): sweep semantic coupling at each rebase stop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.69.0"
+    "version": "0.70.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.69.0",
+      "version": "0.70.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/pr-rebase` now sweeps every rebase stop for semantic coupling git cannot see.** A file that merges clean can still cite something the base renamed or moved — the breakage only surfaces at verification, or after the push. The skill now instructs a sweep of the commit's own files at each stop, folds the fixups into the replayed commit beside the conflict resolutions, and records each in the rebase log with the base change that forced it. **What this asks of you:** nothing.
+
 ## [0.69.0] - 2026-09-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.70.0] - 2026-09-01
+
 ### Changed
 
 - **`/pr-rebase` now sweeps every rebase stop for semantic coupling git cannot see.** A file that merges clean can still cite something the base renamed or moved — the breakage only surfaces at verification, or after the push. The skill now instructs a sweep of the commit's own files at each stop, folds the fixups into the replayed commit beside the conflict resolutions, and records each in the rebase log with the base change that forced it. **What this asks of you:** nothing.
@@ -672,7 +674,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.69.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.70.0...HEAD
+[0.70.0]: https://github.com/bostonaholic/team/compare/v0.69.0...v0.70.0
 [0.69.0]: https://github.com/bostonaholic/team/compare/v0.68.0...v0.69.0
 [0.68.0]: https://github.com/bostonaholic/team/compare/v0.67.0...v0.68.0
 [0.67.0]: https://github.com/bostonaholic/team/compare/v0.66.0...v0.67.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -556,6 +556,16 @@ Then, **once per rebase stop, after every path above is resolved**:
    A rebase with several conflicting commits stops again after this. Each
    stop re-enters step 5 from the top with its own path list.
 
+**A clean git merge is not a semantic merge.** Before continuing past a
+stop, sweep the commit's own files — conflicted or not — for semantic
+coupling to what the base changed: a file the base renamed that this
+branch still cites by its old path, a moved directory, a renamed symbol.
+Git merges those files clean because no lines collide, so nothing stops
+at a marker, and the breakage surfaces only at step 6 — or after the
+push. Apply such fixups now, stage them into the replayed commit beside
+the conflict resolutions, and record each in the step 2 log with the
+base change that forced it.
+
 **To abandon mid-rebase**, `git rebase --abort` restores the pre-rebase
 state exactly. Never `git rebase --skip` (Hard Rule 3).
 


### PR DESCRIPTION
## Summary

A clean git merge is not a semantic merge. Git stops a rebase only where lines collide, so a file whose meaning the base changed — a renamed path, a moved directory, a renamed symbol — replays clean while this branch still cites the old name, and the breakage surfaces only at verification or after the push. `/pr-rebase` now sweeps the replayed commit's own files at every stop, conflicted or not, and folds any fixups into that commit beside the conflict resolutions, each recorded in the step 2 rebase log against the base change that forced it.

This comes from a `/reflect` finding: in a session where the base branch had renamed a skill, four files merged clean while still citing the old path, and the mismatch was caught only at the post-rebase verification step.

## Test plan

- [x] `bun test` passes in the branch worktree (0 fail)
- [x] The new paragraph appears exactly once in skills/pr-rebase/SKILL.md, between step 5's closing paragraph and the abandon-mid-rebase note

🤖 Generated with [Claude Code](https://claude.com/claude-code)