### PR TITLE
fix(dev): make Claude install idempotent

### DIFF
--- a/script/dev-install-claude
+++ b/script/dev-install-claude
@@ -10,24 +10,110 @@ if [ -z "$PLUGIN_VERSION" ]; then
   exit 1
 fi
 
-# Already linked — nothing to do
-if [ -L "$CACHE_PATH" ] && [ "$(readlink "$CACHE_PATH")" = "$PLUGIN_ROOT" ]; then
-  echo "Team plugin already installed (dev)."
-  exit 0
+if [ -L "$CACHE_PATH" ] && [ "$(readlink "$CACHE_PATH")" != "$PLUGIN_ROOT" ]; then
+  echo "Error: ${CACHE_PATH} already links a different checkout:" >&2
+  echo "  $(readlink "$CACHE_PATH")" >&2
+  echo "Run script/dev-uninstall claude from that checkout first." >&2
+  exit 1
+fi
+
+if [ -e "$CACHE_PATH" ] && [ ! -d "$CACHE_PATH" ]; then
+  echo "Error: ${CACHE_PATH} exists and is not a directory or symlink." >&2
+  exit 1
 fi
 
 echo "Installing Team plugin (dev)..."
 echo "  Source: ${PLUGIN_ROOT}"
 echo
 
-claude plugin marketplace add "$PLUGIN_ROOT" --scope user 2>&1
-claude plugin install team@team-dev --scope user 2>&1 || true
+MARKETPLACE_PATH=$(
+  claude plugin marketplace list --json |
+    node -e '
+      const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+      const matches = entries.filter((entry) => entry.name === "team-dev");
+      if (matches.length > 1) throw new Error("multiple team-dev marketplaces found");
+      if (matches.length === 1) {
+        const entry = matches[0];
+        if (entry.source !== "directory" || typeof entry.path !== "string") {
+          throw new Error("team-dev is not a directory marketplace");
+        }
+        process.stdout.write(entry.path);
+      }
+    '
+)
+
+MARKETPLACE_ADDED=false
+if [ -z "$MARKETPLACE_PATH" ]; then
+  claude plugin marketplace add "$PLUGIN_ROOT" --scope user 2>&1
+  MARKETPLACE_ADDED=true
+elif [ "$MARKETPLACE_PATH" != "$PLUGIN_ROOT" ]; then
+  echo "Error: team-dev already points to a different checkout:" >&2
+  echo "  ${MARKETPLACE_PATH}" >&2
+  echo "Run script/dev-uninstall claude from that checkout first." >&2
+  exit 1
+fi
+
+read_plugin_state() {
+  # The JavaScript template literal is intentionally protected from the shell.
+  # shellcheck disable=SC2016
+  claude plugin list --json |
+    node -e '
+      const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+      const matches = entries.filter(
+        (entry) => entry.id === "team@team-dev" && entry.scope === "user",
+      );
+      if (matches.length > 1) throw new Error("multiple user-scope Team installs found");
+      if (matches.length === 1) {
+        const entry = matches[0];
+        if (typeof entry.version !== "string" || typeof entry.installPath !== "string") {
+          throw new Error("Team install metadata is incomplete");
+        }
+        process.stdout.write(`${entry.version}\t${entry.installPath}`);
+      }
+    '
+}
+
+PLUGIN_STATE=$(read_plugin_state)
+INSTALLED_VERSION=""
+INSTALLED_PATH=""
+if [ -n "$PLUGIN_STATE" ]; then
+  IFS=$'\t' read -r INSTALLED_VERSION INSTALLED_PATH <<< "$PLUGIN_STATE"
+fi
+
+if [ -z "$INSTALLED_VERSION" ]; then
+  if [ "$MARKETPLACE_ADDED" = false ]; then
+    claude plugin marketplace update team-dev 2>&1
+  fi
+  if [ -L "$CACHE_PATH" ]; then
+    rm "$CACHE_PATH"
+  fi
+  claude plugin install team@team-dev --scope user 2>&1
+  PLUGIN_STATE=$(read_plugin_state)
+elif [ "$INSTALLED_VERSION" != "$PLUGIN_VERSION" ] || [ "$INSTALLED_PATH" != "$CACHE_PATH" ]; then
+  if [ -L "$CACHE_PATH" ]; then
+    rm "$CACHE_PATH"
+  fi
+  claude plugin marketplace update team-dev 2>&1
+  claude plugin update team@team-dev --scope user 2>&1
+  PLUGIN_STATE=$(read_plugin_state)
+fi
+
+IFS=$'\t' read -r INSTALLED_VERSION INSTALLED_PATH <<< "$PLUGIN_STATE"
+if [ "$INSTALLED_VERSION" != "$PLUGIN_VERSION" ] || [ "$INSTALLED_PATH" != "$CACHE_PATH" ]; then
+  echo "Error: Claude Code did not install Team ${PLUGIN_VERSION} at ${CACHE_PATH}." >&2
+  exit 1
+fi
 
 # Replace the cached copy with a symlink to the source
 if [ -d "$CACHE_PATH" ] && [ ! -L "$CACHE_PATH" ]; then
   rm -rf "$CACHE_PATH"
   ln -s "$PLUGIN_ROOT" "$CACHE_PATH"
   echo "  Linked: ${CACHE_PATH} → ${PLUGIN_ROOT}"
