### PR TITLE
v0.69.0 feat(changelog): keep both sides in changelog rebase conflicts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.68.0"
+    "version": "0.69.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.68.0",
+      "version": "0.69.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The changelog methodology now names the rebase-conflict resolution: keep both sides.** When a branch's `[Unreleased]` entries collide with dated sections the base added, the branch's entries stay under `[Unreleased]`, above the base's newest dated section, and every dated section from the base survives untouched — positional, not either/or. **What this asks of you:** nothing.
+
 ## [0.68.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.69.0] - 2026-09-01
+
 ### Changed
 
 - **The changelog methodology now names the rebase-conflict resolution: keep both sides.** When a branch's `[Unreleased]` entries collide with dated sections the base added, the branch's entries stay under `[Unreleased]`, above the base's newest dated section, and every dated section from the base survives untouched — positional, not either/or. **What this asks of you:** nothing.
@@ -666,7 +668,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.68.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.69.0...HEAD
+[0.69.0]: https://github.com/bostonaholic/team/compare/v0.68.0...v0.69.0
 [0.68.0]: https://github.com/bostonaholic/team/compare/v0.67.0...v0.68.0
 [0.67.0]: https://github.com/bostonaholic/team/compare/v0.66.0...v0.67.0
 [0.66.0]: https://github.com/bostonaholic/team/compare/v0.65.0...v0.66.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -206,6 +206,11 @@ commits are excluded and the rest are rewritten user-facing:
 - **Never duplicate an entry.** Check `[Unreleased]` before you add to it. This
   skill runs more than once against the same branch, so it must be safe to
   repeat: the second run over an unchanged branch writes nothing.
+- **A rebase conflict on the changelog keeps both sides.** When a branch's
+  `[Unreleased]` entries collide with dated sections the base added, the
+  resolution is positional, not either/or: the branch's entries stay under
+  `[Unreleased]`, above the base's newest `## [X.Y.Z]` section, and every
+  dated section from the base survives untouched.
 - **Write in past tense.** "Added X" not "Add X". The changelog records what
   happened.
 - **Keep entries short.** One to two sentences maximum. Link to documentation


### PR DESCRIPTION
## Summary

Under land-time versioning, concurrent PRs collide on `CHANGELOG.md` by construction: each branch appends under the same `[Unreleased]` heading while `main` keeps cutting dated `## [X.Y.Z]` sections directly beneath it. The collision looks like a content conflict but is not one — neither side is stale, and the correct resolution is positional rather than either/or. This adds one rule to the `changelog` skill naming that resolution: the branch's entries stay under `[Unreleased]`, above the base's newest dated section, and every dated section from the base survives untouched. Origin is a `/reflect` finding from a session that resolved this identical conflict shape three separate times across successive rebases.

## Test plan

- [x] `bun test` passes in the branch worktree (0 fail)
- [x] The new rule bullet appears exactly once in skills/changelog/SKILL.md's Rules section, directly after the never-duplicate bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)