### PR TITLE
fix(dev): install every harness when Team cannot own the Git hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Clone-backed Claude installs now refresh after merge and rebase pulls.** Run `script/dev-install claude` once. Team keeps Claude Code pointed at the pulled version, and `script/dev-uninstall claude` removes only Team-owned hooks. Existing non-Team hooks are preserved and require manual integration. **What this asks of you:** reinstall once to add the hooks.
+- **Clone-backed Claude installs now refresh after merge and rebase pulls.** Run `script/dev-install claude` once. Team keeps Claude Code pointed at the pulled version, and `script/dev-uninstall claude` removes only Team-owned hooks. A hooks surface Team does not own — an existing non-Team hook, or a `core.hooksPath` pointing outside the clone — is preserved, and the install completes anyway and tells you it skipped the refresh. **What this asks of you:** reinstall once to add the hooks.
 
 ## [0.81.0] - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ script/dev-install claude
 ```
 
 This adds clone-local hooks for merge and rebase pulls. Existing non-Team hooks
-are never overwritten; setup stops with manual integration instructions.
-Remove the install and Team-owned hooks with:
+and a `core.hooksPath` outside the clone are never overwritten: the install
+still completes, and reports that it skipped the hooks and how to wire them up
+yourself. Remove the install and Team-owned hooks with:
 
 ```bash
 script/dev-uninstall claude

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,9 @@ script/dev-install claude
 ```
 
 This adds clone-local hooks for merge and rebase pulls. Existing non-Team hooks
-are never overwritten; setup stops with manual integration instructions.
-Remove the install and Team-owned hooks with:
+and a `core.hooksPath` outside the clone are never overwritten: the install
+still completes, and reports that it skipped the hooks and how to wire them up
+yourself. Remove the install and Team-owned hooks with:
 
 ```bash
 script/dev-uninstall claude

--- a/script/dev-install
+++ b/script/dev-install
@@ -21,17 +21,17 @@ PULL_HOOK_SOURCE="${HERE}/dev-install-claude-pull-hook"
 resolve_pull_hooks_dir() {
   local common_dir hooks_dir
   common_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-common-dir) || {
-    echo "Error: cannot resolve this checkout's common Git directory." >&2
+    echo "Warning: cannot resolve this checkout's common Git directory." >&2
     return 1
   }
   hooks_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-path hooks) || {
-    echo "Error: cannot resolve this checkout's Git hooks directory." >&2
+    echo "Warning: cannot resolve this checkout's Git hooks directory." >&2
     return 1
   }
   if [ "$hooks_dir" != "${common_dir}/hooks" ]; then
-    echo "Error: the active Git hooks path is outside this clone:" >&2
+    echo "Warning: the active Git hooks path is outside this clone:" >&2
     echo "  ${hooks_dir}" >&2
-    echo "Preserving it. Add 'script/dev-install claude' to its pull hooks manually." >&2
+    echo "Preserving it. Team installs no hooks there." >&2
     return 1
   fi
   printf '%s\n' "$hooks_dir"
