### PR TITLE
feat(dev): refresh Claude installs after pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Clone-backed Claude installs now refresh after merge and rebase pulls.** Run `script/dev-install claude` once. Team keeps Claude Code pointed at the pulled version, and `script/dev-uninstall claude` removes only Team-owned hooks. Existing non-Team hooks are preserved and require manual integration. **What this asks of you:** reinstall once to add the hooks.
+
 ## [0.81.0] - 2026-09-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ The first command registers the checkout as a marketplace; the second installs
 from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
 hooks load with them.
 
+For a clone-backed install that updates when `git pull` changes the checkout:
+
+```bash
+script/dev-install claude
+```
+
+This adds clone-local hooks for merge and rebase pulls. Existing non-Team hooks
+are never overwritten; setup stops with manual integration instructions.
+Remove the install and Team-owned hooks with:
+
+```bash
+script/dev-uninstall claude
+```
+
 **Turn on auto-update, or you stay on the version you installed.** Claude Code
 enables auto-update for official Anthropic marketplaces by default and
 **disables it for local development marketplaces** — which is what a local

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,20 @@ The first command registers the checkout as a marketplace; the second installs
 from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
 hooks load with them.
 
+For a clone-backed install that updates when `git pull` changes the checkout:
+
+```bash
+script/dev-install claude
+```
+
+This adds clone-local hooks for merge and rebase pulls. Existing non-Team hooks
+are never overwritten; setup stops with manual integration instructions.
+Remove the install and Team-owned hooks with:
+
+```bash
+script/dev-uninstall claude
+```
+
 **Turn on auto-update, or you stay on the version you installed.** Claude Code
 enables auto-update for official Anthropic marketplaces by default and
 **disables it for local development marketplaces** — which is what a local

--- a/script/dev-install
+++ b/script/dev-install
@@ -9,9 +9,84 @@ set -euo pipefail
 # Each harness has its own script beside this one, because each host installs
 # a plugin its own way. Adding a harness means adding `dev-install-<name>` and
 # `dev-uninstall-<name>`, then listing it below.
+# The Claude target also installs clone-local hooks that refresh its versioned
+# cache after merge-based and rebase-based pulls.
 
 HARNESSES=(claude codex antigravity)
 HERE="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$HERE")"
+HOOK_MARKER="# Managed by Team dev install."
+
+resolve_pull_hooks_dir() {
+  local common_dir hooks_dir
+  common_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-common-dir) || {
+    echo "Error: cannot resolve this checkout's common Git directory." >&2
+    return 1
+  }
+  hooks_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-path hooks) || {
+    echo "Error: cannot resolve this checkout's Git hooks directory." >&2
+    return 1
+  }
+  if [ "$hooks_dir" != "${common_dir}/hooks" ]; then
+    echo "Error: the active Git hooks path is outside this clone:" >&2
+    echo "  ${hooks_dir}" >&2
+    echo "Preserving it. Add 'script/dev-install claude' to its pull hooks manually." >&2
+    return 1
+  fi
+  printf '%s\n' "$hooks_dir"
+}
+
+preflight_pull_hooks() {
+  local hooks_dir hook_name hook_path
+  hooks_dir=$(resolve_pull_hooks_dir) || return 1
+
+  # Check both destinations before writing either one.
+  for hook_name in post-merge post-rewrite; do
+    hook_path="${hooks_dir}/${hook_name}"
+    if { [ -e "$hook_path" ] || [ -L "$hook_path" ]; } &&
+      { [ -L "$hook_path" ] || [ ! -f "$hook_path" ] || ! grep -qxF "$HOOK_MARKER" "$hook_path"; }; then
+      echo "Error: ${hook_path} exists and is not managed by Team." >&2
+      echo "Preserving it. Add 'script/dev-install claude' to that hook manually." >&2
+      return 1
+    fi
+  done
+}
+
+install_pull_hooks() {
+  local hooks_dir hook_name hook_path temp_path
+  preflight_pull_hooks
+  hooks_dir=$(resolve_pull_hooks_dir)
+
+  mkdir -p "$hooks_dir"
+  for hook_name in post-merge post-rewrite; do
+    hook_path="${hooks_dir}/${hook_name}"
+    temp_path=$(mktemp "${hooks_dir}/.team-${hook_name}.XXXXXX")
+    # These variables belong to the generated hook, not this installer.
+    # shellcheck disable=SC2016
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'set -euo pipefail' \
+      '' \
+      '# Managed by Team dev install.' \
+      '# Re-run the Claude installer after merge pulls and rebase pulls.' \
+      '[ "${TEAM_DEV_INSTALL_HOOK_RUNNING:-}" != "1" ] || exit 0' \
+      'HOOK_NAME="${0##*/}"' \
+      '[ "$HOOK_NAME" != "post-rewrite" ] || [ "${1:-}" = "rebase" ] || exit 0' \
+      'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {' \
+      '  echo "Error: Team pull hook cannot resolve the checkout root." >&2' \
+      '  exit 1' \
+      '}' \
+      '[ -x "$ROOT/script/dev-install" ] || {' \
+      '  echo "Error: Team pull hook cannot run $ROOT/script/dev-install." >&2' \
+      '  exit 1' \
+      '}' \
+      'TEAM_DEV_INSTALL_HOOK_RUNNING=1 "$ROOT/script/dev-install" claude' \
+      >"$temp_path"
+    chmod 0755 "$temp_path"
+    mv "$temp_path" "$hook_path"
+    echo "Installed Git hook: ${hook_path}"
+  done
+}
 
 case "${1:-}" in
   "")
