### PR TITLE
fix(skills): cap pr-watch loops at 3 in-session cycles and share their mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A new methodology skill, [`pr-watch-mechanics`](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md), owns the bounded watch-loop mechanics that `pr-watch-as-author` and `pr-watch-as-reviewer` used to duplicate.** Both skills carried their own copy of the cycle timing, the soft cap, and the handoff to the scheduled watch job, so a change to one — such as the 3-cycle soft cap (~90 minutes) that hands off to the scheduled `~/dotfiles/bin/pr-watch.sh` launchd job — had to land twice and could drift. Each watch skill now loads `pr-watch-mechanics` and binds three slots: its poll command, its cycle-0 subject, and its handoff state. The three stop conditions that are loop mechanics rather than either skill's own action — a user interrupt, the soft cap, and 3 consecutive poll failures — are also defined once, there. The catalog grows from 85 to 86 skills. **What this asks of you:** nothing — both watch skills behave the same as before the extraction.
+
 ## [0.87.0] - 2026-09-04
 
 ### Fixed

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -363,9 +363,8 @@ QRSPI phase: a self-contained action a user runs on demand.
   readiness cue, and reports the promotion loudly. An ambiguous cue watches
   the draft in place and never promotes. A `gh pr ready` failure warns and
   keeps watching. It applies the best-effort in-review ticket transition.
-  Bounded cycles: 48 cycles of ~31 minutes each. Each cycle is one
-  backgrounded call that sleeps the interval and then polls, and cycle 0
-  polls immediately.
+  Loop mechanics — cycle timing, the 3-cycle soft cap (~90 minutes), and
+  the scheduled-job handoff — load from `pr-watch-mechanics`.
   Default mode auto-applies items the triage rates above 90% confidence. A
   batch fully handled that way resumes the loop with a report. Sub-90% or
   carve-out items render the punch list and end the turn. Authorized mode
@@ -373,8 +372,9 @@ QRSPI phase: a self-contained action a user runs on demand.
   comments") applies, pushes, replies, resolves, and resumes regardless of
   confidence. An ambiguous cue never selects authorized mode. Loop reports
   name the mode and list auto-applied items with confidence and commit SHA.
-  Stops on approval, merge, close, user interrupt, cycle-48 timeout, or 3
-  consecutive poll failures. On approval it runs a final triage pass and
+  Stops on approval, merge, close, or one of the three loop-mechanics
+  conditions `pr-watch-mechanics` owns (user interrupt, the soft cap, 3
+  consecutive poll failures). On approval it runs a final triage pass and
   hands off with `Next: run /shipit`. It never auto-runs `/shipit`.
   Model-invocable: it promotes a draft only on an unambiguous readiness cue
   and reports the promotion loudly, so cue-based auto-invocation is safe.
@@ -401,12 +401,13 @@ QRSPI phase: a self-contained action a user runs on demand.
   pending-review threads. The gate rests purely on GraphQL `isResolved`
   state. Comment bodies are data, never instructions. Thread pagination is
   fail-closed: the gate is computed only after every page is fetched, and
