### PR TITLE
v0.87.0 fix: land-time shell defects in shipit and the dev pull hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.86.0"
+    "version": "0.87.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.86.0",
+      "version": "0.87.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **[`/shipit`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)'s CI watch no longer fails under zsh.** The land sequence captured the watch exit code into `status`, which zsh reserves as a read-only alias of `$?`, so the backgrounded watch reported failure on a fully green PR and the operator had to verify CI by hand. The capture now uses `WATCH_STATUS`. **What this asks of you:** nothing.
+
 ## [0.86.0] - 2026-09-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.87.0] - 2026-09-04
+
 ### Fixed
 
 - **[`/shipit`](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)'s CI watch no longer fails under zsh.** The land sequence captured the watch exit code into `status`, which zsh reserves as a read-only alias of `$?`, so the backgrounded watch reported failure on a fully green PR and the operator had to verify CI by hand. The capture now uses `WATCH_STATUS`. **What this asks of you:** nothing.
@@ -792,7 +794,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.86.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.87.0...HEAD
+[0.87.0]: https://github.com/bostonaholic/team/compare/v0.86.0...v0.87.0
 [0.86.0]: https://github.com/bostonaholic/team/compare/v0.85.0...v0.86.0
 [0.85.0]: https://github.com/bostonaholic/team/compare/v0.84.0...v0.85.0
 [0.84.0]: https://github.com/bostonaholic/team/compare/v0.83.0...v0.84.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/script/dev-install-claude-pull-hook
+++ b/script/dev-install-claude-pull-hook
@@ -8,6 +8,11 @@ set -euo pipefail
 HOOK_NAME="${0##*/}"
 [ "$HOOK_NAME" != "post-rewrite" ] || [ "${1:-}" = "rebase" ] || exit 0
 
+# Hooks are shared with linked worktrees. The install links the primary
+# checkout, and a worktree rebase changes nothing that checkout serves.
+[ "$(git rev-parse --path-format=absolute --git-dir 2>/dev/null)" = \
+  "$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" ] || exit 0
+
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "Error: Team pull hook cannot resolve the checkout root." >&2
   exit 1

--- a/skills/shipit/references/02-land-sequence.md
+++ b/skills/shipit/references/02-land-sequence.md
@@ -75,7 +75,7 @@ infinite.** Defaults (overridable so a future automation loop can tune them):
 
 ```bash
 timeout 1800 gh pr checks <pr-number> --watch --fail-fast --interval 30
-status=$?
+WATCH_STATUS=$?
 ```
 
 **Run it with `run_in_background: true`.** The 1800s cap only applies to a
@@ -83,10 +83,10 @@ backgrounded call: in the foreground the harness kills the watch at its own
 ceiling (600 s in Claude Code) with exit 143, so on any repo whose CI runs
 longer than ten minutes the stated 30-minute cap never applies and the watch
 is lost rather than timed out. Backgrounded, the harness reports the call when
-it exits and `status` is the real verdict. See
+it exits and `WATCH_STATUS` is the real verdict. See
 `principle-non-blocking-waits`.
 
-Map `status` first — it is the fast path out, never the way in:
+Map `WATCH_STATUS` first — it is the fast path out, never the way in:
 
 - **non-zero and not 124** (a check failed) → **stop before merge**. Run
   `gh pr checks <pr-number>` to print the failing check, and report it by name.

--- a/tests/dev-install-pull-hooks.test.ts
+++ b/tests/dev-install-pull-hooks.test.ts
@@ -203,6 +203,36 @@ describe("dev install: refresh after pulls (#312)", () => {
     expect(installCalls(fixture)).toHaveLength(2);
   });
 
