### PR TITLE
fix(dev): keep the harness asymmetry out of dev-install's output

### DIFF
--- a/script/dev-install
+++ b/script/dev-install
@@ -10,7 +10,11 @@ set -euo pipefail
 # a plugin its own way. Adding a harness means adding `dev-install-<name>` and
 # `dev-uninstall-<name>`, then listing it below.
 # The Claude target also installs clone-local hooks that refresh its versioned
-# cache after merge-based and rebase-based pulls.
+# cache after merge-based and rebase-based pulls. Only Claude needs them: its
+# install path embeds the plugin version, so a pull that bumps plugin.json
+# strands the link, while Codex and Antigravity link a fixed path that resolves
+# through to the checkout whatever a pull changes. That asymmetry is an
+# implementation detail — keep it out of the output the user reads.
 
 HARNESSES=(claude codex antigravity)
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -40,7 +44,7 @@ resolve_pull_hooks_dir() {
 preflight_pull_hooks() {
   local hooks_dir hook_name hook_path
   if [ ! -f "$PULL_HOOK_SOURCE" ] || [ ! -x "$PULL_HOOK_SOURCE" ]; then
-    echo "Warning: Claude pull hook is missing or not executable:" >&2
+    echo "Warning: Team's pull hook is missing or not executable:" >&2
     echo "  ${PULL_HOOK_SOURCE}" >&2
     return 1
   fi
@@ -59,10 +63,12 @@ preflight_pull_hooks() {
 }
 
 report_skipped_pull_hooks() {
-  echo "Skipped the Claude pull hooks (see the warning above)." >&2
-  echo "Every targeted harness installed. To keep the Claude cache fresh, either" >&2
-  echo "re-run 'script/dev-install claude' after each pull, or call it from your" >&2
-  echo "own post-merge and post-rewrite hooks." >&2
+  # Names the command the user actually typed, so the remedy never asks them to
+  # care that Claude is the only harness a pull can strand.
+  echo "Skipped this clone's Git hooks (see the warning above)." >&2
+  echo "Every targeted harness installed. To keep the install current, either" >&2
+  echo "re-run '${INVOCATION}' after each pull, or call it from your own" >&2
+  echo "post-merge and post-rewrite hooks." >&2
 }
 
 install_pull_hooks() {
@@ -87,6 +93,8 @@ install_pull_hooks() {
     echo "Installed Git hook: ${hook_path}"
   done
 }
+
+INVOCATION="script/dev-install${1:+ $1}"
 
 case "${1:-}" in
   "")

--- a/tests/regression-314-foreign-hooks-path.test.ts
+++ b/tests/regression-314-foreign-hooks-path.test.ts
@@ -133,6 +133,12 @@ describe("dev install: an unownable hooks surface never blocks the install (#314
     expect(result.output).toContain("outside this clone");
     expect(result.output).toContain(foreignHooks);
     expect(result.output).toContain("Skipped");
+    // The remedy echoes the command the user typed. Which harness a pull can
+    // strand is an implementation detail, so no harness name reaches the user.
+    expect(result.output).toContain("re-run 'script/dev-install' after each");
+    for (const harness of HARNESSES) {
+      expect(result.output.toLowerCase()).not.toContain(harness);
+    }
   });
 
   test("an existing unmanaged hook is preserved and still installs every harness", () => {


### PR DESCRIPTION
Closes #317

## Why

When `script/dev-install` cannot own this clone's Git hooks — a `core.hooksPath` outside the clone, or an existing hook Team does not own — it skips them and prints a remedy. That remedy named Claude and told the reader to re-run `script/dev-install claude`, even when the reader had run the bare `script/dev-install`. Nothing in the output says why one of three harnesses is singled out, so the message reads as an oversight in the hook install rather than a deliberate scope.

Claude is in fact the only harness a pull can strand: its install path embeds the plugin version, so a pull that bumps `plugin.json` leaves the symlink at the old version. Codex and Antigravity link a fixed path that resolves through to the checkout whatever a pull changes. That is an implementation detail of how three hosts load a plugin, and the person reading install output cannot act on it.

## What changes

The skip report names no harness, and its remedy echoes back the command the reader typed — a bare run is told to re-run the bare command. The reason moved into a source comment, where the next person to touch the hook install needs it.

No behavior change. The hooks still re-run the Claude installer alone, and an unownable hooks surface is still a skip that installs every targeted harness and exits 0.

Dev-only change, so no version bump and no changelog cut. The existing `[Unreleased]` bullet's claims stay true.

## Test plan

- New tripwire: the skip output contains no harness name and states the remedy the reader can act on.
- Verified the dev-install, pull-hook, docs-parity, and guarded-prose suites all pass.
- Verified the deterministic version gate classifies the branch as dev-only, so no bump is required.
- Verified the script still parses and lints clean.
