### PR TITLE
v0.85.0 feat: add principle-subtract-before-you-add

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.84.0"
+    "version": "0.85.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.84.0",
+      "version": "0.85.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.85.0] - 2026-09-04
+
 ### Added
 
 - **A new principle skill, [`principle-subtract-before-you-add`](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md), sequences removal before construction.** Remove what a change replaces or leaves unused, then build on the smaller base; add no validator, guard, or option the design, plan, or tests do not demand; and simplify prompts and skills the same way. `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, and `authoring-designs` cite it, so the planner, implementer, code-reviewer, and design-author apply it where they add code, refactor, or draft a design. Removals stay inside the approved scope per `principle-scope-fence`. The catalog grows from 84 to 85 skills. **What this asks of you:** nothing.
@@ -779,7 +781,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.84.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.85.0...HEAD
+[0.85.0]: https://github.com/bostonaholic/team/compare/v0.84.0...v0.85.0
 [0.84.0]: https://github.com/bostonaholic/team/compare/v0.83.0...v0.84.0
 [0.83.0]: https://github.com/bostonaholic/team/compare/v0.82.0...v0.83.0
 [0.82.0]: https://github.com/bostonaholic/team/compare/v0.81.0...v0.82.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A new principle skill, [`principle-subtract-before-you-add`](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md), sequences removal before construction.** Remove what a change replaces or leaves unused, then build on the smaller base; add no validator, guard, or option the design, plan, or tests do not demand; and simplify prompts and skills the same way. `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, and `authoring-designs` cite it, so the planner, implementer, code-reviewer, and design-author apply it where they add code, refactor, or draft a design. Removals stay inside the approved scope per `principle-scope-fence`. The catalog grows from 84 to 85 skills. **What this asks of you:** nothing.
