### PR TITLE
fix: name the missing gh scope and refuse an empty board item id

### DIFF
--- a/.claude/scripts/project-item-id.sh
+++ b/.claude/scripts/project-item-id.sh
@@ -41,7 +41,7 @@ esac
 # pipe-clean) rather than failing to find an item that is genuinely on the board.
 LIMIT=10000
 items_json="$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit "$LIMIT")" \
-  || die "failed to list project items (is gh authenticated?)"
+  || die "failed to list project items — gh's error above names the cause; a token missing a project scope needs: gh auth refresh -s <scope gh named>"
 
 total="$(printf '%s' "$items_json" | jq -r '.totalCount // (.items | length)')"
 fetched="$(printf '%s' "$items_json" | jq -r '.items | length')"

--- a/.claude/scripts/project-set-status.sh
+++ b/.claude/scripts/project-set-status.sh
@@ -35,7 +35,13 @@ die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 
 { [ "$#" -ge 1 ] && [ "$#" -le 2 ]; } || die "usage: $(basename "$0") <status> [item-id]"
 status="$1"
-item_id="${2:--}"
+if [ "$#" -eq 2 ]; then
+  item_id="$2"
+  [ -n "$item_id" ] \
+    || die "empty item id — the resolver printed nothing, so fix that first; an empty argument never falls through to stdin"
+else
+  item_id="-"
+fi
 
 command -v gh >/dev/null 2>&1 || die "gh CLI not found"
 command -v jq >/dev/null 2>&1 || die "jq not found"
@@ -49,7 +55,7 @@ fi
 
 # Status field ID + the option ID for the requested column (case-insensitive).
 fields_json="$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json)" \