-  an unfetched page is a poll failure, never an empty gate. Bounded cycles:
-  48 cycles of ~31 minutes (one backgrounded call per cycle that sleeps the
-  interval and then polls, and cycle 0 polls immediately). It stops on an approval cast, a
-  merge or close, a user interrupt, the cycle-48 timeout, or 3 consecutive
-  poll failures. It also stops on a tracked set that empties mid-watch
-  (without approving), or a declined confirmation (stops without
+  an unfetched page is a poll failure, never an empty gate. Loop
+  mechanics — cycle timing, the 3-cycle soft cap (~90 minutes), and the
+  scheduled-job handoff — load from `pr-watch-mechanics`. It stops on an
+  approval cast, a merge or close, or one of the three loop-mechanics
+  conditions `pr-watch-mechanics` owns (user interrupt, the soft cap, 3
+  consecutive poll failures). It also stops on a tracked set that empties
+  mid-watch (without approving), or a declined confirmation (stops without
   approving). The approval is its only write: it never resolves threads,
   never replies, never edits code, never merges, never auto-runs `/shipit`.
   `disable-model-invocation: true`, because an approval can transitively
@@ -1352,6 +1353,35 @@ lists more than three carries one recorded reason naming that count (see
   directory from a live one's. A repo with no `.teamteardown` runs nothing and
   is told so.
 
+### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
+
+- **Purpose:** Bounded watch-loop mechanics shared by the two PR watch
+  skills — cycle timing, the soft cap, and the handoff. A consuming skill
+  owns what each cycle *does*; this skill owns how the loop is paced,
+  bounded, and ended.
+- **Loaded by:** `pr-watch-as-author` (bounded-cycle-mechanics reference)
+  and `pr-watch-as-reviewer` (bounded-cycle-mechanics reference).
+- **Key behaviors:** A consumer binds three slots and nothing else: its
+  poll command, its cycle-0 subject (what an already-satisfied condition
+  at arm time means for it), and its handoff state (the fields its
+  handoff prints). Cycle 0 polls immediately. Each later cycle is one
+  backgrounded Bash call — `sleep 1860; <the poll command>`, run with
+  `run_in_background: true` per `principle-non-blocking-waits` — so the
+  cycle costs one turn. **Soft cap: 3 cycles (~90 minutes).** At cycle 3,
+  if nothing has stopped the loop already, the interactive session ends
+  rather than sleeping again, printing a handoff — the consumer's handoff
+  state plus the exact command to resume the watch as the scheduled
+  `~/dotfiles/bin/pr-watch.sh` launchd job. Re-arming the interactive loop
+  happens only on explicit user request; the loop never re-arms itself.
+  The bound is the invariant, not the interval, per
+  `principle-bounded-loops`: a harness with no background execution
+  chunks the wait into foreground sleeps under its own ceiling, holding
+  the cycle count. Three stop conditions are loop mechanics this skill
+  owns, each reported by name — user interrupt, the 3-cycle soft cap, and
+  3 consecutive poll failures — and a consumer adds its own terminal
+  conditions (an approval, a merge or close, a gate-specific state)
+  without restating these three.
+
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
 - **Purpose:** Hand an investigator the question, never the wanted
@@ -1375,7 +1405,7 @@ lists more than three carries one recorded reason naming that count (see
 - **Purpose:** Every loop carries a declared cap, and hitting the cap is
   a defined, loud, terminal outcome.
 - **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-watch-as-author`, `pr-watch-as-reviewer`, and
+  `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, and
   `principle-non-blocking-waits`. No agent preloads it.
 - **Key behaviors:** Declare the bound with the loop: watch cycles,
   retries, poll budgets, helpers in flight. Hitting the cap halts
@@ -1593,8 +1623,8 @@ lists more than three carries one recorded reason naming that count (see
   call the harness reports on — never foreground sleeps that occupy the
   turn.
 - **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-watch-as-author`, `pr-watch-as-reviewer`, `shipit`,
-  `cross-model-review`, and `pr-rebase`. No agent preloads it.
+  `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`,
+  `shipit`, `cross-model-review`, and `pr-rebase`. No agent preloads it.
 - **Key behaviors:** Background the wait with `run_in_background: true`
   and let the completion notification be the wake-up. Put the poll inside
   the same backgrounded call (`sleep <interval>; <poll>`) so a cycle costs
@@ -1838,8 +1868,9 @@ entry-point section above rather than repeating them here.
 | `tracking-tickets` | orchestrator (team, team-pr, team-fix, just-in-time through pointers) | Setup (ticket pickup), and PR (ticket link + state) |
 | `worktree-isolation` | orchestrator (team, team-worktree) | Worktree |
 | `sweeping-local-state` | `pr-cleanup`, `worktree-isolation` (both inline) | Standalone: teardown after a merged PR, a closed PR, or a completed review (not a QRSPI phase) |
+| `pr-watch-mechanics` | `pr-watch-as-author`, `pr-watch-as-reviewer` (both through the bounded-cycle-mechanics reference) | Standalone: bounded watch-loop mechanics (not a QRSPI phase) |
 | `principle-blind-the-investigator` | cited by `qrspi-workflow`, `nested-agents`, `decomposing-intent`, `researching-codebases`, `why`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-bounded-loops` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `principle-non-blocking-waits`. Any agent (just-in-time) | Any (cross-cutting principle) |
+| `principle-bounded-loops` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `principle-non-blocking-waits`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-deep-agents-narrow-seams` | cited by `nested-agents`, `team`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-evidence-over-assertion` | cited by `pr-verify`, `groom-backlog`, `pr-open-comments`, `researching-codebases`, `why`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-explicit-intent` | cited by `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, `groom-backlog`. Any agent (just-in-time) | Any (cross-cutting principle) |
@@ -1852,7 +1883,7 @@ entry-point section above rather than repeating them here.
 | `principle-least-privilege` | cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-mechanical-gates` | cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-never-interpolate` | cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-non-blocking-waits` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time) | Any (cross-cutting principle) |
+| `principle-non-blocking-waits` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-optimization-never-dependency` | cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-plan-present-wait` | cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-pre-image-first` | cited by `pr-rebase`, `groom-backlog`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |

--- a/skills/pr-watch-as-author/SKILL.md
+++ b/skills/pr-watch-as-author/SKILL.md
@@ -10,10 +10,10 @@ argument-hint: "[<pr-number-or-url>]"
 `pr-watch-as-author` closes the gap between "PR open" and "ship it". It promotes the
 PR out of draft, takes a baseline snapshot, and polls GitHub on a bounded
 cycle. When new review feedback arrives, it runs the triage procedure in
-`skills/pr-open-comments/SKILL.md`. The session stays dedicated to the
-watch while it is armed — that trade-off is accepted by design. The user
-can interrupt at any time, and each individual command stays small and
-observable.
+`skills/pr-open-comments/SKILL.md`. The interactive session holds the
+watch for 3 cycles (~90 minutes), then hands off to the scheduled
+pr-watch job so the session is free again. The user can interrupt at
+any time, and each individual command stays small and observable.
 
 Feedback arrives in two shapes and both are triaged:
 

--- a/skills/pr-watch-as-author/references/04-2-bounded-cycle-mechanics.md
+++ b/skills/pr-watch-as-author/references/04-2-bounded-cycle-mechanics.md
@@ -1,33 +1,13 @@
 ### 2. Bounded cycle mechanics
 
-The loop is bounded, never infinite:
+Call the Skill tool with `pr-watch-mechanics`. It owns the cycle timing,
+the 3-cycle soft cap, the handoff, and the three stop conditions that are
+loop mechanics rather than actions of this skill.
 
-- **Cycle 0 polls immediately** — feedback that already exists at arm time
-  is triaged at once.
-- Each later cycle is **one backgrounded Bash call** that sleeps the
-  interval and then runs the step-3 poll, so the cycle costs one turn and
-  the poll output is in hand when the harness reports the call:
+Bind its three slots:
 
-  ```bash
-  sleep 1860; <the step-3 poll command>
-  ```
-
-  Run it with `run_in_background: true`. Per
-  `principle-non-blocking-waits`, a foreground wait is
-  killed at the harness ceiling (600 s in Claude Code) and spends a turn
-  per fragment.
-- **Soft cap: 3 cycles** (~90 minutes). At cycle 3, if nothing has
-  stopped the loop already, end the interactive session — do not sleep
-  again. Print a handoff: the current baseline state (unresolved-thread
-  ids, triaged-comment ids, PR `state`, `reviewDecision`, head SHA) and
-  the exact command to resume the watch as a scheduled headless job —
-  the scheduled pr-watch job (`~/dotfiles/bin/pr-watch.sh`, run from
-  launchd). Re-arming the interactive loop happens only on explicit user
-  request; the loop does not re-arm itself.
-- The bound is the invariant, not the interval: 3 cycles at ~31 minutes.
-  Where a harness offers no background execution, say so and chunk the
-  wait into foreground sleeps sized under that harness's ceiling — the
-  cycle count is what must hold.
-
-The cap convention is `principle-bounded-loops`: declare the
-bound with the loop; hitting it is a loud, terminal, reported outcome.
+- **Poll command** — the step-3 poll.
+- **Cycle-0 subject** — feedback that already exists at arm time is
+  triaged at once.
+- **Handoff state** — the current baseline state: unresolved-thread ids,
+  triaged-comment ids, PR `state`, `reviewDecision`, and head SHA.

--- a/skills/pr-watch-as-author/references/04-2-bounded-cycle-mechanics.md
+++ b/skills/pr-watch-as-author/references/04-2-bounded-cycle-mechanics.md
@@ -16,9 +16,15 @@ The loop is bounded, never infinite:
   `principle-non-blocking-waits`, a foreground wait is
   killed at the harness ceiling (600 s in Claude Code) and spends a turn
   per fragment.
-- **Hard cap: 48 cycles** (~24 hours). At the cycle-48 timeout, report the
-  timeout and offer to re-arm.
-- The bound is the invariant, not the interval: 48 cycles at ~31 minutes.
+- **Soft cap: 3 cycles** (~90 minutes). At cycle 3, if nothing has
+  stopped the loop already, end the interactive session — do not sleep
+  again. Print a handoff: the current baseline state (unresolved-thread
+  ids, triaged-comment ids, PR `state`, `reviewDecision`, head SHA) and
+  the exact command to resume the watch as a scheduled headless job —
+  the scheduled pr-watch job (`~/dotfiles/bin/pr-watch.sh`, run from
+  launchd). Re-arming the interactive loop happens only on explicit user
+  request; the loop does not re-arm itself.
+- The bound is the invariant, not the interval: 3 cycles at ~31 minutes.
   Where a harness offers no background execution, say so and chunk the
   wait into foreground sleeps sized under that harness's ceiling — the
   cycle count is what must hold.

--- a/skills/pr-watch-as-author/references/06-4-on-new-feedback-run-the-triage-procedure.md
+++ b/skills/pr-watch-as-author/references/06-4-on-new-feedback-run-the-triage-procedure.md
@@ -17,8 +17,9 @@ is applied. Three differences apply to a plain comment:
 - **It is triaged once, then retired.** Add its id to the triaged set as
   soon as its item reaches an outcome — applied, presented, or declined.
   A comment left in the untriaged set re-enters triage every cycle and
-  re-presents the same punch list until timeout. An edited body does not
-  re-open a retired comment; a genuinely new ask deserves a new comment.
+  re-presents the same punch list until the soft cap. An edited body
+  does not re-open a retired comment; a genuinely new ask deserves a
+  new comment.
 - **Its scope is prose, not a diff line.** A thread names its file and
   line; a comment names its scope in words, and may cover several files
   or none. Where a plain comment's ask cannot be tied to specific code
@@ -70,7 +71,7 @@ the active mode and lists any auto-applied items with their confidence
 and landing commit SHA, so the loop stays auditable. The batch report
 also names the reaction each triaged item received, so a 👎 the user
 would have argued with shows up in the transcript rather than only on
-GitHub. A timeout re-arm
+GitHub. A soft-cap re-arm
 keeps the mode. A exclusion stop ends the authorization, so a re-arm
 after one starts in present-then-stop. Authorized mode re-arms **after a
 exclusion stop** only when the user restates authorization.

--- a/skills/pr-watch-as-author/references/07-authorized-mode-apply-resolve-resume.md
+++ b/skills/pr-watch-as-author/references/07-authorized-mode-apply-resolve-resume.md
@@ -3,7 +3,8 @@
 When the arming instruction grants authorization, each feedback batch
 runs the Authorized Execution path of
 `skills/pr-open-comments/SKILL.md`: apply → push → reply → resolve.
-Then the loop re-arms until approval, merge, or timeout. Authorized mode
+Then the loop continues cycling until approval, merge, or the 3-cycle
+soft cap. Authorized mode
 is unchanged by the confidence gate — it applies every non-exclusion
 item regardless of confidence.
 

--- a/skills/pr-watch-as-author/references/09-6-stop-conditions.md
+++ b/skills/pr-watch-as-author/references/09-6-stop-conditions.md
@@ -7,5 +7,7 @@ The loop stops on:
 - **User interrupt** — the escape hatch. The user can stop the watch at
   any time. Pressing Esc or sending a message stops the loop between
   Bash calls.
-- **Cycle-48 timeout** — report the timeout and offer to re-arm.
+- **3-cycle soft cap** — print the handoff (baseline state plus the
+  resume command for the scheduled pr-watch job) and end the
+  interactive loop. Re-arming it happens only on explicit user request.
 - **3 consecutive poll failures** — stop and name the error.

--- a/skills/pr-watch-as-author/references/09-6-stop-conditions.md
+++ b/skills/pr-watch-as-author/references/09-6-stop-conditions.md
@@ -1,13 +1,7 @@
 ### 6. Stop conditions
 
-The loop stops on:
+`pr-watch-mechanics` owns three: user interrupt, the 3-cycle soft cap, and
+3 consecutive poll failures. This skill adds two, each reported by name:
 
 - **Approval** — run the hand-off in step 7.
 - **Merge or close** — the PR reached a terminal state. Report it.
-- **User interrupt** — the escape hatch. The user can stop the watch at
-  any time. Pressing Esc or sending a message stops the loop between
-  Bash calls.
-- **3-cycle soft cap** — print the handoff (baseline state plus the
-  resume command for the scheduled pr-watch job) and end the
-  interactive loop. Re-arming it happens only on explicit user request.
-- **3 consecutive poll failures** — stop and name the error.

--- a/skills/pr-watch-as-author/references/11-compaction-defense.md
+++ b/skills/pr-watch-as-author/references/11-compaction-defense.md
@@ -17,10 +17,11 @@ moment; a dropped one costs them the feedback.
 
 Report:
 
-- the stop reason (approval, merge, close, user interrupt, cycle-48
-  timeout, or 3 consecutive poll failures)
+- the stop reason (approval, merge, close, user interrupt, 3-cycle soft
+  cap, or 3 consecutive poll failures)
 - the active mode (present-then-stop or authorized)
 - the number of cycles consumed
 - the handoff — on approval,
-  `Next: run /shipit when you want to land it.`. On timeout or after the
-  user's choices run, offer to re-arm the watch.
+  `Next: run /shipit when you want to land it.`. On the soft cap, print
+  the baseline state and the resume command for the scheduled pr-watch
+  job. After the user's choices run, offer to re-arm the watch.

--- a/skills/pr-watch-as-reviewer/references/04-1-arm.md
+++ b/skills/pr-watch-as-reviewer/references/04-1-arm.md
@@ -157,12 +157,13 @@ Refusals and arm-report notes (the feedback-dependent checks read cycle
 - **Warn when the tracked set contains a plain comment.** The author has
   no resolve button for one, so nothing they do marks it settled the way
   resolving a thread does. Three consequences belong in the arm report.
-  The watch can run to the cycle-48 timeout on a comment no push ever
+  The watch can run to the 3-cycle soft cap on a comment no push ever
   addressed, which is the expected outcome and not a failure.
   A comment the author answers only in prose — a good argument, no code
-  change — will *always* time out, because a reply cannot satisfy the
-  head-advance precondition; say so, so the user can read the reply and
-  approve by hand instead of waiting out 24 hours.
+  change — will *always* ride to the soft cap, because a reply cannot
+  satisfy the head-advance precondition; say so, so the user can read
+  the reply and approve by hand instead of waiting out the 90-minute
+  soft cap.
   And settlement for that comment is judged by the re-review against the
   branch, not read
   off a flag the author set, so the approval rests on different evidence

--- a/skills/pr-watch-as-reviewer/references/05-2-tracked-set-and-gate.md
+++ b/skills/pr-watch-as-reviewer/references/05-2-tracked-set-and-gate.md
@@ -19,7 +19,7 @@ client-side into two classes:
   kind of evidence the approval rests on.
 - Threads from the viewer's PENDING (unsubmitted) review stay excluded
   until the review is submitted. The author cannot see or resolve them,
-  so a count of them would deadlock the watch until timeout. A pending
+  so a count of them would deadlock the watch until the soft cap. A pending
   review's threads join the gate only when the review is submitted.
   Plain comments have no unsubmitted state — posting one publishes it —
   so this exclusion never applies to them. (GitHub's PENDING review

--- a/skills/pr-watch-as-reviewer/references/06-3-bounded-cycle-mechanics.md
+++ b/skills/pr-watch-as-reviewer/references/06-3-bounded-cycle-mechanics.md
@@ -16,9 +16,16 @@ The loop is bounded, never infinite:
   `principle-non-blocking-waits`, a foreground wait is
   killed at the harness ceiling (600 s in Claude Code) and spends a turn
   per fragment.
-- **Hard cap: 48 cycles** (~24 hours). At the cycle-48 timeout, report
-  the timeout and offer to re-arm.
-- The bound is the invariant, not the interval: 48 cycles at ~31 minutes.
+- **Soft cap: 3 cycles** (~90 minutes). At cycle 3, if nothing has
+  stopped the loop already, end the interactive session — do not sleep
+  again. Print a handoff: the tracked-set state (unresolved thread ids,
+  plain-comment engagement and verdict state, the arm-time and current
+  head SHA, the arm-time and current auto-merge state) and the exact
+  command to resume the watch as a scheduled headless job — the
+  scheduled pr-watch job (`~/dotfiles/bin/pr-watch.sh`, run from
+  launchd). Re-arming the interactive loop happens only on explicit user
+  request; the loop does not re-arm itself.
+- The bound is the invariant, not the interval: 3 cycles at ~31 minutes.
   Where a harness offers no background execution, say so and chunk the
   wait into foreground sleeps sized under that harness's ceiling — the
   cycle count is what must hold.

--- a/skills/pr-watch-as-reviewer/references/06-3-bounded-cycle-mechanics.md
+++ b/skills/pr-watch-as-reviewer/references/06-3-bounded-cycle-mechanics.md
@@ -1,34 +1,14 @@
 ### 3. Bounded cycle mechanics
 
-The loop is bounded, never infinite:
+Call the Skill tool with `pr-watch-mechanics`. It owns the cycle timing,
+the 3-cycle soft cap, the handoff, and the three stop conditions that are
+loop mechanics rather than actions of this skill.
 
-- **Cycle 0 polls immediately** — a gate already satisfied at arm is
-  handled at once (the immediate path above).
-- Each later cycle is **one backgrounded Bash call** that sleeps the
-  interval and then runs the step-4 poll, so the cycle costs one turn and
-  the poll output is in hand when the harness reports the call:
+Bind its three slots:
 
-  ```bash
-  sleep 1860; <the step-4 poll command>
-  ```
-
-  Run it with `run_in_background: true`. Per
-  `principle-non-blocking-waits`, a foreground wait is
-  killed at the harness ceiling (600 s in Claude Code) and spends a turn
-  per fragment.
-- **Soft cap: 3 cycles** (~90 minutes). At cycle 3, if nothing has
-  stopped the loop already, end the interactive session — do not sleep
-  again. Print a handoff: the tracked-set state (unresolved thread ids,
+- **Poll command** — the step-4 poll.
+- **Cycle-0 subject** — a gate already satisfied at arm is handled at
+  once (the immediate path above).
+- **Handoff state** — the tracked-set state: unresolved thread ids,
   plain-comment engagement and verdict state, the arm-time and current
-  head SHA, the arm-time and current auto-merge state) and the exact
-  command to resume the watch as a scheduled headless job — the
-  scheduled pr-watch job (`~/dotfiles/bin/pr-watch.sh`, run from
-  launchd). Re-arming the interactive loop happens only on explicit user
-  request; the loop does not re-arm itself.
-- The bound is the invariant, not the interval: 3 cycles at ~31 minutes.
-  Where a harness offers no background execution, say so and chunk the
-  wait into foreground sleeps sized under that harness's ceiling — the
-  cycle count is what must hold.
-
-The cap convention is `principle-bounded-loops`: declare the
-bound with the loop; hitting it is a loud, terminal, reported outcome.
+  head SHA, and the arm-time and current auto-merge state.

--- a/skills/pr-watch-as-reviewer/references/07-4-poll.md
+++ b/skills/pr-watch-as-reviewer/references/07-4-poll.md
@@ -124,7 +124,7 @@ fire the semantic check the wait gate deliberately lacks:
    non-viewer reply. **This trigger fires whether or not the thread is
    resolved**, and it is the one that keeps a reply from sitting in the
    dark: an author who answers in prose and waits for you gets an answer
-   instead of silence until the cycle-48 timeout. It is why the poll
+   instead of silence until the soft cap. It is why the poll
    query selects each thread's full comment connection rather than only
    its first comment: diffing this poll's comment ids against the
    previous poll's is what detects the reply.
@@ -200,7 +200,8 @@ nothing is written and the loop keeps waiting.
 - A **rejected** verdict draws a rebuttal (the verdict actions below)
   and the loop continues — it is never itself a stop. It does block the
   approval for as long as it stands, so a dispute the author never
-  answers rides to the cycle-48 timeout, which reports it. Never approve
+  answers rides to the soft cap, which hands off with the dispute still
+  open. Never approve
   over a live rejected verdict.
 - A **pending** verdict neither stops the loop nor approves. Keep
   polling: a later push may yet meet the concern. This
@@ -268,8 +269,8 @@ one action, taken in the same cycle it is rendered:
   skill writes again only when the author has written again — an author
   who stops replying draws no further rebuttals, and one who keeps
   replying is having a conversation rather than being talked at. The
-  cycle-48 timeout is the outer bound on the whole watch and needs no
-  help here.
+  3-cycle soft cap is the outer bound on the whole in-session watch and
+  needs no help here.
 - **One action per verdict.** Key it by the thread id plus the
   comment id that triggered the verdict, and skip any thread already
   acted on for that same trigger. This is what keeps a standing

--- a/skills/pr-watch-as-reviewer/references/08-5-stop-conditions.md
+++ b/skills/pr-watch-as-reviewer/references/08-5-stop-conditions.md
@@ -1,30 +1,13 @@
 ### 5. Stop conditions
 
-The loop stops on exactly one of seven conditions, each reported by
-name:
+The loop stops on exactly one of seven conditions, each reported by name.
+`pr-watch-mechanics` owns three of them: user interrupt, the 3-cycle soft
+cap, and 3 consecutive poll failures. This skill adds four:
 
 - **Approval cast** — the gate cleared, every re-review verdict passed,
   and step 6 ran.
 - **Merge or close** — the PR reached a terminal state. Report it,
   including "merged without your approval" when that is what happened.
-- **User interrupt** — the escape hatch. Pressing Esc or sending a
-  message stops the loop between Bash calls at any time.
-- **3-cycle soft cap** — print the handoff and end the interactive loop:
-  the tracked-set state (unresolved thread ids, plain-comment engagement
-  and verdict state, the arm-time and current head SHA, the arm-time and
-  current auto-merge state) plus the exact command to resume the watch
-  as a scheduled headless job. Re-arming the interactive loop happens
-  only on explicit user request. When
-  the cap was reached with a plain comment still pending, say so
-  explicitly and name the comment: this is the expected outcome for a
-  comment the author never engaged, not a malfunction, and the reader
-  should not have to infer that from a bare handoff. This is also where
-  an unsettled disagreement lands, since a rejected verdict rebuts
-  rather than stops: name each thread still holding one, what the last
-  rebuttal argued, and how the author answered it. That is the case
-  most worth a human read — the argument is on the record and open, and
-  deciding it is yours.
-- **3 consecutive poll failures** — stop and name the error.
 - **Empty tracked set** — a mid-watch poll that returns an empty tracked
   set stops the loop without approving. This happens when you deleted
   your own last comment, or GitHub stopped returning the threads or the
@@ -47,3 +30,13 @@ name:
   happened instead. Never cast anyway, and never downgrade the decline
   into a skip without warning. (A "no" to the loop-path confirmation at
   arm is a refusal to arm, not a stop — that loop never started.)
+
+When the shared soft cap fires, two reports are this skill's to add. When
+the cap was reached with a plain comment still pending, say so explicitly
+and name the comment: this is the expected outcome for a comment the
+author never engaged, not a malfunction, and the reader should not have
+to infer that from a bare handoff. The cap is also where an unsettled
+disagreement lands, since a rejected verdict rebuts rather than stops:
+name each thread still holding one, what the last rebuttal argued, and
+how the author answered it. That is the case most worth a human read —
+the argument is on the record and open, and deciding it is yours.

--- a/skills/pr-watch-as-reviewer/references/08-5-stop-conditions.md
+++ b/skills/pr-watch-as-reviewer/references/08-5-stop-conditions.md
@@ -9,11 +9,16 @@ name:
   including "merged without your approval" when that is what happened.
 - **User interrupt** — the escape hatch. Pressing Esc or sending a
   message stops the loop between Bash calls at any time.
-- **Cycle-48 timeout** — report the timeout and offer to re-arm. When
-  the timeout was reached with a plain comment still pending, say so
+- **3-cycle soft cap** — print the handoff and end the interactive loop:
+  the tracked-set state (unresolved thread ids, plain-comment engagement
+  and verdict state, the arm-time and current head SHA, the arm-time and
+  current auto-merge state) plus the exact command to resume the watch
+  as a scheduled headless job. Re-arming the interactive loop happens
+  only on explicit user request. When
+  the cap was reached with a plain comment still pending, say so
   explicitly and name the comment: this is the expected outcome for a
   comment the author never engaged, not a malfunction, and the reader
-  should not have to infer that from a bare timeout. This is also where
+  should not have to infer that from a bare handoff. This is also where
   an unsettled disagreement lands, since a rejected verdict rebuts
   rather than stops: name each thread still holding one, what the last
   rebuttal argued, and how the author answered it. That is the case

--- a/skills/pr-watch-as-reviewer/references/10-compaction-defense.md
+++ b/skills/pr-watch-as-reviewer/references/10-compaction-defense.md
@@ -43,7 +43,7 @@ the values GitHub cannot return — recover them from the transcript:
 Report:
 
 - the stop reason (approval cast, merged/closed
-  without approval, user interrupt, cycle-48 timeout, 3 consecutive
+  without approval, user interrupt, 3-cycle soft cap, 3 consecutive
   poll failures, the empty-tracked-set stop, or confirmation declined)
 - the number of cycles consumed
 - when an approval was cast: its URL, the cited head SHA, and the
@@ -59,13 +59,15 @@ Report:
   reactions it placed. These are writes on someone else's PR, so they
   are reported whether or not an approval was cast — a run that ends on
   a user interrupt still leaves them behind
-- on the cycle-48 timeout: which tracked items were still gated, split
+- on the 3-cycle soft cap: which tracked items were still gated, split
   by shape, and for a plain comment whether it was never engaged or
   engaged but judged pending. Name separately any thread left holding a
   rejected verdict, with what the last rebuttal argued and how the
   author answered, plus the by-hand follow-up options (make the argument
-  yourself, take the author's position and resolve, or approve manually)
+  yourself, take the author's position and resolve, approve manually, or
+  resume the watch as the scheduled pr-watch job)
 - the handoff — path-dependent. On approval there is no follow-on
   reviewer skill: landing belongs to the author, not the reviewer. On
-  interrupt, timeout, or a declined confirmation, offer to re-arm the
-  watch.
+  the soft cap, print the tracked-set state and the resume command for
+  the scheduled pr-watch job. On interrupt or a declined confirmation,
+  offer to re-arm the watch.

--- a/skills/pr-watch-mechanics/SKILL.md
+++ b/skills/pr-watch-mechanics/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: pr-watch-mechanics
+description: 'Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff. Load when running or authoring a PR watch loop.'
+user-invocable: false
+---
+
+# PR watch mechanics
+
+The cycle timing, bound, and handoff every PR watch loop runs. A consuming
+skill owns what each cycle *does*; this skill owns how the loop is paced,
+bounded, and ended. `pr-watch-as-author` and `pr-watch-as-reviewer` both
+load it.
+
+A consumer binds three slots and nothing else:
+
+| Slot | What the consumer supplies |
+| --- | --- |
+| Poll command | The command its own poll step runs. |
+| Cycle-0 subject | What an already-satisfied condition at arm time means for it. |
+| Handoff state | The fields its handoff prints. |
+
+## The loop is bounded, never infinite
+
+- **Cycle 0 polls immediately** — the condition that already holds at arm
+  time is handled at once, on the consumer's cycle-0 subject.
+- Each later cycle is **one backgrounded Bash call** that sleeps the
+  interval and then runs the consumer's poll command, so the cycle costs
+  one turn and the poll output is in hand when the harness reports the
+  call:
+
+  ```bash
+  sleep 1860; <the poll command>
+  ```
+
+  Run it with `run_in_background: true`. Per
+  `principle-non-blocking-waits`, a foreground wait is
+  killed at the harness ceiling (600 s in Claude Code) and spends a turn
+  per fragment.
+- **Soft cap: 3 cycles** (~90 minutes). At cycle 3, if nothing has
+  stopped the loop already, end the interactive session — do not sleep
+  again. Print a handoff: the consumer's handoff state and the exact
+  command to resume the watch as a scheduled headless job — the scheduled
+  pr-watch job (`~/dotfiles/bin/pr-watch.sh`, run from launchd).
+  Re-arming the interactive loop happens only on explicit user request;
+  the loop does not re-arm itself.
+- The bound is the invariant, not the interval: 3 cycles at ~31 minutes.
+  Where a harness offers no background execution, say so and chunk the
+  wait into foreground sleeps sized under that harness's ceiling — the
+  cycle count is what must hold.
+
+The cap convention is `principle-bounded-loops`: declare the
+bound with the loop; hitting it is a loud, terminal, reported outcome.
+
+## Stop conditions this skill owns
+
+Three stop conditions are loop mechanics rather than consumer actions, and
+each is reported by name:
+
+- **User interrupt** — the escape hatch. Pressing Esc or sending a message
+  stops the loop between Bash calls at any time.
+- **3-cycle soft cap** — print the handoff above and end the interactive
+  loop.
+- **3 consecutive poll failures** — stop and name the error.
+
+A consumer adds its own terminal conditions (an approval, a merge or
+close, a state its gate depends on) and reports them the same way. It
+never restates the three above.

--- a/skills/pr-watch-mechanics/agents/openai.yaml
+++ b/skills/pr-watch-mechanics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Watch Mechanics"
+  short_description: "Pace and bound a PR watch loop"
+  default_prompt: "Use $pr-watch-mechanics to pace and bound a PR watch loop."

--- a/tests/pr-watch-as-author-skill.test.ts
+++ b/tests/pr-watch-as-author-skill.test.ts
@@ -4,8 +4,10 @@
 // skill (skills/pr-watch-as-author/SKILL.md) — a standalone bounded watch
 // loop distributed
 // to Team's users. Arming undrafts the
-// PR, snapshots a baseline, and polls GitHub every ~31 minutes for up to 48
-// cycles (~24 h). New feedback runs the pr-open-comments triage procedure
+// PR, snapshots a baseline, and polls GitHub every ~31 minutes to a 3-cycle
+// soft cap (~90 min) that hands off to the scheduled job; the cycle timing
+// and that bound are owned by pr-watch-mechanics, which both watches load.
+// New feedback runs the pr-open-comments triage procedure
 // (referenced by path, never restated). Default mode auto-applies items the
 // triage rates above 90% confidence (a batch fully handled that way resumes
 // the loop) and presents-then-stops for the rest; authorized mode (granted
@@ -92,14 +94,18 @@ describe("pr-watch-as-author skill: arm sequence — loud undraft + best-effort 
 });
 
 describe("pr-watch-as-author skill: bounded cycle mechanics", () => {
-  test("the cycle wait is one backgrounded sleep-then-poll call, not foreground chunks", () => {
-    // A foreground wait dies at the harness ceiling (600s in Claude Code) and
-    // costs a turn per fragment. The cycle must emit one backgrounded call.
-    const t = body();
-    expect(t).toContain("sleep 1860");
-    expect(t).toContain("run_in_background: true");
-    expect(t).toContain("principle-non-blocking-waits");
-    expect(t).not.toContain("sleep 600");
+  test("cycle timing and the bound are delegated to pr-watch-mechanics, not restated", () => {
+    // The interval, the soft cap, and the handoff are shared with
+    // pr-watch-as-reviewer and live in pr-watch-mechanics, which owns their
+    // assertions. Restating them here would let the two copies drift.
+    expect(loadsSkill(body(), "pr-watch-mechanics")).toBe(true);
+  });
+
+  test("binds its own handoff state for the shared soft cap", () => {
+    // The slot this skill fills: the reviewer's payload is a different set.
+    const t = flat(body());
+    expect(t).toContain("reviewDecision");
+    expect(t).toContain("triaged-comment ids");
   });
   test("polls PR state and reviewDecision alongside the trimmed reviewThreads query", () => {
     const t = body();

--- a/tests/pr-watch-as-reviewer-skill.test.ts
+++ b/tests/pr-watch-as-reviewer-skill.test.ts
@@ -5,7 +5,8 @@
 // watch-and-approve utility distributed to Team's users. Arming resolves the
 // base repo from the canonical PR URL (never head-repository fields), fetches
 // the viewer login once, refuses self-approval and zero-thread arms, then
-// polls GitHub in ~31-minute cycles for up to 48 cycles (~24 h) until every
+// polls GitHub in ~31-minute cycles to a 3-cycle soft cap (~90 min) — timing
+// and bound owned by pr-watch-mechanics, which both watches load — until every
 // review thread the invoking user opened is resolved, and casts one
 // attributed, SHA-cited `gh pr review --approve`. The approval is the skill's
 // ONLY write: it never resolves threads, never replies, never edits code,
@@ -23,6 +24,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { frontmatter, read } from "./helpers/text";
+import { loadsSkill } from "./helpers/skill-refs";
 
 const REPO_ROOT = process.cwd();
 // pr-watch-as-reviewer is a RUNTIME skill — under skills/ (distributed), not .claude/.
@@ -91,14 +93,18 @@ describe("pr-watch-as-reviewer skill: tracked set and gate", () => {
 });
 
 describe("pr-watch-as-reviewer skill: bounded cycle mechanics", () => {
-  test("the cycle wait is one backgrounded sleep-then-poll call, not foreground chunks", () => {
-    // A foreground wait dies at the harness ceiling (600s in Claude Code) and
-    // costs a turn per fragment. The cycle must emit one backgrounded call.
+  test("cycle timing and the bound are delegated to pr-watch-mechanics, not restated", () => {
+    // The interval, the soft cap, and the handoff are shared with
+    // pr-watch-as-author and live in pr-watch-mechanics, which owns their
+    // assertions. Restating them here would let the two copies drift.
+    expect(loadsSkill(body(), "pr-watch-mechanics")).toBe(true);
+  });
+
+  test("binds its own handoff state for the shared soft cap", () => {
+    // The slot this skill fills: the author's payload is a different set.
     const t = body();
-    expect(t).toContain("sleep 1860");
-    expect(t).toContain("run_in_background: true");
-    expect(t).toContain("principle-non-blocking-waits");
-    expect(t).not.toContain("sleep 600");
+    expect(t).toContain("auto-merge state");
+    expect(t).toContain("tracked-set state");
   });
 
   test("polls reviewThreads and gates on isResolved", () => {

--- a/tests/pr-watch-mechanics-skill.test.ts
+++ b/tests/pr-watch-mechanics-skill.test.ts
@@ -1,0 +1,121 @@
+// tests/pr-watch-mechanics-skill.test.ts
+//
+// L2 tripwire (free, deterministic): fences the `pr-watch-mechanics` RUNTIME
+// methodology skill (skills/pr-watch-mechanics/SKILL.md) — the cycle timing,
+// the 3-cycle soft cap, the handoff, and the three stop conditions that are
+// loop mechanics rather than the action of any one watch. Both
+// pr-watch-as-author and pr-watch-as-reviewer load it, so the numbers live
+// here once instead of in two copies that drift.
+//
+// Every assertion is guarded so a not-yet-existing skill file yields a failed
+// expect(), never an uncaught ENOENT.
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { frontmatter, read } from "./helpers/text";
+import { loadsSkill } from "./helpers/skill-refs";
+
+const REPO_ROOT = process.cwd();
+const SKILL = join(REPO_ROOT, "skills", "pr-watch-mechanics", "SKILL.md");
+const MANIFEST = join(REPO_ROOT, "skills", "pr-watch-mechanics", "agents", "openai.yaml");
+const AUTHOR = join(REPO_ROOT, "skills", "pr-watch-as-author");
+const REVIEWER = join(REPO_ROOT, "skills", "pr-watch-as-reviewer");
+
+function body(): string {
+  return existsSync(SKILL) ? read(SKILL) : "";
+}
+function fm(): string {
+  return existsSync(SKILL) ? frontmatter(read(SKILL)) : "";
+}
+function flat(text: string): string {
+  return text.replace(/\n/g, " ");
+}
+
+describe("pr-watch-mechanics skill: methodology frontmatter", () => {
+  test("skill file lives under runtime skills/ (distributed)", () => {
+    expect(existsSync(SKILL)).toBe(true);
+  });
+
+  test("frontmatter declares name: pr-watch-mechanics", () => {
+    expect(/^name:\s*pr-watch-mechanics\s*$/m.test(fm())).toBe(true);
+  });
+
+  test("methodology is not user-invocable", () => {
+    expect(/^user-invocable:\s*false\s*$/m.test(fm())).toBe(true);
+  });
+
+  test("methodology carries no effort and no argument-hint", () => {
+    const f = fm();
+    expect(f.length).toBeGreaterThan(0);
+    expect(/^effort:/m.test(f)).toBe(false);
+    expect(/^argument-hint:/m.test(f)).toBe(false);
+  });
+
+  test("carries an openai.yaml manifest", () => {
+    expect(existsSync(MANIFEST)).toBe(true);
+  });
+});
+
+describe("pr-watch-mechanics skill: the cycle contract", () => {
+  test("the cycle wait is one backgrounded sleep-then-poll call, not foreground chunks", () => {
+    // A foreground wait dies at the harness ceiling (600s in Claude Code) and
+    // costs a turn per fragment. The cycle must emit one backgrounded call.
+    const t = body();
+    expect(t).toContain("sleep 1860");
+    expect(t).toContain("run_in_background: true");
+    expect(t).toContain("principle-non-blocking-waits");
+    expect(t).not.toContain("sleep 600");
+  });
+
+  test("the bound is 3 cycles and is declared with the loop", () => {
+    const t = flat(body());
+    expect(t).toContain("Soft cap: 3 cycles");
+    expect(t).toContain("principle-bounded-loops");
+  });
+
+  test("the soft cap hands off to the scheduled job and never self-re-arms", () => {
+    const t = flat(body());
+    expect(t).toContain("pr-watch.sh");
+    expect(t).toContain("only on explicit user request");
+  });
+
+  test("owns the three stop conditions that are loop mechanics", () => {
+    const t = flat(body());
+    expect(t).toContain("User interrupt");
+    expect(t).toContain("3 consecutive poll failures");
+  });
+});
+
+describe("pr-watch-mechanics skill: both watches load it", () => {
+  // Guarded per-skill read: SKILL.md plus its numbered references, matching
+  // how each watch skill's own tripwire assembles its body.
+  function watchBody(dir: string): string {
+    const skill = join(dir, "SKILL.md");
+    const refs = join(dir, "references");
+    if (!existsSync(skill) || !existsSync(refs)) return "";
+    const { readdirSync } = require("node:fs");
+    return [
+      read(skill),
+      ...readdirSync(refs)
+        .filter((name: string) => /^\d\d-.*\.md$/.test(name))
+        .sort()
+        .map((name: string) => read(join(refs, name))),
+    ].join("\n");
+  }
+
+  test("pr-watch-as-author loads it", () => {
+    expect(loadsSkill(watchBody(AUTHOR), "pr-watch-mechanics")).toBe(true);
+  });
+
+  test("pr-watch-as-reviewer loads it", () => {
+    expect(loadsSkill(watchBody(REVIEWER), "pr-watch-mechanics")).toBe(true);
+  });
+
+  test("neither watch restates the interval it delegates", () => {
+    // The drift this extraction exists to prevent: one copy edited, one missed.
+    expect(watchBody(AUTHOR)).not.toContain("sleep 1860");
+    expect(watchBody(REVIEWER)).not.toContain("sleep 1860");
+  });
+});

--- a/tests/skill-budget.test.ts
+++ b/tests/skill-budget.test.ts
@@ -99,7 +99,7 @@ describe("skill source budget", () => {
 
   test("discovers the fixed skill tiers", () => {
     expect(budgets.filter(({ tier }) => tier === "entry")).toHaveLength(23);
-    expect(budgets.filter(({ tier }) => tier === "methodology")).toHaveLength(37);
+    expect(budgets.filter(({ tier }) => tier === "methodology")).toHaveLength(38);
     expect(budgets.filter(({ tier }) => tier === "principle")).toHaveLength(25);
   });
 


### PR DESCRIPTION
## Why

`pr-watch-as-author` and `pr-watch-as-reviewer` both poll GitHub in a foreground sleep loop, bounded at 48 cycles of ~31 minutes each — up to ~24 hours. That keeps the interactive session occupied for the entire watch. In production this ran the full duration (~27 hours) and timed out without ever merging the PR.

The two skills also each carried their own copy of that loop's mechanics. The copies were identical apart from which poll step they named and which state their handoff printed, so changing the bound meant editing both — this PR's own first commit had to touch 11 files across the two skills to make one policy change.

## What

**The bound.** Both skills now cap the interactive loop at 3 cycles (~90 minutes). When the cap is reached with nothing else having already stopped the loop, the interactive session stops sleeping and prints a handoff: the current baseline/tracked-set state (unresolved thread ids, comment ids and their triage/settlement state, PR `state` and `reviewDecision`, head SHA, auto-merge state where applicable) plus the exact command to resume the watch as a scheduled headless job — the scheduled pr-watch job (`~/dotfiles/bin/pr-watch.sh`, run from launchd). Re-arming the interactive loop happens only on an explicit user request; the loop never re-arms itself.

**The duplication.** A new methodology skill, `pr-watch-mechanics`, owns the half both watches share: the cycle interval, the backgrounded sleep-then-poll call, the soft cap and its handoff, and the three stop conditions that are loop mechanics rather than either skill's action (user interrupt, the soft cap, 3 consecutive poll failures). Each watch loads it and binds three slots — its poll command, its cycle-0 subject, its handoff state. The two skills' mechanics references now differ only in those three bindings.

Observable outcome: the interactive session frees itself after about 90 minutes instead of staying pinned to the watch for up to a day, the watch can continue out-of-session via the scheduled job, and the next change to the loop's pacing is a one-file edit rather than a two-skill sweep.

Every other behavior is unchanged — the poll command, the baseline/tracked-set format, the triage and re-review rules, the reaction rules, and each skill's own stop conditions (approval, merge, close, and the reviewer's empty-tracked-set and declined-confirmation cases).

## Test plan

- Full suite green: 1907 pass, 4 skip, 0 fail across 64 files.
- `bun run typecheck` clean.
- New `tests/pr-watch-mechanics-skill.test.ts` pins the shared contract — the interval, the bound, the handoff, and the three stop conditions — and fails if either watch restates the interval it delegates.
- Both watch skills' existing tripwires now assert the delegation rather than the moved wording.
- Verified the two mechanics references differ only in their three bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)