### PR TITLE
docs(codex): drop the skill-removal step, the guard key is documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,25 +85,15 @@ its skill catalog, so it shortens the longest descriptions; the skills still
 work. The `/team-*` pipeline commands load but cannot dispatch Claude Code
 agents, so they will not run the pipeline. The standalone utilities do.
 
-> **Three skills lose a safety guard here.** `team:pr-watch-as-reviewer` casts
-> an approval that can transitively merge a PR, `team:pr-rebase` force-pushes a
-> rewritten branch over published history, and `team:reflect` rewrites skill
-> files and files public issues. All three set `disable-model-invocation`
-> so only a person can start them, and **Codex ignores that key**. To keep the
-> guards:
->
-> ```bash
-> rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
-> rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-rebase
-> rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/reflect
-> ```
->
-> Re-running `codex plugin add` restores them.
->
-> All three also declare `allow_implicit_invocation: false` in their
-> `agents/openai.yaml`, which asks Codex for the same guarantee in the host's
-> own vocabulary. The removal step above stands until a live Codex build is
-> observed to honor that key.
+> **Three skills stay user-only, through this host's own key.**
+> `team:pr-watch-as-reviewer` casts an approval that can transitively merge a
+> PR, `team:pr-rebase` force-pushes a rewritten branch over published history,
+> and `team:reflect` rewrites skill files and files public issues. Codex does
+> not read `disable-model-invocation`, so all three declare
+> `policy.allow_implicit_invocation: false` in their `agents/openai.yaml`.
+> Codex will not start a skill carrying that key on its own; you invoke it
+> explicitly with `$team:pr-rebase`. See
+> [Optional metadata](https://learn.chatgpt.com/docs/build-skills).
 
 </details>
 
@@ -119,9 +109,9 @@ so it installs as a native Antigravity plugin — all skills and all 13 agents.
 `agy plugin uninstall team` removes it.
 
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
-install copies the checkout, so upgrading means installing again. Unlike Codex,
-this host honors `disable-model-invocation`, so nothing needs removing
-afterward.
+install copies the checkout, so upgrading means installing again. This host
+reads `disable-model-invocation` directly, so the three user-only skills need
+no host-specific declaration the way they do on Codex.
 
 Developing Team itself? The install copies, so link your checkout instead:
 

--- a/README.md
+++ b/README.md
@@ -85,16 +85,6 @@ its skill catalog, so it shortens the longest descriptions; the skills still
 work. The `/team-*` pipeline commands load but cannot dispatch Claude Code
 agents, so they will not run the pipeline. The standalone utilities do.
 
-> **Three skills stay user-only, through this host's own key.**
-> `team:pr-watch-as-reviewer` casts an approval that can transitively merge a
-> PR, `team:pr-rebase` force-pushes a rewritten branch over published history,
-> and `team:reflect` rewrites skill files and files public issues. Codex does
-> not read `disable-model-invocation`, so all three declare
-> `policy.allow_implicit_invocation: false` in their `agents/openai.yaml`.
-> Codex will not start a skill carrying that key on its own; you invoke it
-> explicitly with `$team:pr-rebase`. See
-> [Optional metadata](https://learn.chatgpt.com/docs/build-skills).
-
 </details>
 
 <details>
@@ -109,9 +99,7 @@ so it installs as a native Antigravity plugin — all skills and all 13 agents.
 `agy plugin uninstall team` removes it.
 
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
-install copies the checkout, so upgrading means installing again. This host
-reads `disable-model-invocation` directly, so the three user-only skills need
-no host-specific declaration the way they do on Codex.
+install copies the checkout, so upgrading means installing again.
 
 Developing Team itself? The install copies, so link your checkout instead:
 

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -164,7 +164,7 @@ facility, so the design must work around it.
 |----------------|-------------|-----------|
 | Agent/skill Markdown bodies | native (loaded as-is) | native (system-prompt body) |
 | Custom slash entry points | native (SKILL.md auto-register) | native (built-ins and Skills. Prompts are deprecated in favor of Skills.) |
-| On-demand SKILL.md injection | native (`skills:` + auto-load) | native (`.agents/skills/SKILL.md`, description-matched implicit invocation). A skill may opt out through `policy.allow_implicit_invocation: false` in its `agents/openai.yaml`; unverified on a live build |
+| On-demand SKILL.md injection | native (`skills:` + auto-load) | native (`.agents/skills/SKILL.md`, description-matched implicit invocation). A skill opts out through `policy.allow_implicit_invocation: false` in its `agents/openai.yaml` — [documented](https://learn.chatgpt.com/docs/build-skills) to block implicit invocation while leaving `$skill` working |
 | Subagent dispatch (parallel) | native (Agent/Task tool) | native (`spawn_agent`/`wait_agent`…, `features.multi_agent`) |
 | Nested subagents | native (depth 2, ≤4, read-only) | workaround: `max_depth=1`, nesting capped one level |
 | Structured agent→caller output | native (final-text JSON envelope) | native and strongest (`--output-schema` JSON Schema). A silent-drop bug under tools ([codex#15451](https://github.com/openai/codex/issues/15451)) was fixed April 2026 |
@@ -304,8 +304,8 @@ full parity. It starts from the matrix and works around the named gaps.
 - Skills port natively to `.agents/skills/SKILL.md` (description-matched implicit
   invocation). Each skill also ships `agents/openai.yaml`, which names it in the
   catalog; the three guarded skills declare `policy.allow_implicit_invocation:
-  false` there to opt out of that matching. Whether this host honors the key is
-  unverified on a live build.
+  false` there to opt out of that matching, which is this host's documented
+  equivalent of `disable-model-invocation`.
 - Hooks: reuse the 4 `.mjs` files. The shim adapts to Codex
   `hooks.json`/`[hooks]`, whose schema mirrors Claude closely
   (`permissionDecision:"deny"`/exit 2). Events map nearly 1:1
@@ -385,16 +385,17 @@ the agent list 52 of them. The two missing ones were exactly `pr-rebase` and
 `pr-watch-as-reviewer` — the skills that set the key **as of that probe**. The
 guarded set has since grown to three: `reflect` sets it too, so this host
 withholds that one as well. This host therefore keeps every guarded skill out
-of the model's reach on its own, which is the opposite of Codex, and it is why
-Team's install for this host withholds nothing and needs no post-install
-removal step.
+of the model's reach on its own, and it is why Team's install for this host
+withholds nothing.
 
-Codex now gets the closest thing it has to the same claim: `pr-rebase`,
-`pr-watch-as-reviewer`, and `reflect` each declare
-`policy.allow_implicit_invocation: false` in their `agents/openai.yaml`. That
-narrows the gap without closing it. The declaration is a request to a host that
-has not been observed to honor it, where this host's behavior was observed
-directly, so the Codex install keeps both its warning and its removal step.
+Codex reaches the same end through its own key rather than this one:
+`pr-rebase`, `pr-watch-as-reviewer`, and `reflect` each declare
+`policy.allow_implicit_invocation: false` in their `agents/openai.yaml`.
+OpenAI [documents](https://learn.chatgpt.com/docs/build-skills) that key as
+blocking implicit invocation while leaving explicit `$skill` invocation
+working, which is what `disable-model-invocation` buys on the other two hosts.
+The difference is in evidence, not in outcome: this host's behavior was
+observed on a live probe, Codex's rests on the documented contract.
 
 **Paths and naming.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,25 +128,15 @@ budgets its skill catalog, so it shortens the longest descriptions; the skills
 still work. The `/team-*` pipeline commands load but cannot dispatch Claude
 Code agents, so they will not run the pipeline. The standalone utilities do.
 
-> **Three skills lose a safety guard here.** `team:pr-watch-as-reviewer` casts
-> an approval that can transitively merge a PR, `team:pr-rebase` force-pushes
-> a rewritten branch over published history, and `team:reflect` rewrites skill
-> files and files public issues. All three set
-> `disable-model-invocation` so only a person can start them, and **Codex
-> ignores that key**. To keep the guards:
-
-```bash
-rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-watch-as-reviewer
-rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/pr-rebase
-rm -rf "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/reflect
-```
-
-Re-running `codex plugin add` restores them.
-
-All three also declare `allow_implicit_invocation: false` in their
-`agents/openai.yaml`, which asks Codex for the same guarantee in the host's own
-vocabulary. The removal step above stands until a live Codex build is observed
-to honor that key.
+> **Three skills stay user-only, through this host's own key.**
+> `team:pr-watch-as-reviewer` casts an approval that can transitively merge a
+> PR, `team:pr-rebase` force-pushes a rewritten branch over published history,
+> and `team:reflect` rewrites skill files and files public issues. Codex does
+> not read `disable-model-invocation`, so all three declare
+> `policy.allow_implicit_invocation: false` in their `agents/openai.yaml`.
+> Codex will not start a skill carrying that key on its own; you invoke it
+> explicitly with `$team:pr-rebase`. See
+> [Optional metadata](https://learn.chatgpt.com/docs/build-skills).
 
 ### Antigravity CLI
 
@@ -159,9 +149,9 @@ so it installs as a native Antigravity plugin — every skill and every agent
 installs with it. `agy plugin uninstall team` removes it.
 
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
-install copies the checkout, so upgrading means installing again. Unlike
-Codex, this host honors `disable-model-invocation`, so nothing needs removing
-afterward.
+install copies the checkout, so upgrading means installing again. This host
+reads `disable-model-invocation` directly, so the three user-only skills need
+no host-specific declaration the way they do on Codex.
 
 Developing Team itself? The install copies, so link your checkout instead:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,16 +128,6 @@ budgets its skill catalog, so it shortens the longest descriptions; the skills
 still work. The `/team-*` pipeline commands load but cannot dispatch Claude
 Code agents, so they will not run the pipeline. The standalone utilities do.
 
-> **Three skills stay user-only, through this host's own key.**
-> `team:pr-watch-as-reviewer` casts an approval that can transitively merge a
-> PR, `team:pr-rebase` force-pushes a rewritten branch over published history,
-> and `team:reflect` rewrites skill files and files public issues. Codex does
-> not read `disable-model-invocation`, so all three declare
-> `policy.allow_implicit_invocation: false` in their `agents/openai.yaml`.
-> Codex will not start a skill carrying that key on its own; you invoke it
-> explicitly with `$team:pr-rebase`. See
-> [Optional metadata](https://learn.chatgpt.com/docs/build-skills).
-
 ### Antigravity CLI
 
 ```bash
@@ -149,9 +139,7 @@ so it installs as a native Antigravity plugin — every skill and every agent
 installs with it. `agy plugin uninstall team` removes it.
 
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
-install copies the checkout, so upgrading means installing again. This host
-reads `disable-model-invocation` directly, so the three user-only skills need
-no host-specific declaration the way they do on Codex.
+install copies the checkout, so upgrading means installing again.
 
 Developing Team itself? The install copies, so link your checkout instead:
 

--- a/script/dev-install-antigravity
+++ b/script/dev-install-antigravity
@@ -11,11 +11,9 @@ set -euo pipefail
 #
 # Discovery follows a symlinked plugin root, and this host honors
 # disable-model-invocation, so pr-rebase, pr-watch-as-reviewer, and reflect stay
-# out of the model's reach on their own. Nothing is withheld here, unlike the
-# Codex install, whose host ignores that key. Those three also declare
-# allow_implicit_invocation: false in their agents/openai.yaml, which is the
-# Codex-side restatement of the same claim; this host needs neither, because
-# the frontmatter key alone already binds it.
+# out of the model's reach on their own. Those three also declare
+# allow_implicit_invocation: false in their agents/openai.yaml, which is what
+# binds the same claim on Codex; this host needs only the frontmatter key.
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # The `.gemini` spelling below is correct: it is Antigravity CLI's own global

--- a/script/dev-install-codex
+++ b/script/dev-install-codex
@@ -46,20 +46,9 @@ if command -v codex >/dev/null 2>&1; then
   done <<<"$plugin_list"
 fi
 
-# Which key guards the three user-only skills here. Printed on BOTH exit
-# paths — the already-linked path below returns 0 before the tail ever runs,
-# so a re-install would otherwise silently drop it.
-print_invocation_notice() {
-  echo "  Note: pr-watch-as-reviewer, pr-rebase, and reflect stay user-only here."
-  echo "        Codex does not read disable-model-invocation, so all three declare"
-  echo "        allow_implicit_invocation: false in their agents/openai.yaml, which"
-  echo "        keeps Codex from starting them implicitly. Invoke them explicitly."
-}
-
 # Already linked — nothing to do
 if [ -L "$TARGET" ] && [ "$(readlink "$TARGET")" = "$SKILLS_SRC" ]; then
   echo "Team skills already installed for Codex (dev)."
-  print_invocation_notice
   exit 0
 fi
 
@@ -77,7 +66,6 @@ echo
 mkdir -p "$(dirname "$TARGET")"
 ln -sfn "$SKILLS_SRC" "$TARGET"
 echo "  Linked: ${TARGET} → ${SKILLS_SRC}"
-print_invocation_notice
 
 echo
 echo "Done. Codex loads the skills at the next thread start."

--- a/script/dev-install-codex
+++ b/script/dev-install-codex
@@ -46,17 +46,14 @@ if command -v codex >/dev/null 2>&1; then
   done <<<"$plugin_list"
 fi
 
-# The model-invocation caveat. Printed on BOTH exit paths — the
-# already-linked path below returns 0 before the tail ever runs, so a
-# re-install would otherwise silently drop the one warning that matters.
+# Which key guards the three user-only skills here. Printed on BOTH exit
+# paths — the already-linked path below returns 0 before the tail ever runs,
+# so a re-install would otherwise silently drop it.
 print_invocation_notice() {
-  echo "  Note: pr-watch-as-reviewer, pr-rebase, and reflect are model-invocable on"
-  echo "        Codex, which ignores disable-model-invocation. The first one's"
-  echo "        approval can merge a PR; the second force-pushes a rewritten"
-  echo "        branch; reflect rewrites skill files and files public issues."
-  echo "        All three now declare allow_implicit_invocation: false in their"
-  echo "        agents/openai.yaml; this warning and the removal step stand until"
-  echo "        a live Codex build proves that key is honored."
+  echo "  Note: pr-watch-as-reviewer, pr-rebase, and reflect stay user-only here."
+  echo "        Codex does not read disable-model-invocation, so all three declare"
+  echo "        allow_implicit_invocation: false in their agents/openai.yaml, which"
+  echo "        keeps Codex from starting them implicitly. Invoke them explicitly."
 }
 
 # Already linked — nothing to do

--- a/tests/dev-install-codex.test.ts
+++ b/tests/dev-install-codex.test.ts
@@ -104,12 +104,12 @@ describe("dev install: codex harness", () => {
     expect(readlinkSync(teamLink(home))).toBe(join(REPO_ROOT, "skills"));
   });
 
-  test("install announces that Codex ignores disable-model-invocation", () => {
+  test("install announces which key keeps the three skills user-only", () => {
     // All three user-only skills install like any other skill here, so the run
-    // has to name them — the guard they rely on is honored by Claude Code and
-    // ignored by Codex. pr-watch-as-reviewer's approval can merge a PR;
-    // pr-rebase force-pushes a rewritten branch; reflect rewrites skill files
-    // and files public issues. Identifiers only, never wording.
+    // has to name them and name the key that guards them on this host: Codex
+    // does not read disable-model-invocation, so the guard rests on
+    // allow_implicit_invocation in agents/openai.yaml. Identifiers only,
+    // never wording.
     const { output } = run(INSTALL, newHome());
     expect(output).toContain("pr-watch-as-reviewer");
     expect(output).toContain("pr-rebase");
@@ -121,7 +121,7 @@ describe("dev install: codex harness", () => {
   test("a re-install still announces the guard on the already-linked path", () => {
     // The already-linked path returns 0 before the tail ever prints, so the
     // notice has to be reachable from both exits. A developer re-running the
-    // installer is the likeliest reader of a warning they skimmed the first
+    // installer is the likeliest reader of a note they skimmed the first
     // time; without this, that run says only "already installed".
     const home = newHome();
     expect(run(INSTALL, home).status).toBe(0);

--- a/tests/dev-install-codex.test.ts
+++ b/tests/dev-install-codex.test.ts
@@ -104,36 +104,6 @@ describe("dev install: codex harness", () => {
     expect(readlinkSync(teamLink(home))).toBe(join(REPO_ROOT, "skills"));
   });
 
-  test("install announces which key keeps the three skills user-only", () => {
-    // All three user-only skills install like any other skill here, so the run
-    // has to name them and name the key that guards them on this host: Codex
-    // does not read disable-model-invocation, so the guard rests on
-    // allow_implicit_invocation in agents/openai.yaml. Identifiers only,
-    // never wording.
-    const { output } = run(INSTALL, newHome());
-    expect(output).toContain("pr-watch-as-reviewer");
-    expect(output).toContain("pr-rebase");
-    expect(output).toContain("reflect");
-    expect(output).toContain("disable-model-invocation");
-    expect(output).toContain("allow_implicit_invocation");
-  });
-
-  test("a re-install still announces the guard on the already-linked path", () => {
-    // The already-linked path returns 0 before the tail ever prints, so the
-    // notice has to be reachable from both exits. A developer re-running the
-    // installer is the likeliest reader of a note they skimmed the first
-    // time; without this, that run says only "already installed".
-    const home = newHome();
-    expect(run(INSTALL, home).status).toBe(0);
-
-    const { output } = run(INSTALL, home);
-
-    expect(output).toContain("pr-watch-as-reviewer");
-    expect(output).toContain("pr-rebase");
-    expect(output).toContain("reflect");
-    expect(output).toContain("allow_implicit_invocation");
-  });
-
   // Stacking the dev symlink on a native plugin install makes Codex find the
   // same skills under two roots and render every one twice — a doubled
   // catalog, worse truncation, and an ambiguous source. The guard reads the

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -2,15 +2,9 @@
 //
 // L2 tripwire (free, deterministic): README.md and docs/index.md are the two
 // self-contained install surfaces (GitHub and team.bostonaholic.dev). Each
-// must carry all ten install/uninstall command strings verbatim, and every
-// `rm -rf` safety-guard invocation on each surface must point at the Codex
-// plugin cache prefix — a mistyped prefix is a silent no-op for the reader.
-//
-// This file pins WHERE removal points (the path prefix). WHICH skills are
-// named after the prefix is a separate invariant — set equality against the
-// guarded-skill set on disk, in tests/pr-watch-as-reviewer-skill.test.ts.
-// The skill names are deliberately not pinned here: freezing them in this
-// file would fight that invariant.
+// must carry all ten install/uninstall command strings verbatim, so a reader
+// on either surface can install and uninstall on every host without leaving
+// the page.
 //
 // Defensive reads: a missing file → "" so content assertions FAIL cleanly
 // rather than throwing ENOENT (the mechanical gate rejects crashes).
@@ -27,17 +21,6 @@ const DOCS_INDEX_MD = join(REPO_ROOT, "docs", "index.md");
 
 function readIf(path: string): string {
   return existsSync(path) ? read(path) : "";
-}
-
-// The path prefix every removal command must target. The skill name after
-// the prefix belongs to the set-equality invariant, not this file. The :?
-// expansion makes an unset CODEX_HOME abort loudly instead of no-opping.
-const RM_RF_PREFIX = '"${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/';
-
-// Every rm -rf invocation's target token, path shape only — prose around
-// the command can change freely without touching this extraction.
-function rmRfTargets(text: string): string[] {
-  return [...text.matchAll(/rm -rf\s+(\S+)/g)].map((m) => m[1] ?? "");
 }
 
 describe("docs-install-parity: README.md and docs/index.md each carry all ten install/uninstall command strings verbatim", () => {
@@ -73,33 +56,5 @@ describe("docs-install-parity: README.md and docs/index.md each carry all ten in
     expect(docsIndex).toContain("agy plugin uninstall team");
     expect(docsIndex).toContain("script/dev-install antigravity");
     expect(docsIndex).toContain("script/dev-uninstall antigravity");
-  });
-});
-
-describe('docs-install-parity: every rm -rf invocation on each surface targets the prefix "${CODEX_HOME:?}/plugins/cache"/*/team/*/skills/', () => {
-  test("README.md has rm -rf invocations and every one targets the Codex cache prefix", () => {
-    const readme = readIf(README_MD);
-    expect(readme.length).toBeGreaterThan(0);
-
-    const targets = rmRfTargets(readme);
-    // Positive control: the extractor must find the invocations known to
-    // exist, or the prefix assertions below prove nothing.
-    expect(targets.length).toBeGreaterThan(0);
-    for (const target of targets) {
-      expect(target).toStartWith(RM_RF_PREFIX);
-    }
-  });
-
-  test("docs/index.md has rm -rf invocations and every one targets the Codex cache prefix", () => {
-    const docsIndex = readIf(DOCS_INDEX_MD);
-    expect(docsIndex.length).toBeGreaterThan(0);
-
-    const targets = rmRfTargets(docsIndex);
-    // Positive control: a page with no removal commands has lost the safety
-    // guard entirely — that must fail here, not vacuously pass the loop.
-    expect(targets.length).toBeGreaterThan(0);
-    for (const target of targets) {
-      expect(target).toStartWith(RM_RF_PREFIX);
-    }
   });
 });

--- a/tests/guarded-skill-prose.test.ts
+++ b/tests/guarded-skill-prose.test.ts
@@ -1,28 +1,22 @@
 // tests/guarded-skill-prose.test.ts
 //
-// L2 tripwire (free, deterministic): the three guarded-skill prose surfaces
-// that no test pinned, so they stayed green while wrong.
+// L2 tripwire (free, deterministic): the guarded-skill prose surfaces that
+// no test pinned, so they stayed green while wrong.
 //
 // A skill setting `disable-model-invocation: true` is a skill whose blast
 // radius is large enough that only a deliberate human invocation may start it.
-// Five surfaces owe that set a mention, and two of them are already pinned by
-// set equality (tests/pr-watch-as-reviewer-skill.test.ts reads the
-// README.md and docs/index.md removal lists). The other three carry the same
-// claim in prose and comments and were pinned by nothing:
+// Two surfaces name that set in prose and comments:
 //
 //   script/dev-install-antigravity  — the comment naming which skills this
 //                                     host keeps out of the model's reach
-//   script/dev-install-codex        — the post-install notice naming which
-//                                     skills stay model-invocable on Codex
 //   docs/cross-host-portability.md  — the Antigravity probe result
 //
-// A skill added to the guarded set without touching those three ships a
-// silently weakened safety claim: an Antigravity user reads a comment that
-// omits the new skill, and a Codex user is never told to delete it.
+// A skill added to the guarded set without touching those two ships a
+// silently weakened safety claim: a reader gets a list that omits it.
 //
 // This asserts a CONTRACT — the presence of a skill NAME, matched as a whole
-// token — never a wording. A rewrite of any of the three surfaces that keeps
-// every guarded name stays green.
+// token — never a wording. A rewrite of either surface that keeps every
+// guarded name stays green.
 
 import { describe, expect, test } from "bun:test";
 import { existsSync, readdirSync } from "node:fs";
@@ -32,10 +26,9 @@ import { frontmatter, read } from "./helpers/text";
 
 const REPO_ROOT = process.cwd();
 
-// The three prose surfaces this file exists to pin.
+// The prose surfaces this file exists to pin.
 const SURFACES = [
   join("script", "dev-install-antigravity"),
-  join("script", "dev-install-codex"),
   join("docs", "cross-host-portability.md"),
 ];
 
@@ -79,7 +72,7 @@ describe("the guarded-skill set on disk", () => {
   });
 });
 
-describe("every guarded skill is named on all three unpinned prose surfaces", () => {
+describe("every guarded skill is named on every unpinned prose surface", () => {
   for (const relative of SURFACES) {
     test(`${relative} names every guarded skill`, () => {
       const text = surface(relative);

--- a/tests/pr-watch-as-reviewer-skill.test.ts
+++ b/tests/pr-watch-as-reviewer-skill.test.ts
@@ -19,7 +19,7 @@
 // not clean assertion failures.
 
 import { describe, expect, test } from "bun:test";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { frontmatter, read } from "./helpers/text";
@@ -291,86 +291,3 @@ describe("pr-watch-as-reviewer skill: PENDING-review check is a fenced snippet",
   });
 });
 
-describe("pr-watch-as-reviewer skill: Codex removal commands target the guarded skills on both install surfaces", () => {
-  // Codex ignores disable-model-invocation, so both install surfaces —
-  // README.md (GitHub) and docs/index.md (team.bostonaholic.dev) — tell
-  // Codex users to remove the guarded skills after installing. A rename or
-  // move of a skill must fail the build until each surface's removal path
-  // moves with it.
-  const README = join(REPO_ROOT, "README.md");
-  const DOCS_INDEX = join(REPO_ROOT, "docs", "index.md");
-
-  // Defensive read: missing file → "" so assertions FAIL (not throw).
-  function readmeBody(): string {
-    return existsSync(README) ? read(README) : "";
-  }
-  function docsIndexBody(): string {
-    return existsSync(DOCS_INDEX) ? read(DOCS_INDEX) : "";
-  }
-
-  // Every rm -rf target must be a real skill that actually sets the flag —
-  // a rename or move must fail the build until the README path moves with it.
-  function removalTargets(readme: string): string[] {
-    // Match the path shape only, never the surrounding prose, so a README
-    // rewrite that keeps the paths correct stays green.
-    return [...readme.matchAll(/rm -rf .*\/skills\/([A-Za-z0-9._-]+)/g)].map(
-      (m) => m[1] ?? "",
-    );
-  }
-
-  // Skills on disk that disable model invocation — the set the README owes
-  // Codex users a removal line for.
-  function guardedSkills(): string[] {
-    const skillsRoot = join(REPO_ROOT, "skills");
-    return readdirSync(skillsRoot, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => d.name)
-      .filter((name) => {
-        const file = join(skillsRoot, name, "SKILL.md");
-        if (!existsSync(file)) return false;
-        return /^disable-model-invocation:\s*true\s*$/m.test(
-          frontmatter(read(file)),
-        );
-      })
-      .sort();
-  }
-
-  test("every rm -rf path names a skill that exists and disables model invocation", () => {
-    const readme = readmeBody();
-    // Guard: a missing README must fail cleanly, not vacuously pass.
-    expect(readme.length).toBeGreaterThan(0);
-
-    const targets = removalTargets(readme);
-    expect(targets.length).toBeGreaterThan(0);
-
-    for (const targetName of targets) {
-      const targetSkill = join(REPO_ROOT, "skills", targetName, "SKILL.md");
-      expect(existsSync(targetSkill)).toBe(true);
-
-      const targetFrontmatter = existsSync(targetSkill)
-        ? frontmatter(read(targetSkill))
-        : "";
-      expect(/^disable-model-invocation:\s*true\s*$/m.test(targetFrontmatter)).toBe(
-        true,
-      );
-    }
-  });
-
-  test("the removal list covers every skill that disables model invocation", () => {
-    // The dangerous direction: a NEW user-only skill ships, Codex ignores its
-    // flag, and the README never tells anyone to remove it. Set equality
-    // catches that as well as a stale line for a deleted skill.
-    const readme = readmeBody();
-    expect(readme.length).toBeGreaterThan(0);
-    expect([...new Set(removalTargets(readme))].sort()).toEqual(guardedSkills());
-  });
-
-  test("rm -rf targets in docs/index.md equal the guarded-skill set on disk", () => {
-    // Same set equality, second surface: a docs page whose removal list is a
-    // stale subset of README's ships a silently weakened safety guard.
-    const docsIndex = docsIndexBody();
-    // Guard: a missing docs page must fail cleanly, not vacuously pass.
-    expect(docsIndex.length).toBeGreaterThan(0);
-    expect([...new Set(removalTargets(docsIndex))].sort()).toEqual(guardedSkills());
-  });
-});


### PR DESCRIPTION
## Why

`pr-watch-as-reviewer`, `pr-rebase`, and `reflect` set `disable-model-invocation` so only a person can start them — one casts an approval that can transitively merge a PR, one force-pushes a rewritten branch over published history, one rewrites skill files and files public issues.

Codex does not read that key. So the Codex install instructions told users to `rm -rf` the three skill directories after installing, every doc surface carried a caveat saying the `agents/openai.yaml` fallback was unverified on a live build, and the dev install printed four lines about it on every run.

It is not unverified. OpenAI [documents](https://learn.chatgpt.com/docs/build-skills) `policy.allow_implicit_invocation: false` as blocking implicit invocation while leaving explicit `$skill` invocation working — the same guarantee `disable-model-invocation` buys on Claude Code and Antigravity. All three skills already declare it. The removal step deletes working skills for no gain, and the notices tell a reader about a guard that needs nothing from them.

## What changes

The `rm -rf` instructions, the caveat, and the whole Codex blockquote are gone from `README.md` and `docs/index.md`. The Antigravity paragraphs no longer contrast against a Codex caveat that no longer exists. `script/dev-install-codex` loses `print_invocation_notice` and both call sites, so a dev install says only what it did.

`docs/cross-host-portability.md` keeps the explanation, which is the doc whose job it is, along with the one real distinction: Antigravity's behavior was observed on a live probe, Codex's rests on the documented contract.

Four test blocks pinned the removed text and are deleted or narrowed: the `rm -rf` target set-equality block in `tests/pr-watch-as-reviewer-skill.test.ts`, the `rm -rf` prefix block in `tests/docs-install-parity.test.ts`, and the two install-output tests in `tests/dev-install-codex.test.ts`. `tests/guarded-skill-prose.test.ts` drops `script/dev-install-codex` from its surface list, since that file no longer carries the claim.

The guarded set stays pinned: as prose on `script/dev-install-antigravity` and `docs/cross-host-portability.md`, and mechanically in `tests/skill-openai-yaml.test.ts`, which asserts set equality in both directions between skills setting `disable-model-invocation: true` and skills declaring `allow_implicit_invocation: false`.

No skill body, agent, hook, or manifest changes — dev-only, so no version bump.

## Test plan

- `bun test` — 1933 pass, 4 skip, 0 fail.
- Confirmed no `rm -rf` install instruction, "Codex ignores that key" caveat, or install-time notice remains on any doc or script surface.
- Confirmed the frontmatter-to-manifest guard invariant still fails the build when broken, via the existing both-directions set equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)