### PR TITLE
fix(docs): add hover links to skill headers

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 # minima was intentionally removed: the site is hand-rolled via
-# _layouts/default.html + assets/css/site.css + assets/js/theme-toggle.js.
+# _layouts/default.html + assets/css/site.css + assets/js/*.js.
 # Run locally with `bundle exec jekyll serve` from docs/. `minima` still
 # appears in Gemfile.lock only as a transitive dep of github-pages, NOT as the theme.
 title: Team

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -46,5 +46,6 @@
     <main class="container">{{ content }}</main>
     {% include footer.html %}
     <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
+    <script src="{{ '/assets/js/heading-anchors.js' | relative_url }}" defer></script>
   </body>
 </html>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -118,6 +118,32 @@ h3 {
   letter-spacing: 0.25px;
 }
 
+main h3 {
+  position: relative;
+}
+
+main h3 .heading-anchor {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 0.5em);
+  transform: translateY(-50%);
+  white-space: nowrap;
+  color: var(--muted-2);
+  background: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+main h3:hover .heading-anchor,
+main h3 .heading-anchor:focus-visible {
+  opacity: 1;
+}
+
+main h3 .heading-anchor:hover {
+  color: var(--fg);
+  background: none;
+}
+
 p {
   margin: 1em 0;
 }
@@ -407,6 +433,10 @@ a:focus-visible,
   }
 
   a {
+    transition: none;
+  }
+
+  main h3 .heading-anchor {
     transition: none;
   }
 }

--- a/docs/assets/js/heading-anchors.js
+++ b/docs/assets/js/heading-anchors.js
@@ -1,0 +1,18 @@
+(function () {
+  "use strict";
+
+  function init() {
+    document.querySelectorAll("main h3[id]").forEach(function (heading) {
+      var anchor = document.createElement("a");
+      anchor.className = "heading-anchor";
+      anchor.href = "#" + heading.id;
+      anchor.setAttribute("aria-label", "Link to this section");
+      anchor.title = "Link to this section";
+      anchor.textContent = "#";
+      heading.appendChild(document.createTextNode(" "));
+      heading.appendChild(anchor);
+    });
+  }
+
+  init();
+})();

--- a/tests/docs-nav.test.ts
+++ b/tests/docs-nav.test.ts
@@ -34,6 +34,15 @@ const VERSIONING_MD = join(REPO_ROOT, "docs", "versioning.md");
 const PROJECT_TRACKING_MD = join(REPO_ROOT, "docs", "project-tracking.md");
 const TESTING_MD = join(REPO_ROOT, "docs", "testing.md");
 const PORTABILITY_MD = join(REPO_ROOT, "docs", "cross-host-portability.md");
+const DEFAULT_LAYOUT = join(REPO_ROOT, "docs", "_layouts", "default.html");
+const HEADING_ANCHORS_JS = join(
+  REPO_ROOT,
+  "docs",
+  "assets",
+  "js",
+  "heading-anchors.js",
+);
+const SITE_CSS = join(REPO_ROOT, "docs", "assets", "css", "site.css");
 
 function readIf(path: string): string {
   return existsSync(path) ? read(path) : "";
@@ -96,5 +105,28 @@ describe("docs site nav: membership and ordering are data-driven from audience +
 
     expect(nonIntegers(orders)).toEqual([]);
     expect(duplicates(orders)).toEqual([]);
+  });
+});
+
+describe("docs skill headers: section links are exposed on hover", () => {
+  const layout = readIf(DEFAULT_LAYOUT);
+  const script = readIf(HEADING_ANCHORS_JS);
+  const css = readIf(SITE_CSS);
+
+  test("default layout loads the heading-anchor script", () => {
+    expect(layout).toContain("/assets/js/heading-anchors.js");
+  });
+
+  test("the script links every h3 with its generated heading id", () => {
+    expect(script).toContain('querySelectorAll("main h3[id]")');
+    expect(script).toContain('anchor.href = "#" + heading.id');
+    expect(script).toContain('anchor.className = "heading-anchor"');
+  });
+
+  test("the permalink appears on heading hover and keyboard focus", () => {
+    expect(css).toContain("position: absolute");
+    expect(css).toContain("right: calc(100% + 0.5em)");
+    expect(css).toContain("main h3:hover .heading-anchor");
+    expect(css).toContain("main h3 .heading-anchor:focus-visible");
   });
 });


### PR DESCRIPTION
## Summary
- Add hover and keyboard-focus permalink links to every skill header.
- Keep the header text aligned by positioning the link outside the heading flow.
- Add deterministic docs contract checks.

## Test plan
- [x] `bun test` (1,930 passed, 4 skipped)
- [x] `bun test tests/docs-nav.test.ts`
- [x] `node --check docs/assets/js/heading-anchors.js`
- [x] `git diff --check`
- [x] Jekyll build with repo Ruby 3.3.6 and Bundler 2.7.1