### PR TITLE
docs: name the promotion, the ladder it climbs, and the governance behind it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Team
 
-A plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the main Claude Code session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
+**You have been made tech lead. Your team never sleeps.**
+
+13 specialists, five reviewers who can block you, and a written record of every decision. You keep the two calls that were always yours: what to build, and what to ship. The promotion comes with no headcount req.
+
+Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the main Claude Code session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
 
 Team installs on Claude Code, on Codex CLI, and on Antigravity CLI. The full pipeline needs Claude Code, because that is the host that dispatches the agents. The standalone utilities work on all three.
 
@@ -141,6 +145,21 @@ or multi-repo setup.
 
 Each downstream command takes the artifact directory `docs/plans/<id>/` as
 its argument.
+
+## The governance stack
+
+Every team you have worked on had rules that made its output trustworthy: an author does not approve their own pull request, a design gets challenged before it is built, security reads the change before it ships. Team ships those rules as machinery rather than as manners.
+
+| The rule | How Team enforces it |
+|----------|----------------------|
+| An author never approves their own work | Reviewers hold no `Write` or `Edit` tool and run in `plan` mode. Pinned by `tests/protocol.test.ts`, not requested in a prompt. |
+| Review is not a rubber stamp | The implement loop re-runs until no Blocking or Major finding is left. There is no fixed number of rounds to outwait. |
+| A reviewer cannot be lobbied | Reviewers read the diff and a spec written before the code existed, never the implementer's account of its own work. |
+| The design is challenged before it is built | A fresh-context adversarial design review hard-gates the pipeline. |
+| Nobody escalates to dodge a check | The orchestrator is forbidden from handing a blocking finding to the human mid-run. |
+| Every decision is on the record | `docs/plans/<id>/` holds the task, the questions, the research, the design, every review verdict, and the plan. Files in the repo, not chat history. |
+
+You cannot overrule the security reviewer by asking nicely. [docs/ethos.md](docs/ethos.md) explains why each rule exists, and [docs/vision.md](docs/vision.md) covers how far the delegation goes.
 
 ## Design philosophy
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **You have been made tech lead. Your team never sleeps.**
 
-13 specialists, five reviewers who can block you, and a written record of every decision. You keep the two calls that were always yours: what to build, and what to ship. The promotion comes with no headcount req.
-
 Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the main Claude Code session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
 
 Team installs on Claude Code, on Codex CLI, and on Antigravity CLI. The full pipeline needs Claude Code, because that is the host that dispatches the agents. The standalone utilities work on all three.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,11 @@ nav_label: home
 
 # Team
 
-Autonomous feature delivery for Claude Code.
+**You have been made tech lead. Your team never sleeps.**
+
+13 specialists, five reviewers who can block you, and a written record of every
+decision. You keep the two calls that were always yours: what to build, and what
+to ship. The promotion comes with no headcount req.
 
 ## What is Team?
 
@@ -38,6 +42,33 @@ WORKTREE → QUESTION → RESEARCH → DESIGN → STRUCTURE → PLAN → IMPLEME
 | **Plan** | The planner derives a tactical implementation plan from the structure. The implementer reads it. No gate applies. |
 | **Implement** | Test-first → slice execution → 5 parallel reviewers + typed retry loop. |
 | **PR** | Update changelog, commit, open pull request. |
+
+## The governance stack
+
+Every team you have worked on had rules that made its output trustworthy: an
+author does not approve their own pull request, a design gets challenged before
+it is built, security reads the change before it ships. Team ships those rules
+as machinery rather than as manners.
+
+| The rule | How Team enforces it |
+|----------|----------------------|
+| An author never approves their own work | Reviewers hold no `Write` or `Edit` tool and run in `plan` mode. Pinned by `tests/protocol.test.ts`, not requested in a prompt. |
+| Review is not a rubber stamp | The implement loop re-runs until no Blocking or Major finding is left. There is no fixed number of rounds to outwait. |
+| A reviewer cannot be lobbied | Reviewers read the diff and a spec written before the code existed, never the implementer's account of its own work. |
+| The design is challenged before it is built | A fresh-context adversarial design review hard-gates the pipeline. |
+| Nobody escalates to dodge a check | The orchestrator is forbidden from handing a blocking finding to the human mid-run. |
+| Every decision is on the record | `docs/plans/<id>/` holds the task, the questions, the research, the design, every review verdict, and the plan. Files in the repo, not chat history. |
+
+You cannot overrule the security reviewer by asking nicely. [Ethos](ethos.md)
+explains why each rule exists.
+
+## How far the delegation goes
+
+Team's scope today is contained: a groomed ticket, one repository, a context
+that already exists. Each rung above that hands Team a less framed problem — a
+problem statement, then an outcome to move — until one person carries
+company-significant work from problem definition through measured outcomes.
+[Vision](vision.md) has the ladder.
 
 ## Install
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,6 @@ nav_label: home
 
 **You have been made tech lead. Your team never sleeps.**
 