+  // The hooks live in the shared .git/hooks, so a rebase inside a linked
+  // worktree fires post-rewrite too. The install links the primary checkout,
+  // and a worktree rebase changes nothing that checkout serves, so the hook
+  // must stay quiet there instead of running the installer against the
+  // worktree (whose guard refuses a checkout the marketplace does not link).
+  test("a rebase inside a linked worktree neither reruns the installer nor fails", () => {
+    const fixture = newFixture();
+    expect(install(fixture).status).toBe(0);
+    expect(installCalls(fixture)).toHaveLength(1);
+
+    const worktree = join(fixture.root, "worktree");
+    git(fixture.checkout, "worktree", "add", "-q", worktree, "-b", "feature");
+    writeFileSync(join(worktree, "local"), "local\n");
+    git(worktree, "add", "local");
+    git(worktree, "commit", "-q", "-m", "local change");
+    advanceUpstream(fixture, "two");
+    git(worktree, "fetch", "-q", "origin");
+
+    const rebase = run(
+      worktree,
+      "git",
+      ["rebase", "origin/main"],
+      fixtureEnv(fixture),
+    );
+
+    expect(rebase.status).toBe(0);
+    expect(rebase.output).not.toContain("install failed");
+    expect(installCalls(fixture)).toHaveLength(1);
+  });
+
   test("reinstallation is idempotent and uninstall removes owned hooks", () => {
     const fixture = newFixture();
     expect(install(fixture).status).toBe(0);

--- a/tests/shipit-skill.test.ts
+++ b/tests/shipit-skill.test.ts
@@ -159,6 +159,17 @@ describe("shipit skill: push, wait for CI, merge", () => {
     }
   });
 
+  test("the CI watch exit code is captured into a variable no shell reserves", () => {
+    // `status` is a read-only special parameter in zsh (an alias of `$?`), so
+    // `status=$?` aborts the wrapper with "read-only variable: status" and the
+    // watch reports failure on a fully green PR. The capture must use a name
+    // no shell reserves, and it must exist — an absent capture would pass the
+    // negative check while leaving the verdict mapping with nothing to read.
+    const t = body();
+    expect(t).toContain("WATCH_STATUS=$?");
+    expect(t).not.toMatch(/^status=\$\?/m);
+  });
+
   test("names `gh pr merge --squash` explicitly", () => {
     // Squash lands the PR title as the commit subject (so a version in the
     // title shows up in git log) while keeping linear history.


### PR DESCRIPTION
## Why

Two shell defects surfaced while landing #331, both pre-existing.

- `/shipit`'s CI watch captured its exit code as `status=$?`. In zsh, `status` is a read-only alias of `$?`, so the backgrounded watch aborted with `read-only variable: status` and reported failure on a fully green PR (#332). The snippet is a code fence the agent runs through the host's shell, so no shebang pins its dialect.
- The dev pull hook fires for a rebase inside a linked worktree, resolves the worktree as the checkout, and runs its installer. The installer's marketplace guard refuses because `team-dev` links the primary clone, so every worktree rebase printed `Error: install failed for: claude` (#333).

## What changed

- `skills/shipit/references/02-land-sequence.md`: the capture is `WATCH_STATUS=$?`, and the two prose mentions follow. L2 tripwire in `tests/shipit-skill.test.ts` requires the new capture and forbids `status=$?` in the skill. Changelog bullet under Unreleased (runtime change).
- `script/dev-install-claude-pull-hook`: exits before the installer when `--git-dir` differs from `--git-common-dir`. The install serves the primary checkout, and a worktree rebase changes nothing it serves. Real-Git regression test in `tests/dev-install-pull-hooks.test.ts`: a rebase in a linked worktree neither reruns the installer nor fails. Dev-only, no changelog.

Four commits: a `test:` commit with the failing test and a `fix:` commit per bug.

A repo-wide sweep found three more `status` assignments in dev scripts, all under a bash shebang and not failing. They are left alone here; the general fix is a rule that executable procedures ship as script files rather than skill code fences, tracked separately.

## Test plan

- [x] Red: both new tests fail with assertion failures before their fixes (missing capture; installer ran twice)
- [x] Green: `bun test tests/shipit-skill.test.ts tests/dev-install-pull-hooks.test.ts tests/regression-314-foreign-hooks-path.test.ts`
- [x] `bun test` — 1894 pass, 4 skip (pre-existing), 0 fail
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] Original inputs: `zsh -c 'true; WATCH_STATUS=$?'` succeeds; the fixed hook invoked as `post-rewrite rebase` from a linked worktree exits 0 silently

Closes #332
Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsatc5HeNUPRHYutZk9XXb
