### PR TITLE
v0.71.0 feat(pr-rebase): skip UNKNOWN-baseline checks at verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.70.0"
+    "version": "0.71.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.70.0",
+      "version": "0.71.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.71.0] - 2026-09-01
+
 ### Changed
 
 - **`/pr-rebase` no longer has to re-run a check whose baseline is `UNKNOWN`.** Such a check maps to `UNKNOWN` in the verification table whatever it returns, so re-running it produces no evidence either way — it may now be skipped, and it is reported `UNKNOWN` in the table regardless. **What this asks of you:** nothing.
@@ -678,7 +680,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.70.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.71.0...HEAD
+[0.71.0]: https://github.com/bostonaholic/team/compare/v0.70.0...v0.71.0
 [0.70.0]: https://github.com/bostonaholic/team/compare/v0.69.0...v0.70.0
 [0.69.0]: https://github.com/bostonaholic/team/compare/v0.68.0...v0.69.0
 [0.68.0]: https://github.com/bostonaholic/team/compare/v0.67.0...v0.68.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/pr-rebase` no longer has to re-run a check whose baseline is `UNKNOWN`.** Such a check maps to `UNKNOWN` in the verification table whatever it returns, so re-running it produces no evidence either way — it may now be skipped, and it is reported `UNKNOWN` in the table regardless. **What this asks of you:** nothing.
+
 ## [0.70.0] - 2026-09-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -573,6 +573,10 @@ state exactly. Never `git rebase --skip` (Hard Rule 3).
 
 Re-run **the same checks, the same commands, in the same order** as step 2.
 Do not add a check that had no baseline, and do not drop one that did.
+The one exception: a check whose baseline is `UNKNOWN` may be skipped —
+the verdict table maps it to `UNKNOWN` whatever it returns now, so
+re-running it can produce no evidence either way. Report it `UNKNOWN`
+in the table regardless.
 
 Classify each check by comparing `AFTER` to `BASELINE`:
 


### PR DESCRIPTION
## Summary

`/pr-rebase` step 6 required re-running every step 2 check verbatim, including checks whose baseline came back `UNKNOWN`. But the verdict table maps an `UNKNOWN` baseline to `UNKNOWN` no matter what the check returns afterward, so that rerun cannot produce evidence either way — it is pure cost. Step 6 now permits skipping such a check while still requiring it be reported `UNKNOWN` in the table, so the no-evidence state still carries into step 7 and the completion report. Origin is a `/reflect` finding from a session that re-ran a known-broken typecheck (exit 127) four times across two rebase runs and learned nothing each time.

## Test plan

- [x] `bun test` passes in the branch worktree (0 fail)
- [x] The exception sentence appears exactly once in skills/pr-rebase/SKILL.md, directly after step 6's same-checks mandate

🤖 Generated with [Claude Code](https://claude.com/claude-code)