### PR TITLE
fix(dev): use one wording template across the dev install scripts

### DIFF
--- a/script/dev-install-claude
+++ b/script/dev-install-claude
@@ -22,7 +22,7 @@ if [ -e "$CACHE_PATH" ] && [ ! -d "$CACHE_PATH" ]; then
   exit 1
 fi
 
-echo "Installing Team plugin (dev)..."
+echo "Installing Team for Claude Code (dev)..."
 echo "  Source: ${PLUGIN_ROOT}"
 echo
 
@@ -110,7 +110,7 @@ if [ -d "$CACHE_PATH" ] && [ ! -L "$CACHE_PATH" ]; then
   ln -s "$PLUGIN_ROOT" "$CACHE_PATH"
   echo "  Linked: ${CACHE_PATH} → ${PLUGIN_ROOT}"
 elif [ -L "$CACHE_PATH" ]; then
-  echo "Team plugin already installed (dev)."
+  echo "Team already installed for Claude Code (dev)."
 else
   echo "Error: Claude Code reported Team at ${CACHE_PATH}, but that directory does not exist." >&2
   exit 1

--- a/script/dev-install-codex
+++ b/script/dev-install-codex
@@ -48,7 +48,7 @@ fi
 
 # Already linked — nothing to do
 if [ -L "$TARGET" ] && [ "$(readlink "$TARGET")" = "$SKILLS_SRC" ]; then
-  echo "Team skills already installed for Codex (dev)."
+  echo "Team already installed for Codex (dev)."
   exit 0
 fi
 
@@ -59,7 +59,7 @@ if [ -e "$TARGET" ] && [ ! -L "$TARGET" ]; then
   exit 1
 fi
 
-echo "Installing Team skills for Codex (dev)..."
+echo "Installing Team for Codex (dev)..."
 echo "  Source: ${SKILLS_SRC}"
 echo
 

--- a/script/dev-uninstall-claude
+++ b/script/dev-uninstall-claude
@@ -5,7 +5,7 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_VERSION=$(node -p "require('${PLUGIN_ROOT}/.claude-plugin/plugin.json').version")
 CACHE_PATH="${HOME}/.claude/plugins/cache/team-dev/team/${PLUGIN_VERSION}"
 
-echo "Uninstalling Team plugin (dev)..."
+echo "Uninstalling Team for Claude Code (dev)..."
 echo
 
 claude plugin uninstall team@team-dev 2>&1 || true

--- a/script/dev-uninstall-codex
+++ b/script/dev-uninstall-codex
@@ -12,7 +12,7 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_SRC="${PLUGIN_ROOT}/skills"
 TARGET="${HOME}/.agents/skills/team"
 
-echo "Uninstalling Team skills for Codex (dev)..."
+echo "Uninstalling Team for Codex (dev)..."
 echo
 
 if [ ! -L "$TARGET" ] && [ ! -e "$TARGET" ]; then


### PR DESCRIPTION
## Why

A bare `script/dev-install` runs all three harness installers in sequence, so a developer reads their output as one report. Each installer named the thing being installed differently:

```
Team plugin already installed (dev).
Team skills already installed for Codex (dev).
Team already installed for Antigravity (dev).
```

Three names for one plugin on three hosts. The Claude line also names no harness at all, so in the combined output there is nothing tying it to Claude Code.

## What changed

Every install and uninstall script now prints the same shape — `Installing Team for <Harness> (dev)...`, `Team already installed for <Harness> (dev).`, `Uninstalling Team for <Harness> (dev)...`. Antigravity already used it; Claude Code and Codex now match.

The trailing `Done.` lines still differ, because what each host does differs: Claude Code needs a restart, Codex loads the skills at the next thread start, Antigravity loads the skills and agents at the next session start. Codex's `Source:` line still points at `skills/` rather than the repo root, which is what it links.

Output only. No install, link, or teardown behavior changes.

## Not in scope

Two asymmetries left alone, both structural rather than wording:

- Claude Code's already-installed path prints the `Installing...` header and `Source:` line before it reports `already installed`, while Codex and Antigravity check first and exit after one line. Claude Code's installer cannot check first — it has to query `claude plugin list` to know the state — so matching would mean moving the header down past the marketplace and install block.
- `dev-uninstall-claude` prints no `Nothing to do:` line; the other two do.

## Test plan

- `bun test` — 1933 pass, 4 skip, 0 fail.
- The install/uninstall suites (`tests/dev-install-codex.test.ts`, `tests/dev-install-antigravity.test.ts`, `tests/regression-309-idempotent-install.test.ts`, `tests/regression-314-foreign-hooks-path.test.ts`) exercise the idempotent re-run path against a temporary `HOME` and assert on the `already installed` substring, which both the old and new wording carry.
- No version bump and no changelog entry: `script/` is not part of the distributed plugin, so `.github/scripts/version-bump-required.sh` requires no bump on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)