### PR TITLE
v0.72.0 feat(codex): add agents/openai.yaml to every skill, gated by an L2 tripwire

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.71.0"
+    "version": "0.72.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -327,6 +327,66 @@ Gate yourself before acting:
 
 ---
 
+## Part 4 — Host manifest
+
+Every skill under `skills/` also ships `skills/<name>/agents/openai.yaml`, the
+per-skill manifest Codex reads to build its catalog entry. Without it, Codex
+falls back to the directory name and a truncated `description:`. It is optional
+upstream and mandatory here — `tests/skill-openai-yaml.test.ts` gates it.
+
+This part consumes Part 0's name and Part 1's verdict, so run it last.
+
+The whole file, for a skill that is model-invocable at all:
+
+```yaml
+# Codex host manifest for the <name> skill.
+interface:
+  display_name: "<Display Name>"
+  short_description: "<imperative phrase>"
+  default_prompt: "Use $team:<name> to <short description, first letter lowercased>."
+```
+
+**Style.** Two-space indent. Every string value double-quoted; every key
+unquoted. No icons, no brand color, no dependencies — the four remaining
+`interface` keys are deliberately unused.
+
+**The three fields.** Each is derived, not invented:
+
+1. `display_name` — title-case the kebab `name:`. Split on `-`; uppercase any
+   token in `{pr, ux, qrspi, solid}`; leave any token in
+   `{a, as, at, by, for, in, of, on, the, to}` lowercase unless it comes first;
+   otherwise capitalize the first character. A `principle-` prefix becomes the
+   literal `Principle: ` — so `principle-fail-closed` renders
+   `Principle: Fail Closed`, and `pr-verify` renders `PR Verify`. A new acronym
+   is a decision: add it to that list in the test in the same change.
+2. `short_description` — 25 to 64 characters inclusive, imperative, verb first,
+   first character capitalized, no trailing period, and unique across every
+   skill. **It must be a verb phrase, not a noun phrase.** `"Architecture
+   Decision Record format"` sits inside the window and is still wrong: read it
+   back inside the `default_prompt` below and it is not a request. `"Record an
+   architectural decision"` is. Do not open with an article or an acronym —
+   the template lowercases the first character, and `"sOLID"` is the result.
+3. `default_prompt` — the template exactly: `Use $team:<name> to <short
+   description with its first character lowercased>.` The `$team:` namespace is
+   how Codex names a skill from this plugin; it is not optional and not
+   per-skill.
+
+**The one fork.** If the Part 1 verdict was **user-invocable only**, append a
+blank line and a policy block:
+
+```yaml
+
+policy:
+  allow_implicit_invocation: false
+```
+
+That is the Codex-side restatement of `disable-model-invocation: true`, and the
+gate asserts the two agree in both directions: a policy block on a skill that
+never set the frontmatter key fails just as loudly as a guarded skill without
+one. Any other verdict emits no `policy` block at all.
+
+---
+
 ## Acceptance checklist (verify before the skill is done)
 
 Classification
@@ -363,3 +423,12 @@ Context
 - [ ] Heavy/broad reading delegated to subagents. Conclusions returned, not transcripts.
 - [ ] Searches/excerpts over whole-file reads. No copying large files into sub-tasks.
 - [ ] Payload left complete (not compressed for size). Working set kept lean.
+
+Host manifest
+- [ ] File exists at `skills/<name>/agents/openai.yaml`.
+- [ ] `short_description` is an imperative phrase of 25–64 characters — a verb
+      phrase, not a noun phrase.
+- [ ] Every string value double-quoted; every key unquoted.
+- [ ] `default_prompt` is the template, naming `$team:<name>`.
+- [ ] `policy` block present if and only if the frontmatter sets
+      `disable-model-invocation: true`.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -347,8 +347,10 @@ interface:
 ```
 
 **Style.** Two-space indent. Every string value double-quoted; every key
-unquoted. No icons, no brand color, no dependencies — the four remaining
-`interface` keys are deliberately unused.
+unquoted. The three remaining `interface` keys — `icon_small`, `icon_large`,
+`brand_color` — are deliberately unused, and so is `dependencies`, which is a
+TOP-LEVEL key in the spec, never an `interface` one. Nesting it under
+`interface:` fails the gate's interface allowlist.
 
 **The three fields.** Each is derived, not invented:
 
@@ -430,5 +432,7 @@ Host manifest
       phrase, not a noun phrase.
 - [ ] Every string value double-quoted; every key unquoted.
 - [ ] `default_prompt` is the template, naming `$team:<name>`.
-- [ ] `policy` block present if and only if the frontmatter sets
+- [ ] `policy` block present, and carrying the literal
+      `allow_implicit_invocation: false`, if and only if the frontmatter sets
       `disable-model-invocation: true`.
+- [ ] `bun test tests/skill-openai-yaml.test.ts` passes.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -339,7 +339,6 @@ This part consumes Part 0's name and Part 1's verdict, so run it last.
 The whole file, for a skill that is model-invocable at all:
 
 ```yaml
-# Codex host manifest for the <name> skill.
 interface:
   display_name: "<Display Name>"
   short_description: "<imperative phrase>"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.72.0] - 2026-09-01
+
 ### Added
 
-- **Every skill now ships a Codex host manifest, so Codex names it properly instead of guessing.** Without `agents/openai.yaml` Codex falls back to the directory name and a truncated `description:`; each skill now declares its own display name, a short imperative description, and the `Use $team:<name> to …` prompt Codex offers. **What this asks of you:** nothing — reinstall on Codex to pick up the new catalog entries.
+- **Every skill now ships a Codex host manifest, so Codex names it properly instead of guessing.** Without `agents/openai.yaml` Codex falls back to the directory name and a truncated `description:`; each skill now declares its own display name, a short imperative description, and the `Use $team:<name> to …` prompt Codex offers. **What this asks of you:** reinstall on Codex to pick up the new catalog entries.
 - **The three user-invoked-only skills now restate that guard where Codex can read it.** `/pr-rebase`, `/pr-watch-as-reviewer`, and `/reflect` each rewrite something that cannot be undone — published history, an approval that can trigger a merge, your `SKILL.md` files and public issues — so their manifests declare `allow_implicit_invocation: false`, matching the `disable-model-invocation: true` they already carried for Claude Code. **What this asks of you:** nothing.
 
 ## [0.71.0] - 2026-09-01
@@ -685,7 +687,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.71.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.72.0...HEAD
+[0.72.0]: https://github.com/bostonaholic/team/compare/v0.71.0...v0.72.0
 [0.71.0]: https://github.com/bostonaholic/team/compare/v0.70.0...v0.71.0
 [0.70.0]: https://github.com/bostonaholic/team/compare/v0.69.0...v0.70.0
 [0.69.0]: https://github.com/bostonaholic/team/compare/v0.68.0...v0.69.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every skill now ships a Codex host manifest, so Codex names it properly instead of guessing.** Without `agents/openai.yaml` Codex falls back to the directory name and a truncated `description:`; each skill now declares its own display name, a short imperative description, and the `Use $team:<name> to …` prompt Codex offers. **What this asks of you:** nothing — reinstall on Codex to pick up the new catalog entries.
+- **The three user-invoked-only skills now restate that guard where Codex can read it.** `/pr-rebase`, `/pr-watch-as-reviewer`, and `/reflect` each rewrite something that cannot be undone — published history, an approval that can trigger a merge, your `SKILL.md` files and public issues — so their manifests declare `allow_implicit_invocation: false`, matching the `disable-model-invocation: true` they already carried for Claude Code. **What this asks of you:** nothing.
+
 ## [0.71.0] - 2026-09-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ agents, so they will not run the pipeline. The standalone utilities do.
 > ```
 >
 > Re-running `codex plugin add` restores them.
+>
+> All three also declare `allow_implicit_invocation: false` in their
+> `agents/openai.yaml`, which asks Codex for the same guarantee in the host's
+> own vocabulary. The removal step above stands until a live Codex build is
+> observed to honor that key.
 
 </details>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -801,6 +801,34 @@ consumers, and behaviors), see [skills.md](skills.md).
    toward the limit like any methodology skill. A bundle of rules never
    takes the prefix, however principle-shaped its content.
 
+### Codex host manifests
+
+Every skill under `skills/` carries `agents/openai.yaml`, the per-skill
+manifest Codex reads to build its catalog entry. Without one, Codex falls back
+to the directory name and a truncated `description:`. The file is optional
+upstream and mandatory here, gated by `tests/skill-openai-yaml.test.ts`.
+
+Three fields, each derived from the skill's own `SKILL.md` frontmatter rather
+than stored twice: `display_name` title-cases the kebab `name:` through two
+closed lists (acronyms up, joiners down) with a `principle-` prefix rendered as
+`Principle: `; `short_description` is an imperative phrase in the spec's 25-64
+character window; `default_prompt` is `Use $<ns>:<name> to
+<short_description>.` over the namespace in `.codex-plugin/plugin.json`. No
+icons, no brand color. A `policy` block declaring
+`allow_implicit_invocation: false` appears if and only if the frontmatter sets
+`disable-model-invocation: true`, and the test asserts that equality in both
+directions.
+
+`short_description` is the one field no derivation produces, and that is where
+drift lives. `.claude/skills/create-team-skill/` teaches the manifest for a new
+skill and says nothing about keeping it current when a `description:` is
+rewritten later. Reflect is the concrete actor: `skills/reflect/SKILL.md`
+consults that guide before editing an existing skill, so the guide is reachable
+on an edit path, but it is silent about `short_description` — leaving Reflect
+able to rewrite a `description:` and leave the manifest stale. Nothing detects
+that today; the gate checks the manifest's shape, never its agreement with the
+prose it summarizes.
+
 ## 7. Hooks
 
 Runtime hooks (`hooks/`, distributed with the plugin):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -813,7 +813,8 @@ than stored twice: `display_name` title-cases the kebab `name:` through two
 closed lists (acronyms up, joiners down) with a `principle-` prefix rendered as
 `Principle: `; `short_description` is an imperative phrase in the spec's 25-64
 character window; `default_prompt` is `Use $<ns>:<name> to
-<short_description>.` over the namespace in `.codex-plugin/plugin.json`. No
+<short_description with its first character lowercased>.` over the namespace in
+`.codex-plugin/plugin.json`. No
 icons, no brand color. A `policy` block declaring
 `allow_implicit_invocation: false` appears if and only if the frontmatter sets
 `disable-model-invocation: true`, and the test asserts that equality in both

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -164,7 +164,7 @@ facility, so the design must work around it.
 |----------------|-------------|-----------|
 | Agent/skill Markdown bodies | native (loaded as-is) | native (system-prompt body) |
 | Custom slash entry points | native (SKILL.md auto-register) | native (built-ins and Skills. Prompts are deprecated in favor of Skills.) |