@@ -28,6 +103,17 @@ case "${1:-}" in
     ;;
 esac
 
+CLAUDE_TARGETED=false
+for harness in "${targets[@]}"; do
+  if [ "$harness" = "claude" ]; then
+    CLAUDE_TARGETED=true
+    break
+  fi
+done
+if [ "$CLAUDE_TARGETED" = true ]; then
+  preflight_pull_hooks
+fi
+
 failed=()
 for harness in "${targets[@]}"; do
   # One harness failing must not strand the others — report at the end.
@@ -40,4 +126,8 @@ done
 if [ ${#failed[@]} -gt 0 ]; then
   echo "Error: install failed for: ${failed[*]}" >&2
   exit 1
+fi
+
+if [ "$CLAUDE_TARGETED" = true ]; then
+  install_pull_hooks
 fi

--- a/script/dev-install
+++ b/script/dev-install
@@ -16,6 +16,7 @@ HARNESSES=(claude codex antigravity)
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(dirname "$HERE")"
 HOOK_MARKER="# Managed by Team dev install."
+PULL_HOOK_SOURCE="${HERE}/dev-install-claude-pull-hook"
 
 resolve_pull_hooks_dir() {
   local common_dir hooks_dir
@@ -38,6 +39,11 @@ resolve_pull_hooks_dir() {
 
 preflight_pull_hooks() {
   local hooks_dir hook_name hook_path
+  if [ ! -f "$PULL_HOOK_SOURCE" ] || [ ! -x "$PULL_HOOK_SOURCE" ]; then
+    echo "Error: Claude pull hook is missing or not executable:" >&2
+    echo "  ${PULL_HOOK_SOURCE}" >&2
+    return 1
+  fi
   hooks_dir=$(resolve_pull_hooks_dir) || return 1
 
   # Check both destinations before writing either one.
@@ -61,27 +67,7 @@ install_pull_hooks() {
   for hook_name in post-merge post-rewrite; do
     hook_path="${hooks_dir}/${hook_name}"
     temp_path=$(mktemp "${hooks_dir}/.team-${hook_name}.XXXXXX")
-    # These variables belong to the generated hook, not this installer.
-    # shellcheck disable=SC2016
-    printf '%s\n' \
-      '#!/usr/bin/env bash' \
-      'set -euo pipefail' \
-      '' \
-      '# Managed by Team dev install.' \
-      '# Re-run the Claude installer after merge pulls and rebase pulls.' \
-      '[ "${TEAM_DEV_INSTALL_HOOK_RUNNING:-}" != "1" ] || exit 0' \
-      'HOOK_NAME="${0##*/}"' \
-      '[ "$HOOK_NAME" != "post-rewrite" ] || [ "${1:-}" = "rebase" ] || exit 0' \
-      'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {' \
-      '  echo "Error: Team pull hook cannot resolve the checkout root." >&2' \
-      '  exit 1' \
-      '}' \
-      '[ -x "$ROOT/script/dev-install" ] || {' \
-      '  echo "Error: Team pull hook cannot run $ROOT/script/dev-install." >&2' \
-      '  exit 1' \
-      '}' \
-      'TEAM_DEV_INSTALL_HOOK_RUNNING=1 "$ROOT/script/dev-install" claude' \
-      >"$temp_path"
+    cp "$PULL_HOOK_SOURCE" "$temp_path"
     chmod 0755 "$temp_path"
     mv "$temp_path" "$hook_path"
     echo "Installed Git hook: ${hook_path}"

--- a/script/dev-install-claude-pull-hook
+++ b/script/dev-install-claude-pull-hook
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Managed by Team dev install.
+# Re-run the Claude installer after merge pulls and rebase pulls.
+[ "${TEAM_DEV_INSTALL_HOOK_RUNNING:-}" != "1" ] || exit 0
+
+HOOK_NAME="${0##*/}"
+[ "$HOOK_NAME" != "post-rewrite" ] || [ "${1:-}" = "rebase" ] || exit 0
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: Team pull hook cannot resolve the checkout root." >&2
+  exit 1
+}
+[ -x "$ROOT/script/dev-install" ] || {
+  echo "Error: Team pull hook cannot run $ROOT/script/dev-install." >&2
+  exit 1
+}
+
+TEAM_DEV_INSTALL_HOOK_RUNNING=1 "$ROOT/script/dev-install" claude

--- a/script/dev-uninstall
+++ b/script/dev-uninstall
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Dev uninstall, across the harnesses Team supports. Mirrors script/dev-install.
+# Dev uninstall, across the harnesses Team supports. Mirrors script/dev-install,
+# including removal of the clone-local hooks installed for Claude.
 #
 #   script/dev-uninstall          every harness
 #   script/dev-uninstall codex    just that one
 
 HARNESSES=(claude codex antigravity)
 HERE="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$HERE")"
+HOOK_MARKER="# Managed by Team dev install."
+
+remove_pull_hooks() {
+  local common_dir hooks_dir hook_name hook_path
+  common_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-common-dir) || {
+    echo "Error: cannot resolve this checkout's common Git directory." >&2
+    return 1
+  }
+  hooks_dir="${common_dir}/hooks"
+
+  for hook_name in post-merge post-rewrite; do
+    hook_path="${hooks_dir}/${hook_name}"
+    if [ -f "$hook_path" ] && [ ! -L "$hook_path" ] && grep -qxF "$HOOK_MARKER" "$hook_path"; then
+      rm "$hook_path"
+      echo "Removed Git hook: ${hook_path}"
+    elif [ -e "$hook_path" ] || [ -L "$hook_path" ]; then
+      echo "Preserved non-Team Git hook: ${hook_path}"
+    fi
+  done
+}
 
 case "${1:-}" in
   "")
@@ -24,6 +46,14 @@ case "${1:-}" in
     ;;
 esac
 
+CLAUDE_TARGETED=false
+for harness in "${targets[@]}"; do
+  if [ "$harness" = "claude" ]; then
+    CLAUDE_TARGETED=true
+    break
+  fi
+done
+
 failed=()
 for harness in "${targets[@]}"; do
   # Keep going: a harness that is already absent must not block the rest.
@@ -36,4 +66,8 @@ done
 if [ ${#failed[@]} -gt 0 ]; then
   echo "Error: uninstall failed for: ${failed[*]}" >&2
   exit 1
+fi
+
+if [ "$CLAUDE_TARGETED" = true ]; then
+  remove_pull_hooks
 fi

--- a/tests/dev-install-pull-hooks.test.ts
+++ b/tests/dev-install-pull-hooks.test.ts
@@ -1,0 +1,223 @@
+// Real-Git regression tests for issue #312. The hook trigger is the subject,
+// so these fixtures perform actual merge-based and rebase-based pulls.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const INSTALL_SOURCE = join(REPO_ROOT, "script", "dev-install");
+const UNINSTALL_SOURCE = join(REPO_ROOT, "script", "dev-uninstall");
+const tempDirs: string[] = [];
+
+type Fixture = {
+  root: string;
+  upstream: string;
+  remote: string;
+  checkout: string;
+  home: string;
+};
+
+function run(
+  cwd: string,
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8", env });
+  return {
+    status: result.status ?? -1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`,
+  };
+}
+
+function git(cwd: string, ...args: string[]) {
+  const result = run(cwd, "git", args);
+  if (result.status !== 0) throw new Error(result.output);
+  return result.output.trim();
+}
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+function newFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), `team-pull-hook-${process.pid}-`));
+  tempDirs.push(root);
+  const upstream = join(root, "upstream");
+  const remote = join(root, "remote.git");
+  const checkout = join(root, "checkout");
+  const home = join(root, "home");
+
+  mkdirSync(join(upstream, "script"), { recursive: true });
+  mkdirSync(home);
+  git(upstream, "init", "-q", "-b", "main");
+  git(upstream, "config", "user.email", "test@example.com");
+  git(upstream, "config", "user.name", "Test");
+  writeExecutable(
+    join(upstream, "script", "dev-install"),
+    readFileSync(INSTALL_SOURCE, "utf8"),
+  );
+  writeExecutable(
+    join(upstream, "script", "dev-uninstall"),
+    readFileSync(UNINSTALL_SOURCE, "utf8"),
+  );
+  writeExecutable(
+    join(upstream, "script", "dev-install-claude"),
+    '#!/usr/bin/env bash\nprintf "install\\n" >> "$HOME/install-calls"\n',
+  );
+  writeExecutable(
+    join(upstream, "script", "dev-uninstall-claude"),
+    '#!/usr/bin/env bash\nprintf "uninstall\\n" >> "$HOME/uninstall-calls"\n',
+  );
+  writeFileSync(join(upstream, "VERSION"), "one\n");
+  git(upstream, "add", "-A");
+  git(upstream, "commit", "-q", "-m", "initial");
+  git(root, "clone", "-q", "--bare", upstream, remote);
+  git(root, "clone", "-q", remote, checkout);
+  git(upstream, "remote", "add", "origin", remote);
+  git(upstream, "config", "user.email", "test@example.com");
+  git(upstream, "config", "user.name", "Test");
+  git(checkout, "config", "user.email", "test@example.com");
+  git(checkout, "config", "user.name", "Test");
+
+  return { root, upstream, remote, checkout, home };
+}
+
+function fixtureEnv(fixture: Fixture): NodeJS.ProcessEnv {
+  return { ...process.env, HOME: fixture.home };
+}
+
+function install(fixture: Fixture) {
+  return run(
+    fixture.checkout,
+    join(fixture.checkout, "script", "dev-install"),
+    ["claude"],
+    fixtureEnv(fixture),
+  );
+}
+
+function uninstall(fixture: Fixture) {
+  return run(
+    fixture.checkout,
+    join(fixture.checkout, "script", "dev-uninstall"),
+    ["claude"],
+    fixtureEnv(fixture),
+  );
+}
+
+function advanceUpstream(fixture: Fixture, version: string) {
+  writeFileSync(join(fixture.upstream, "VERSION"), `${version}\n`);
+  git(fixture.upstream, "add", "VERSION");
+  git(fixture.upstream, "commit", "-q", "-m", `advance to ${version}`);
+  git(fixture.upstream, "push", "-q", "origin", "main");
+}
+
+function installCalls(fixture: Fixture): string[] {
+  const path = join(fixture.home, "install-calls");
+  return existsSync(path)
+    ? readFileSync(path, "utf8").trim().split("\n").filter(Boolean)
+    : [];
+}
+
+function hookPath(fixture: Fixture, name: "post-merge" | "post-rewrite") {
+  return join(fixture.checkout, ".git", "hooks", name);
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("dev install: refresh after pulls (#312)", () => {
+  test("a merge-based pull reruns the Claude installer", () => {
+    const fixture = newFixture();
+    expect(install(fixture).status).toBe(0);
+    expect(statSync(hookPath(fixture, "post-merge")).mode & 0o111).not.toBe(0);
+    expect(installCalls(fixture)).toHaveLength(1);
+
+    advanceUpstream(fixture, "two");
+    const pull = run(
+      fixture.checkout,
+      "git",
+      ["pull", "--ff-only"],
+      fixtureEnv(fixture),
+    );
+
+    expect(pull.status).toBe(0);
+    expect(installCalls(fixture)).toHaveLength(2);
+  });
+
+  test("a rebase-based pull reruns the Claude installer", () => {
+    const fixture = newFixture();
+    expect(install(fixture).status).toBe(0);
+    expect(statSync(hookPath(fixture, "post-rewrite")).mode & 0o111).not.toBe(
+      0,
+    );
+
+    writeFileSync(join(fixture.checkout, "local"), "local\n");
+    git(fixture.checkout, "add", "local");
+    git(fixture.checkout, "commit", "-q", "-m", "local change");
+    advanceUpstream(fixture, "two");
+
+    const pull = run(
+      fixture.checkout,
+      "git",
+      ["pull", "--rebase"],
+      fixtureEnv(fixture),
+    );
+
+    expect(pull.status).toBe(0);
+    expect(installCalls(fixture)).toHaveLength(2);
+  });
+
+  test("reinstallation is idempotent and uninstall removes owned hooks", () => {
+    const fixture = newFixture();
+    expect(install(fixture).status).toBe(0);
+    const first = readFileSync(hookPath(fixture, "post-merge"), "utf8");
+
+    expect(install(fixture).status).toBe(0);
+    expect(readFileSync(hookPath(fixture, "post-merge"), "utf8")).toBe(first);
+    expect(uninstall(fixture).status).toBe(0);
+    expect(existsSync(hookPath(fixture, "post-merge"))).toBe(false);
+    expect(existsSync(hookPath(fixture, "post-rewrite"))).toBe(false);
+  });
+
+  test("an existing user hook is preserved and blocks installation", () => {
+    const fixture = newFixture();
+    const hook = hookPath(fixture, "post-merge");
+    writeExecutable(hook, "#!/bin/sh\necho user-hook\n");
+
+    const result = install(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("not managed by Team");
+    expect(readFileSync(hook, "utf8")).toBe("#!/bin/sh\necho user-hook\n");
+    expect(existsSync(hookPath(fixture, "post-rewrite"))).toBe(false);
+    expect(installCalls(fixture)).toHaveLength(0);
+  });
+
+  test("a custom hooks path is preserved and blocks installation", () => {
+    const fixture = newFixture();
+    const customHooks = join(fixture.root, "shared-hooks");
+    git(fixture.checkout, "config", "core.hooksPath", customHooks);
+
+    const result = install(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("outside this clone");
+    expect(existsSync(customHooks)).toBe(false);
+    expect(installCalls(fixture)).toHaveLength(0);
+  });
+});

--- a/tests/dev-install-pull-hooks.test.ts
+++ b/tests/dev-install-pull-hooks.test.ts
@@ -19,6 +19,11 @@ import { join } from "node:path";
 const REPO_ROOT = join(import.meta.dir, "..");
 const INSTALL_SOURCE = join(REPO_ROOT, "script", "dev-install");
 const UNINSTALL_SOURCE = join(REPO_ROOT, "script", "dev-uninstall");
+const PULL_HOOK_SOURCE = join(
+  REPO_ROOT,
+  "script",
+  "dev-install-claude-pull-hook",
+);
 const tempDirs: string[] = [];
 
 type Fixture = {
@@ -73,6 +78,10 @@ function newFixture(): Fixture {
   writeExecutable(
     join(upstream, "script", "dev-uninstall"),
     readFileSync(UNINSTALL_SOURCE, "utf8"),
+  );
+  writeExecutable(
+    join(upstream, "script", "dev-install-claude-pull-hook"),
+    readFileSync(PULL_HOOK_SOURCE, "utf8"),
   );
   writeExecutable(
     join(upstream, "script", "dev-install-claude"),
@@ -186,6 +195,12 @@ describe("dev install: refresh after pulls (#312)", () => {
     const fixture = newFixture();
     expect(install(fixture).status).toBe(0);
     const first = readFileSync(hookPath(fixture, "post-merge"), "utf8");
+    expect(first).toBe(
+      readFileSync(
+        join(fixture.checkout, "script", "dev-install-claude-pull-hook"),
+        "utf8",
+      ),
+    );
 
     expect(install(fixture).status).toBe(0);
     expect(readFileSync(hookPath(fixture, "post-merge"), "utf8")).toBe(first);

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -2,7 +2,7 @@
 //
 // L2 tripwire (free, deterministic): README.md and docs/index.md are the two
 // self-contained install surfaces (GitHub and team.bostonaholic.dev). Each
-// must carry all eight install/uninstall command strings verbatim, and every
+// must carry all ten install/uninstall command strings verbatim, and every
 // `rm -rf` safety-guard invocation on each surface must point at the Codex
 // plugin cache prefix — a mistyped prefix is a silent no-op for the reader.
 //
@@ -40,14 +40,16 @@ function rmRfTargets(text: string): string[] {
   return [...text.matchAll(/rm -rf\s+(\S+)/g)].map((m) => m[1] ?? "");
 }
 
-describe("docs-install-parity: README.md and docs/index.md each carry all eight install/uninstall command strings verbatim", () => {
-  test("README.md carries all eight install/uninstall command strings verbatim", () => {
+describe("docs-install-parity: README.md and docs/index.md each carry all ten install/uninstall command strings verbatim", () => {
+  test("README.md carries all ten install/uninstall command strings verbatim", () => {
     const readme = readIf(README_MD);
     // Guard: a missing README must fail cleanly, not vacuously pass.
     expect(readme.length).toBeGreaterThan(0);
 
     expect(readme).toContain("claude plugin marketplace add /path/to/team");
     expect(readme).toContain("claude plugin install team@team-dev");
+    expect(readme).toContain("script/dev-install claude");
+    expect(readme).toContain("script/dev-uninstall claude");
     expect(readme).toContain("codex plugin marketplace add /path/to/team");
     expect(readme).toContain("codex plugin add team@team-dev");
     expect(readme).toContain("agy plugin install /path/to/team");
@@ -56,13 +58,15 @@ describe("docs-install-parity: README.md and docs/index.md each carry all eight 
     expect(readme).toContain("script/dev-uninstall antigravity");
   });
 
-  test("docs/index.md carries all eight install/uninstall command strings verbatim", () => {
+  test("docs/index.md carries all ten install/uninstall command strings verbatim", () => {
     const docsIndex = readIf(DOCS_INDEX_MD);
     // Guard: a missing docs page must fail cleanly, not vacuously pass.
     expect(docsIndex.length).toBeGreaterThan(0);
 
     expect(docsIndex).toContain("claude plugin marketplace add /path/to/team");
     expect(docsIndex).toContain("claude plugin install team@team-dev");
+    expect(docsIndex).toContain("script/dev-install claude");
+    expect(docsIndex).toContain("script/dev-uninstall claude");
     expect(docsIndex).toContain("codex plugin marketplace add /path/to/team");
     expect(docsIndex).toContain("codex plugin add team@team-dev");
     expect(docsIndex).toContain("agy plugin install /path/to/team");


### PR DESCRIPTION
## Summary
- Refreshes clone-backed Claude installs after merge and rebase pulls.
- Preserves non-Team hooks and removes only Team-owned hooks on uninstall.

## Design Decisions
- Use `post-merge` and `post-rewrite` because Git has no `post-pull` hook.
- Refuse custom or occupied hook paths instead of overwriting them.

## Changes
- Install an extracted hook script from `script/dev-install claude`.
- Add real-Git pull tests and document the workflow.

## How to Verify
- `bun test`
- `bun run typecheck`
- `shellcheck script/dev-install script/dev-uninstall`

Closes #312