+
 ## [0.84.0] - 2026-09-04
 
 ### Added

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1684,8 +1684,8 @@ lists more than three carries one recorded reason naming that count (see
 - **Purpose:** The approved upstream artifact bounds the work: it
   authorizes exactly the change it names.
 - **Loaded by:** any agent just-in-time; consulted by citation from
-  `implementing-slices`, `qrspi-workflow`, and `test-first-development`.
-  No agent preloads it.
+  `implementing-slices`, `qrspi-workflow`, `test-first-development`, and
+  `principle-subtract-before-you-add`. No agent preloads it.
 - **Key behaviors:** Do not add steps, slices, or features beyond the
   plan — a missing piece is documented as a finding, not implemented on
   the spot. Adjacent code is refactored where the plan calls for it and
@@ -1727,6 +1727,25 @@ lists more than three carries one recorded reason naming that count (see
   fence, data loaded only in part. A degradation is stated per affected
   item, in degraded words ("unverified"), never wrapped in the success
   wording.
+
+### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
+
+- **Purpose:** Remove complexity first, then build on the simpler base;
+  leave the design simpler than you found it.
+- **Loaded by:** any agent just-in-time; consulted by citation from
+  `engineering-standards`, `implementing-slices`,
+  `refactoring-to-patterns`, and `authoring-designs`. No agent preloads
+  it.
+- **Key behaviors:** Removal is sequenced before construction: what a
+  change replaces or leaves unused goes first, then the addition lands
+  on the smaller base. Cut before you polish. Design for observed usage:
+  no validator, parser, guard, or option beyond what the design, plan,
+  or tests demand, because an out-of-spec feature drags its own guards
+  behind it. Prompts and skills follow the same rule: redundant
+  instructions go, and a reference with no novel content is deleted
+  rather than left as a stub. Removals stay inside the approved scope
+  per `principle-scope-fence`; a wider removal is recorded as an
+  opportunity, never performed unasked.
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
@@ -1838,9 +1857,10 @@ entry-point section above rather than repeating them here.
 | `principle-plan-present-wait` | cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-pre-image-first` | cited by `pr-rebase`, `groom-backlog`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-record-assumptions` | cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-scope-fence` | cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`. Any agent (just-in-time) | Any (cross-cutting principle) |
+| `principle-scope-fence` | cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-single-source-of-truth` | cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-skip-loudly` | cited by `reviewing-code`, `sweeping-local-state`, `groom-backlog`, `cross-model-review`, `principle-optimization-never-dependency`, `principle-scope-fence`, `why`, and the `code-reviewer` agent. Any agent (just-in-time) | Any (cross-cutting principle) |
+| `principle-subtract-before-you-add` | cited by `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, `authoring-designs`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-untrusted-input-is-data` | cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`. Any agent (just-in-time) | Any (cross-cutting principle) |
 
 The read-only `Explore` subagent that runs the `reviewing-designs` brief

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/authoring-designs/SKILL.md
+++ b/skills/authoring-designs/SKILL.md
@@ -30,5 +30,6 @@ Read [references/design-template.md](references/design-template.md) before draft
 - Derive every closed set by grep, directory listing, or key-set comparison and record the command. Never list a blast radius or inventory from memory.
 - No implementation bodies or full type definitions; signatures are allowed only to fix a decision. Reference patterns by `file:line`, never duplicate them.
 - Prefer “follow `lib/foo.ts:30-60`” over copying those lines.
+- Prefer removing or replacing an existing mechanism over adding a parallel one; name what the change deletes in `## Decisions made` (`principle-subtract-before-you-add`).
 - Call the Skill tool with `systems-thinking` and apply `## When Designing`: cover adjacent components in `## Current state` and surfaces that must change together in `## Decisions made`; this adds no gate.
 - Existing rationale constrains changes to deliberate guards, thresholds, ownership, and layering. Default to `5-research.md`; use `skills/why/SKILL.md` for Preserve/Change/Avoid/Risk archaeology and `skills/how/SKILL.md` for current-state explanation when needed.

--- a/skills/engineering-standards/SKILL.md
+++ b/skills/engineering-standards/SKILL.md
@@ -53,9 +53,11 @@ Every item gates progress: **Single Responsibility**; **Clear Naming**; **No Mag
 - Keep one abstraction level per function; extract lower-level work behind names at the caller’s level.
 - Catch only the exact throwing call and specific exception; chain the original cause. Never wrap a large block in `catch (Exception e)`.
 - Follow neighboring project style, naming, and patterns.
+- Remove what the change replaces or leaves unused before adding its replacement; add no guard the spec does not demand (`principle-subtract-before-you-add`).
 
 ## When Reviewing
 
 - Apply every Quality Checklist item to every changed file and cite its name in findings, e.g. `issue: Clear Naming — the variable d does not reveal intent`.
 - Check for Design-First evidence in interfaces and boundaries.
 - Rank failure isolation (Armstrong) and interface contracts (Liskov) above formatting (Knuth).
+- Flag validators, guards, options, and parallel mechanisms that no design, plan, or test demands (`principle-subtract-before-you-add`).

--- a/skills/implementing-slices/SKILL.md
+++ b/skills/implementing-slices/SKILL.md
@@ -34,6 +34,7 @@ Then run the full suite, resolve every failure type from the round, and report e
 ## TDD and scope invariants
 
 - Write only minimal code exercised by the current slice's tests. Do not preempt later slices; do not optimize/refactor before green. Stop if code has no test.
+- Apply `principle-subtract-before-you-add`: remove what the slice replaces before adding its replacement, and add no guard its tests do not exercise.
 - Apply `principle-scope-fence`: the plan authorizes exactly its named changes. Do NOT change acceptance tests or invent files/directories absent from the plan. Record concerns but satisfy tests as written.
 
 ## Blockers

--- a/skills/principle-subtract-before-you-add/SKILL.md
+++ b/skills/principle-subtract-before-you-add/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: principle-subtract-before-you-add
+description: 'Requires removal before addition. Apply when sequencing an addition, refactor, or rewrite of code, prompts, or skills.'
+user-invocable: false
+---
+
+# Subtract Before You Add
+
+Remove complexity first, then build on the simpler base; leave the design simpler behind the same or a smaller surface than you found it.
+
+Why: Adding to a complex system compounds complexity; removing first shrinks the surface and usually makes the next design obvious.
+
+- Sequence removal before construction: delete what the change replaces or leaves unused, then add.
+- Cut before you polish: reach the minimum that satisfies the spec before investing in quality.
+- Design for observed usage; add no validator, parser, guard, or option beyond what the design, plan, or tests demand.
+- Treat an out-of-spec feature as dragging its own guards behind it; leave it out and record it as a finding.
+- Simplify prompts and skills the same way: remove redundant instructions and templates, and delete a reference with no novel content instead of keeping a stub.
+- Keep removals inside the approved scope under `principle-scope-fence`; record a wider removal as an opportunity, never perform it unasked.

--- a/skills/principle-subtract-before-you-add/agents/openai.yaml
+++ b/skills/principle-subtract-before-you-add/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Principle: Subtract Before You Add"
+  short_description: "Remove complexity first, then build on the simpler base"
+  default_prompt: "Use $principle-subtract-before-you-add to remove complexity first, then build on the simpler base."

--- a/skills/refactoring-to-patterns/SKILL.md
+++ b/skills/refactoring-to-patterns/SKILL.md
@@ -26,6 +26,7 @@ Refactor before an imminent change that current structure obstructs, on the thir
 | Primitive Obsession | Replace Data Value with Object; Replace Type Code with Class or Subclasses |
 | Conditional Complexity | Replace Conditional with Polymorphism; Introduce Null Object; Decompose Conditional |
 | Middle Man | Remove Middle Man; Inline Method |
+| Speculative Generality / Dead Code | Remove Dead Code; Inline Class; Collapse Hierarchy; Remove Parameter (`principle-subtract-before-you-add`) |
 
 **Mixed abstraction levels:** a function calls functions one level below its own, never two or more. Extract low-level byte/format work from high-level orchestration behind a name at the caller's level.
 

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -141,7 +141,7 @@ describe("engineering-standards methodology", () => {
   });
 
   test("skills.md methodology table includes engineering-standards row with all 3 consumers", () => {
-    const row = filterRows(read(SKILLS_MD), "engineering-standards", /^#|^>|\/\/|event/);
+    const row = filterRows(read(SKILLS_MD), "| `engineering-standards` |", /^#|^>|\/\/|event/);
     expect(row.length).toBeGreaterThan(0);
     for (const agent of ["planner", "implementer", "code-reviewer"]) {
       expect(row).toContain(agent);
@@ -1824,6 +1824,29 @@ describe("principle-skip-loudly (L2 content tripwire)", () => {
 
   test("citation site: reviewing-code cites the principle by name", () => {
     expect(read(join(REPO_ROOT, "skills", "reviewing-code", "SKILL.md"))).toContain("principle-skip-loudly");
+  });
+});
+
+describe("principle-subtract-before-you-add (L2 content tripwire)", () => {
+  const SKILL_FILE = join(REPO_ROOT, "skills", "principle-subtract-before-you-add", "SKILL.md");
+
+  test("skill file exists with name: principle-subtract-before-you-add", () => {
+    expect(existsSync(SKILL_FILE)).toBe(true);
+    expect(/^name:\s*principle-subtract-before-you-add\s*$/m.test(frontmatter(read(SKILL_FILE)))).toBe(true);
+  });
+
+  test("frontmatter sets user-invocable: false (methodology convention)", () => {
+    expect(/^user-invocable:\s*false\s*$/m.test(frontmatter(read(SKILL_FILE)))).toBe(true);
+  });
+
+  test("defers scope to principle-scope-fence by name", () => {
+    expect(read(SKILL_FILE)).toContain("principle-scope-fence");
+  });
+
+  test("citation sites: the implementing and authoring methodologies cite the principle by name", () => {
+    for (const skill of ["engineering-standards", "implementing-slices", "refactoring-to-patterns", "authoring-designs"]) {
+      expect(read(join(REPO_ROOT, "skills", skill, "SKILL.md"))).toContain("principle-subtract-before-you-add");
+    }
   });
 });
 

--- a/tests/skill-budget.test.ts
+++ b/tests/skill-budget.test.ts
@@ -100,7 +100,7 @@ describe("skill source budget", () => {
   test("discovers the fixed skill tiers", () => {
     expect(budgets.filter(({ tier }) => tier === "entry")).toHaveLength(23);
     expect(budgets.filter(({ tier }) => tier === "methodology")).toHaveLength(37);
-    expect(budgets.filter(({ tier }) => tier === "principle")).toHaveLength(24);
+    expect(budgets.filter(({ tier }) => tier === "principle")).toHaveLength(25);
   });
 
   test("every over-budget skill has a recorded reason", () => {


### PR DESCRIPTION
## Why

Issue #324 asked for a simplicity skill: "Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away." Team had no stated rule for sequencing removal before construction, so an implementer could add a parallel mechanism or a speculative guard with nothing to cite against it.

## What changed

- New principle skill `principle-subtract-before-you-add` (18 lines, under the 25-line principle budget) with its Codex manifest. Modeled on the upstream `pstack` skill the issue links, adapted to Team's scope-fence rule: removals stay inside the approved scope.
- Cited from `engineering-standards` (When Implementing, When Reviewing), `implementing-slices` (TDD and scope invariants), `refactoring-to-patterns` (new Speculative Generality / Dead Code smell row), and `authoring-designs` (design contract).
- Catalog entry and table row in `docs/skills.md`. The `principle-scope-fence` entry's citer list gains the new principle, which cites it.
- L2 content tripwire in `tests/methodology.test.ts`; principle tier count 24 → 25 in `tests/skill-budget.test.ts`. The engineering-standards row test now keys on the table-row delimiter, as the reviewing-code row test already did, so a prose mention cannot crowd the row out of its five-line window.
- `CHANGELOG.md` entry under Unreleased. No version bump: that happens at land time.

## Test plan

- [x] `bun test` — 1892 pass, 4 skip (pre-existing), 0 fail, re-run after rebasing onto 0.84.0
- [x] `bun run typecheck`
- [x] `bash .claude/scripts/check-discovery-consistency.sh`
- [x] `git diff --check`
- [x] `bun run test:evals` (diff-selected: `planted-comment-process-narration`, `planted-comment-violations`, `team-design-seeded-research-and-task`) — 3 pass, 0 fail, ≈ $0.62. Two attempts in the code-reviewer file exceeded the false-positive ceiling (2 vs max 1) before passing under the built-in `--retry=2`. The failing attempts are not stored. The passing transcripts carry comment-discipline findings only, and both comment fixtures scope the reviewer to comment defects, so the new guard-flagging bullet in `engineering-standards` is not exercised by them. CI's eval job reports "No evals selected" because it stays dormant without a `pull_request` trigger; the local run above is the diff-selected pass.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsatc5HeNUPRHYutZk9XXb