-| On-demand SKILL.md injection | native (`skills:` + auto-load) | native (`.agents/skills/SKILL.md`, description-matched implicit invocation) |
+| On-demand SKILL.md injection | native (`skills:` + auto-load) | native (`.agents/skills/SKILL.md`, description-matched implicit invocation). A skill may opt out through `policy.allow_implicit_invocation: false` in its `agents/openai.yaml`; unverified on a live build |
 | Subagent dispatch (parallel) | native (Agent/Task tool) | native (`spawn_agent`/`wait_agent`…, `features.multi_agent`) |
 | Nested subagents | native (depth 2, ≤4, read-only) | workaround: `max_depth=1`, nesting capped one level |
 | Structured agent→caller output | native (final-text JSON envelope) | native and strongest (`--output-schema` JSON Schema). A silent-drop bug under tools ([codex#15451](https://github.com/openai/codex/issues/15451)) was fixed April 2026 |
@@ -302,7 +302,10 @@ full parity. It starts from the matrix and works around the named gaps.
 - Bodies port as-is. Agent roles → TOML in `.codex/agents/` with the same
   system-prompt body.
 - Skills port natively to `.agents/skills/SKILL.md` (description-matched implicit
-  invocation).
+  invocation). Each skill also ships `agents/openai.yaml`, which names it in the
+  catalog; the three guarded skills declare `policy.allow_implicit_invocation:
+  false` there to opt out of that matching. Whether this host honors the key is
+  unverified on a live build.
 - Hooks: reuse the 4 `.mjs` files. The shim adapts to Codex
   `hooks.json`/`[hooks]`, whose schema mirrors Claude closely
   (`permissionDecision:"deny"`/exit 2). Events map nearly 1:1
@@ -385,6 +388,13 @@ withholds that one as well. This host therefore keeps every guarded skill out
 of the model's reach on its own, which is the opposite of Codex, and it is why
 Team's install for this host withholds nothing and needs no post-install
 removal step.
+
+Codex now gets the closest thing it has to the same claim: `pr-rebase`,
+`pr-watch-as-reviewer`, and `reflect` each declare
+`policy.allow_implicit_invocation: false` in their `agents/openai.yaml`. That
+narrows the gap without closing it. The declaration is a request to a host that
+has not been observed to honor it, where this host's behavior was observed
+directly, so the Codex install keeps both its warning and its removal step.
 
 **Paths and naming.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,6 +128,11 @@ rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/reflect
 
 Re-running `codex plugin add` restores them.
 
+All three also declare `allow_implicit_invocation: false` in their
+`agents/openai.yaml`, which asks Codex for the same guarantee in the host's own
+vocabulary. The removal step above stands until a live Codex build is observed
+to honor that key.
+
 ### Antigravity CLI
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/script/dev-install-antigravity
+++ b/script/dev-install-antigravity
@@ -12,7 +12,10 @@ set -euo pipefail
 # Discovery follows a symlinked plugin root, and this host honors
 # disable-model-invocation, so pr-rebase, pr-watch-as-reviewer, and reflect stay
 # out of the model's reach on their own. Nothing is withheld here, unlike the
-# Codex install, whose host ignores that key.
+# Codex install, whose host ignores that key. Those three also declare
+# allow_implicit_invocation: false in their agents/openai.yaml, which is the
+# Codex-side restatement of the same claim; this host needs neither, because
+# the frontmatter key alone already binds it.
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # The `.gemini` spelling below is correct: it is Antigravity CLI's own global

--- a/script/dev-install-codex
+++ b/script/dev-install-codex
@@ -46,9 +46,23 @@ if command -v codex >/dev/null 2>&1; then
   done <<<"$plugin_list"
 fi
 
+# The model-invocation caveat. Printed on BOTH exit paths — the
+# already-linked path below returns 0 before the tail ever runs, so a
+# re-install would otherwise silently drop the one warning that matters.
+print_invocation_notice() {
+  echo "  Note: pr-watch-as-reviewer, pr-rebase, and reflect are model-invocable on"
+  echo "        Codex, which ignores disable-model-invocation. The first one's"
+  echo "        approval can merge a PR; the second force-pushes a rewritten"
+  echo "        branch; reflect rewrites skill files and files public issues."
+  echo "        All three now declare allow_implicit_invocation: false in their"
+  echo "        agents/openai.yaml; this warning and the removal step stand until"
+  echo "        a live Codex build proves that key is honored."
+}
+
 # Already linked — nothing to do
 if [ -L "$TARGET" ] && [ "$(readlink "$TARGET")" = "$SKILLS_SRC" ]; then
   echo "Team skills already installed for Codex (dev)."
+  print_invocation_notice
   exit 0
 fi
 
@@ -66,10 +80,7 @@ echo
 mkdir -p "$(dirname "$TARGET")"
 ln -sfn "$SKILLS_SRC" "$TARGET"
 echo "  Linked: ${TARGET} → ${SKILLS_SRC}"
-echo "  Note: pr-watch-as-reviewer, pr-rebase, and reflect are model-invocable on"
-echo "        Codex, which ignores disable-model-invocation. The first one's"
-echo "        approval can merge a PR; the second force-pushes a rewritten"
-echo "        branch; reflect rewrites skill files and files public issues."
+print_invocation_notice
 
 echo
 echo "Done. Codex loads the skills at the next thread start."

--- a/skills/artifact-frontmatter/agents/openai.yaml
+++ b/skills/artifact-frontmatter/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the artifact-frontmatter skill.
 interface:
   display_name: "Artifact Frontmatter"
   short_description: "Validate a pipeline artifact's frontmatter"

--- a/skills/artifact-frontmatter/agents/openai.yaml
+++ b/skills/artifact-frontmatter/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the artifact-frontmatter skill.
+interface:
+  display_name: "Artifact Frontmatter"
+  short_description: "Validate a pipeline artifact's frontmatter"
+  default_prompt: "Use $team:artifact-frontmatter to validate a pipeline artifact's frontmatter."

--- a/skills/authoring-designs/agents/openai.yaml
+++ b/skills/authoring-designs/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the authoring-designs skill.
 interface:
   display_name: "Authoring Designs"
   short_description: "Draft or revise the design document"

--- a/skills/authoring-designs/agents/openai.yaml
+++ b/skills/authoring-designs/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the authoring-designs skill.
+interface:
+  display_name: "Authoring Designs"
+  short_description: "Draft or revise the design document"
+  default_prompt: "Use $team:authoring-designs to draft or revise the design document."

--- a/skills/changelog/agents/openai.yaml
+++ b/skills/changelog/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the changelog skill.
+interface:
+  display_name: "Changelog"
+  short_description: "Update the changelog for a release"
+  default_prompt: "Use $team:changelog to update the changelog for a release."

--- a/skills/changelog/agents/openai.yaml
+++ b/skills/changelog/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the changelog skill.
 interface:
   display_name: "Changelog"
   short_description: "Update the changelog for a release"

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the code-review skill.
+interface:
+  display_name: "Code Review"
+  short_description: "Review a diff with fresh-context discipline"
+  default_prompt: "Use $team:code-review to review a diff with fresh-context discipline."

--- a/skills/code-review/agents/openai.yaml
+++ b/skills/code-review/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the code-review skill.
 interface:
   display_name: "Code Review"
   short_description: "Review a diff with fresh-context discipline"

--- a/skills/conventional-comments/agents/openai.yaml
+++ b/skills/conventional-comments/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the conventional-comments skill.
 interface:
   display_name: "Conventional Comments"
   short_description: "Label and format a review finding"

--- a/skills/conventional-comments/agents/openai.yaml
+++ b/skills/conventional-comments/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the conventional-comments skill.
+interface:
+  display_name: "Conventional Comments"
+  short_description: "Label and format a review finding"
+  default_prompt: "Use $team:conventional-comments to label and format a review finding."

--- a/skills/cross-model-review/agents/openai.yaml
+++ b/skills/cross-model-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the cross-model-review skill.
+interface:
+  display_name: "Cross Model Review"
+  short_description: "Run a second-vendor review pass"
+  default_prompt: "Use $team:cross-model-review to run a second-vendor review pass."

--- a/skills/cross-model-review/agents/openai.yaml
+++ b/skills/cross-model-review/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the cross-model-review skill.
 interface:
   display_name: "Cross Model Review"
   short_description: "Run a second-vendor review pass"

--- a/skills/decomposing-intent/agents/openai.yaml
+++ b/skills/decomposing-intent/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the decomposing-intent skill.
 interface:
   display_name: "Decomposing Intent"
   short_description: "Decompose a task into neutral questions"

--- a/skills/decomposing-intent/agents/openai.yaml
+++ b/skills/decomposing-intent/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the decomposing-intent skill.
+interface:
+  display_name: "Decomposing Intent"
+  short_description: "Decompose a task into neutral questions"
+  default_prompt: "Use $team:decomposing-intent to decompose a task into neutral questions."

--- a/skills/documenting-decisions/agents/openai.yaml
+++ b/skills/documenting-decisions/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the documenting-decisions skill.
+interface:
+  display_name: "Documenting Decisions"
+  short_description: "Record an architectural decision"
+  default_prompt: "Use $team:documenting-decisions to record an architectural decision."

--- a/skills/documenting-decisions/agents/openai.yaml
+++ b/skills/documenting-decisions/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the documenting-decisions skill.
 interface:
   display_name: "Documenting Decisions"
   short_description: "Record an architectural decision"

--- a/skills/eng-design-doc-review/agents/openai.yaml
+++ b/skills/eng-design-doc-review/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the eng-design-doc-review skill.
 interface:
   display_name: "Eng Design Doc Review"
   short_description: "Adversarially review a design document"

--- a/skills/eng-design-doc-review/agents/openai.yaml
+++ b/skills/eng-design-doc-review/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the eng-design-doc-review skill.
+interface:
+  display_name: "Eng Design Doc Review"
+  short_description: "Adversarially review a design document"
+  default_prompt: "Use $team:eng-design-doc-review to adversarially review a design document."

--- a/skills/engineering-standards/agents/openai.yaml
+++ b/skills/engineering-standards/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the engineering-standards skill.
+interface:
+  display_name: "Engineering Standards"
+  short_description: "Apply the engineering quality standards"
+  default_prompt: "Use $team:engineering-standards to apply the engineering quality standards."

--- a/skills/engineering-standards/agents/openai.yaml
+++ b/skills/engineering-standards/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the engineering-standards skill.
 interface:
   display_name: "Engineering Standards"
   short_description: "Apply the engineering quality standards"

--- a/skills/finding-files/agents/openai.yaml
+++ b/skills/finding-files/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the finding-files skill.
+interface:
+  display_name: "Finding Files"
+  short_description: "Locate files relevant to an area"
+  default_prompt: "Use $team:finding-files to locate files relevant to an area."

--- a/skills/finding-files/agents/openai.yaml
+++ b/skills/finding-files/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the finding-files skill.
 interface:
   display_name: "Finding Files"
   short_description: "Locate files relevant to an area"

--- a/skills/git-commit/agents/openai.yaml
+++ b/skills/git-commit/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the git-commit skill.
+interface:
+  display_name: "Git Commit"
+  short_description: "Write an atomic conventional commit"
+  default_prompt: "Use $team:git-commit to write an atomic conventional commit."

--- a/skills/git-commit/agents/openai.yaml
+++ b/skills/git-commit/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the git-commit skill.
 interface:
   display_name: "Git Commit"
   short_description: "Write an atomic conventional commit"

--- a/skills/groom-backlog/agents/openai.yaml
+++ b/skills/groom-backlog/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the groom-backlog skill.
 interface:
   display_name: "Groom Backlog"
   short_description: "Groom a project backlog end to end"

--- a/skills/groom-backlog/agents/openai.yaml
+++ b/skills/groom-backlog/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the groom-backlog skill.
+interface:
+  display_name: "Groom Backlog"
+  short_description: "Groom a project backlog end to end"
+  default_prompt: "Use $team:groom-backlog to groom a project backlog end to end."

--- a/skills/how/agents/openai.yaml
+++ b/skills/how/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the how skill.
 interface:
   display_name: "How"
   short_description: "Explain how a subsystem works"

--- a/skills/how/agents/openai.yaml
+++ b/skills/how/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the how skill.
+interface:
+  display_name: "How"
+  short_description: "Explain how a subsystem works"
+  default_prompt: "Use $team:how to explain how a subsystem works."

--- a/skills/implementing-slices/agents/openai.yaml
+++ b/skills/implementing-slices/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the implementing-slices skill.
 interface:
   display_name: "Implementing Slices"
   short_description: "Execute an implementation plan slice by slice"

--- a/skills/implementing-slices/agents/openai.yaml
+++ b/skills/implementing-slices/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the implementing-slices skill.
+interface:
+  display_name: "Implementing Slices"
+  short_description: "Execute an implementation plan slice by slice"
+  default_prompt: "Use $team:implementing-slices to execute an implementation plan slice by slice."

--- a/skills/nested-agents/agents/openai.yaml
+++ b/skills/nested-agents/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the nested-agents skill.
+interface:
+  display_name: "Nested Agents"
+  short_description: "Spawn a nested sub-agent safely"
+  default_prompt: "Use $team:nested-agents to spawn a nested sub-agent safely."

--- a/skills/nested-agents/agents/openai.yaml
+++ b/skills/nested-agents/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the nested-agents skill.
 interface:
   display_name: "Nested Agents"
   short_description: "Spawn a nested sub-agent safely"

--- a/skills/planning-implementation/agents/openai.yaml
+++ b/skills/planning-implementation/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the planning-implementation skill.
+interface:
+  display_name: "Planning Implementation"
+  short_description: "Turn a structure into file-level steps"
+  default_prompt: "Use $team:planning-implementation to turn a structure into file-level steps."

--- a/skills/planning-implementation/agents/openai.yaml
+++ b/skills/planning-implementation/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the planning-implementation skill.
 interface:
   display_name: "Planning Implementation"
   short_description: "Turn a structure into file-level steps"

--- a/skills/pr-cleanup/agents/openai.yaml
+++ b/skills/pr-cleanup/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the pr-cleanup skill.
+interface:
+  display_name: "PR Cleanup"
+  short_description: "Tear down branch state after a PR"
+  default_prompt: "Use $team:pr-cleanup to tear down branch state after a PR."

--- a/skills/pr-cleanup/agents/openai.yaml
+++ b/skills/pr-cleanup/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the pr-cleanup skill.
 interface:
   display_name: "PR Cleanup"
   short_description: "Tear down branch state after a PR"

--- a/skills/pr-open-comments/agents/openai.yaml
+++ b/skills/pr-open-comments/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the pr-open-comments skill.
+interface:
+  display_name: "PR Open Comments"
+  short_description: "Triage unresolved PR review comments"
+  default_prompt: "Use $team:pr-open-comments to triage unresolved PR review comments."

--- a/skills/pr-open-comments/agents/openai.yaml
+++ b/skills/pr-open-comments/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the pr-open-comments skill.
 interface:
   display_name: "PR Open Comments"
   short_description: "Triage unresolved PR review comments"

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -43,6 +43,8 @@ up on a discarded line of development, and no verification step can undo
 that after the fact. Per `skills/principle-explicit-intent/SKILL.md`, the
 deliberate invocation is the authorization to publish: once the step 6 gate
 reports no regression, the run publishes without stopping to re-ask (step 7).
+`agents/openai.yaml` restates the same guard for Codex as
+`policy.allow_implicit_invocation: false`.
 
 ## Input
 

--- a/skills/pr-rebase/agents/openai.yaml
+++ b/skills/pr-rebase/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the pr-rebase skill.
 interface:
   display_name: "PR Rebase"
   short_description: "Rebase a branch onto its base"

--- a/skills/pr-rebase/agents/openai.yaml
+++ b/skills/pr-rebase/agents/openai.yaml
@@ -1,0 +1,8 @@
+# Codex host manifest for the pr-rebase skill.
+interface:
+  display_name: "PR Rebase"
+  short_description: "Rebase a branch onto its base"
+  default_prompt: "Use $team:pr-rebase to rebase a branch onto its base."
+
+policy:
+  allow_implicit_invocation: false

--- a/skills/pr-verify/agents/openai.yaml
+++ b/skills/pr-verify/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the pr-verify skill.
+interface:
+  display_name: "PR Verify"
+  short_description: "Verify a PR's test plan with evidence"
+  default_prompt: "Use $team:pr-verify to verify a PR's test plan with evidence."

--- a/skills/pr-verify/agents/openai.yaml
+++ b/skills/pr-verify/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the pr-verify skill.
 interface:
   display_name: "PR Verify"
   short_description: "Verify a PR's test plan with evidence"

--- a/skills/pr-watch-as-author/agents/openai.yaml
+++ b/skills/pr-watch-as-author/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the pr-watch-as-author skill.
 interface:
   display_name: "PR Watch as Author"
   short_description: "Watch your own PR for review feedback"

--- a/skills/pr-watch-as-author/agents/openai.yaml
+++ b/skills/pr-watch-as-author/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the pr-watch-as-author skill.
+interface:
+  display_name: "PR Watch as Author"
+  short_description: "Watch your own PR for review feedback"
+  default_prompt: "Use $team:pr-watch-as-author to watch your own PR for review feedback."

--- a/skills/pr-watch-as-reviewer/SKILL.md
+++ b/skills/pr-watch-as-reviewer/SKILL.md
@@ -36,6 +36,8 @@ passes casts `gh pr review --approve` on your behalf and stops. Model
 invocation is disabled (`disable-model-invocation: true`): on a PR with
 auto-merge enabled, an approval can transitively trigger an irreversible
 merge, so only a deliberate human invocation arms the watch.
+`agents/openai.yaml` restates the same guard for Codex as
+`policy.allow_implicit_invocation: false`.
 
 Feedback comes in two shapes, and the watch tracks both:
 

--- a/skills/pr-watch-as-reviewer/agents/openai.yaml
+++ b/skills/pr-watch-as-reviewer/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the pr-watch-as-reviewer skill.
 interface:
   display_name: "PR Watch as Reviewer"
   short_description: "Watch a PR you review, then approve once"

--- a/skills/pr-watch-as-reviewer/agents/openai.yaml
+++ b/skills/pr-watch-as-reviewer/agents/openai.yaml
@@ -1,0 +1,8 @@
+# Codex host manifest for the pr-watch-as-reviewer skill.
+interface:
+  display_name: "PR Watch as Reviewer"
+  short_description: "Watch a PR you review, then approve once"
+  default_prompt: "Use $team:pr-watch-as-reviewer to watch a PR you review, then approve once."
+
+policy:
+  allow_implicit_invocation: false

--- a/skills/principle-blind-the-investigator/agents/openai.yaml
+++ b/skills/principle-blind-the-investigator/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-blind-the-investigator skill.
 interface:
   display_name: "Principle: Blind the Investigator"
   short_description: "Hand an investigator the question, never the answer"

--- a/skills/principle-blind-the-investigator/agents/openai.yaml
+++ b/skills/principle-blind-the-investigator/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-blind-the-investigator skill.
+interface:
+  display_name: "Principle: Blind the Investigator"
+  short_description: "Hand an investigator the question, never the answer"
+  default_prompt: "Use $team:principle-blind-the-investigator to hand an investigator the question, never the answer."

--- a/skills/principle-bounded-loops/agents/openai.yaml
+++ b/skills/principle-bounded-loops/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-bounded-loops skill.
+interface:
+  display_name: "Principle: Bounded Loops"
+  short_description: "Declare a loop's cap and make hitting it loud"
+  default_prompt: "Use $team:principle-bounded-loops to declare a loop's cap and make hitting it loud."

--- a/skills/principle-bounded-loops/agents/openai.yaml
+++ b/skills/principle-bounded-loops/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-bounded-loops skill.
 interface:
   display_name: "Principle: Bounded Loops"
   short_description: "Declare a loop's cap and make hitting it loud"

--- a/skills/principle-deep-agents-narrow-seams/agents/openai.yaml
+++ b/skills/principle-deep-agents-narrow-seams/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-deep-agents-narrow-seams skill.
+interface:
+  display_name: "Principle: Deep Agents Narrow Seams"
+  short_description: "Keep complexity inside, keep the seam narrow"
+  default_prompt: "Use $team:principle-deep-agents-narrow-seams to keep complexity inside, keep the seam narrow."

--- a/skills/principle-deep-agents-narrow-seams/agents/openai.yaml
+++ b/skills/principle-deep-agents-narrow-seams/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-deep-agents-narrow-seams skill.
 interface:
   display_name: "Principle: Deep Agents Narrow Seams"
   short_description: "Keep complexity inside, keep the seam narrow"

--- a/skills/principle-evidence-over-assertion/agents/openai.yaml
+++ b/skills/principle-evidence-over-assertion/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-evidence-over-assertion skill.
+interface:
+  display_name: "Principle: Evidence Over Assertion"
+  short_description: "Cite the evidence behind every verdict"
+  default_prompt: "Use $team:principle-evidence-over-assertion to cite the evidence behind every verdict."

--- a/skills/principle-evidence-over-assertion/agents/openai.yaml
+++ b/skills/principle-evidence-over-assertion/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-evidence-over-assertion skill.
 interface:
   display_name: "Principle: Evidence Over Assertion"
   short_description: "Cite the evidence behind every verdict"

--- a/skills/principle-explicit-intent/agents/openai.yaml
+++ b/skills/principle-explicit-intent/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-explicit-intent skill.
 interface:
   display_name: "Principle: Explicit Intent"
   short_description: "Fire an irreversible act on stated intent only"

--- a/skills/principle-explicit-intent/agents/openai.yaml
+++ b/skills/principle-explicit-intent/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-explicit-intent skill.
+interface:
+  display_name: "Principle: Explicit Intent"
+  short_description: "Fire an irreversible act on stated intent only"
+  default_prompt: "Use $team:principle-explicit-intent to fire an irreversible act on stated intent only."

--- a/skills/principle-fail-closed/agents/openai.yaml
+++ b/skills/principle-fail-closed/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-fail-closed skill.
 interface:
   display_name: "Principle: Fail Closed"
   short_description: "Treat an unevaluable guarantee as a no"

--- a/skills/principle-fail-closed/agents/openai.yaml
+++ b/skills/principle-fail-closed/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-fail-closed skill.
+interface:
+  display_name: "Principle: Fail Closed"
+  short_description: "Treat an unevaluable guarantee as a no"
+  default_prompt: "Use $team:principle-fail-closed to treat an unevaluable guarantee as a no."

--- a/skills/principle-files-are-the-contract/agents/openai.yaml
+++ b/skills/principle-files-are-the-contract/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-files-are-the-contract skill.
+interface:
+  display_name: "Principle: Files Are the Contract"
+  short_description: "Pass state between steps as files on disk"
+  default_prompt: "Use $team:principle-files-are-the-contract to pass state between steps as files on disk."

--- a/skills/principle-files-are-the-contract/agents/openai.yaml
+++ b/skills/principle-files-are-the-contract/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-files-are-the-contract skill.
 interface:
   display_name: "Principle: Files Are the Contract"
   short_description: "Pass state between steps as files on disk"

--- a/skills/principle-fix-root-causes/agents/openai.yaml
+++ b/skills/principle-fix-root-causes/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-fix-root-causes skill.
 interface:
   display_name: "Principle: Fix Root Causes"
   short_description: "Trace each symptom to its root and fix it there"

--- a/skills/principle-fix-root-causes/agents/openai.yaml
+++ b/skills/principle-fix-root-causes/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-fix-root-causes skill.
+interface:
+  display_name: "Principle: Fix Root Causes"
+  short_description: "Trace each symptom to its root and fix it there"
+  default_prompt: "Use $team:principle-fix-root-causes to trace each symptom to its root and fix it there."

--- a/skills/principle-generator-evaluator/agents/openai.yaml
+++ b/skills/principle-generator-evaluator/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-generator-evaluator skill.
 interface:
   display_name: "Principle: Generator Evaluator"
   short_description: "Keep the generator from grading its own work"

--- a/skills/principle-generator-evaluator/agents/openai.yaml
+++ b/skills/principle-generator-evaluator/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-generator-evaluator skill.
+interface:
+  display_name: "Principle: Generator Evaluator"
+  short_description: "Keep the generator from grading its own work"
+  default_prompt: "Use $team:principle-generator-evaluator to keep the generator from grading its own work."

--- a/skills/principle-human-owns-the-ends/agents/openai.yaml
+++ b/skills/principle-human-owns-the-ends/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-human-owns-the-ends skill.
+interface:
+  display_name: "Principle: Human Owns the Ends"
+  short_description: "Consult the human at the ends, not mid-run"
+  default_prompt: "Use $team:principle-human-owns-the-ends to consult the human at the ends, not mid-run."

--- a/skills/principle-human-owns-the-ends/agents/openai.yaml
+++ b/skills/principle-human-owns-the-ends/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-human-owns-the-ends skill.
 interface:
   display_name: "Principle: Human Owns the Ends"
   short_description: "Consult the human at the ends, not mid-run"

--- a/skills/principle-idempotent-reruns/agents/openai.yaml
+++ b/skills/principle-idempotent-reruns/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-idempotent-reruns skill.
 interface:
   display_name: "Principle: Idempotent Reruns"
   short_description: "Make a re-run converge on the same end state"

--- a/skills/principle-idempotent-reruns/agents/openai.yaml
+++ b/skills/principle-idempotent-reruns/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-idempotent-reruns skill.
+interface:
+  display_name: "Principle: Idempotent Reruns"
+  short_description: "Make a re-run converge on the same end state"
+  default_prompt: "Use $team:principle-idempotent-reruns to make a re-run converge on the same end state."

--- a/skills/principle-least-privilege/agents/openai.yaml
+++ b/skills/principle-least-privilege/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-least-privilege skill.
+interface:
+  display_name: "Principle: Least Privilege"
+  short_description: "Enforce a constraint by withholding the tool"
+  default_prompt: "Use $team:principle-least-privilege to enforce a constraint by withholding the tool."

--- a/skills/principle-least-privilege/agents/openai.yaml
+++ b/skills/principle-least-privilege/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-least-privilege skill.
 interface:
   display_name: "Principle: Least Privilege"
   short_description: "Enforce a constraint by withholding the tool"

--- a/skills/principle-mechanical-gates/agents/openai.yaml
+++ b/skills/principle-mechanical-gates/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-mechanical-gates skill.
+interface:
+  display_name: "Principle: Mechanical Gates"
+  short_description: "Enforce a rule with a deterministic check"
+  default_prompt: "Use $team:principle-mechanical-gates to enforce a rule with a deterministic check."

--- a/skills/principle-mechanical-gates/agents/openai.yaml
+++ b/skills/principle-mechanical-gates/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-mechanical-gates skill.
 interface:
   display_name: "Principle: Mechanical Gates"
   short_description: "Enforce a rule with a deterministic check"

--- a/skills/principle-never-interpolate/agents/openai.yaml
+++ b/skills/principle-never-interpolate/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-never-interpolate skill.
+interface:
+  display_name: "Principle: Never Interpolate"
+  short_description: "Keep external values out of shell commands"
+  default_prompt: "Use $team:principle-never-interpolate to keep external values out of shell commands."

--- a/skills/principle-never-interpolate/agents/openai.yaml
+++ b/skills/principle-never-interpolate/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-never-interpolate skill.
 interface:
   display_name: "Principle: Never Interpolate"
   short_description: "Keep external values out of shell commands"

--- a/skills/principle-optimization-never-dependency/agents/openai.yaml
+++ b/skills/principle-optimization-never-dependency/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-optimization-never-dependency skill.
 interface:
   display_name: "Principle: Optimization Never Dependency"
   short_description: "Skip an enhancement loudly and fall back inline"

--- a/skills/principle-optimization-never-dependency/agents/openai.yaml
+++ b/skills/principle-optimization-never-dependency/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-optimization-never-dependency skill.
+interface:
+  display_name: "Principle: Optimization Never Dependency"
+  short_description: "Skip an enhancement loudly and fall back inline"
+  default_prompt: "Use $team:principle-optimization-never-dependency to skip an enhancement loudly and fall back inline."

--- a/skills/principle-plan-present-wait/agents/openai.yaml
+++ b/skills/principle-plan-present-wait/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-plan-present-wait skill.
+interface:
+  display_name: "Principle: Plan Present Wait"
+  short_description: "Present a plan and wait before mutating"
+  default_prompt: "Use $team:principle-plan-present-wait to present a plan and wait before mutating."

--- a/skills/principle-plan-present-wait/agents/openai.yaml
+++ b/skills/principle-plan-present-wait/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-plan-present-wait skill.
 interface:
   display_name: "Principle: Plan Present Wait"
   short_description: "Present a plan and wait before mutating"

--- a/skills/principle-pre-image-first/agents/openai.yaml
+++ b/skills/principle-pre-image-first/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-pre-image-first skill.
 interface:
   display_name: "Principle: Pre Image First"
   short_description: "Capture a recoverable pre-image before destroying"

--- a/skills/principle-pre-image-first/agents/openai.yaml
+++ b/skills/principle-pre-image-first/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-pre-image-first skill.
+interface:
+  display_name: "Principle: Pre Image First"
+  short_description: "Capture a recoverable pre-image before destroying"
+  default_prompt: "Use $team:principle-pre-image-first to capture a recoverable pre-image before destroying."

--- a/skills/principle-progress-tracking/agents/openai.yaml
+++ b/skills/principle-progress-tracking/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-progress-tracking skill.
+interface:
+  display_name: "Principle: Progress Tracking"
+  short_description: "Seed one todo per step and mark each done"
+  default_prompt: "Use $team:principle-progress-tracking to seed one todo per step and mark each done."

--- a/skills/principle-progress-tracking/agents/openai.yaml
+++ b/skills/principle-progress-tracking/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-progress-tracking skill.
 interface:
   display_name: "Principle: Progress Tracking"
   short_description: "Seed one todo per step and mark each done"

--- a/skills/principle-record-assumptions/agents/openai.yaml
+++ b/skills/principle-record-assumptions/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-record-assumptions skill.
+interface:
+  display_name: "Principle: Record Assumptions"
+  short_description: "Resolve an open question as an auditable assumption"
+  default_prompt: "Use $team:principle-record-assumptions to resolve an open question as an auditable assumption."

--- a/skills/principle-record-assumptions/agents/openai.yaml
+++ b/skills/principle-record-assumptions/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-record-assumptions skill.
 interface:
   display_name: "Principle: Record Assumptions"
   short_description: "Resolve an open question as an auditable assumption"

--- a/skills/principle-scope-fence/agents/openai.yaml
+++ b/skills/principle-scope-fence/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-scope-fence skill.
 interface:
   display_name: "Principle: Scope Fence"
   short_description: "Work only inside the change the plan names"

--- a/skills/principle-scope-fence/agents/openai.yaml
+++ b/skills/principle-scope-fence/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-scope-fence skill.
+interface:
+  display_name: "Principle: Scope Fence"
+  short_description: "Work only inside the change the plan names"
+  default_prompt: "Use $team:principle-scope-fence to work only inside the change the plan names."

--- a/skills/principle-single-source-of-truth/agents/openai.yaml
+++ b/skills/principle-single-source-of-truth/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-single-source-of-truth skill.
 interface:
   display_name: "Principle: Single Source of Truth"
   short_description: "Define a rule once and consult that owner"

--- a/skills/principle-single-source-of-truth/agents/openai.yaml
+++ b/skills/principle-single-source-of-truth/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-single-source-of-truth skill.
+interface:
+  display_name: "Principle: Single Source of Truth"
+  short_description: "Define a rule once and consult that owner"
+  default_prompt: "Use $team:principle-single-source-of-truth to define a rule once and consult that owner."

--- a/skills/principle-skip-loudly/agents/openai.yaml
+++ b/skills/principle-skip-loudly/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-skip-loudly skill.
+interface:
+  display_name: "Principle: Skip Loudly"
+  short_description: "Report what did not happen as loudly as what did"
+  default_prompt: "Use $team:principle-skip-loudly to report what did not happen as loudly as what did."

--- a/skills/principle-skip-loudly/agents/openai.yaml
+++ b/skills/principle-skip-loudly/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-skip-loudly skill.
 interface:
   display_name: "Principle: Skip Loudly"
   short_description: "Report what did not happen as loudly as what did"

--- a/skills/principle-untrusted-input-is-data/agents/openai.yaml
+++ b/skills/principle-untrusted-input-is-data/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the principle-untrusted-input-is-data skill.
+interface:
+  display_name: "Principle: Untrusted Input Is Data"
+  short_description: "Treat text from outside as data, never instructions"
+  default_prompt: "Use $team:principle-untrusted-input-is-data to treat text from outside as data, never instructions."

--- a/skills/principle-untrusted-input-is-data/agents/openai.yaml
+++ b/skills/principle-untrusted-input-is-data/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the principle-untrusted-input-is-data skill.
 interface:
   display_name: "Principle: Untrusted Input Is Data"
   short_description: "Treat text from outside as data, never instructions"

--- a/skills/product-requirements-doc/agents/openai.yaml
+++ b/skills/product-requirements-doc/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the product-requirements-doc skill.
+interface:
+  display_name: "Product Requirements Doc"
+  short_description: "Write a structured product spec"
+  default_prompt: "Use $team:product-requirements-doc to write a structured product spec."

--- a/skills/product-requirements-doc/agents/openai.yaml
+++ b/skills/product-requirements-doc/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the product-requirements-doc skill.
 interface:
   display_name: "Product Requirements Doc"
   short_description: "Write a structured product spec"

--- a/skills/product-thinking/agents/openai.yaml
+++ b/skills/product-thinking/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the product-thinking skill.
 interface:
   display_name: "Product Thinking"
   short_description: "Weigh user demand while shaping scope"

--- a/skills/product-thinking/agents/openai.yaml
+++ b/skills/product-thinking/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the product-thinking skill.
+interface:
+  display_name: "Product Thinking"
+  short_description: "Weigh user demand while shaping scope"
+  default_prompt: "Use $team:product-thinking to weigh user demand while shaping scope."

--- a/skills/qrspi-workflow/agents/openai.yaml
+++ b/skills/qrspi-workflow/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the qrspi-workflow skill.
+interface:
+  display_name: "QRSPI Workflow"
+  short_description: "Govern the pipeline's phase transitions"
+  default_prompt: "Use $team:qrspi-workflow to govern the pipeline's phase transitions."

--- a/skills/qrspi-workflow/agents/openai.yaml
+++ b/skills/qrspi-workflow/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the qrspi-workflow skill.
 interface:
   display_name: "QRSPI Workflow"
   short_description: "Govern the pipeline's phase transitions"

--- a/skills/refactoring-to-patterns/agents/openai.yaml
+++ b/skills/refactoring-to-patterns/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the refactoring-to-patterns skill.
+interface:
+  display_name: "Refactoring to Patterns"
+  short_description: "Refactor code smells into known patterns"
+  default_prompt: "Use $team:refactoring-to-patterns to refactor code smells into known patterns."

--- a/skills/refactoring-to-patterns/agents/openai.yaml
+++ b/skills/refactoring-to-patterns/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the refactoring-to-patterns skill.
 interface:
   display_name: "Refactoring to Patterns"
   short_description: "Refactor code smells into known patterns"

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -43,7 +43,8 @@ make it more than "summarize this session":
 Model invocation is disabled (`disable-model-invocation: true`). A run rewrites
 `SKILL.md` files that every future run reads and creates issues that are public
 and irreversible, and no verification afterwards undoes either. Only a
-deliberate invocation starts it.
+deliberate invocation starts it. `agents/openai.yaml` restates the same guard
+for Codex as `policy.allow_implicit_invocation: false`.
 
 ## Input
 

--- a/skills/reflect/agents/openai.yaml
+++ b/skills/reflect/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the reflect skill.
 interface:
   display_name: "Reflect"
   short_description: "Mine this session for durable learnings"

--- a/skills/reflect/agents/openai.yaml
+++ b/skills/reflect/agents/openai.yaml
@@ -1,0 +1,8 @@
+# Codex host manifest for the reflect skill.
+interface:
+  display_name: "Reflect"
+  short_description: "Mine this session for durable learnings"
+  default_prompt: "Use $team:reflect to mine this session for durable learnings."
+
+policy:
+  allow_implicit_invocation: false

--- a/skills/researching-codebases/agents/openai.yaml
+++ b/skills/researching-codebases/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the researching-codebases skill.
+interface:
+  display_name: "Researching Codebases"
+  short_description: "Answer research questions with file citations"
+  default_prompt: "Use $team:researching-codebases to answer research questions with file citations."

--- a/skills/researching-codebases/agents/openai.yaml
+++ b/skills/researching-codebases/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the researching-codebases skill.
 interface:
   display_name: "Researching Codebases"
   short_description: "Answer research questions with file citations"

--- a/skills/review-severity-tiers/agents/openai.yaml
+++ b/skills/review-severity-tiers/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the review-severity-tiers skill.
 interface:
   display_name: "Review Severity Tiers"
   short_description: "Sort a finding into a severity tier"

--- a/skills/review-severity-tiers/agents/openai.yaml
+++ b/skills/review-severity-tiers/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the review-severity-tiers skill.
+interface:
+  display_name: "Review Severity Tiers"
+  short_description: "Sort a finding into a severity tier"
+  default_prompt: "Use $team:review-severity-tiers to sort a finding into a severity tier."

--- a/skills/reviewing-documentation/agents/openai.yaml
+++ b/skills/reviewing-documentation/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the reviewing-documentation skill.
+interface:
+  display_name: "Reviewing Documentation"
+  short_description: "Review a diff for documentation gaps"
+  default_prompt: "Use $team:reviewing-documentation to review a diff for documentation gaps."

--- a/skills/reviewing-documentation/agents/openai.yaml
+++ b/skills/reviewing-documentation/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the reviewing-documentation skill.
 interface:
   display_name: "Reviewing Documentation"
   short_description: "Review a diff for documentation gaps"

--- a/skills/reviewing-security/agents/openai.yaml
+++ b/skills/reviewing-security/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the reviewing-security skill.
 interface:
   display_name: "Reviewing Security"
   short_description: "Review a diff for security vulnerabilities"

--- a/skills/reviewing-security/agents/openai.yaml
+++ b/skills/reviewing-security/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the reviewing-security skill.
+interface:
+  display_name: "Reviewing Security"
+  short_description: "Review a diff for security vulnerabilities"
+  default_prompt: "Use $team:reviewing-security to review a diff for security vulnerabilities."

--- a/skills/running-quality-checks/agents/openai.yaml
+++ b/skills/running-quality-checks/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the running-quality-checks skill.
 interface:
   display_name: "Running Quality Checks"
   short_description: "Run every available check in speed order"

--- a/skills/running-quality-checks/agents/openai.yaml
+++ b/skills/running-quality-checks/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the running-quality-checks skill.
+interface:
+  display_name: "Running Quality Checks"
+  short_description: "Run every available check in speed order"
+  default_prompt: "Use $team:running-quality-checks to run every available check in speed order."

--- a/skills/shipit/agents/openai.yaml
+++ b/skills/shipit/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the shipit skill.
+interface:
+  display_name: "Shipit"
+  short_description: "Land a reviewed pull request"
+  default_prompt: "Use $team:shipit to land a reviewed pull request."

--- a/skills/shipit/agents/openai.yaml
+++ b/skills/shipit/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the shipit skill.
 interface:
   display_name: "Shipit"
   short_description: "Land a reviewed pull request"

--- a/skills/slicing-work/agents/openai.yaml
+++ b/skills/slicing-work/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the slicing-work skill.
+interface:
+  display_name: "Slicing Work"
+  short_description: "Break a design into vertical slices"
+  default_prompt: "Use $team:slicing-work to break a design into vertical slices."

--- a/skills/slicing-work/agents/openai.yaml
+++ b/skills/slicing-work/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the slicing-work skill.
 interface:
   display_name: "Slicing Work"
   short_description: "Break a design into vertical slices"

--- a/skills/solid/agents/openai.yaml
+++ b/skills/solid/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the solid skill.
 interface:
   display_name: "SOLID"
   short_description: "Apply the SOLID design principles"

--- a/skills/solid/agents/openai.yaml
+++ b/skills/solid/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the solid skill.
+interface:
+  display_name: "SOLID"
+  short_description: "Apply the SOLID design principles"
+  default_prompt: "Use $team:solid to apply the SOLID design principles."

--- a/skills/sweeping-local-state/agents/openai.yaml
+++ b/skills/sweeping-local-state/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the sweeping-local-state skill.
 interface:
   display_name: "Sweeping Local State"
   short_description: "Tear down machine-local state after a PR"

--- a/skills/sweeping-local-state/agents/openai.yaml
+++ b/skills/sweeping-local-state/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the sweeping-local-state skill.
+interface:
+  display_name: "Sweeping Local State"
+  short_description: "Tear down machine-local state after a PR"
+  default_prompt: "Use $team:sweeping-local-state to tear down machine-local state after a PR."

--- a/skills/systematic-debugging/agents/openai.yaml
+++ b/skills/systematic-debugging/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the systematic-debugging skill.
 interface:
   display_name: "Systematic Debugging"
   short_description: "Diagnose a failure from evidence first"

--- a/skills/systematic-debugging/agents/openai.yaml
+++ b/skills/systematic-debugging/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the systematic-debugging skill.
+interface:
+  display_name: "Systematic Debugging"
+  short_description: "Diagnose a failure from evidence first"
+  default_prompt: "Use $team:systematic-debugging to diagnose a failure from evidence first."

--- a/skills/systems-thinking/agents/openai.yaml
+++ b/skills/systems-thinking/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the systems-thinking skill.
+interface:
+  display_name: "Systems Thinking"
+  short_description: "Weigh a change's blast radius"
+  default_prompt: "Use $team:systems-thinking to weigh a change's blast radius."

--- a/skills/systems-thinking/agents/openai.yaml
+++ b/skills/systems-thinking/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the systems-thinking skill.
 interface:
   display_name: "Systems Thinking"
   short_description: "Weigh a change's blast radius"

--- a/skills/team-design/agents/openai.yaml
+++ b/skills/team-design/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-design skill.
 interface:
   display_name: "Team Design"
   short_description: "Decide the approach before writing code"

--- a/skills/team-design/agents/openai.yaml
+++ b/skills/team-design/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-design skill.
+interface:
+  display_name: "Team Design"
+  short_description: "Decide the approach before writing code"
+  default_prompt: "Use $team:team-design to decide the approach before writing code."

--- a/skills/team-fix/agents/openai.yaml
+++ b/skills/team-fix/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-fix skill.
+interface:
+  display_name: "Team Fix"
+  short_description: "Run the compressed bug-fix pipeline"
+  default_prompt: "Use $team:team-fix to run the compressed bug-fix pipeline."

--- a/skills/team-fix/agents/openai.yaml
+++ b/skills/team-fix/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-fix skill.
 interface:
   display_name: "Team Fix"
   short_description: "Run the compressed bug-fix pipeline"

--- a/skills/team-implement/agents/openai.yaml
+++ b/skills/team-implement/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-implement skill.
 interface:
   display_name: "Team Implement"
   short_description: "Execute and verify the implementation phase"

--- a/skills/team-implement/agents/openai.yaml
+++ b/skills/team-implement/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-implement skill.
+interface:
+  display_name: "Team Implement"
+  short_description: "Execute and verify the implementation phase"
+  default_prompt: "Use $team:team-implement to execute and verify the implementation phase."

--- a/skills/team-plan/agents/openai.yaml
+++ b/skills/team-plan/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-plan skill.
 interface:
   display_name: "Team Plan"
   short_description: "Produce the tactical implementation plan"

--- a/skills/team-plan/agents/openai.yaml
+++ b/skills/team-plan/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-plan skill.
+interface:
+  display_name: "Team Plan"
+  short_description: "Produce the tactical implementation plan"
+  default_prompt: "Use $team:team-plan to produce the tactical implementation plan."

--- a/skills/team-pr/agents/openai.yaml
+++ b/skills/team-pr/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-pr skill.
+interface:
+  display_name: "Team PR"
+  short_description: "Open the pull request after verification"
+  default_prompt: "Use $team:team-pr to open the pull request after verification."

--- a/skills/team-pr/agents/openai.yaml
+++ b/skills/team-pr/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-pr skill.
 interface:
   display_name: "Team PR"
   short_description: "Open the pull request after verification"

--- a/skills/team-question/agents/openai.yaml
+++ b/skills/team-question/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-question skill.
+interface:
+  display_name: "Team Question"
+  short_description: "Decompose a feature into task and questions"
+  default_prompt: "Use $team:team-question to decompose a feature into task and questions."

--- a/skills/team-question/agents/openai.yaml
+++ b/skills/team-question/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-question skill.
 interface:
   display_name: "Team Question"
   short_description: "Decompose a feature into task and questions"

--- a/skills/team-research/agents/openai.yaml
+++ b/skills/team-research/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-research skill.
 interface:
   display_name: "Team Research"
   short_description: "Research a codebase area before changing it"

--- a/skills/team-research/agents/openai.yaml
+++ b/skills/team-research/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-research skill.
+interface:
+  display_name: "Team Research"
+  short_description: "Research a codebase area before changing it"
+  default_prompt: "Use $team:team-research to research a codebase area before changing it."

--- a/skills/team-structure/agents/openai.yaml
+++ b/skills/team-structure/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-structure skill.
+interface:
+  display_name: "Team Structure"
+  short_description: "Break the reviewed design into slices"
+  default_prompt: "Use $team:team-structure to break the reviewed design into slices."

--- a/skills/team-structure/agents/openai.yaml
+++ b/skills/team-structure/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-structure skill.
 interface:
   display_name: "Team Structure"
   short_description: "Break the reviewed design into slices"

--- a/skills/team-worktree/agents/openai.yaml
+++ b/skills/team-worktree/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team-worktree skill.
 interface:
   display_name: "Team Worktree"
   short_description: "Prepare an isolated git worktree"

--- a/skills/team-worktree/agents/openai.yaml
+++ b/skills/team-worktree/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team-worktree skill.
+interface:
+  display_name: "Team Worktree"
+  short_description: "Prepare an isolated git worktree"
+  default_prompt: "Use $team:team-worktree to prepare an isolated git worktree."

--- a/skills/team/agents/openai.yaml
+++ b/skills/team/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the team skill.
+interface:
+  display_name: "Team"
+  short_description: "Run the full autonomous feature pipeline"
+  default_prompt: "Use $team:team to run the full autonomous feature pipeline."

--- a/skills/team/agents/openai.yaml
+++ b/skills/team/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the team skill.
 interface:
   display_name: "Team"
   short_description: "Run the full autonomous feature pipeline"

--- a/skills/technical-design-doc/agents/openai.yaml
+++ b/skills/technical-design-doc/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the technical-design-doc skill.
+interface:
+  display_name: "Technical Design Doc"
+  short_description: "Structure a technical design document"
+  default_prompt: "Use $team:technical-design-doc to structure a technical design document."

--- a/skills/technical-design-doc/agents/openai.yaml
+++ b/skills/technical-design-doc/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the technical-design-doc skill.
 interface:
   display_name: "Technical Design Doc"
   short_description: "Structure a technical design document"

--- a/skills/test-driven-bug-fix/agents/openai.yaml
+++ b/skills/test-driven-bug-fix/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the test-driven-bug-fix skill.
+interface:
+  display_name: "Test Driven Bug Fix"
+  short_description: "Reproduce a bug, then fix it red to green"
+  default_prompt: "Use $team:test-driven-bug-fix to reproduce a bug, then fix it red to green."

--- a/skills/test-driven-bug-fix/agents/openai.yaml
+++ b/skills/test-driven-bug-fix/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the test-driven-bug-fix skill.
 interface:
   display_name: "Test Driven Bug Fix"
   short_description: "Reproduce a bug, then fix it red to green"

--- a/skills/test-first-development/agents/openai.yaml
+++ b/skills/test-first-development/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the test-first-development skill.
+interface:
+  display_name: "Test First Development"
+  short_description: "Write acceptance tests before the code"
+  default_prompt: "Use $team:test-first-development to write acceptance tests before the code."

--- a/skills/test-first-development/agents/openai.yaml
+++ b/skills/test-first-development/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the test-first-development skill.
 interface:
   display_name: "Test First Development"
   short_description: "Write acceptance tests before the code"

--- a/skills/test-style/agents/openai.yaml
+++ b/skills/test-style/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the test-style skill.
+interface:
+  display_name: "Test Style"
+  short_description: "Write behavior-focused, non-flaky tests"
+  default_prompt: "Use $team:test-style to write behavior-focused, non-flaky tests."

--- a/skills/test-style/agents/openai.yaml
+++ b/skills/test-style/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the test-style skill.
 interface:
   display_name: "Test Style"
   short_description: "Write behavior-focused, non-flaky tests"

--- a/skills/tracking-tickets/agents/openai.yaml
+++ b/skills/tracking-tickets/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the tracking-tickets skill.
 interface:
   display_name: "Tracking Tickets"
   short_description: "Move a tracker ticket through its states"

--- a/skills/tracking-tickets/agents/openai.yaml
+++ b/skills/tracking-tickets/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the tracking-tickets skill.
+interface:
+  display_name: "Tracking Tickets"
+  short_description: "Move a tracker ticket through its states"
+  default_prompt: "Use $team:tracking-tickets to move a tracker ticket through its states."

--- a/skills/verifying-ux/agents/openai.yaml
+++ b/skills/verifying-ux/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the verifying-ux skill.
+interface:
+  display_name: "Verifying UX"
+  short_description: "Boot the app and verify it live"
+  default_prompt: "Use $team:verifying-ux to boot the app and verify it live."

--- a/skills/verifying-ux/agents/openai.yaml
+++ b/skills/verifying-ux/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the verifying-ux skill.
 interface:
   display_name: "Verifying UX"
   short_description: "Boot the app and verify it live"

--- a/skills/why/agents/openai.yaml
+++ b/skills/why/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the why skill.
 interface:
   display_name: "Why"
   short_description: "Investigate the design rationale behind code"

--- a/skills/why/agents/openai.yaml
+++ b/skills/why/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the why skill.
+interface:
+  display_name: "Why"
+  short_description: "Investigate the design rationale behind code"
+  default_prompt: "Use $team:why to investigate the design rationale behind code."

--- a/skills/worktree-isolation/agents/openai.yaml
+++ b/skills/worktree-isolation/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the worktree-isolation skill.
+interface:
+  display_name: "Worktree Isolation"
+  short_description: "Run the pipeline in isolated worktrees"
+  default_prompt: "Use $team:worktree-isolation to run the pipeline in isolated worktrees."

--- a/skills/worktree-isolation/agents/openai.yaml
+++ b/skills/worktree-isolation/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the worktree-isolation skill.
 interface:
   display_name: "Worktree Isolation"
   short_description: "Run the pipeline in isolated worktrees"

--- a/skills/writing-prose/agents/openai.yaml
+++ b/skills/writing-prose/agents/openai.yaml
@@ -1,0 +1,5 @@
+# Codex host manifest for the writing-prose skill.
+interface:
+  display_name: "Writing Prose"
+  short_description: "Write and assess plain-language prose"
+  default_prompt: "Use $team:writing-prose to write and assess plain-language prose."

--- a/skills/writing-prose/agents/openai.yaml
+++ b/skills/writing-prose/agents/openai.yaml
@@ -1,4 +1,3 @@
-# Codex host manifest for the writing-prose skill.
 interface:
   display_name: "Writing Prose"
   short_description: "Write and assess plain-language prose"

--- a/tests/dev-install-codex.test.ts
+++ b/tests/dev-install-codex.test.ts
@@ -105,14 +105,33 @@ describe("dev install: codex harness", () => {
   });
 
   test("install announces that Codex ignores disable-model-invocation", () => {
-    // Both user-only skills install like any other skill here, so the run has
-    // to name them — the guard they rely on is honored by Claude Code and
+    // All three user-only skills install like any other skill here, so the run
+    // has to name them — the guard they rely on is honored by Claude Code and
     // ignored by Codex. pr-watch-as-reviewer's approval can merge a PR;
-    // pr-rebase force-pushes a rewritten branch.
+    // pr-rebase force-pushes a rewritten branch; reflect rewrites skill files
+    // and files public issues. Identifiers only, never wording.
     const { output } = run(INSTALL, newHome());
     expect(output).toContain("pr-watch-as-reviewer");
     expect(output).toContain("pr-rebase");
+    expect(output).toContain("reflect");
     expect(output).toContain("disable-model-invocation");
+    expect(output).toContain("allow_implicit_invocation");
+  });
+
+  test("a re-install still announces the guard on the already-linked path", () => {
+    // The already-linked path returns 0 before the tail ever prints, so the
+    // notice has to be reachable from both exits. A developer re-running the
+    // installer is the likeliest reader of a warning they skimmed the first
+    // time; without this, that run says only "already installed".
+    const home = newHome();
+    expect(run(INSTALL, home).status).toBe(0);
+
+    const { output } = run(INSTALL, home);
+
+    expect(output).toContain("pr-watch-as-reviewer");
+    expect(output).toContain("pr-rebase");
+    expect(output).toContain("reflect");
+    expect(output).toContain("allow_implicit_invocation");
   });
 
   // Stacking the dev symlink on a native plugin install makes Codex find the

--- a/tests/skill-openai-yaml.test.ts
+++ b/tests/skill-openai-yaml.test.ts
@@ -1,0 +1,483 @@
+// tests/skill-openai-yaml.test.ts
+//
+// L2 tripwire (free, deterministic): every skill under `skills/` carries a
+// Codex host manifest at `agents/openai.yaml`, and every field in it is
+// mechanically derivable from that skill's own `SKILL.md` frontmatter.
+//
+// The contract, per skill:
+//
+//   - the file exists, parses, and is a mapping
+//   - `interface.display_name` / `short_description` / `default_prompt` are
+//     non-empty strings
+//   - `display_name` is the kebab `name:` title-cased through two closed
+//     lists (uppercase acronyms, lowercase joiners), with a `principle-`
+//     prefix rendered as `Principle: `
+//   - `short_description` is 25-64 characters inclusive (the Codex spec's own
+//     window) and does not open with an article, which is the cheap tell for
+//     the noun phrase that reads as nonsense after the word "to" below
+//   - `default_prompt` is exactly `Use $<ns>:<name> to <short_description>.`,
+//     where `<ns>` is the plugin namespace read from `.codex-plugin/plugin.json`
+//     — the manifest Codex prefers, pinned equal to `.claude-plugin/plugin.json`
+//     by tests/version-consistency.test.ts
+//   - top-level, `interface`, and `policy` keys stay inside the spec's
+//     allowlists
+//   - read from the RAW TEXT, not the parse tree: every `interface` value is a
+//     double-quoted scalar, no key is quoted, and a `policy` block is exactly
+//     `allow_implicit_invocation: false`. `Bun.YAML.parse` returns the same
+//     value for `"x"` and `x`, so the parse tree cannot see the spec's style
+//     rule at all.
+//
+// And repo-wide: `short_description` is unique across every skill, and the set
+// of skills carrying a `policy` block equals the set whose frontmatter sets
+// `disable-model-invocation: true` — in BOTH directions, each side rebuilt
+// from disk.
+//
+// Sibling: tests/guarded-skill-prose.test.ts pins the same guarded set where it
+// appears in prose. This file pins it where it appears as structured data. The
+// enumeration comes from `skillNames()` (tests/helpers/skill-refs.ts), which
+// reads `skills/` only — that is what keeps the dev-only `.claude/skills/` out
+// of scope by construction, with no exclusion list to drift.
+//
+// Every check collects offenders and asserts once, so a single run names every
+// violator instead of aborting on the first.
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { skillNames } from "./helpers/skill-refs";
+import { frontmatter, read } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+
+// The Codex spec's own window for `short_description`, inclusive on both ends.
+const SHORT_DESCRIPTION_MIN = 25;
+const SHORT_DESCRIPTION_MAX = 64;
+
+// The spec's key allowlists. Anything outside them is a typo or an invention.
+const TOP_LEVEL_KEYS = ["interface", "policy"];
+const INTERFACE_KEYS = [
+  "display_name",
+  "short_description",
+  "icon_small",
+  "icon_large",
+  "brand_color",
+  "default_prompt",
+];
+const POLICY_KEYS = ["allow_implicit_invocation"];
+
+// The two closed lists the `display_name` derivation runs on. They are a creep
+// fence, the way EXPECTED_GUARDED is in tests/guarded-skill-prose.test.ts: a
+// new acronym in a skill name is a decision that must land here.
+const ACRONYMS = ["pr", "ux", "qrspi", "solid"];
+const JOINERS = ["a", "as", "at", "by", "for", "in", "of", "on", "the", "to"];
+
+// A leading article is the cheap tell for a noun phrase, which reads as
+// nonsense spliced after "to" in `default_prompt`.
+const ARTICLES = ["a", "an", "the"];
+
+// The canonical shape, used as the known-good baseline the three raw-text
+// matchers are proved against below.
+const SAMPLE_MANIFEST = `# Codex host manifest for the pr-rebase skill.
+interface:
+  display_name: "PR Rebase"
+  short_description: "Rebase a branch onto its base"
+  default_prompt: "Use $team:pr-rebase to rebase a branch onto its base."
+
+policy:
+  allow_implicit_invocation: false
+`;
+
+// The plugin namespace Codex builds its skill names from. Read defensively: a
+// missing or malformed manifest yields "" so the guard below FAILS rather than
+// throwing, and rather than silently asserting `Use $:<name> to ...`.
+function pluginNamespace(): string {
+  const file = join(REPO_ROOT, ".codex-plugin", "plugin.json");
+  if (!existsSync(file)) return "";
+  try {
+    const parsed: unknown = JSON.parse(read(file));
+    if (typeof parsed !== "object" || parsed === null) return "";
+    const name = (parsed as Record<string, unknown>)["name"];
+    return typeof name === "string" ? name : "";
+  } catch {
+    return "";
+  }
+}
+
+const NAMESPACE = pluginNamespace();
+
+// `display_name` from the skill's kebab `name:`. Split on `-`; uppercase any
+// acronym; leave any joiner lowercase unless it leads; else capitalize. A
+// `principle-` prefix becomes the literal `Principle: `.
+function displayNameFor(name: string): string {
+  const isPrinciple = name.startsWith("principle-");
+  const rest = isPrinciple ? name.slice("principle-".length) : name;
+  const words = rest.split("-").map((token, index) => {
+    if (ACRONYMS.includes(token)) return token.toUpperCase();
+    if (index > 0 && JOINERS.includes(token)) return token;
+    return token.charAt(0).toUpperCase() + token.slice(1);
+  });
+  return `${isPrinciple ? "Principle: " : ""}${words.join(" ")}`;
+}
+
+// `default_prompt`: the one fixed template, over the namespace, the skill's
+// `name:`, and its own `short_description` with the first character lowercased.
+function promptFor(name: string, shortDescription: string): string {
+  const spliced = shortDescription.charAt(0).toLowerCase() + shortDescription.slice(1);
+  return `Use $${NAMESPACE}:${name} to ${spliced}.`;
+}
+
+// --- the three raw-text matchers -------------------------------------------
+// Each takes manifest text and returns the offending lines. They are the only
+// checks that can see the spec's style rule, and each is proved against a
+// known positive under "the sweep can see a positive" below.
+
+// Style rule, value half: every value under `interface:` is a double-quoted
+// scalar.
+function unquotedInterfaceValues(text: string): string[] {
+  const offenders: string[] = [];
+  let inInterface = false;
+  for (const line of text.split("\n")) {
+    if (/^\S/.test(line)) {
+      inInterface = /^interface:\s*$/.test(line);
+      continue;
+    }
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    if (!inInterface) continue;
+    const value = line.slice(line.indexOf(":") + 1).trim();
+    if (!/^"([^"\\]|\\.)*"$/.test(value)) offenders.push(trimmed);
+  }
+  return offenders;
+}
+
+// Style rule, key half: no key is quoted. A quoted key is the only thing that
+// can put a quote character first on a non-comment line.
+function quotedKeys(text: string): string[] {
+  const offenders: string[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    if (/^["']/.test(trimmed)) offenders.push(trimmed);
+  }
+  return offenders;
+}
+
+// The policy block, when present, is exactly one line with exactly one value.
+// `allow_implicit_invocation: true` restates the documented default and is the
+// opposite of the safety claim the block exists to make.
+function malformedPolicyLines(text: string): string[] {
+  const lines = text.split("\n");
+  const start = lines.findIndex((line) => /^policy:\s*$/.test(line));
+  if (start === -1) return [];
+  return lines
+    .slice(start + 1)
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"))
+    .filter((line) => line !== "allow_implicit_invocation: false");
+}
+
+// --- enumeration ------------------------------------------------------------
+
+type Manifest = {
+  skill: string;
+  relative: string;
+  exists: boolean;
+  raw: string;
+  mapping: Record<string, unknown> | null;
+  parseError: string;
+  declaredName: string;
+  disablesModelInvocation: boolean;
+};
+
+// One record per skill, read once. Every failure value below names the skill,
+// so a failure is diagnosable from the assertion output alone.
+function manifests(): Manifest[] {
+  return [...skillNames(REPO_ROOT)].sort().map((skill) => {
+    const relative = join("skills", skill, "agents", "openai.yaml");
+    const absolute = join(REPO_ROOT, relative);
+    const skillFrontmatter = frontmatter(read(join(REPO_ROOT, "skills", skill, "SKILL.md")));
+    const declared = /^name:\s*(\S+)\s*$/m.exec(skillFrontmatter);
+    const base = {
+      skill,
+      relative,
+      declaredName: declared?.[1] ?? "",
+      disablesModelInvocation: /^disable-model-invocation:\s*true\s*$/m.test(skillFrontmatter),
+    };
+    if (!existsSync(absolute)) {
+      return { ...base, exists: false, raw: "", mapping: null, parseError: "" };
+    }
+    const raw = read(absolute);
+    try {
+      const parsed: unknown = Bun.YAML.parse(raw);
+      const mapping =
+        typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : null;
+      return { ...base, exists: true, raw, mapping, parseError: mapping ? "" : "not a mapping" };
+    } catch (error) {
+      // Wrapped so a genuinely malformed file becomes ONE named offender
+      // rather than aborting the sweep before every other skill is checked.
+      return {
+        ...base,
+        exists: true,
+        raw,
+        mapping: null,
+        parseError: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+}
+
+const MANIFESTS = manifests();
+
+// The subset that got far enough to have fields worth checking. Every check
+// below runs over this, so a missing or unparseable file is reported exactly
+// once, by the check that owns it.
+const PARSED = MANIFESTS.filter((m) => m.mapping !== null);
+
+function interfaceBlock(m: Manifest): Record<string, unknown> {
+  const block = m.mapping?.["interface"];
+  return typeof block === "object" && block !== null && !Array.isArray(block)
+    ? (block as Record<string, unknown>)
+    : {};
+}
+
+function stringField(m: Manifest, field: string): string {
+  const value = interfaceBlock(m)[field];
+  return typeof value === "string" ? value : "";
+}
+
+// --- offender collectors ----------------------------------------------------
+// Each returns the offending skills, named, so one run reports every violator.
+
+function missingFile(): string[] {
+  return MANIFESTS.filter((m) => !m.exists).map((m) => m.relative);
+}
+
+function unparseable(): string[] {
+  return MANIFESTS.filter((m) => m.exists && m.mapping === null).map(
+    (m) => `${m.skill}: ${m.parseError}`,
+  );
+}
+
+function missingInterfaceFields(): string[] {
+  const required = ["display_name", "short_description", "default_prompt"];
+  return PARSED.flatMap((m) =>
+    required
+      .filter((field) => stringField(m, field).trim() === "")
+      .map((field) => `${m.skill}: ${field}`),
+  );
+}
+
+function wrongDisplayNames(): string[] {
+  return PARSED.filter((m) => stringField(m, "display_name") !== displayNameFor(m.declaredName)).map(
+    (m) => `${m.skill}: "${stringField(m, "display_name")}" != "${displayNameFor(m.declaredName)}"`,
+  );
+}
+
+function shortDescriptionsOutsideWindow(): string[] {
+  return PARSED.filter((m) => {
+    const length = stringField(m, "short_description").length;
+    return length < SHORT_DESCRIPTION_MIN || length > SHORT_DESCRIPTION_MAX;
+  }).map((m) => `${m.skill}: ${stringField(m, "short_description").length} chars`);
+}
+
+function shortDescriptionsOpeningWithAnArticle(): string[] {
+  return PARSED.filter((m) => {
+    const first = stringField(m, "short_description").split(/\s+/)[0] ?? "";
+    return ARTICLES.includes(first.toLowerCase());
+  }).map((m) => `${m.skill}: "${stringField(m, "short_description")}"`);
+}
+
+function duplicateShortDescriptions(): string[] {
+  const seen = new Map<string, string>();
+  const duplicates: string[] = [];
+  for (const m of PARSED) {
+    const value = stringField(m, "short_description");
+    const owner = seen.get(value);
+    if (owner === undefined) seen.set(value, m.skill);
+    else duplicates.push(`${m.skill} duplicates ${owner}: "${value}"`);
+  }
+  return duplicates;
+}
+
+function wrongDefaultPrompts(): string[] {
+  return PARSED.filter(
+    (m) =>
+      stringField(m, "default_prompt") !==
+      promptFor(m.declaredName, stringField(m, "short_description")),
+  ).map((m) => `${m.skill}: "${stringField(m, "default_prompt")}"`);
+}
+
+function keysOutsideAllowlist(
+  block: (m: Manifest) => Record<string, unknown>,
+  allowed: string[],
+): string[] {
+  return PARSED.flatMap((m) =>
+    Object.keys(block(m))
+      .filter((key) => !allowed.includes(key))
+      .map((key) => `${m.skill}: ${key}`),
+  );
+}
+
+function policyBlock(m: Manifest): Record<string, unknown> {
+  const block = m.mapping?.["policy"];
+  return typeof block === "object" && block !== null && !Array.isArray(block)
+    ? (block as Record<string, unknown>)
+    : {};
+}
+
+function rawTextOffenders(matcher: (text: string) => string[]): string[] {
+  return PARSED.flatMap((m) => matcher(m.raw).map((line) => `${m.skill}: ${line}`));
+}
+
+function topLevelKeysOutsideAllowlist(): string[] {
+  return keysOutsideAllowlist((m) => m.mapping ?? {}, TOP_LEVEL_KEYS);
+}
+
+function interfaceKeysOutsideAllowlist(): string[] {
+  return keysOutsideAllowlist(interfaceBlock, INTERFACE_KEYS);
+}
+
+function policyKeysOutsideAllowlist(): string[] {
+  return keysOutsideAllowlist(policyBlock, POLICY_KEYS);
+}
+
+// Both sides of the guarded-set equality, each rebuilt from disk.
+function skillsWithPolicyBlock(): string[] {
+  return PARSED.filter((m) => m.mapping !== null && "policy" in m.mapping).map((m) => m.skill);
+}
+
+function skillsDisablingModelInvocation(): string[] {
+  return MANIFESTS.filter((m) => m.disablesModelInvocation).map((m) => m.skill);
+}
+
+// Guarded skills whose manifest never declares the policy — the safety claim
+// stated in prose but absent from the data Codex reads.
+function guardedWithoutPolicyBlock(): string[] {
+  const withPolicy = skillsWithPolicyBlock();
+  return skillsDisablingModelInvocation().filter((skill) => !withPolicy.includes(skill));
+}
+
+// The other direction: a policy block on a skill that never asked for one.
+function policyBlockWithoutGuard(): string[] {
+  const guarded = skillsDisablingModelInvocation();
+  return skillsWithPolicyBlock().filter((skill) => !guarded.includes(skill));
+}
+
+describe("the sweep can see a positive (L2 tripwire)", () => {
+  // docs/testing.md, "Prove a negative check can find a positive": a check
+  // that finds nothing has not distinguished absent from blind. Both halves
+  // are covered here — an empty-haystack floor, and each raw-text matcher
+  // pointed at a known positive.
+
+  test("the enumeration sees every skill and resolves the plugin namespace", () => {
+    // Floors, not exact counts: adding a skill is ordinary work. The `> 50`
+    // floor is the one tests/skill-tool-invocation.test.ts:51 puts on skill
+    // names alone. Without this, a moved directory or a broken enumerator
+    // turns every check below into a permanently green no-op.
+    expect(MANIFESTS.length).toBeGreaterThan(50);
+    expect(NAMESPACE.length).toBeGreaterThan(0);
+  });
+
+  test("the three raw-text matchers report nothing on a well-formed manifest", () => {
+    // The known-good baseline. Without it, the three mutation tests below
+    // could pass because the matcher fires on everything.
+    expect(unquotedInterfaceValues(SAMPLE_MANIFEST)).toEqual([]);
+    expect(quotedKeys(SAMPLE_MANIFEST)).toEqual([]);
+    expect(malformedPolicyLines(SAMPLE_MANIFEST)).toEqual([]);
+  });
+
+  test("the unquoted-value matcher reports a manifest whose value lost its quotes", () => {
+    const mutated = SAMPLE_MANIFEST.replace('display_name: "PR Rebase"', "display_name: PR Rebase");
+
+    expect(unquotedInterfaceValues(mutated)).toEqual(["display_name: PR Rebase"]);
+  });
+
+  test("the quoted-key matcher reports a manifest whose key gained quotes", () => {
+    const mutated = SAMPLE_MANIFEST.replace("  display_name:", '  "display_name":');
+
+    expect(quotedKeys(mutated)).toEqual(['"display_name": "PR Rebase"']);
+  });
+
+  test("the policy-line matcher reports a policy block that allows implicit invocation", () => {
+    const mutated = SAMPLE_MANIFEST.replace(
+      "allow_implicit_invocation: false",
+      "allow_implicit_invocation: true",
+    );
+
+    expect(malformedPolicyLines(mutated)).toEqual(["allow_implicit_invocation: true"]);
+  });
+});
+
+describe("every skill has a valid agents/openai.yaml (L2 tripwire)", () => {
+  test("every skill directory carries the manifest", () => {
+    expect(missingFile()).toEqual([]);
+  });
+
+  test("every manifest parses as YAML into a mapping", () => {
+    expect(unparseable()).toEqual([]);
+  });
+
+  test("every manifest carries three non-empty interface strings", () => {
+    expect(missingInterfaceFields()).toEqual([]);
+  });
+
+  test("every display_name is the derivation of its skill's own name", () => {
+    expect(wrongDisplayNames()).toEqual([]);
+  });
+
+  test("every short_description sits inside the spec's 25-64 character window", () => {
+    expect(shortDescriptionsOutsideWindow()).toEqual([]);
+  });
+
+  test("no short_description opens with an article", () => {
+    expect(shortDescriptionsOpeningWithAnArticle()).toEqual([]);
+  });
+
+  test("every default_prompt is the namespaced template over name and short_description", () => {
+    expect(wrongDefaultPrompts()).toEqual([]);
+  });
+
+  test("no manifest carries a top-level key outside interface and policy", () => {
+    expect(topLevelKeysOutsideAllowlist()).toEqual([]);
+  });
+
+  test("no interface block carries a key outside the spec's six", () => {
+    expect(interfaceKeysOutsideAllowlist()).toEqual([]);
+  });
+
+  test("no policy block carries a key beyond allow_implicit_invocation", () => {
+    expect(policyKeysOutsideAllowlist()).toEqual([]);
+  });
+
+  test("every interface value is a double-quoted scalar in the raw text", () => {
+    expect(rawTextOffenders(unquotedInterfaceValues)).toEqual([]);
+  });
+
+  test("no key is quoted in the raw text", () => {
+    expect(rawTextOffenders(quotedKeys)).toEqual([]);
+  });
+
+  test("every policy block is exactly allow_implicit_invocation: false", () => {
+    expect(rawTextOffenders(malformedPolicyLines)).toEqual([]);
+  });
+});
+
+describe("the guarded set and the policy-block set agree in both directions (L2 tripwire)", () => {
+  // Both sides rebuilt from disk, the way tests/guarded-skill-prose.test.ts
+  // does it, so neither side can drift into agreement with a stale constant.
+
+  test("every skill disabling model invocation carries a policy block", () => {
+    expect(guardedWithoutPolicyBlock()).toEqual([]);
+  });
+
+  test("every skill carrying a policy block disables model invocation", () => {
+    expect(policyBlockWithoutGuard()).toEqual([]);
+  });
+
+  test("no two skills share a short_description", () => {
+    expect(duplicateShortDescriptions()).toEqual([]);
+  });
+});

--- a/tests/skill-openai-yaml.test.ts
+++ b/tests/skill-openai-yaml.test.ts
@@ -89,8 +89,7 @@ const LEADING_ACRONYM = /^[A-Z]{2,}/;
 
 // The canonical shape, used as the known-good baseline the three raw-text
 // matchers are proved against below.
-const SAMPLE_MANIFEST = `# Codex host manifest for the pr-rebase skill.
-interface:
+const SAMPLE_MANIFEST = `interface:
   display_name: "PR Rebase"
   short_description: "Rebase a branch onto its base"
   default_prompt: "Use $team:pr-rebase to rebase a branch onto its base."

--- a/tests/skill-openai-yaml.test.ts
+++ b/tests/skill-openai-yaml.test.ts
@@ -13,8 +13,11 @@
 //     lists (uppercase acronyms, lowercase joiners), with a `principle-`
 //     prefix rendered as `Principle: `
 //   - `short_description` is 25-64 characters inclusive (the Codex spec's own
-//     window) and does not open with an article, which is the cheap tell for
-//     the noun phrase that reads as nonsense after the word "to" below
+//     window), opens with a capital, carries no trailing period, and opens
+//     with neither an article nor an acronym. The article is the cheap tell
+//     for the noun phrase that reads as nonsense after the word "to" below;
+//     the period and the acronym both survive the splice into
+//     `default_prompt` and render there as `works..` and `sOLID`
 //   - `default_prompt` is exactly `Use $<ns>:<name> to <short_description>.`,
 //     where `<ns>` is the plugin namespace read from `.codex-plugin/plugin.json`
 //     — the manifest Codex prefers, pinned equal to `.claude-plugin/plugin.json`
@@ -23,14 +26,16 @@
 //     allowlists
 //   - read from the RAW TEXT, not the parse tree: every `interface` value is a
 //     double-quoted scalar, no key is quoted, and a `policy` block is exactly
-//     `allow_implicit_invocation: false`. `Bun.YAML.parse` returns the same
-//     value for `"x"` and `x`, so the parse tree cannot see the spec's style
-//     rule at all.
+//     `allow_implicit_invocation: false` — present, not merely un-contradicted.
+//     `Bun.YAML.parse` returns the same value for `"x"` and `x`, so the parse
+//     tree cannot see the spec's style rule at all.
 //
 // And repo-wide: `short_description` is unique across every skill, and the set
-// of skills carrying a `policy` block equals the set whose frontmatter sets
-// `disable-model-invocation: true` — in BOTH directions, each side rebuilt
-// from disk.
+// of skills DECLARING `allow_implicit_invocation: false` equals the set whose
+// frontmatter sets `disable-model-invocation: true` — in BOTH directions, each
+// side rebuilt from disk. Both halves of that declaration check are positive:
+// an empty `policy:` block satisfies neither, because the whole point of the
+// block is the value it carries, not the key that holds it.
 //
 // Sibling: tests/guarded-skill-prose.test.ts pins the same guarded set where it
 // appears in prose. This file pins it where it appears as structured data. The
@@ -75,6 +80,12 @@ const JOINERS = ["a", "as", "at", "by", "for", "in", "of", "on", "the", "to"];
 // A leading article is the cheap tell for a noun phrase, which reads as
 // nonsense spliced after "to" in `default_prompt`.
 const ARTICLES = ["a", "an", "the"];
+
+// An acronym is matched by shape, not by list: two or more consecutive capitals
+// leading the first word. `promptFor` lowercases only the first character, so
+// "SOLID" splices in as "sOLID". A shape check needs no creep fence, and it
+// catches an acronym nobody has coined yet.
+const LEADING_ACRONYM = /^[A-Z]{2,}/;
 
 // The canonical shape, used as the known-good baseline the three raw-text
 // matchers are proved against below.
@@ -165,16 +176,19 @@ function quotedKeys(text: string): string[] {
 
 // The policy block, when present, is exactly one line with exactly one value.
 // `allow_implicit_invocation: true` restates the documented default and is the
-// opposite of the safety claim the block exists to make.
+// opposite of the safety claim the block exists to make. An EMPTY block is the
+// same loss stated more quietly, so it is an offender too: a check that only
+// filters out wrong lines reports nothing when every line is gone.
 function malformedPolicyLines(text: string): string[] {
   const lines = text.split("\n");
   const start = lines.findIndex((line) => /^policy:\s*$/.test(line));
   if (start === -1) return [];
-  return lines
+  const body = lines
     .slice(start + 1)
     .map((line) => line.trim())
-    .filter((line) => line !== "" && !line.startsWith("#"))
-    .filter((line) => line !== "allow_implicit_invocation: false");
+    .filter((line) => line !== "" && !line.startsWith("#"));
+  if (body.length === 0) return ["policy: declares nothing"];
+  return body.filter((line) => line !== "allow_implicit_invocation: false");
 }
 
 // --- enumeration ------------------------------------------------------------
@@ -290,6 +304,26 @@ function shortDescriptionsOpeningWithAnArticle(): string[] {
   }).map((m) => `${m.skill}: "${stringField(m, "short_description")}"`);
 }
 
+function shortDescriptionsNotCapitalized(): string[] {
+  return PARSED.filter((m) => {
+    const first = stringField(m, "short_description").charAt(0);
+    return first !== "" && first !== first.toUpperCase();
+  }).map((m) => `${m.skill}: "${stringField(m, "short_description")}"`);
+}
+
+// A trailing period survives the splice and renders as `... works..`.
+function shortDescriptionsEndingInAPeriod(): string[] {
+  return PARSED.filter((m) => stringField(m, "short_description").endsWith(".")).map(
+    (m) => `${m.skill}: "${stringField(m, "short_description")}"`,
+  );
+}
+
+function shortDescriptionsOpeningWithAnAcronym(): string[] {
+  return PARSED.filter((m) => LEADING_ACRONYM.test(stringField(m, "short_description"))).map(
+    (m) => `${m.skill}: "${stringField(m, "short_description")}"`,
+  );
+}
+
 function duplicateShortDescriptions(): string[] {
   const seen = new Map<string, string>();
   const duplicates: string[] = [];
@@ -344,9 +378,15 @@ function policyKeysOutsideAllowlist(): string[] {
   return keysOutsideAllowlist(policyBlock, POLICY_KEYS);
 }
 
-// Both sides of the guarded-set equality, each rebuilt from disk.
-function skillsWithPolicyBlock(): string[] {
-  return PARSED.filter((m) => m.mapping !== null && "policy" in m.mapping).map((m) => m.skill);
+// Both sides of the guarded-set equality, each rebuilt from disk. The
+// declaration is read POSITIVELY — the value must be there and must be
+// `false`. Testing for the `policy` key instead would let a bare `policy:`
+// (which parses to null, and whose empty body no line filter can see) stand in
+// for the safety claim six prose surfaces make on its behalf.
+function skillsDeclaringNoImplicitInvocation(): string[] {
+  return PARSED.filter((m) => policyBlock(m)["allow_implicit_invocation"] === false).map(
+    (m) => m.skill,
+  );
 }
 
 function skillsDisablingModelInvocation(): string[] {
@@ -355,15 +395,15 @@ function skillsDisablingModelInvocation(): string[] {
 
 // Guarded skills whose manifest never declares the policy — the safety claim
 // stated in prose but absent from the data Codex reads.
-function guardedWithoutPolicyBlock(): string[] {
-  const withPolicy = skillsWithPolicyBlock();
-  return skillsDisablingModelInvocation().filter((skill) => !withPolicy.includes(skill));
+function guardedWithoutDeclaration(): string[] {
+  const declaring = skillsDeclaringNoImplicitInvocation();
+  return skillsDisablingModelInvocation().filter((skill) => !declaring.includes(skill));
 }
 
-// The other direction: a policy block on a skill that never asked for one.
-function policyBlockWithoutGuard(): string[] {
+// The other direction: the declaration on a skill that never asked for one.
+function declarationWithoutGuard(): string[] {
   const guarded = skillsDisablingModelInvocation();
-  return skillsWithPolicyBlock().filter((skill) => !guarded.includes(skill));
+  return skillsDeclaringNoImplicitInvocation().filter((skill) => !guarded.includes(skill));
 }
 
 describe("the sweep can see a positive (L2 tripwire)", () => {
@@ -409,6 +449,14 @@ describe("the sweep can see a positive (L2 tripwire)", () => {
 
     expect(malformedPolicyLines(mutated)).toEqual(["allow_implicit_invocation: true"]);
   });
+
+  test("the policy-line matcher reports a policy block that declares nothing", () => {
+    // The quiet mutation: the block survives, the claim does not. A filter for
+    // wrong lines cannot see this — there are no lines left to be wrong.
+    const mutated = SAMPLE_MANIFEST.replace("\n  allow_implicit_invocation: false", "");
+
+    expect(malformedPolicyLines(mutated)).toEqual(["policy: declares nothing"]);
+  });
 });
 
 describe("every skill has a valid agents/openai.yaml (L2 tripwire)", () => {
@@ -434,6 +482,22 @@ describe("every skill has a valid agents/openai.yaml (L2 tripwire)", () => {
 
   test("no short_description opens with an article", () => {
     expect(shortDescriptionsOpeningWithAnArticle()).toEqual([]);
+  });
+
+  test("every short_description opens with a capital", () => {
+    expect(shortDescriptionsNotCapitalized()).toEqual([]);
+  });
+
+  test("no short_description ends in a period", () => {
+    expect(shortDescriptionsEndingInAPeriod()).toEqual([]);
+  });
+
+  test("no short_description opens with an acronym", () => {
+    expect(shortDescriptionsOpeningWithAnAcronym()).toEqual([]);
+  });
+
+  test("no two skills share a short_description", () => {
+    expect(duplicateShortDescriptions()).toEqual([]);
   });
 
   test("every default_prompt is the namespaced template over name and short_description", () => {
@@ -469,15 +533,11 @@ describe("the guarded set and the policy-block set agree in both directions (L2 
   // Both sides rebuilt from disk, the way tests/guarded-skill-prose.test.ts
   // does it, so neither side can drift into agreement with a stale constant.
 
-  test("every skill disabling model invocation carries a policy block", () => {
-    expect(guardedWithoutPolicyBlock()).toEqual([]);
+  test("every skill disabling model invocation declares allow_implicit_invocation: false", () => {
+    expect(guardedWithoutDeclaration()).toEqual([]);
   });
 
-  test("every skill carrying a policy block disables model invocation", () => {
-    expect(policyBlockWithoutGuard()).toEqual([]);
-  });
-
-  test("no two skills share a short_description", () => {
-    expect(duplicateShortDescriptions()).toEqual([]);
+  test("every skill declaring allow_implicit_invocation: false disables model invocation", () => {
+    expect(declarationWithoutGuard()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Every skill under `skills/` now ships an `agents/openai.yaml` — the OpenAI Codex
host manifest — and a gating L2 tripwire keeps it that way. The three
user-invoked-only skills restate their invocation guard in the Codex-native form.

Before this, Codex fell back to the directory name and a truncated `description:`
for all 81 skills, and `disable-model-invocation: true` reached Codex not at all.

**Official spec:** [developers.openai.com/codex/skills](https://developers.openai.com/codex/skills)
(→ `learn.chatgpt.com/docs/build-skills.md`) and the `openai/skills` skill-creator
reference `references/openai_yaml.md`.

## What changed

**81 manifests.** Three `interface` fields per skill, three of them derived
mechanically from the skill's own `SKILL.md` frontmatter:

| Field | Derivation |
|---|---|
| `display_name` | title-cased from `name:`, with a closed acronym list (`pr`, `ux`, `qrspi`, `solid`), a joiner list, and `principle-` rendering as `Principle: ` |
| `short_description` | **authored**, not derived — the spec pins a 25–64 character window and every existing `description:` runs 150–400 chars |
| `default_prompt` | `Use $<ns>:<name> to <short_description, first char lowercased>.` with `<ns>` read from `.codex-plugin/plugin.json` |
| `policy.allow_implicit_invocation: false` | emitted iff the skill sets `disable-model-invocation: true` |

**A gating test.** `tests/skill-openai-yaml.test.ts` — L2, free, deterministic,
25 assertions. It enumerates via `skillNames()`, parses each manifest, and pins
the derivations, the character window, the key allowlists, the raw-text style
rules a parse tree cannot see, and set-equality in both directions between the
guarded set and the policy-block set. Blindness guards cover both halves: a
skill-count floor for the empty haystack, and positive-fire mutation tests
proving each raw-text matcher actually reports.

**Seven prose surfaces** now state the new declaration with the same hedge —
it is a request to a host not yet observed to honor it, so the existing `rm -rf`
removal step still stands: `README.md`, `docs/index.md`,
`docs/cross-host-portability.md` (3 ranges), `docs/architecture.md`,
`script/dev-install-codex` (the notice moved into a function so it now prints on
the already-installed exit path too), `script/dev-install-antigravity`, and the
three guarded `SKILL.md` bodies.

**The authoring guide.** `.claude/skills/create-team-skill/SKILL.md` gains a
Part 4 and five checklist rows, so every new skill emits a compliant manifest.

## Deviation from the upstream spec, on purpose

The spec calls `agents/openai.yaml` **optional / recommended**. This repo makes
it **mandatory** and gates it. Two things justify the 81 files:

1. `script/dev-install-codex` already warns that Codex ignores
   `disable-model-invocation`. `policy.allow_implicit_invocation: false` is the
   Codex-native control for exactly that gap.
2. The same script names Codex catalog description truncation as a known pain.

The filename is `openai.yaml`, against this repo's `.yml` habit for its nine
other YAML files. The external spec fixes it; not an inconsistency to flag.

## Test plan

- [x] `bun test` — 1870 pass, 4 skip, 0 fail (58 files)
- [x] `bun run typecheck` — clean
- [x] `bash .claude/scripts/check-discovery-consistency.sh` — all assertions pass
- [x] 81 skill directories, 81 manifests — 100% coverage
- [x] Exactly 3 manifests carry a `policy` block, matching exactly the 3 skills setting `disable-model-invocation: true`
- [x] Gate fires under mutation: bare `policy:`, deleted declaration line, deleted block, declaration on an unguarded skill, `"false"` string, `False`, `no`, `0`, `true`, duplicate keys in both orders, trailing period, lowercase first char, leading acronym — every one turns the suite red
- [x] All 81 `short_description` values: 28–51 chars, unique, imperative verb-first, no leading article or acronym
- [x] `.github/scripts/version-bump-required.sh` exits 1 — **expected** pre-land state for a runtime branch; the bump happens at land time
- [x] All commits signed (ED25519, good signature)

## Review notes

Non-blocking findings from the five-reviewer gate, recorded rather than fixed.

**Disclosure — the invocation token was not observed on a live host.**
All 81 manifests render `Use $team:<name> to ...`. That token comes from this
repo's own documentation of Codex naming (`script/dev-install-codex:7-9`,
`README.md:68`, `docs/index.md:111`), not from a live Codex build. The manual
probe the design called for was not run: the implementer is non-interactive, and
the local Codex install symlinks the developer's main checkout rather than this
worktree, so it was left untouched. If a live build resolves only `$<name>`, the
fix is one sweep over the `default_prompt` line in 81 files plus one constant in
the test, Part 4's template line and its checklist row, and one line in
`docs/architecture.md`.

**[code-reviewer]**
- The three new `short_description` predicates (capital, no trailing period, no
  leading acronym) have no positive-fire proof inside the suite. All three were
  verified by hand to fire; the proof lives in a transcript rather than in the
  test, where the next author would see it.
- `tests/skill-openai-yaml.test.ts:417` cites a sibling test by line number. That
  is the only `.ts:<line>` comment reference in the whole suite and it will rot
  on the first insertion above it.
- `tests/dev-install-codex.test.ts:127` drives the real `codex` binary through an
  inherited env, so it fails on a machine that has Team installed as a native
  Codex plugin — for a reason unrelated to the behavior under test. The file
  already owns a `stubCodex` helper that closes this boundary.
- `malformedPolicyLines` slices from `policy:` to end of file without stopping at
  the next top-level key, so a manifest ordering `policy` before `interface`
  reports every interface line as an offender. Fail-closed; the cost is a
  misleading diagnostic.
- The `"policy: declares nothing"` sentinel is a literal in both the matcher and
  the test that asserts it. A named constant would bind them.
- A flow-style `policy: {allow_implicit_invocation: false}` bypasses the raw-text
  matcher. Not a safety hole — the parse-tree set equality still catches both
  dangerous variants — but the style rule is unenforced for that shape.
- The `dependencies` correction in Part 4 says nesting it under `interface:`
  fails the gate. True, and emitting it at top level fails too, which the
  sentence does not say.
- `CHANGELOG.md:12` — "**What this asks of you:** nothing — reinstall on Codex"
  reads as self-contradicting; the reinstall is the ask.
- `docs/architecture.md:817` — ragged reflow left from the formula correction.

**[security-reviewer]** (0 CRITICAL, 0 HIGH, 2 LOW)
- The sentence added to the three guarded `SKILL.md` bodies omits the "unverified
  on a live build" hedge every other surface carries. These are the three skills
  where a wrong inference is costly.
- Same flow-style blind spot in the raw-text policy matcher, reported above.

**[ux-reviewer]**
- Part 4's `short_description` acronym rule could be read as scoped to the
  `display_name` acronym allowlist. It is actually a shape check (`/^[A-Z]{2,}/`)
  on any leading run of two or more capitals. One clarifying clause would settle
  it. Following Part 4 literally still produced a passing manifest first try.
- Part 4's `short_description` bullet packs five rules into one sentence.

**Known gap, accepted by design.** `short_description` is authored, so nothing
checks it against the `description:` it summarizes. A later description rewrite
can leave it stale silently. Every candidate check breaks on a meaning-preserving
rewrite, which `docs/testing.md` classes as a wording pin. The gap is recorded in
`docs/architecture.md`, naming `/reflect` as the one caller that reaches the
authoring guide on an edit.

**Not a defect.** An earlier verifier run reported `tests/pre-merge-guard.test.ts`
failing on a leaked `/tmp` script plus an eval budget regression. Five reviewer
agents were running `bun test` concurrently against a shared `/tmp`, and that
test snapshots `/tmp` before and after to detect leaks. Re-run in isolation:
135 pass, 0 fail.

## Versioning

No version assigned. Bullets accumulate under `## [Unreleased]`; the six version
strings, the dated changelog section, and the `vX.Y.Z` title prefix stay
untouched until land time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
