### PR TITLE
v0.74.0 fix(skills): make the verdict itself the bound in bounded-loops

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.73.0"
+    "version": "0.74.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.73.0",
+      "version": "0.74.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`principle-bounded-loops` no longer reads as licence to invent a round cap for the review loops.** Its opening rule — every loop carries a declared cap — is absolute, and its accommodation for a loop that ends on a verdict was a soft trailing clause. An agent applying the principle to the IMPLEMENT review loop supplied the number the loop deliberately omits, and announced it was capping the loop at round six. The principle now states that a verdict terminal condition **is** the bound, that the missing count is the design rather than a gap for a reader to fill, and that Team's two review loops are that case: DESIGN ends on the reviewer's verdict, IMPLEMENT ends when no Blocking or Major finding is left. **What this asks of you:** nothing. The mechanical guard is widened to match: the forbidden-pattern sweep in [`tests/protocol.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/protocol.test.ts) banned the historical five-valued wording, so a stated cap of six swept clean; it now trips on a round or revision cap at any count.
+
 ## [0.73.0] - 2026-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.74.0] - 2026-09-01
+
 ### Fixed
 
 - **`principle-bounded-loops` no longer reads as licence to invent a round cap for the review loops.** Its opening rule — every loop carries a declared cap — is absolute, and its accommodation for a loop that ends on a verdict was a soft trailing clause. An agent applying the principle to the IMPLEMENT review loop supplied the number the loop deliberately omits, and announced it was capping the loop at round six. The principle now states that a verdict terminal condition **is** the bound, that the missing count is the design rather than a gap for a reader to fill, and that Team's two review loops are that case: DESIGN ends on the reviewer's verdict, IMPLEMENT ends when no Blocking or Major finding is left. **What this asks of you:** nothing. The mechanical guard is widened to match: the forbidden-pattern sweep in [`tests/protocol.test.ts`](https://github.com/bostonaholic/team/blob/main/tests/protocol.test.ts) banned the historical five-valued wording, so a stated cap of six swept clean; it now trips on a round or revision cap at any count.
@@ -697,7 +699,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.73.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.74.0...HEAD
+[0.74.0]: https://github.com/bostonaholic/team/compare/v0.73.0...v0.74.0
 [0.73.0]: https://github.com/bostonaholic/team/compare/v0.72.0...v0.73.0
 [0.72.0]: https://github.com/bostonaholic/team/compare/v0.71.0...v0.72.0
 [0.71.0]: https://github.com/bostonaholic/team/compare/v0.70.0...v0.71.0

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1325,9 +1325,13 @@ context (see [architecture.md](architecture.md#design-guidelines)).
   retries, poll budgets, helpers in flight. Hitting the cap halts
   terminally with everything unresolved reported — never silently
   restart, extend, or soften the exit criteria. A retry budget is small
-  and stated. The same rule bounds output as size budgets (a ~200-line
-  design, a ≤ 30-line helper reply): over budget means restructure and
-  name what was dropped, never silent truncation.
+  and stated. A loop that ends on a verdict rather than a count is
+  already bounded — the verdict is the bound, the missing number is the
+  design, and a reader never supplies a count the loop deliberately
+  omits. Team's two review loops are that case. The same rule bounds
+  output as size budgets (a ~200-line design, a ≤ 30-line helper reply):
+  over budget means restructure and name what was dropped, never silent
+  truncation.
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/principle-bounded-loops/SKILL.md
+++ b/skills/principle-bounded-loops/SKILL.md
@@ -20,9 +20,13 @@ one, at a bounded and pre-agreed cost.
 - Hitting the cap halts terminally: report everything unresolved. Never
   silently restart, extend, or soften the exit criteria to escape.
 - A retry budget is small and stated ("retry once, then halt loudly").
-- A loop that ends on a verdict rather than a count still declares its
-  terminal condition, and the operator who can stop the run is its outer
-  bound.
+- A loop that ends on a verdict rather than a count is already bounded:
+  the verdict is the bound. Declare that terminal condition, and then
+  never supply a count the loop deliberately omits — the missing number
+  is the design, not a gap for a reader to fill. The operator who can
+  stop the run is the outer bound. Team's two review loops are this
+  case: DESIGN ends on the reviewer's verdict, IMPLEMENT ends when no
+  Blocking or Major finding is left, and neither takes a round cap.
 
 ## Size budgets
 

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -1298,6 +1298,15 @@ describe("principle-bounded-loops (L2 content tripwire)", () => {
     expect(text).toContain("Never silent truncation");
   });
 
+  // A reader who takes "every loop carries a cap" as licence to supply the
+  // missing number reintroduces the round cap both review loops shed. The
+  // principle has to say the verdict IS the bound, and that an omitted count
+  // is a decision rather than a gap.
+  test("pins that a verdict terminal condition is itself the bound", () => {
+    const text = squash(read(SKILL_FILE));
+    expect(text).toContain("never supply a count the loop deliberately omits");
+  });
+
   test("citation site: pr-watch-as-author cites the principle by path", () => {
     expect(read(join(REPO_ROOT, "skills", "pr-watch-as-author", "SKILL.md"))).toContain("skills/principle-bounded-loops/SKILL.md");
   });

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1118,36 +1118,60 @@ describe("no stated round or revision cap (L2 forbidden-pattern sweep)", () => {
     "AGENTS.md",
   ];
 
+  // Any count a bound could name. `1`/`one` is excluded on purpose: "at the
+  // cost of one round" is the loop paying for a re-review, not a bound on it.
+  const COUNT = String.raw`(?:[2-9]|[1-9]\d+|two|three|four|five|six|seven|eight|nine|ten)`;
+  // The same set without multi-digit numerals, for the pattern that reads a
+  // bare cap value with no round or revision noun to scope it. A legitimate
+  // cap on something else ("capped at 30 reply lines") must stay unswept.
+  const SMALL_COUNT = String.raw`(?:[2-9]|two|three|four|five|six|seven|eight|nine|ten)`;
+
+  // Each entry plants two positives: the historical five-valued text that
+  // motivated the pattern, and the same claim at a different count. A pattern
+  // pinned to the old number bans the old wording, not the rule — a run that
+  // announced a cap of six is what put the second sample here.
   const CAP_PATTERNS = [
     {
-      label: "a five-round review bound",
-      pattern: /\b(?:5|five)[-\s]rounds?\b/i,
-      planted:
+      label: "a numbered round review bound",
+      pattern: new RegExp(String.raw`\b${COUNT}[-\s]rounds?\b`, "i"),
+      planted: [
         "- **Bounded veto.** The review loop is capped at five rounds, then halts to a\n  human.",
+        "- **Bounded veto.** The review loop is capped at six rounds, then halts\n  loudly to a human.",
+      ],
     },
     {
-      label: "a five-revision design bound",
-      pattern: /\b(?:5|five)[-\s]revisions?\b/i,
-      planted:
+      label: "a numbered revision design bound",
+      pattern: new RegExp(String.raw`\b${COUNT}[-\s]revisions?\b`, "i"),
+      planted: [
         "runs. Cap at 5 revisions. At cap, the run halts terminally and reports\nthe unresolved findings — no consultation, no PR.",
+        "runs. Cap at 6 revisions. At cap, the run halts terminally and reports\nthe unresolved findings — no consultation, no PR.",
+      ],
     },
     {
-      label: "a terminal `revision: 5`",
-      pattern: /revision:\s*5\b/,
-      planted:
+      label: "a terminal numbered `revision:`",
+      // `revision: 0` and `revision: 1` are the first-draft values the schema
+      // really uses, so the terminal-cap pattern starts at 2.
+      pattern: /revision:\s*[2-9]\d*\b/,
+      planted: [
         "   frontmatter, then a fresh review round runs. Cap at `revision: 5`. At\n   cap, halt terminally and report the unresolved findings — no PR.",
+        "   frontmatter, then a fresh review round runs. Cap at `revision: 6`. At\n   cap, halt terminally and report the unresolved findings — no PR.",
+      ],
     },
     {
-      label: "a cap whose value is 5",
-      pattern: /\bcap(?:ped)?\s+(?:at\s+|is\s+)?(?:5|five)\b/i,
-      planted:
+      label: "a numbered cap value",
+      pattern: new RegExp(String.raw`\bcap(?:ped)?\s+(?:at\s+|is\s+)?${SMALL_COUNT}\b`, "i"),
+      planted: [
         "`revision: <n+1>` in the new draft's frontmatter. The cap is 5. At the\ncap, the run halts terminally.",
+        "`revision: <n+1>` in the new draft's frontmatter. The cap is 6. At the\ncap, the run halts terminally.",
+      ],
     },
     {
-      label: "a round-count comparison against 5",
-      pattern: /\bround count\s*[<>≥≤]=?\s*(?:5|five)\b/i,
-      planted:
+      label: "a numbered round-count comparison",
+      pattern: new RegExp(String.raw`\bround count\s*[<>≥≤]=?\s*${COUNT}\b`, "i"),
+      planted: [
         "   - If round count ≥ 5: **halt** with a full unresolved-findings\n     summary — terminal; no PR is opened.",
+        "   - If round count ≥ 6: **halt** with a full unresolved-findings\n     summary — terminal; no PR is opened.",
+      ],
     },
     {
       label: "a branch taken at or under a cap",
@@ -1155,21 +1179,25 @@ describe("no stated round or revision cap (L2 forbidden-pattern sweep)", () => {
       // and "cap" sit on different lines, so this pattern matches only once
       // flat() has joined them.
       pattern: /\b(?:at|under)\s+(?:the\s+)?cap\b/i,
-      planted:
+      planted: [
         "`revision: <n+1>` in the new draft's frontmatter. The cap is 5. At the\ncap, the run halts terminally.",
+      ],
     },
     {
       label: "a revision cap or revision budget",
       pattern: /\brevision\s+(?:cap|budget)\b/i,
-      planted:
+      planted: [
         "(machine policy). The pass runs on **every design-review round**, up to\nthe revision cap. Relative to the code-review pass, the payload is a\ndesign document rather than a diff.",
+      ],
     },
   ];
 
   for (const { label, pattern, planted } of CAP_PATTERNS) {
     test(`no file states ${label}`, () => {
-      // Planted positive: prove the pattern still sees the text it bans.
-      expect(pattern.test(flat(planted))).toBe(true);
+      // Planted positives: prove the pattern still sees the text it bans.
+      for (const sample of planted) {
+        expect(pattern.test(flat(sample))).toBe(true);
+      }
       // Guard: an empty corpus must fail, not vacuously pass the sweep.
       expect(SWEPT_FILES.length).toBeGreaterThan(0);
       const offenders = SWEPT_FILES.filter((rel) =>


### PR DESCRIPTION
## Problem

A run announced it was *"capping the review loop at round 6 per `principle-bounded-loops`"*. Both review loops shed their round caps in #273 (v0.63.0): DESIGN ends on the reviewer's verdict, IMPLEMENT ends when no Blocking or Major finding remains. Nothing may re-introduce a count.

Two levels let it back in:

1. **The principle invites it.** `skills/principle-bounded-loops/SKILL.md` opens with an absolute — *every loop carries a declared cap* — and carried its accommodation for a verdict-terminated loop as a soft trailing clause. A reader applying the principle to the review loop finds no number and supplies one.
2. **The gate could not see it.** The L2 forbidden-pattern sweep in `tests/protocol.test.ts` bans the *old text* rather than the rule: every number-bearing pattern is pinned to the literal `5`. A doc or prompt stating a cap of six sweeps clean.

## Fix

**`skills/principle-bounded-loops/SKILL.md`** — the verdict-terminated bullet now says a loop ending on a verdict is *already bounded* (the verdict is the bound), that the missing count is the design rather than a gap for a reader to fill, and names Team's two review loops as that case. `docs/skills.md` mirrors it.

**`tests/protocol.test.ts`** — the sweep's count is generalized. Two fragments, because the patterns differ in how tightly a noun scopes them:

- `COUNT` (`2-9`, multi-digit, `two`–`ten`) for the patterns already scoped by `rounds` / `revisions` / `round count`. `1`/`one` is excluded on purpose — *"at the cost of one round"* is the loop paying for a re-review, not a bound on it.
- `SMALL_COUNT` (no multi-digit) for the bare cap-value pattern, so legitimate non-round caps (`capped at 30 reply lines`, `cap 25`, `agents.max_threads=6`) stay unswept.
- `revision: [2-9]\d*` — `revision: 0` and `revision: 1` are the real first-draft values.

Each pattern now plants **two** positives: the historical five-valued text that motivated it, and the same claim at six.

**`tests/methodology.test.ts`** — an L2 tripwire pinning the new clause in the principle.

## Test plan

- [x] **Reproduce (before).** Append `The review loop is capped at six rounds, then halts loudly to a human.` to `docs/ethos.md`, run the sweep → **7 pass, 0 fail**. The gate does not see it.
- [x] **Red.** The new methodology tripwire fails against the unmodified principle (`Expected to contain: "never supply a count the loop deliberately omits"`).
- [x] **Green (gate).** Same planted round-6 text against the generalized sweep → **fails**, `offenders: ["docs/ethos.md"]`.
- [x] **Green (principle).** Protocol + methodology suites → 394 pass, 0 fail.
- [x] **No false positives.** Full corpus (`docs/`, `skills/`, `agents/`, `README.md`, `AGENTS.md`) sweeps clean under every generalized pattern.
- [x] **Full suite.** `bun test` → **1845 pass, 4 skip, 0 fail** across 57 files.
- [x] **Typecheck.** `bunx tsc --noEmit` clean.

## Pre-merge

Runtime change (`skills/` ships), so this bumps at land time. A `### Fixed` bullet is under `## [Unreleased]`; no version is assigned yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