@@ -40,7 +40,7 @@ resolve_pull_hooks_dir() {
 preflight_pull_hooks() {
   local hooks_dir hook_name hook_path
   if [ ! -f "$PULL_HOOK_SOURCE" ] || [ ! -x "$PULL_HOOK_SOURCE" ]; then
-    echo "Error: Claude pull hook is missing or not executable:" >&2
+    echo "Warning: Claude pull hook is missing or not executable:" >&2
     echo "  ${PULL_HOOK_SOURCE}" >&2
     return 1
   fi
@@ -51,25 +51,39 @@ preflight_pull_hooks() {
     hook_path="${hooks_dir}/${hook_name}"
     if { [ -e "$hook_path" ] || [ -L "$hook_path" ]; } &&
       { [ -L "$hook_path" ] || [ ! -f "$hook_path" ] || ! grep -qxF "$HOOK_MARKER" "$hook_path"; }; then
-      echo "Error: ${hook_path} exists and is not managed by Team." >&2
-      echo "Preserving it. Add 'script/dev-install claude' to that hook manually." >&2
+      echo "Warning: ${hook_path} exists and is not managed by Team." >&2
+      echo "Preserving it. Team replaces no hook it does not own." >&2
       return 1
     fi
   done
 }
 
+report_skipped_pull_hooks() {
+  echo "Skipped the Claude pull hooks (see the warning above)." >&2
+  echo "Every targeted harness installed. To keep the Claude cache fresh, either" >&2
+  echo "re-run 'script/dev-install claude' after each pull, or call it from your" >&2
+  echo "own post-merge and post-rewrite hooks." >&2
+}
+
 install_pull_hooks() {
   local hooks_dir hook_name hook_path temp_path
-  preflight_pull_hooks
-  hooks_dir=$(resolve_pull_hooks_dir)
+  # Re-check at write time: the harness installs ran since the first preflight.
+  preflight_pull_hooks || return 1
+  hooks_dir=$(resolve_pull_hooks_dir) || return 1
 
-  mkdir -p "$hooks_dir"
+  # `set -e` does not reach here: the caller tests this function's status, so
+  # every write reports its own failure and leaves no temp file behind.
+  mkdir -p "$hooks_dir" || return 1
   for hook_name in post-merge post-rewrite; do
     hook_path="${hooks_dir}/${hook_name}"
-    temp_path=$(mktemp "${hooks_dir}/.team-${hook_name}.XXXXXX")
-    cp "$PULL_HOOK_SOURCE" "$temp_path"
-    chmod 0755 "$temp_path"
-    mv "$temp_path" "$hook_path"
+    temp_path=$(mktemp "${hooks_dir}/.team-${hook_name}.XXXXXX") || return 1
+    if ! { cp "$PULL_HOOK_SOURCE" "$temp_path" &&
+      chmod 0755 "$temp_path" &&
+      mv "$temp_path" "$hook_path"; }; then
+      rm -f "$temp_path"
+      echo "Warning: cannot install Git hook: ${hook_path}" >&2
+      return 1
+    fi
     echo "Installed Git hook: ${hook_path}"
   done
 }
@@ -96,8 +110,13 @@ for harness in "${targets[@]}"; do
     break
   fi
 done
-if [ "$CLAUDE_TARGETED" = true ]; then
-  preflight_pull_hooks
+# Decide the pull hooks before the harness output scrolls by, but never gate the
+# install on them: they only re-run the Claude installer after a pull, so a
+# hooks surface Team cannot own is a skip, not a failure.
+# See skills/principle-optimization-never-dependency/SKILL.md.
+PULL_HOOKS_OWNED=false
+if [ "$CLAUDE_TARGETED" = true ] && preflight_pull_hooks; then
+  PULL_HOOKS_OWNED=true
 fi
 
 failed=()
@@ -115,5 +134,7 @@ if [ ${#failed[@]} -gt 0 ]; then
 fi
 
 if [ "$CLAUDE_TARGETED" = true ]; then
-  install_pull_hooks
+  if [ "$PULL_HOOKS_OWNED" = false ] || ! install_pull_hooks; then
+    report_skipped_pull_hooks
+  fi
 fi

--- a/tests/dev-install-pull-hooks.test.ts
+++ b/tests/dev-install-pull-hooks.test.ts
@@ -34,13 +34,25 @@ type Fixture = {
   home: string;
 };
 
+// Neutralize the developer's own Git config. Two reasons: a global commit hook
+// manager costs ~0.9s per fixture commit, which alone times this suite out; and
+// a global `core.hooksPath` would decide the very condition under test.
+const HERMETIC_GIT = {
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
 function run(
   cwd: string,
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv = process.env,
 ) {
-  const result = spawnSync(command, args, { cwd, encoding: "utf8", env });
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...env, ...HERMETIC_GIT },
+  });
   return {
     status: result.status ?? -1,
     output: `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`,

--- a/tests/dev-install-pull-hooks.test.ts
+++ b/tests/dev-install-pull-hooks.test.ts
@@ -209,30 +209,33 @@ describe("dev install: refresh after pulls (#312)", () => {
     expect(existsSync(hookPath(fixture, "post-rewrite"))).toBe(false);
   });
 
-  test("an existing user hook is preserved and blocks installation", () => {
+  // A hooks surface Team does not own is preserved, and the pull-hook refresh
+  // is skipped — but the install itself proceeds. See #314 and
+  // tests/regression-314-foreign-hooks-path.test.ts.
+  test("an existing user hook is preserved and the install still runs", () => {
     const fixture = newFixture();
     const hook = hookPath(fixture, "post-merge");
     writeExecutable(hook, "#!/bin/sh\necho user-hook\n");
 
     const result = install(fixture);
 
-    expect(result.status).not.toBe(0);
+    expect(result.status).toBe(0);
     expect(result.output).toContain("not managed by Team");
     expect(readFileSync(hook, "utf8")).toBe("#!/bin/sh\necho user-hook\n");
     expect(existsSync(hookPath(fixture, "post-rewrite"))).toBe(false);
-    expect(installCalls(fixture)).toHaveLength(0);
+    expect(installCalls(fixture)).toHaveLength(1);
   });
 
-  test("a custom hooks path is preserved and blocks installation", () => {
+  test("a custom hooks path is preserved and the install still runs", () => {
     const fixture = newFixture();
     const customHooks = join(fixture.root, "shared-hooks");
     git(fixture.checkout, "config", "core.hooksPath", customHooks);
 
     const result = install(fixture);
 
-    expect(result.status).not.toBe(0);
+    expect(result.status).toBe(0);
     expect(result.output).toContain("outside this clone");
     expect(existsSync(customHooks)).toBe(false);
-    expect(installCalls(fixture)).toHaveLength(0);
+    expect(installCalls(fixture)).toHaveLength(1);
   });
 });

--- a/tests/regression-314-foreign-hooks-path.test.ts
+++ b/tests/regression-314-foreign-hooks-path.test.ts
@@ -1,0 +1,167 @@
+// Regression test for issue #314. A hooks surface Team cannot own must not
+// abort the plugin install. The pull hook re-runs the Claude installer after a
+// pull; nothing about installing a harness depends on it, so its absence skips
+// loudly and the install proceeds (principle-optimization-never-dependency).
+//
+// Real Git is the subject here: the bug is what `git rev-parse --git-path
+// hooks` reports under a `core.hooksPath` that resolves outside the clone.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const HARNESSES = ["claude", "codex", "antigravity"] as const;
+const COPIED_SCRIPTS = [
+  "dev-install",
+  "dev-install-claude-pull-hook",
+] as const;
+const tempDirs: string[] = [];
+
+type Fixture = { root: string; checkout: string; home: string };
+
+// Hermetic Git: the machine's own global config may set `core.hooksPath`, which
+// is the very condition under test. Neutralize it so each case sets it itself.
+const HERMETIC_GIT = {
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
+function run(cwd: string, command: string, args: string[], home?: string) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...HERMETIC_GIT, ...(home ? { HOME: home } : {}) },
+  });
+  return {
+    status: result.status ?? -1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`,
+  };
+}
+
+function git(cwd: string, ...args: string[]) {
+  const result = run(cwd, "git", args);
+  if (result.status !== 0) throw new Error(result.output);
+  return result.output.trim();
+}
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+function newFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), `team-hooks-path-${process.pid}-`));
+  tempDirs.push(root);
+  const checkout = join(root, "checkout");
+  const home = join(root, "home");
+
+  mkdirSync(join(checkout, "script"), { recursive: true });
+  mkdirSync(home);
+  git(checkout, "init", "-q", "-b", "main");
+  git(checkout, "config", "user.email", "test@example.com");
+  git(checkout, "config", "user.name", "Test");
+
+  for (const script of COPIED_SCRIPTS) {
+    writeExecutable(
+      join(checkout, "script", script),
+      readFileSync(join(REPO_ROOT, "script", script), "utf8"),
+    );
+  }
+  // Each harness installer records that it ran, so "nothing installed" — the
+  // reported symptom — is directly observable.
+  for (const harness of HARNESSES) {
+    writeExecutable(
+      join(checkout, "script", `dev-install-${harness}`),
+      `#!/usr/bin/env bash\nprintf "%s\\n" "${harness}" >> "${join(root, "install-calls")}"\n`,
+    );
+  }
+  writeFileSync(join(checkout, "VERSION"), "one\n");
+  git(checkout, "add", "-A");
+  git(checkout, "commit", "-q", "-m", "initial");
+
+  return { root, checkout, home };
+}
+
+function install(fixture: Fixture, ...args: string[]) {
+  return run(
+    fixture.checkout,
+    join(fixture.checkout, "script", "dev-install"),
+    args,
+    fixture.home,
+  );
+}
+
+function installCalls(fixture: Fixture): string[] {
+  const path = join(fixture.root, "install-calls");
+  return existsSync(path)
+    ? readFileSync(path, "utf8").trim().split("\n").filter(Boolean)
+    : [];
+}
+
+function cloneHook(fixture: Fixture, name: "post-merge" | "post-rewrite") {
+  return join(fixture.checkout, ".git", "hooks", name);
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("dev install: an unownable hooks surface never blocks the install (#314)", () => {
+  test("a hooks path outside the clone skips the pull hooks and installs every harness", () => {
+    const fixture = newFixture();
+    const foreignHooks = join(fixture.root, "shared-hooks");
+    git(fixture.checkout, "config", "core.hooksPath", foreignHooks);
+
+    const result = install(fixture);
+
+    expect(result.status).toBe(0);
+    expect(installCalls(fixture)).toEqual([...HARNESSES]);
+    // The foreign hooks path is preserved: Team writes nothing into it.
+    expect(existsSync(foreignHooks)).toBe(false);
+    // Skip loudly: name what was skipped, why, and how to get it back.
+    expect(result.output).toContain("outside this clone");
+    expect(result.output).toContain(foreignHooks);
+    expect(result.output).toContain("Skipped");
+  });
+
+  test("an existing unmanaged hook is preserved and still installs every harness", () => {
+    const fixture = newFixture();
+    const userHook = "#!/bin/sh\necho user-hook\n";
+    writeExecutable(cloneHook(fixture, "post-merge"), userHook);
+
+    const result = install(fixture);
+
+    expect(result.status).toBe(0);
+    expect(installCalls(fixture)).toEqual([...HARNESSES]);
+    expect(readFileSync(cloneHook(fixture, "post-merge"), "utf8")).toBe(userHook);
+    // All-or-nothing: one unownable hook leaves the sibling alone too.
+    expect(existsSync(cloneHook(fixture, "post-rewrite"))).toBe(false);
+    expect(result.output).toContain("not managed by Team");
+    expect(result.output).toContain("Skipped");
+  });
+
+  // Positive control: the assertions above must be able to observe the
+  // difference between "skipped" and "installed", or they prove nothing.
+  test("an ownable hooks surface still installs the pull hooks", () => {
+    const fixture = newFixture();
+
+    const result = install(fixture);
+
+    expect(result.status).toBe(0);
+    expect(installCalls(fixture)).toEqual([...HARNESSES]);
+    expect(existsSync(cloneHook(fixture, "post-merge"))).toBe(true);
+    expect(existsSync(cloneHook(fixture, "post-rewrite"))).toBe(true);
+    expect(result.output).not.toContain("Skipped");
+  });
+});


### PR DESCRIPTION
Closes #314

## Why

`script/dev-install` installed nothing when the checkout had a `core.hooksPath` resolving outside the clone. It exited 1 before the harness loop, so no harness installed at all — not Claude, not Codex, not Antigravity. A shared or organization-wide gitconfig that points `core.hooksPath` at a central hooks directory is a common setup, and on any machine using one the plugin was simply unavailable.

The post-merge/post-rewrite hooks only re-run the Claude installer after a pull. Nothing about installing a harness depends on them, so they are an enhancement rather than a guarantee, and wiring one as a dependency turns its absence into an outage (`skills/principle-optimization-never-dependency`). The guarantee belongs to the write alone.

## What changed

A hooks surface Team does not own — a foreign `core.hooksPath`, or an existing hook Team did not write — now preserves what is there, names the skip and its reason, installs every targeted harness, and exits 0. Team still writes into no foreign hooks directory and still replaces no hook it does not own.

Observed after the fix, against a clone whose `core.hooksPath` points outside it (path redacted):

```
Warning: the active Git hooks path is outside this clone:
  /path/to/shared/git-hooks
Preserving it. Team installs no hooks there.
installed claude
installed codex
installed antigravity
Skipped the Claude pull hooks (see the warning above).
Every targeted harness installed. To keep the Claude cache fresh, either
re-run 'script/dev-install claude' after each pull, or call it from your
own post-merge and post-rewrite hooks.
EXIT=0
```

The `[Unreleased]` changelog entry from #313 is corrected in place rather than given a new `Fixed` bullet: the abort never reached a release, so a reader would have nothing to match it against. README and `docs/index.md` said setup *stops* on a non-Team hook, which is no longer true.

Dev-only change (`script/`, `tests/`, docs), so no version bump.

## Also here

One adjacent commit, same root cause, found while fixing this: the pull-hook test fixture ran Git on the developer's real environment, so every setup commit paid the globally configured commit hook manager — measured at 2.795s for three commits versus 0.089s hermetic. The rebase-pull test crossed bun's 5s limit and timed out intermittently, including on unmodified `main`. That file now runs in 5.3s rather than 17.8s.

## Test plan

- New `tests/regression-314-foreign-hooks-path.test.ts` pins the reported case, the sibling unowned-hook case, and a positive control so the skip assertions cannot pass by being blind. Verified red at the test-only commit (2 fail), green after the fix.
- The two tests in `tests/dev-install-pull-hooks.test.ts` that asserted the abort now assert the install proceeds.
- Reproduced the original failure and the fixed behavior end to end in a scratch clone under a real out-of-clone `core.hooksPath`, confirming exit 0 and all three harnesses installed.
- Full free suite green: 1940 pass, 4 skip. `tsc --noEmit` and `shellcheck` clean.
- `tests/version-bump-required.test.ts` flakes at its 5s limit under full-suite load. Pre-existing and unrelated: it passes in isolation in 30.8s on this branch and 31.0s on pristine `main`. Same commit-hook cost, already noted locally; left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
