### PR TITLE
v0.86.0 fix(skills): cite the waiting principle in pr-rebase, verify dependency claims by resolving them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.85.0"
+    "version": "0.86.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.85.0",
+      "version": "0.86.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.86.0] - 2026-09-04
+
+### Changed
+
+- **[`/pr-rebase`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md) no longer holds the turn open while the project's checks run.** The skill runs the full check suite twice — once for the baseline before the rebase, once to compare after it — and it was the only long-wait skill in the plugin that did not cite `principle-non-blocking-waits`. It cites it now, and the step that captures the baseline says to spend that wait as one backgrounded call. A foreground wait gets killed at the harness ceiling, so on a repo whose checks run longer than that, the run used to lose its baseline instead of timing out. **What this asks of you:** nothing.
+- **[`principle-evidence-over-assertion`](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md) now treats a version range as a claim, not as evidence.** To support a statement about what a dependency does, load the lowest version its range admits and call the API there. That boundary is where a removed constant or a missing symbol actually breaks, and neither the range nor a changelog shows it. Every skill and agent that applies the principle picks up the new rule. **What this asks of you:** nothing.
+
 ## [0.85.0] - 2026-09-04
 
 ### Added
@@ -781,7 +788,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.85.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.86.0...HEAD
+[0.86.0]: https://github.com/bostonaholic/team/compare/v0.85.0...v0.86.0
 [0.85.0]: https://github.com/bostonaholic/team/compare/v0.84.0...v0.85.0
 [0.84.0]: https://github.com/bostonaholic/team/compare/v0.83.0...v0.84.0
 [0.83.0]: https://github.com/bostonaholic/team/compare/v0.82.0...v0.83.0

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1593,8 +1593,8 @@ lists more than three carries one recorded reason naming that count (see
   call the harness reports on — never foreground sleeps that occupy the
   turn.
 - **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-watch-as-author`, `pr-watch-as-reviewer`, `shipit`, and
-  `cross-model-review`. No agent preloads it.
+  `pr-watch-as-author`, `pr-watch-as-reviewer`, `shipit`,
+  `cross-model-review`, and `pr-rebase`. No agent preloads it.
 - **Key behaviors:** Background the wait with `run_in_background: true`
   and let the completion notification be the wake-up. Put the poll inside
   the same backgrounded call (`sleep <interval>; <poll>`) so a cycle costs
@@ -1852,7 +1852,7 @@ entry-point section above rather than repeating them here.
 | `principle-least-privilege` | cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-mechanical-gates` | cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-never-interpolate` | cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-non-blocking-waits` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `shipit`, `cross-model-review`. Any agent (just-in-time) | Any (cross-cutting principle) |
+| `principle-non-blocking-waits` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-optimization-never-dependency` | cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-plan-present-wait` | cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-pre-image-first` | cited by `pr-rebase`, `groom-backlog`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-rebase/SKILL.md
+++ b/skills/pr-rebase/SKILL.md
@@ -50,5 +50,5 @@ Read each reference completely when reaching that stage. Follow them in order; l
 
 ## Applied principles
 
-Load and apply: `principle-never-interpolate`, `principle-pre-image-first`, and
-`principle-untrusted-input-is-data`.
+Load and apply: `principle-never-interpolate`, `principle-pre-image-first`,
+`principle-untrusted-input-is-data`, and `principle-non-blocking-waits`.

--- a/skills/pr-rebase/references/07-step-2-capture-the-baseline-and-the-recovery-anchor.md
+++ b/skills/pr-rebase/references/07-step-2-capture-the-baseline-and-the-recovery-anchor.md
@@ -27,6 +27,10 @@
    *names* are what makes the comparison precise; a bare "12 failed" cannot
    distinguish a pre-existing failure from a new one.
 
+   A check suite is the long wait this procedure runs twice, so spend it per
+   `principle-non-blocking-waits`: one backgrounded call the harness reports
+   on, never a foreground `sleep` sized to just miss the turn ceiling.
+
 3. Classify each check `PASS`, `FAIL`, or `UNKNOWN`. `UNKNOWN` is for a
    check that could not execute at all — missing dependencies, a command not
    found, a service it needs is down. A `FAIL` baseline is fine and does not

--- a/skills/principle-evidence-over-assertion/SKILL.md
+++ b/skills/principle-evidence-over-assertion/SKILL.md
@@ -12,3 +12,4 @@ Give every verdict cited evidence from a command run, file:line read, or authori
 - Allow No PASS without cited evidence; report unverifiable items at degraded confidence.
 - Ground verdicts in named facts you observed; verify third-party claims at concrete file:line before adopting them.
 - Treat reviewer or model agreement as corroboration, never proof or a substitute for your check.
+- Verify a dependency claim by resolving it, never by reading a version range or a changelog; load the lowest version the range admits and call the API there, because that boundary is where a removed constant or a missing symbol actually breaks.


### PR DESCRIPTION
## Why

Two gaps a `/reflect` run over a long session turned up. Both were verified against the files rather than recalled, and two other findings from the same run were refuted the same way and dropped.

`pr-rebase` runs the project's whole check suite twice — once for its pre-rebase baseline, once for the post-rebase comparison — and was the only long-wait skill that did not cite `principle-non-blocking-waits`. `shipit`, `cross-model-review`, `pr-watch-as-author`, and `pr-watch-as-reviewer` all cite it. The session that surfaced this waited on both of those check runs with foreground sleeps sized just under the turn ceiling, which is the exact shape that principle already names as the anti-pattern.

`principle-evidence-over-assertion` had no rule covering a claim about a dependency. Its bullets reach a mutated value, an uncited PASS, an observed fact, and another reviewer's agreement — none of them reach a claim about what a version range admits or when an API appeared. For those the authoritative answer is what the resolver resolves and what the loaded library answers, not a `file:line` in the repo. In that same session, reading a range instead of resolving it produced a dependency floor that admitted a version missing a constant the application needs on every validation failure.

## What changes

`pr-rebase` declares `principle-non-blocking-waits` in its Applied principles list, and its step 2 reference states that the check suite is spent as one backgrounded call rather than a foreground sleep. `principle-evidence-over-assertion` gains a fifth rule: resolve the lowest version the range admits and call the API there, rather than reading the range or a changelog.

`docs/skills.md` records which files cite each principle and a tripwire test enforces the match, so the new citation lands with its two consumer-list entries.

## Test plan

- `bun test` — 1892 pass, 4 skip, 0 fail
- `tsc --noEmit` — clean
- Rebased onto `main` twice: after #327 compressed skills to reference density, and again onto v0.85.0. The citation has to live in `SKILL.md`: the tripwire builds its citation index from that file alone and never reads `references/`, so a citation placed in a reference file would not register and the `docs/skills.md` consumer list would then be wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