-  || die "failed to list project fields (is gh authenticated?)"
+  || die "failed to list project fields — gh's error above names the cause; a token missing a project scope needs: gh auth refresh -s <scope gh named>"
 read -r field_id option_id <<EOF
 $(printf '%s' "$fields_json" | jq -r --arg s "$status" '
   .fields[] | select(.name == "Status") | .id as $fid
@@ -60,7 +66,7 @@ EOF
   || die "unknown status: '$status' (valid: Backlog, Ready, In progress, In review, Done)"
 
 project_id="$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.id')" \
-  || die "failed to resolve project id"
+  || die "failed to resolve project id — gh's error above names the cause; a token missing a project scope needs: gh auth refresh -s <scope gh named>"
 
 # Perform the edit. Capture its output instead of suppressing it, so a silent
 # or partial failure surfaces in the error rather than being masked (bug #141).
@@ -78,7 +84,7 @@ edit_out="$(gh project item-edit \
 # first page is still found.
 LIMIT=10000
 items_json="$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit "$LIMIT")" \
-  || die "failed to re-read project status for verification (is gh authenticated?)"
+  || die "failed to re-read project status for verification — gh's error above names the cause; a token missing a project scope needs: gh auth refresh -s <scope gh named>"
 actual="$(printf '%s' "$items_json" \
   | jq -r --arg id "$item_id" '.items[] | select(.id == $id) | .status')"
 [ -n "$actual" ] \

--- a/docs/project-tracking.md
+++ b/docs/project-tracking.md
@@ -227,6 +227,12 @@ case-insensitive: `Backlog`, `Bugs`, `Ready`, `In progress`, `In review`, or
 to work if someone recreates a field or an option. They are dev-only helpers
 under `.claude/`. They are not part of the distributed plugin.
 
+> **Token scopes.** Reading the board needs the `read:project` scope and
+> editing a card needs `project`; a default `gh auth login` token carries
+> neither. Without them `gh issue edit --add-project` reports the project as
+> not found and the scripts above fail with gh's own message naming the
+> scope. Grant it once: `gh auth refresh -s project`.
+
 > **The script checks each move. It does not assume it.**
 > `project-set-status.sh` does not trust the edit's exit code. It fires `gh
 > project item-edit` and does not suppress the command's output. It then

--- a/tests/project-item-id.test.ts
+++ b/tests/project-item-id.test.ts
@@ -90,3 +90,35 @@ describe("project-item-id.sh: source contract", () => {
     expect(read(SCRIPT)).toContain("--limit");
   });
 });
+
+// A fake `gh` whose `project` subcommands fail the way the real CLI does when
+// the token lacks the project scope: the scope name and the remedy on stderr,
+// exit 1. The resolver must surface that cause, not report a generic auth
+// failure ("is gh authenticated?") that sends the operator to `gh auth login`.
+const FAKE_GH_NO_SCOPE = `#!/usr/bin/env bash
+echo "error: your authentication token is missing required scopes [read:project]" >&2
+echo "To request it, run:  gh auth refresh -s read:project" >&2
+exit 1
+`;
+
+const noScopeBin = mkdtempSync(join(tmpdir(), "project-item-id-noscope-"));
+writeFileSync(join(noScopeBin, "gh"), FAKE_GH_NO_SCOPE);
+chmodSync(join(noScopeBin, "gh"), 0o755);
+afterAll(() => rmSync(noScopeBin, { recursive: true, force: true }));
+
+describe("project-item-id.sh: names a missing token scope", () => {
+  function runNoScope(issue: string) {
+    const env = { ...process.env, PATH: `${noScopeBin}:${process.env.PATH ?? ""}` };
+    const r = spawnSync("bash", [SCRIPT, issue], { encoding: "utf8", env });
+    return { status: r.status, out: (r.stdout ?? "").trim(), err: r.stderr ?? "" };
+  }
+
+  test("reports the missing scope and the gh auth refresh remedy, not a generic auth failure", () => {
+    const r = runNoScope("42");
+    expect(r.status).not.toBe(0);
+    expect(r.out).toBe("");
+    expect(r.err).toMatch(/read:project/);
+    expect(r.err).toMatch(/gh auth refresh -s read:project/);
+    expect(r.err).not.toMatch(/is gh authenticated/i);
+  });
+});

--- a/tests/project-set-status.test.ts
+++ b/tests/project-set-status.test.ts
@@ -131,3 +131,47 @@ describe("project-set-status.sh: source contract", () => {
     expect(read(SCRIPT)).toContain("item-list");
   });
 });
+
+describe("project-set-status.sh: an empty item id fails loudly", () => {
+  // The resolver prints nothing when it fails, so a caller that captured its
+  // output hands the setter an empty second argument. That must be a loud
+  // failure at once, never a fall-through to reading stdin — in a pipeline the
+  // read hangs until the caller's timeout.
+  test("rejects an explicit empty item id without reading stdin", () => {
+    const env = {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      GH_FAKE_STATE: stateFile,
+      GH_FAKE_MASK: "0",
+    };
+    // stdin carries a valid id: the old fall-through would read it and succeed.
+    const r = spawnSync("bash", [SCRIPT, "In review", ""], {
+      encoding: "utf8",
+      env,
+      input: "PVTI_TEST\n",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr ?? "").toMatch(/empty item id/i);
+  });
+});
+
+const FAKE_GH_NO_SCOPE_SETTER = `#!/usr/bin/env bash
+echo "error: your authentication token is missing required scopes [read:project]" >&2
+echo "To request it, run:  gh auth refresh -s read:project" >&2
+exit 1
+`;
+const noScopeBin = mkdtempSync(join(tmpdir(), "project-set-status-noscope-"));
+writeFileSync(join(noScopeBin, "gh"), FAKE_GH_NO_SCOPE_SETTER);
+chmodSync(join(noScopeBin, "gh"), 0o755);
+afterAll(() => rmSync(noScopeBin, { recursive: true, force: true }));
+
+describe("project-set-status.sh: names a missing token scope", () => {
+  test("reports the missing scope and the gh auth refresh remedy, not a generic auth failure", () => {
+    const env = { ...process.env, PATH: `${noScopeBin}:${process.env.PATH ?? ""}` };
+    const r = spawnSync("bash", [SCRIPT, "In review", "PVTI_TEST"], { encoding: "utf8", env });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr ?? "").toMatch(/read:project/);
+    expect(r.stderr ?? "").toMatch(/gh auth refresh -s read:project/);
+    expect(r.stderr ?? "").not.toMatch(/is gh authenticated/i);
+  });
+});


### PR DESCRIPTION
## Summary

- The dev board scripts hid `gh`'s own missing-scope error behind "is gh authenticated?", sending the operator toward `gh auth login` when the fix is `gh auth refresh -s read:project` (or `-s project` for edits). Each failure message now points at gh's error and the refresh remedy.
- `project-set-status.sh` treated an explicit empty item id like an omitted one and fell through to reading stdin, so a pipeline whose resolver had failed hung until the caller's timeout. An empty argument now fails at once; stdin is read only when the argument is omitted or `-`.
- `docs/project-tracking.md` states the two token scopes the board needs and the one-time grant.

## Changes

- `.claude/scripts/project-item-id.sh`, `.claude/scripts/project-set-status.sh` — error messages name the cause and remedy; the setter's argument handling rejects an empty id.
- `docs/project-tracking.md` — token-scope note beside the script recipe.
- `tests/project-item-id.test.ts`, `tests/project-set-status.test.ts` — three hermetic tests against fake `gh` binaries (L3): missing-scope stderr surfaces the remedy and not the generic auth question; an explicit empty id fails without reading stdin.

## How to Verify

- `bun test tests/project-item-id.test.ts tests/project-set-status.test.ts` — 13 pass
- `bun test` — 0 fail; `bun run typecheck` — clean
- Mutation check: reverting the empty-id guard reds `rejects an explicit empty item id without reading stdin`
- With a token lacking `read:project`: `.claude/scripts/project-item-id.sh 298` prints gh's scope error followed by the pointer to it; `(sleep 3; echo X) | .claude/scripts/project-set-status.sh Backlog ""` fails immediately with "empty item id"

Dev-only change (`.claude/`, `docs/`, `tests/`): no runtime file touched, so no version bump at land.

## References
- Task: docs/plans/2026-09-03-gh-token-read-project-scope/task.md