-13 specialists, five reviewers who can block you, and a written record of every
-decision. You keep the two calls that were always yours: what to build, and what
-to ship. The promotion comes with no headcount req.
-
 ## What is Team?
 
 Team orchestrates 13 specialized agents. They range from isolated researchers to adversarial

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,6 +1,6 @@
 ---
 title: Vision
-description: "Team's north star: a human keeps the board fed and reviews finished work, and everything in between runs itself via a continuously running, board-driven control loop."
+description: "Team's north star: a human keeps the board fed and reviews finished work, everything in between runs itself via a continuously running, board-driven control loop, and one person takes on work that used to need a team."
 audience: [user, developer]
 nav_order: 2
 nav_label: vision
@@ -17,6 +17,7 @@ nav_label: vision
 - [What the human does](#what-the-human-does)
 - [What the system does](#what-the-system-does)
 - [Why this is the goal](#why-this-is-the-goal)
+- [What one person becomes](#what-one-person-becomes)
 - [How we get there](#how-we-get-there)
 
 ## The one-sentence vision
@@ -88,6 +89,38 @@ starting runs, and shepherding cards across the board. Loop-driven development
 automates that orchestration too. The human's role collapses to the two
 decisions only a human should own, **what to build** and **what to ship**, and
 the machine handles the mechanical flow.
+
+## What one person becomes
+
+Absorbing the mechanics of delivery does one thing for the human: it raises the
+size of problem one person can take on.
+
+Autonomy has a scope, and Team's is contained today. A groomed ticket, one
+repository, a context that already exists: the problem arrives framed and the
+machine carries it to a PR. Each rung above that widens the frame. What the
+human hands over stops being a ticket and becomes a problem statement, then an
+outcome to move. The framing, the context, the decisions, and the verification
+that used to arrive *with* the ticket become things the system produces on the
+way.
+
+| Rung | The human supplies | Team supplies |
+|------|--------------------|---------------|
+| **Contained scope** | a groomed ticket in an established context | design, implementation, review, a PR |
+| **Defined problem** | a problem inside a known context | the items, their order, and the delivery of each |
+| **Ambiguous problem** | an outcome worth moving | the framing, the context, the decisions, the systems, and the proof the outcome moved |
+
+The rungs extend the board in both directions. Rung two adds the work before the
+Backlog, turning a problem into ready items — the `Backlog → Ready` step
+[`/groom-backlog`](skills.md#groom-backlog) already performs. Rung three adds
+the work after Done: deciding what to measure, then reporting whether the
+shipped thing moved it.
+
+At the top rung a builder is a one-person fleet, carrying company-significant
+work from problem definition through measured outcomes: creating the context
+others work from, making the decisions, building the systems, and running the
+verification, at a scope that used to require a team.
+
+**Team is the tool that lets one person scale as a team.**
 
 ## How we get there
 


### PR DESCRIPTION
## Why

Two gaps in how Team explains itself.

`docs/vision.md` describes the human's role collapsing to two decisions — what to build and what to ship — but never says what that collapse buys. A reader finishes it knowing the human does less, not knowing the human takes on more. Autonomy has a scope, and the scope grows.

`README.md` and the docs home open on a category description, "autonomous feature delivery for Claude Code." That states what Team is and not what it does for the person installing it, and it cedes the position to every other tool that also delivers features autonomously. The claim Team can actually defend is a role change: you arrive as the tech lead of a fleet that does not sleep. What makes that claim survivable is the part nobody else ships — the governance that keeps an unattended middle trustworthy.

## What changes

**`docs/vision.md`** gains `## What one person becomes`, between "Why this is the goal" and "How we get there":

- A three-rung table — contained scope, defined problem, ambiguous problem — stating what the human supplies and what Team supplies at each.
- How the rungs extend the existing board diagram in both directions: rung two is the work before the Backlog, which `/groom-backlog` already does; rung three is the work after Done, deciding what to measure and reporting whether it moved.
- The end state at the top rung: a builder as a one-person fleet, working at a scope that used to require a team.

**`README.md` and `docs/index.md`** lead with the role instead of the category, and both gain a governance-stack table mapping each rule a trustworthy team runs on to the mechanism that enforces it here: reviewers with no write tool and `plan` mode, a review loop that ends on agreement rather than on a count, reviewers who read a spec written before the code existed, a design review that hard-gates, an orchestrator that cannot escalate mid-run, and every decision on disk under `docs/plans/<id>/`. Every row is a claim already pinned by a test or an invariant in `AGENTS.md`. The docs home also links out to the vision's ladder.

## Test plan

- `bun test` — 1892 pass, 4 skip, 0 fail, on both commits.
- The new prose clears the L2 forbidden-pattern sweep in `tests/protocol.test.ts`: the governance table describes the review loop without naming a round or revision count.
- Anchors and links checked by hand — the new Contents entry matches its heading, and `skills.md#groom-backlog`, `ethos.md`, and `vision.md` are targets already cited elsewhere in the same files.

Docs-only, so no version bump and no changelog entry per the runtime-vs-development split in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