+elif [ -L "$CACHE_PATH" ]; then
+  echo "Team plugin already installed (dev)."
+else
+  echo "Error: Claude Code reported Team at ${CACHE_PATH}, but that directory does not exist." >&2
+  exit 1
 fi
 
 echo

--- a/tests/regression-309-idempotent-install.test.ts
+++ b/tests/regression-309-idempotent-install.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const INSTALL = join(REPO_ROOT, "script", "dev-install-claude");
+const VERSION = JSON.parse(
+  readFileSync(join(REPO_ROOT, ".claude-plugin", "plugin.json"), "utf8"),
+).version;
+
+const tempDirs: string[] = [];
+
+function newHome(): string {
+  const home = mkdtempSync(join(tmpdir(), `team-install-${process.pid}-`));
+  const binDir = join(home, "bin");
+  mkdirSync(binDir);
+  tempDirs.push(home);
+
+  const stub = join(binDir, "claude");
+  writeFileSync(
+    stub,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+STATE="$HOME/state"
+mkdir -p "$STATE"
+printf '%s\n' "$*" >> "$STATE/calls"
+
+case "$1 $2 $3" in
+  "plugin marketplace list")
+    if [ -f "$STATE/marketplace-path" ]; then
+      path=$(<"$STATE/marketplace-path")
+      printf '[{"name":"team-dev","source":"directory","path":"%s"}]\n' "$path"
+    else
+      printf '[]\n'
+    fi
+    ;;
+  "plugin marketplace add")
+    if [ -f "$STATE/marketplace-path" ]; then
+      echo "Marketplace 'team-dev' is already installed" >&2
+      exit 1
+    fi
+    printf '%s' "$4" > "$STATE/marketplace-path"
+    ;;
+  "plugin marketplace update")
+    ;;
+  "plugin install team@team-dev")
+    if [ -f "$STATE/installed-version" ]; then
+      echo "Plugin 'team@team-dev' is already installed" >&2
+      exit 1
+    fi
+    printf '%s' "$PLUGIN_VERSION" > "$STATE/installed-version"
+    mkdir -p "$HOME/.claude/plugins/cache/team-dev/team/$PLUGIN_VERSION"
+    ;;
+  "plugin update team@team-dev")
+    printf '%s' "$PLUGIN_VERSION" > "$STATE/installed-version"
+    mkdir -p "$HOME/.claude/plugins/cache/team-dev/team/$PLUGIN_VERSION"
+    ;;
+  "plugin list --json")
+    if [ -f "$STATE/installed-version" ]; then
+      version=$(<"$STATE/installed-version")
+      printf '[{"id":"team@team-dev","version":"%s","scope":"user","installPath":"%s/.claude/plugins/cache/team-dev/team/%s"}]\n' "$version" "$HOME" "$version"
+    else
+      printf '[]\n'
+    fi
+    ;;
+  *)
+    echo "Unexpected claude call: $*" >&2
+    exit 64
+    ;;
+esac
+`,
+  );
+  chmodSync(stub, 0o755);
+  return home;
+}
+
+function run(home: string) {
+  const result = spawnSync("bash", [INSTALL], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: `${join(home, "bin")}:${process.env.PATH ?? ""}`,
+      PLUGIN_VERSION: VERSION,
+    },
+  });
+  return {
+    status: result.status ?? -1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`,
+  };
+}
+
+const cachePath = (home: string) =>
+  join(home, ".claude", "plugins", "cache", "team-dev", "team", VERSION);
+const statePath = (home: string, name: string) => join(home, "state", name);
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
+describe("regression #309: Claude dev installation is idempotent", () => {
+  test("a repeated install restores a cache directory to the checkout symlink", () => {
+    const home = newHome();
+    expect(run(home).status).toBe(0);
+
+    rmSync(cachePath(home));
+    mkdirSync(cachePath(home));
+    writeFileSync(join(cachePath(home), "copied-cache"), "owned by Claude\n");
+    writeFileSync(statePath(home, "calls"), "");
+
+    const second = run(home);
+
+    expect(second.status).toBe(0);
+    expect(lstatSync(cachePath(home)).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(cachePath(home))).toBe(REPO_ROOT);
+    expect(existsSync(join(cachePath(home), "copied-cache"))).toBe(false);
+    expect(readFileSync(statePath(home, "calls"), "utf8")).not.toMatch(
+      /marketplace (add|update)|plugin (install|update)/,
+    );
+
+    const third = run(home);
+    expect(third.status).toBe(0);
+    expect(third.output).toContain("already installed");
+    expect(readlinkSync(cachePath(home))).toBe(REPO_ROOT);
+  });
+
+  test("a repeated install updates an older installed version", () => {
+    const home = newHome();
+    mkdirSync(join(home, "state"));
+    writeFileSync(statePath(home, "marketplace-path"), REPO_ROOT);
+    writeFileSync(statePath(home, "installed-version"), "0.0.1");
+    mkdirSync(join(home, ".claude/plugins/cache/team-dev/team/0.0.1"), {
+      recursive: true,
+    });
+
+    const result = run(home);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(statePath(home, "installed-version"), "utf8")).toBe(
+      VERSION,
+    );
+    expect(lstatSync(cachePath(home)).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(cachePath(home))).toBe(REPO_ROOT);
+    const calls = readFileSync(statePath(home, "calls"), "utf8");
+    expect(calls.indexOf("plugin marketplace update team-dev")).toBeLessThan(
+      calls.indexOf("plugin update team@team-dev"),
+    );
+  });
+
+  test("an existing marketplace for another checkout is refused", () => {
+    const home = newHome();
+    const foreign = join(home, "other-team-checkout");
+    mkdirSync(join(home, "state"));
+    writeFileSync(statePath(home, "marketplace-path"), foreign);
+
+    const result = run(home);
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("different checkout");
+    expect(readFileSync(statePath(home, "marketplace-path"), "utf8")).toBe(
+      foreign,
+    );
+    expect(existsSync(cachePath(home))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Makes repeated Claude dev installs inspect existing marketplace and plugin state, repair copied cache directories, and update stale installed versions. Refuses foreign checkout ownership and validates the final installed version and path before replacing the managed cache with a symlink.

## Test plan

- [x] `bun test` — 1,933 passed, 4 skipped
- [x] `bun run typecheck`
- [x] `bash -n script/dev-install-claude`
- [x] `shellcheck script/dev-install-claude`

Closes #309