### PR TITLE
docs(skills): one sentence plus Mentions per catalog entry

### DIFF
--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,7 +82,7 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, and a `**Mentions:**` list. Rewriting a `description` updates that entry in the same commit.
+- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by a `**Mentions:**` list only when the skill's own `.md` files name at least one other skill; omit the block entirely when they name none. Rewriting a `description` updates that entry in the same commit.
 - Sort `Mentions:` in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`), and list every backticked skill name in any `.md` under `skills/<name>/`, references and prompt templates included. `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -81,7 +81,9 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 ## Integrate
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
-- Add methodology and principles to `docs/skills.md`; collapse consumer restatements to the bare skill name.
+- Add methodology and principles to `docs/skills.md`.
+- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, and a `**Mentions:**` list. Rewriting a `description` updates that entry in the same commit.
+- Sort `Mentions:` in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`), and list every backticked skill name in any `.md` under `skills/<name>/`, references and prompt templates included. `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.
 - For runtime behavior, update `CHANGELOG.md` under `Unreleased`; version only at land time.
@@ -91,7 +93,7 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 Read `docs/testing.md` before changing tests. Convert exact-heading or sentence assertions to command, number, name, path, ordering, occurrence, or behavioral checks. Run the narrowest relevant tests, then:
 
 ```bash
-bun test tests/skill-budget.test.ts tests/skill-openai-yaml.test.ts
+bun test tests/skill-budget.test.ts tests/skill-openai-yaml.test.ts tests/docs-skills-catalog.test.ts
 bash .claude/scripts/check-discovery-consistency.sh
 bun run typecheck
 bun test

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -813,8 +813,8 @@ cross-links in the orchestrator's prose, not a parent loading the skill as
 a building block. The two front-door pairs are how a composed methodology
 keeps a user-facing entry point without becoming one.)
 
-For the full per-skill reference (all skills, their arguments,
-consumers, and behaviors), see [skills.md](skills.md).
+For the full per-skill reference (all skills, each with the skills it
+mentions), see [skills.md](skills.md).
 
 ### Design guidelines
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,6 @@ script/dev-uninstall antigravity
 - **[Vision](vision.md)**: the loop-driven end state Team builds toward.
 - **[Ethos](ethos.md)**: the principles that make the autonomous middle trustworthy.
 - **[Architecture](architecture.md)**: full design, artifact frontmatter, phase-inference rules.
-- **[Skills](skills.md)**: all skills, their arguments, consumers, and behaviors.
+- **[Skills](skills.md)**: all skills, each with the skills it mentions.
 - **[Cross-host portability](cross-host-portability.md)**: the capability matrix for Codex CLI, the Antigravity CLI host facts, and the chosen portability strategy.
 - **[GitHub repository](https://github.com/bostonaholic/team)**: source, agents, skills.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: "The Team plugin's skills: pipeline entry-point slash commands, standalone utilities (shipit, pr-open-comments, pr-watch-as-author, pr-watch-as-reviewer, groom-backlog, pr-cleanup, pr-verify, pr-rebase, reflect, why, how), and methodology skills loaded by agents, with purpose, arguments, consumers, and behaviors."
+description: "The Team plugin's skills: pipeline entry-point slash commands, standalone utilities (shipit, pr-open-comments, pr-watch-as-author, pr-watch-as-reviewer, groom-backlog, pr-cleanup, pr-verify, pr-rebase, reflect, why, how), and methodology skills loaded by agents, each with the skills it mentions."
 audience: [user, developer]
 nav_order: 5
 nav_label: skills
@@ -16,268 +16,155 @@ nav_label: skills
 > This page is a hand-maintained reference. When it disagrees with a
 > `SKILL.md`, the `SKILL.md` wins.
 
-## Contents
-
-- [Two flavors of skill](#two-flavors-of-skill)
-- [Entry-point skills](#entry-point-skills)
-- [Standalone utilities](#standalone-utilities)
-- [Methodology skills](#methodology-skills)
-- [Skill ↔ agent ↔ phase](#skill--agent--phase)
-- [Name-collision pairs](#name-collision-pairs)
-- [See also](#see-also)
-
-## Two flavors of skill
-
-Every skill lives under `skills/<name>/SKILL.md` as YAML frontmatter plus a
-Markdown body. A single frontmatter field, `argument-hint`, sorts the
-catalog into two flavors:
-
-Frontmatter descriptions provide routing only: what a skill does and when to
-load or invoke it. Commands, numbers, names, paths, and hard rules remain in
-the skill body.
-
-- **Entry-point skills carry `argument-hint`.** Claude Code registers them
-  as slash commands (`/team`, `/team-research`, and so on). The
-  `argument-hint` documents what to pass as `$ARGUMENTS`.
-- **Methodology skills omit `argument-hint`.** They are never invoked
-  directly. Agents load them through one
-  of two mechanisms: a `skills:`
-  YAML **block** list in the agent's frontmatter, one indented `- <name>`
-  per line (e.g., `agents/design-author.md` declares a block list of four
-  names — `product-thinking`, `principle-progress-tracking`,
-  `authoring-designs`, `writing-prose`), or an inline
-  prose load
-  instruction in the agent body (e.g., `Load skills/<name>/SKILL.md for
-  …`).
-
-That `argument-hint` marker is the whole flavor distinction. Most
-`argument-hint` skills drive a QRSPI phase, but some (`shipit`,
-`pr-open-comments`, `pr-watch-as-author`, `pr-watch-as-reviewer`, `groom-backlog`,
-`pr-cleanup`, `pr-verify`, `pr-rebase`, `reflect`, `why`, and `how`) are
-standalone utilities.
-They land a
-reviewed PR, triage its unresolved review feedback, and watch it for new
-feedback. They also watch it as a reviewer, approve when your threads
-resolve, groom a project backlog, tear down branch state after a PR is
-finished, verify a PR's test plan, rebase a branch onto its base
-without changing what it does, mine a finished session for the
-learnings worth keeping, investigate the design rationale behind code,
-and explain how a subsystem works.
-None is a pipeline phase.
-
-For *why* the system is shaped this way (the three-tier argument-discovery
-design, the shared helper contract, and the skill load limits),
-see [architecture.md §6](architecture.md#6-skills). The architecture page
-explains the design. The full per-skill enumeration now lives here.
+Each entry is one sentence, copied from that skill's frontmatter
+`description`. A `**Mentions:**` list follows it when the skill's own `.md`
+files name other skills — a load, a citation, and a passing mention alike.
+For what separates a load from a citation, and for how a skill is loaded at
+all, see [architecture.md §6](architecture.md#6-skills).
 
 ## Entry-point skills
 
-Each entry-point skill either kicks off a full run (`team`, `team-fix`) or
-drives one phase of the QRSPI pipeline. The phases are Worktree, Question,
-Research, Design, Structure, Plan, Implement, and PR. What ties most of
-them together is a shared argument-resolution chain and a common body
-template.
-
-The **downstream phase skills**, `team-question` through `team-pr`, plus
-the optional `eng-design-doc-review`, share a consistent body template. It
-holds an `## Input` section that describes `$ARGUMENTS` and an
-`## Execution` section of numbered steps. The final operational section
-states what to report and the `Next: run /team-…` handoff. The `team`
-orchestrator does not follow that template. It walks a Phase Loop instead
-(see its entry below).
-
-**Shared argument resolution (three-tier discovery).** Eight of these
-skills consume an artifact directory rather than a free-form description:
-`team-research`, `team-design`, `team-structure`, `team-plan`,
-`team-worktree`, `team-implement`, `team-pr`, and `eng-design-doc-review`.
-For all eight, the `docs/plans/<id>/` argument is **optional** and resolves
-through the same three-tier chain:
-
-1. **Tier 1: explicit `$ARGUMENTS`.** If you pass a directory path, it is
-   used directly.
-2. **Tier 2: newest-mtime convention discovery.** With no argument, the
-   shared `skills/team/discover-topic.sh` helper scans `docs/plans/` for the
-   most recently modified topic directory that holds the predecessor artifact
-   it needs. `team-structure` also requires a passing design review.
-3. **Tier 3: fallback.** Empty helper output activates the consumer's existing
-   fallback: seven skills use `AskUserQuestion`; `team-pr` checks the current
-   branch's standalone work instead.
-
-The entries below say "resolves `$ARGUMENTS` through the shared three-tier
-chain above" instead of repeating these tiers. The two skills that take a
-free-form description (`team`, `team-question`, `team-fix`) state their own
-argument shape.
+Each carries `argument-hint`, so it is a slash command, and each either kicks off a
+full run or drives one phase of the QRSPI pipeline.
 
 ### [team](https://github.com/bostonaholic/team/blob/main/skills/team/SKILL.md)
 
-- **Purpose:** Run the full eight-phase QRSPI pipeline end to end, from a
-  raw request to an opened pull request.
-- **`$ARGUMENTS`:** `<ticket id, issue URL, or feature description>`.
-- **Phase:** Drives all phases (Worktree → Question → Research → Design →
-  Structure → Plan → Implement → PR).
-- **Key behaviors:** Walks a linear Phase Loop, dispatching the specialist
-  agent(s) for each phase per its phase table, then running that phase's
-  gate before advancing. Enforces the adversarial design-review gate
-  (Design)
-  and the aggregate five-reviewer review gate during Implement. That
-  aggregate gate sorts every finding into Blocking / Major / Minor-and-below
-  tiers and auto-loops on any Blocking or Major (the no-consult rule: the
-  user is never asked about any finding mid-run), recording the remaining
-  Minor-and-below findings in the PR body's `## Review notes`. The
-  cross-model pass runs
-  before every design-review round,
-  feeding `cross-model-notes.md` and `cross-model-raw.md`. Its
-  body is organized as `## Input`,
-  `## Setup`, `## The Phase Loop`, `## Gate Handling`, and `## Rules`,
-  not the downstream Input / Execution template.
+Runs the 8-phase QRSPI feature pipeline.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `changelog`
+- `cross-model-review`
+- `principle-deep-agents-narrow-seams`
+- `principle-fail-closed`
+- `principle-files-are-the-contract`
+- `principle-idempotent-reruns`
+- `principle-progress-tracking`
+- `qrspi-workflow`
+- `review-severity-tiers`
+- `reviewing-designs`
+- `running-quality-checks`
+- `team-implement`
+- `team-pr`
+- `team-worktree`
+- `tracking-tickets`
+- `worktree-isolation`
 
 ### [team-question](https://github.com/bostonaholic/team/blob/main/skills/team-question/SKILL.md)
 
-- **Purpose:** Decompose a raw intent into a task statement plus a neutral
-  question set, producing `1-task.md` and `2-questions.md`.
-- **`$ARGUMENTS`:** `<ticket id, issue URL, or task description>`.
-- **Phase:** Question (the pipeline's first phase).
-- **Key behaviors:** The only step that sees your original description. It
-  emits the neutral `2-questions.md` so the downstream research sees only the
-  questions, not your task framing.
+Decomposes a feature into task and question artifacts.
+
+**Mentions:**
+
+- `decomposing-intent`
+- `product-requirements-doc`
+- `qrspi-workflow`
 
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
-- **Purpose:** Run isolated codebase research against the neutral question set.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Research (isolated).
-- **Key behaviors:** Reads only `2-questions.md`, never the task, so the
-  research carries no opinion-bias. Writes `5-research.md`.
+Researches a codebase area before changes.
+
+**Mentions:**
+
+- `team`
 
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
-- **Purpose:** Draft the alignment doc and run the adversarial design
-  review that gates advancement.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Design (design review).
-- **Key behaviors:** Dispatches the design-author to write a ~200-line
-  `6-design.md`. The design-author resolves its own open questions as
-  recorded assumptions. The skill then runs the adversarial design-review
-  loop (`design-review-<n>.md`, where APPROVE and COMMENT advance).
-  The cross-model pass
-  runs before every design-review round,
-  feeding `cross-model-notes.md` and `cross-model-raw.md`.
+Drafts and adversarially reviews a design.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `cross-model-review`
+- `principle-fail-closed`
+- `principle-idempotent-reruns`
+- `reviewing-designs`
+- `team`
 
 ### [team-structure](https://github.com/bostonaholic/team/blob/main/skills/team-structure/SKILL.md)
 
-- **Purpose:** Break the reviewed design into vertical slices with
-  per-slice verification checkpoints.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Structure (autonomous, no gate).
-- **Key behaviors:** Produces the ~2-page `7-structure.md`, then advances
-  to PLAN automatically.
+Breaks a reviewed design into verified slices.
+
+**Mentions:**
+
+- `principle-fail-closed`
+- `team`
 
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
-- **Purpose:** Turn the structure into a tactical, file-level
-  implementation plan.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Plan.
-- **Key behaviors:** Writes `8-plan.md` for the implementer. The plan is a
-  tactical artifact, not a human-reviewed gate.
+Produces the tactical implementation plan.
+
+**Mentions:**
+
+- `team`
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
-- **Purpose:** Prepare an isolated git worktree. In a full `/team` run this
-  is the **leading** phase, and it runs before QUESTION. `docs/plans/<id>/`
-  is thus authored inside the worktree, and the home checkout's
-  `git status` stays clean for the whole run.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Worktree (the first phase).
-- **Key behaviors:** Creates the branch and home worktree first, then
-  authors `docs/plans/<id>/` inside it so implementation, and every prior
-  phase's artifacts, never touch the main checkout. Loads
-  `worktree-isolation` for the single- and multi-repo topology. The
-  confirmation dialog fires only on standalone invocation, because a full
-  `/team` run creates worktrees without a pause. Multi-repo creation
-  refuses any repo path outside the home repo's sibling set (realpath
-  containment).
+Prepares isolated git worktrees.
+
+**Mentions:**
+
+- `qrspi-workflow`
+- `team`
+- `worktree-isolation`
 
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
-- **Purpose:** Implement the plan. Write tests first, work slice by slice,
-  then run the adversarial reviewer loop.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Implement.
-- **Key behaviors:** Runs the test-first → slice-execution → five-reviewer
-  verify sub-pipeline. The verify loop sorts findings into Blocking / Major
-  / Minor-and-below tiers. While any Blocking or Major remains it
-  re-dispatches the implementer automatically without consulting the user
-  (the no-consult rule), until no Blocking or Major finding remains.
-  Minor-and-below findings are recorded in the PR body's `## Review notes`
-  once Blocking and Major are clean, and never surfaced mid-run.
-- **Standalone Mode:** Invoked with no resolvable directory, it bootstraps
-  the missing upstream artifacts inline rather than hard-erroring.
+Executes and verifies implementation slices.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `principle-progress-tracking`
+- `review-severity-tiers`
+- `running-quality-checks`
+- `team`
+- `team-pr`
 
 ### [team-pr](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md)
 
-- **Purpose:** Update the changelog, commit, and open the pull request.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** PR (the pipeline's final phase).
-- **Key behaviors:** Loads `git-commit` for commit discipline and
-  `changelog` for the changelog update. Adds a PR body from its template,
-  held to the `writing-prose` prose bar: the body addresses one busy reader
-  making one decision, so `## Summary` opens with the recommendation or the
-  observable outcome rather than a sentence describing the PR.
-  Renders a conditional `## Screenshots` section from ux-reviewer's capture
-  manifest (`docs/plans/<id>/screenshots/manifest.md`) and uploads the PNGs
-  through GitHub's user-attachments pipeline so they render inline. Any
-  capture or upload failure degrades to a visible note with local paths,
-  and the PR always opens. Leaves the worktree in place after opening the
-  PR so you can iterate. Teardown waits until the PR merges or you ask.
-  The final report suggests arming `/pr-watch-as-author` once the PR is ready
-  for review.
-- **Standalone Mode:** Invoked with no resolvable directory, it bootstraps
-  the missing upstream artifacts inline rather than hard-erroring.
+Opens a pull request after verification.
+
+**Mentions:**
+
+- `changelog`
+- `git-commit`
+- `principle-optimization-never-dependency`
+- `team`
+- `tracking-tickets`
+- `verifying-ux`
+- `worktree-isolation`
+- `writing-prose`
 
 ### [team-fix](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md)
 
-- **Purpose:** Run a compressed bug-fix pipeline that skips the QRSPI
-  ceremony.
-- **`$ARGUMENTS`:** `<ticket id, issue URL, or bug description>`.
-- **Phase:** Standalone fix flow (not a QRSPI phase). Runs the compressed
-  pipeline `WORKTREE → REPRODUCE → RED → GREEN → VERIFY → SHIP`.
-- **Key behaviors:** Loads `test-driven-bug-fix` for reproduce-first,
-  red-green discipline: a failing test that reproduces the bug, then the
-  fix that turns it green. The leading WORKTREE phase is the pipeline's one
-  hard gate: a documented branch-gate block resolves the default branch and
-  the fix never commits to it. A non-default branch is reused in place;
-  otherwise the run isolates into a `<id>` worktree, and a worktree that
-  cannot be created degrades to a plain `<id>` branch rather than to the
-  default branch. Ship re-asserts the gate before it pushes.
+Runs the compressed bug-fix pipeline.
+
+**Mentions:**
+
+- `principle-explicit-intent`
+- `principle-fix-root-causes`
+- `principle-progress-tracking`
+- `systematic-debugging`
+- `team-worktree`
+- `test-driven-bug-fix`
+- `tracking-tickets`
+- `why`
+- `worktree-isolation`
 
 ### [eng-design-doc-review](https://github.com/bostonaholic/team/blob/main/skills/eng-design-doc-review/SKILL.md)
 
-- **Purpose:** Adversarially audit `6-design.md` with fresh context. It is
-  the front door over the `reviewing-designs` brief, which the pipeline's
-  DESIGN review gate loads directly. Standalone invocation remains
-  available.
-- **`$ARGUMENTS`:** `[docs/plans/<id>/]` is optional. It resolves through
-  the shared three-tier chain above.
-- **Phase:** Design (front door over the `reviewing-designs` brief) +
-  standalone audit.
-- **Key behaviors:** Loads the `reviewing-designs` brief and dispatches it
-  to the built-in read-only `Explore` subagent (not the `design-author`
-  agent), with the artifact directory substituted, so the audit reads the
-  design with fresh eyes. That subagent loads four methodology skills as
-  its review criteria
-  (`technical-design-doc`, `reviewing-code`, `engineering-standards`, and
-  `documenting-decisions`), which makes this one more consumer of all
-  four, plus a conditional fifth — `cross-model-review`, loaded only when
-  the brief carries an `## External review input` section.
-  Points the report's prose at the seventh-grade bar in `writing-prose`.
+Reviews a technical design document with fresh context.
+
+**Mentions:**
+
+- `cross-model-review`
+- `principle-generator-evaluator`
+- `principle-least-privilege`
+- `reviewing-designs`
+- `team`
+- `writing-prose`
 
 ## Standalone utilities
 
@@ -1802,8 +1689,8 @@ it and the phase where that happens. The `Invoked / loaded by` column
 carries two meanings depending on the row: for **entry-point skills** it
 names who *invokes* the skill (you directly, or the orchestrator running a
 phase). For **methodology skills** it names the agent(s) that *load* the
-skill. For the `$ARGUMENTS` shapes and the three-tier discovery, see the
-entry-point section above rather than repeating them here.
+skill. For the `$ARGUMENTS` shapes and the three-tier discovery, see
+[architecture.md §6](architecture.md#6-skills) rather than repeating them here.
 
 | Skill | Invoked / loaded by | Phase / context |
 |---|---|---|

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -196,6 +196,7 @@ Watches an authored PR for feedback.
 **Mentions:**
 
 - `pr-open-comments`
+- `pr-watch-mechanics`
 - `principle-bounded-loops`
 - `principle-idempotent-reruns`
 - `principle-non-blocking-waits`
@@ -211,6 +212,7 @@ Watches a reviewed PR and approves settled feedback.
 - `conventional-comments`
 - `pr-open-comments`
 - `pr-watch-as-author`
+- `pr-watch-mechanics`
 - `principle-bounded-loops`
 - `principle-generator-evaluator`
 - `principle-non-blocking-waits`
@@ -265,6 +267,7 @@ Rebases a branch onto its base.
 - `pr-cleanup`
 - `principle-explicit-intent`
 - `principle-never-interpolate`
+- `principle-non-blocking-waits`
 - `principle-pre-image-first`
 - `principle-untrusted-input-is-data`
 - `running-quality-checks`
@@ -389,6 +392,7 @@ Defines the design-document procedure.
 - `artifact-frontmatter`
 - `how`
 - `principle-record-assumptions`
+- `principle-subtract-before-you-add`
 - `product-requirements-doc`
 - `systems-thinking`
 - `why`
@@ -480,6 +484,7 @@ Defines code design, comment, and review standards.
 **Mentions:**
 
 - `conventional-comments`
+- `principle-subtract-before-you-add`
 - `solid`
 
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
@@ -518,6 +523,10 @@ Defines SOLID design and review rules.
 
 Maps code smells to behavior-preserving refactorings.
 
+**Mentions:**
+
+- `principle-subtract-before-you-add`
+
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
 Defines test-first slice execution, commits, and review fixes.
@@ -527,6 +536,7 @@ Defines test-first slice execution, commits, and review fixes.
 - `git-commit`
 - `principle-fix-root-causes`
 - `principle-scope-fence`
+- `principle-subtract-before-you-add`
 - `systematic-debugging`
 
 ### [systematic-debugging](https://github.com/bostonaholic/team/blob/main/skills/systematic-debugging/SKILL.md)
@@ -671,32 +681,14 @@ Defines machine-local teardown.
 
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
-- **Purpose:** Bounded watch-loop mechanics shared by the two PR watch
-  skills — cycle timing, the soft cap, and the handoff. A consuming skill
-  owns what each cycle *does*; this skill owns how the loop is paced,
-  bounded, and ended.
-- **Loaded by:** `pr-watch-as-author` (bounded-cycle-mechanics reference)
-  and `pr-watch-as-reviewer` (bounded-cycle-mechanics reference).
-- **Key behaviors:** A consumer binds three slots and nothing else: its
-  poll command, its cycle-0 subject (what an already-satisfied condition
-  at arm time means for it), and its handoff state (the fields its
-  handoff prints). Cycle 0 polls immediately. Each later cycle is one
-  backgrounded Bash call — `sleep 1860; <the poll command>`, run with
-  `run_in_background: true` per `principle-non-blocking-waits` — so the
-  cycle costs one turn. **Soft cap: 3 cycles (~90 minutes).** At cycle 3,
-  if nothing has stopped the loop already, the interactive session ends
-  rather than sleeping again, printing a handoff — the consumer's handoff
-  state plus the exact command to resume the watch as the scheduled
-  `~/dotfiles/bin/pr-watch.sh` launchd job. Re-arming the interactive loop
-  happens only on explicit user request; the loop never re-arms itself.
-  The bound is the invariant, not the interval, per
-  `principle-bounded-loops`: a harness with no background execution
-  chunks the wait into foreground sleeps under its own ceiling, holding
-  the cycle count. Three stop conditions are loop mechanics this skill
-  owns, each reported by name — user interrupt, the 3-cycle soft cap, and
-  3 consecutive poll failures — and a consumer adds its own terminal
-  conditions (an approval, a merge or close, a gate-specific state)
-  without restating these three.
+Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
+
+**Mentions:**
+
+- `pr-watch-as-author`
+- `pr-watch-as-reviewer`
+- `principle-bounded-loops`
+- `principle-non-blocking-waits`
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
@@ -817,22 +809,11 @@ Requires skipped work to be reported explicitly.
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
-- **Purpose:** Remove complexity first, then build on the simpler base;
-  leave the design simpler than you found it.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `engineering-standards`, `implementing-slices`,
-  `refactoring-to-patterns`, and `authoring-designs`. No agent preloads
-  it.
-- **Key behaviors:** Removal is sequenced before construction: what a
-  change replaces or leaves unused goes first, then the addition lands
-  on the smaller base. Cut before you polish. Design for observed usage:
-  no validator, parser, guard, or option beyond what the design, plan,
-  or tests demand, because an out-of-spec feature drags its own guards
-  behind it. Prompts and skills follow the same rule: redundant
-  instructions go, and a reference with no novel content is deleted
-  rather than left as a stub. Removals stay inside the approved scope
-  per `principle-scope-fence`; a wider removal is recorded as an
-  opportunity, never performed unasked.
+Requires removal before addition.
+
+**Mentions:**
+
+- `principle-scope-fence`
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -322,555 +322,352 @@ Reviews a diff with fresh context.
 
 ## Methodology skills
 
-The methodology skills carry no `argument-hint` and are never invoked
-directly. A methodology that also wants a user-facing command does not
-become the exception: it stays `user-invocable: false` and a separate
-front-door skill carries the command. The front door is catalogued as a
-command — under [Entry-point skills](#entry-point-skills) or
-[Standalone utilities](#standalone-utilities), whichever fits its role —
-while the methodology stays in this section. Two pairs hold that shape:
-`reviewing-code` with its front door `code-review`, catalogued under
-Standalone utilities, and `reviewing-designs` with its front door
-`eng-design-doc-review`, catalogued under Entry-point skills (see
-[architecture.md](architecture.md#methodology-skills-loaded-by-agents-not-directly-invoked)).
-Agents load them through one of two mechanisms. The first is a
-`skills:` YAML list in the agent's frontmatter. The second is an inline
-prose load instruction in the agent body. See the "Two flavors of skill"
-section above. The "Loaded by" line for each skill names its consumers from
-the per-agent load manifest. Three names is what an agent gets
-without argument, and every name in the list counts — a `principle-`
-skill and the agent's own extracted procedure skill alike. An agent that
-lists more than three carries one recorded reason naming that count (see
-[architecture.md](architecture.md#design-guidelines)).
+These carry no `argument-hint`. They are never invoked directly; agents load
+them.
 
 ### [qrspi-workflow](https://github.com/bostonaholic/team/blob/main/skills/qrspi-workflow/SKILL.md)
 
-- **Purpose:** Phase discipline: the phase sequence, gates, and
-  anti-patterns every phase follows.
-- **Loaded by:** orchestrator skills.
-- **Key behaviors:** The structural backbone of the pipeline: defines the
-  phase sequence, the gate mechanics (severity tiers and the no-consult
-  rule for the aggregate review gate), the phase-inference table, and an
-  anti-patterns catalog. The artifact/frontmatter schema it once carried is
-  canonical in `artifact-frontmatter`. This skill keeps pointers.
+Defines QRSPI phases, artifacts, gates, and state transitions.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `principle-blind-the-investigator`
+- `principle-files-are-the-contract`
+- `principle-human-owns-the-ends`
+- `principle-mechanical-gates`
+- `principle-scope-fence`
+- `principle-single-source-of-truth`
+- `review-severity-tiers`
+- `slicing-work`
+- `team`
+- `worktree-isolation`
 
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
-- **Purpose:** The artifact schema contract for `docs/plans/<id>/`.
-- **Loaded by:** orchestrator skills and artifact-authoring agents
-  just-in-time through pointers (qrspi-workflow, decomposing-intent,
-  `team`). No agent preloads it.
-- **Key behaviors:** Carries the artifact inventory and `<id>` forms, plus
-  the YAML frontmatter schema and phase enum. It also carries the
-  `4-repos.md` and `3-prd.md` schemas, the topic-consistency invariant, the
-  `ticketId` scope rule, and the design-review record mechanics
-  (`design-review-<n>.md` verdicts). Defers to
-  `hooks/session-start-recover.mjs` as the executable canon for
-  `ID_RE`/`PHASE_FILES` rather than forking them.
+Defines pipeline artifact schemas.
+
+**Mentions:**
+
+- `principle-files-are-the-contract`
+- `principle-single-source-of-truth`
+- `product-requirements-doc`
+- `qrspi-workflow`
+- `worktree-isolation`
 
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
-- **Purpose:** Codebase research contract for the Research phase.
-- **Loaded by:** researcher.
-- **Key behaviors:** Carries the investigation contract (every claim
-  cites code read in this run; cross-repo contracts are findings) and
-  the compressed research-report output format with its 100-line budget
-  (150 in multi-repo mode). How to investigate is left to the model.
-  The isolation stance itself (2-questions.md only,
-  never 1-task.md) stays in the researcher agent as identity.
+Defines evidence-only codebase research and `5-research.md`.
+
+**Mentions:**
+
+- `principle-blind-the-investigator`
+- `principle-evidence-over-assertion`
 
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
-- **Purpose:** File-location search strategy for the Research phase.
-- **Loaded by:** file-finder.
-- **Key behaviors:** Glob by naming convention, content search,
-  import/dependency tracing, directory exploration, and config/manifest
-  checks, scoped to the vocabulary in `2-questions.md`. Deliberately
-  self-contained: the file-finder runs on haiku, so the skill carries
-  everything inline with no cross-references.
+Locates files by naming, structure, and imports.
 
 ### [decomposing-intent](https://github.com/bostonaholic/team/blob/main/skills/decomposing-intent/SKILL.md)
 
-- **Purpose:** Artifact templates and decomposition procedure for the
-  Question phase.
-- **Loaded by:** questioner.
-- **Key behaviors:** Carries the `1-task.md` and `2-questions.md` body
-  templates, the topic-slug rules, and the process steps. It also carries
-  the multi-repo detection flow: an autonomous allowlist, sibling-directory
-  resolution with realpath containment, the loud single-repo fallback, and
-  the `4-repos.md` schema pointer. Conditionally loads
-  `product-requirements-doc` for vague, multi-story, cross-cutting, or
-  behavior-replacing requests, producing `3-prd.md` alongside `1-task.md`.
+Defines task and question artifacts plus multi-repo detection.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `principle-blind-the-investigator`
+- `principle-never-interpolate`
+- `principle-record-assumptions`
+- `product-requirements-doc`
 
 ### [authoring-designs](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md)
 
-- **Purpose:** Design-document authoring procedure for the Design phase.
-- **Loaded by:** design-author.
-- **Key behaviors:** Carries the repo-scope confirmation flow and the
-  autonomous open-questions resolution rule. Self-resolved choices land in
-  `## Decisions made`, marked "Assumption — chosen without user review". It
-  also carries the `6-design.md` document template with its six-category
-  edge-case walk. When `1-task.md` references a `3-prd.md`, reads it first and
-  honors its scope boundaries and acceptance criteria per
-  `product-requirements-doc`'s "Consuming a PRD downstream" section.
+Defines the design-document procedure.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `how`
+- `principle-record-assumptions`
+- `product-requirements-doc`
+- `systems-thinking`
+- `why`
+- `writing-prose`
 
 ### [slicing-work](https://github.com/bostonaholic/team/blob/main/skills/slicing-work/SKILL.md)
 
-- **Purpose:** Vertical-slice breakdown methodology for the Structure
-  phase.
-- **Loaded by:** structure-planner.
-- **Key behaviors:** Carries the vertical-slice rationale and the
-  `7-structure.md` document format. Its slicing rules are that every slice
-  ends in a passing test and holds 1-3 acceptance tests. Edge cases come
-  from the design, and slices order by user value. The skill also carries
-  the slicing heuristics: walking-skeleton first, and migrations alone are
-  never a slice.
+Defines vertical slices and verification checkpoints.
 
 ### [planning-implementation](https://github.com/bostonaholic/team/blob/main/skills/planning-implementation/SKILL.md)
 
-- **Purpose:** Tactical planning methodology for the Plan phase.
-- **Loaded by:** planner.
-- **Key behaviors:** Carries the `8-plan.md` document template that expands
-  each vertical slice into file-level steps with acceptance-test mappings.
-  Its tactical rules are one slice at a time, reuse over reinvention, and
-  under 300 lines. It also forbids implementation code, keeps slices
-  atomic, and matches test coverage to the structure.
+Defines the tactical plan schema.
 
 ### [reviewing-code](https://github.com/bostonaholic/team/blob/main/skills/reviewing-code/SKILL.md)
 
-- **Purpose:** Generator-evaluator separation and the gate verdict
-  vocabulary.
-- **Loaded by:** code-reviewer, security-reviewer, ux-reviewer,
-  technical-writer (4), the `code-review` front door on direct
-  invocation, and `reviewing-designs` as a review criterion.
-- **Key behaviors:** Defines how a reviewer reads with fresh eyes and emits
-  a structured verdict. Findings use the format defined in
-  `conventional-comments`; format follows the artifact, so the
-  ux-reviewer's live-verification report uses its own
-  Working/Broken/Could Improve format instead. The gate-type and severity-tier map lives in
-  `review-severity-tiers`. Points review-comment prose at the seventh-grade
-  bar in `writing-prose`. Carries the Comment red flags check with its
-  split severity regime. Ticket or plan references and TODO or FIXME
-  comments in code comments block on first occurrence. What-restating
-  comments, wordy comments, and commented-out code escalate from
-  `suggestion:` to `issue:` when repeated across the diff. The same style
-  tier covers the judgment classes. These are process narration, comments
-  far from the code they explain, and vague or speculative comments. They
-  also include duplicated documentation, fragile positional references,
-  stale comments, style divergence, and signature-restating doc comments.
-  A constraint-gated
-  missing-why finding is capped at `suggestion (non-blocking)` and never
-  forces a REQUEST CHANGES verdict. Also carries the
-  Code Reviewer inspection contract (the non-negotiable obligations —
-  done-criteria verification, the test run, the every-surface check — and
-  the unordered per-file coverage checklist). The security review
-  methodology lives in `reviewing-security`.
+Defines adversarial code review and evidence-based findings.
+
+**Mentions:**
+
+- `conventional-comments`
+- `cross-model-review`
+- `engineering-standards`
+- `principle-generator-evaluator`
+- `principle-least-privilege`
+- `principle-skip-loudly`
+- `review-severity-tiers`
+- `reviewing-security`
+- `solid`
+- `test-style`
+- `why`
+- `writing-prose`
 
 ### [reviewing-designs](https://github.com/bostonaholic/team/blob/main/skills/reviewing-designs/SKILL.md)
 
-- **Purpose:** The adversarial design-document review brief, held in one
-  place for every caller that dispatches it.
-- **Loaded by:** `team` and `team-design` at the DESIGN review gate, and
-  the `eng-design-doc-review` front door on direct invocation (3).
-- **Key behaviors:** The brief is **self-contained**: everything under its
-  `## Review brief` heading is the whole prompt a fresh-context read-only
-  `Explore` subagent receives, including the definition of `$ARGUMENTS`
-  the caller substitutes before dispatch. It names the four operating
-  manuals the reviewer loads (`technical-design-doc`, `reviewing-code`,
-  `engineering-standards`, `documenting-decisions`) plus
-  `cross-model-review` as a conditional fifth, walks an eight-step review
-  process, and ends on one of APPROVE, REQUEST CHANGES, or COMMENT.
-  Changing its headings, process, or verdict set is a pipeline change.
+Defines adversarial design review and verdicts.
+
+**Mentions:**
+
+- `conventional-comments`
+- `cross-model-review`
+- `documenting-decisions`
+- `eng-design-doc-review`
+- `engineering-standards`
+- `reviewing-code`
+- `team`
+- `technical-design-doc`
+- `writing-prose`
 
 ### [conventional-comments](https://github.com/bostonaholic/team/blob/main/skills/conventional-comments/SKILL.md)
 
-- **Purpose:** The Conventional Comments format for review findings.
-- **Loaded by:** code-reviewer, security-reviewer, and technical-writer
-  (3), the `reviewing-designs` subagent loads it for its findings. The
-  `ux-reviewer` does not preload it: its Working/Broken/Could Improve
-  report is not Conventional Comments.
-- **Key behaviors:** Carries the label and decoration syntax and the
-  code-directed comment style, which critiques the code and not the coder.
-  It also carries the three comment types (`issue`, `suggestion`, and
-  `nitpick`) with literal examples. Every comment includes a specific
-  `file:line` reference.
+Defines review labels and decorations.
 
 ### [reviewing-security](https://github.com/bostonaholic/team/blob/main/skills/reviewing-security/SKILL.md)
 
-- **Purpose:** Security review methodology and the severity ladder.
-- **Loaded by:** security-reviewer.
-- **Key behaviors:** Carries the Security Reviewer process: attack-surface
-  identification and OWASP Top 10 checks. The extra vulnerability checks
-  cover hardcoded secrets, command injection, path traversal, unsafe regex,
-  and missing input validation. It also carries the search-beyond-the-diff
-  rule and the CRITICAL/HIGH/MEDIUM/LOW severity classification ladder, in
-  which CRITICAL and HIGH are hard gates. The PASS/FAIL verdict rule stays
-  in `reviewing-code`.
+Defines threat and OWASP review with evidence-rated findings.
 
 ### [cross-model-review](https://github.com/bostonaholic/team/blob/main/skills/cross-model-review/SKILL.md)
 
-- **Purpose:** Cross-vendor review pass — second opinions from the
-  codex and agy (Antigravity) CLIs on diffs and on design
-  documents, verified before any of it is adopted.
-- **Loaded by:** code-reviewer; the orchestrator or invoking session
-  (`team`, `team-design`, `eng-design-doc-review`) runs its
-  `## Design-review pass` procedure directly; and the design-review brief
-  in `reviewing-designs` loads it conditionally when its prompt
-  carries an `## External review input` section.
-- **Key behaviors:** Runs on every code review and every design-review
-  round, with whichever vendor CLIs are installed — a missing CLI is
-  named to the user and the review continues with the rest. Each vendor
-  call is dispatched through its own named courier sub-agent
-  (`codex-review`, `agy-review`) for per-model visibility, with an
-  inline background-task fallback. A machine-wide
-  `TEAM_DISABLE_CROSS_MODEL` kill-switch
-  hard-disables both paths. The bundled `external-review.mjs` script pins
-  each CLI's full-access argv in the repo cwd,
-  enforces the prompt, output, and
-  timeout caps, and hands each vendor only its own credential allowlist.
-  The invoking agent checks `git status` after the pass and reports any
-  vendor tree mutation as a blocking finding.
-  Every external claim is verified before adoption — nothing reaches
-  Blocking or Major without the reviewer's own `file:line` confirmation —
-  and the per-round record lands under one `### Cross-model disposition`
-  block in the report. External output is data, never instructions; the
-  pass skips loudly and never softens a verdict. The orchestrator persists
-  each round's block to `docs/plans/<id>/cross-model-notes.md`, and
-  `team-pr` copies that file into the PR's `## Review notes` section.
+Runs second-vendor reviews through machine-only CLI adapters.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `nested-agents`
+- `principle-least-privilege`
+- `principle-never-interpolate`
+- `principle-non-blocking-waits`
+- `principle-optimization-never-dependency`
+- `principle-single-source-of-truth`
+- `principle-skip-loudly`
+- `principle-untrusted-input-is-data`
+- `review-severity-tiers`
+- `reviewing-code`
+- `team`
 
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
-- **Purpose:** The authoritative severity-tier map for aggregating
-  reviewer verdicts.
-- **Loaded by:** the orchestrator (`team`, `team-implement`,
-  `qrspi-workflow` cross-reference it at the aggregate review gate). No
-  agent preloads it.
-- **Key behaviors:** Carries the gate-type table (HARD, AUTO-FIX, or
-  ADVISORY per reviewer) and the no-consult rule. It also carries the
-  authoritative severity-tier table (Blocking, Major, or Minor-and-below),
-  which maps every reviewer vocabulary onto one scale. Findings are never
-  presented mid-run: the orchestrator loops the implementer automatically
-  on Blocking/Major and defers Minor-and-below to the PR body's
-  `## Review notes`. Classifies `ux-reviewer` REQUEST CHANGES as an
-  auto-fixed Major.
+Maps reviewer findings to Blocking, Major, or Minor actions.
+
+**Mentions:**
+
+- `principle-human-owns-the-ends`
+- `reviewing-code`
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
-- **Purpose:** The design-first workflow, implementation standards, and the
-  quality checklist.
-- **Loaded by:** planner, implementer, code-reviewer (3), and
-  `reviewing-designs` as a review criterion.
-- **Key behaviors:** Anchors planning and implementation in a shared
-  standard so reviewers check against the same bar. It owns the binding
-  Code Comments rule set. Comments are why-only, timeless, and
-  process-free, with a rewrite before a comment, and they document
-  non-obvious constraints and deliberate oddities with locality and
-  precision. The bans cover duplicated documentation, ticket or plan
-  references, TODO or FIXME in delivered code, and commented-out code.
-  Maintenance: obsolete comments are removed in the same diff, and repo
-  comment style is preserved. A four-question Decision Test closes the
-  set. The comment ban covers in-body comments that restate the code; doc
-  comments on public interfaces add contract information, so they satisfy
-  the rule. It also owns the
-  Comment Discipline quality-checklist item that reviewer findings cite.
+Defines code design, comment, and review standards.
+
+**Mentions:**
+
+- `conventional-comments`
+- `solid`
 
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
-- **Purpose:** Treat acceptance tests as the immutable scope fence.
-- **Loaded by:** test-architect, code-reviewer, and the orchestrator.
-- **Key behaviors:** Tests are written first and never edited to pass. The
-  implementation must satisfy them as the contract. Every new test must fail
-  with an assertion, never an error, and the project's static checks must pass
-  before handoff — a green suite does not imply a green type checker. The style
-  rules every acceptance test follows live in `test-style`.
+Defines acceptance tests as the implementation scope contract.
+
+**Mentions:**
+
+- `principle-mechanical-gates`
+- `principle-scope-fence`
+- `test-style`
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
-- **Purpose:** Test style rules and the flaky-test red-flag catalog.
-- **Loaded by:** test-architect and code-reviewer just-in-time, through
-  pointers from `test-first-development` and `reviewing-code` (no agent
-  preloads it).
-- **Key behaviors:** Carries the full style-rule set:
-  behavior-not-implementation, DAMP setup, narrow assertions, and
-  actionable failures. It also carries the deterministic-input rules
-  (control the clock, seed all randomness, own your state, impose order,
-  and keep hermetic boundaries) and the fidelity ladder. It holds the audit
-  checklist too, plus the single copy of the reviewer-facing flaky-test
-  red-flag catalog with its canonical time-bomb example pair. The
-  always-blocking severity regime for flaky flags stays in `reviewing-code`.
+Defines deterministic behavioral tests and flaky-test red flags.
+
+**Mentions:**
+
+- `reviewing-code`
+- `test-first-development`
 
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
-- **Purpose:** Reproduce-first, red-green bug discipline.
-- **Loaded by:** team-fix.
-- **Key behaviors:** Write a failing test that reproduces the bug, then make
-  it green. No fix lands without a reproducing test.
+Defines reproduce-red-green-refactor bug fixes.
+
+**Mentions:**
+
+- `principle-fix-root-causes`
+- `systematic-debugging`
 
 ### [solid](https://github.com/bostonaholic/team/blob/main/skills/solid/SKILL.md)
 
-- **Purpose:** The five object-oriented design principles.
-- **Loaded by:** implementer, code-reviewer (2). Cited by
-  `engineering-standards` and `reviewing-code`.
-- **Key behaviors:** SRP, OCP, LSP, ISP, and DIP as concrete checkpoints
-  for new code and review.
+Defines SOLID design and review rules.
 
 ### [refactoring-to-patterns](https://github.com/bostonaholic/team/blob/main/skills/refactoring-to-patterns/SKILL.md)
 
-- **Purpose:** Code smells and the safe transformations that resolve them
-  (Fowler).
-- **Loaded by:** implementer.
-- **Key behaviors:** Name the smell, apply the pattern in its own commit,
-  and keep tests green at every step.
+Maps code smells to behavior-preserving refactorings.
 
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
-- **Purpose:** Slice-by-slice execution procedure for the Implement phase.
-- **Loaded by:** implementer.
-- **Key behaviors:** Defines the implementer's two dispatch modes: initial,
-  and review-fix with typed failure classes. It defines the slice-execution
-  loop, in which the implementer implements the steps, runs the slice's
-  acceptance tests, commits atomically, and reports. It also defines TDD
-  discipline within a slice, blocker handling, and the implementer's own
-  scope-fence bounds (acceptance tests are immutable, file paths are
-  real); the plan-authorizes-exactly-what-it-names rule is consulted from
-  `principle-scope-fence`.
+Defines test-first slice execution, commits, and review fixes.
+
+**Mentions:**
+
+- `git-commit`
+- `principle-fix-root-causes`
+- `principle-scope-fence`
+- `systematic-debugging`
 
 ### [systematic-debugging](https://github.com/bostonaholic/team/blob/main/skills/systematic-debugging/SKILL.md)
 
-- **Purpose:** Evidence-first root-cause diagnosis.
-- **Loaded by:** the implementer's preloaded `implementing-slices` skill
-  carries an inline **conditional**
-  `Load skills/systematic-debugging/SKILL.md` directive, fired only on a
-  **non-obvious** mid-slice failure (it drills the Root Cause Analysis (5
-  Whys) chain before editing). For every other agent it remains
-  **advisory**: no static `Load skills/<name>/SKILL.md` instruction names
-  it. Those agents load it on demand when an investigation begins.
-- **Key behaviors:** Gather evidence before theorizing, then isolate the
-  root cause rather than patching symptoms.
+Defines reproduce, hypothesize, isolate, and fix workflow.
+
+**Mentions:**
+
+- `principle-fix-root-causes`
+- `test-driven-bug-fix`
+- `why`
 
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
-- **Purpose:** Mechanical verification procedure for the Implement phase's
-  verify gate.
-- **Loaded by:** verifier.
-- **Key behaviors:** Detect the checks the project configures in scripts,
-  Makefile targets, CI steps, and tool config. Run them fastest-first in
-  speed order: format, lint, typecheck, build, then test. Capture the exact
-  command and exit code as evidence, then derive a PASS/FAIL verdict. The
-  skill is deliberately self-contained. The verifier runs on haiku, so the
-  skill carries everything inline with no cross-references.
+Runs project-native tests, static checks, builds, and linters.
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
-- **Purpose:** Todo-first progress convention for multi-step procedures.
-- **Loaded by:** every multi-step agent (questioner, design-author,
-  structure-planner, planner, test-architect, implementer, code-reviewer,
-  security-reviewer, ux-reviewer, technical-writer, researcher, verifier);
-  consulted by citation from `team`, `team-implement`, and `team-fix`.
-- **Key behaviors:** A convention, not a gate: it produces no artifact and
-  blocks nothing. When a procedure has two or more steps, seed one todo
-  item per step before starting and mark each complete as you go. A
-  goals-and-constraints procedure seeds one item per natural unit of work
-  (a slice, a question, a finding), never one per sentence of guidance.
-  The orchestrator owns the phase ledger. An agent tracks its own
-  sub-steps in its own context and never merges them up.
+Requires one live ledger for ordered procedures.
+
+**Mentions:**
+
+- `qrspi-workflow`
+- `team-fix`
 
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
-- **Purpose:** Guardrails for the four `Agent`-tool holders that spawn
-  read-only nested sub-agents.
-- **Loaded by:** researcher, implementer, code-reviewer, security-reviewer
-  (4).
-- **Key behaviors:** Nesting is an optimization, never a dependency: if the
-  `Agent` tool is missing or a dispatch fails, the agent does the work
-  inline. Carries the fail-closed version gate (Claude Code ≥ 2.1.172), the
-  read-only default, and the depth budget. The per-agent caps follow. The
-  researcher fans out at most 4 isolation-preserving exploration scouts.
-  The implementer fans out at most 2 read-only scouts, overlapping the
-  next slice's scouting with the current slice's work. Scouts are
-  long-lived: a follow-up question inside a live scout's territory goes
-  to that scout over `SendMessage` instead of a cold respawn, under the
-  same caps and isolation invariant. The code-reviewer
-  and security-reviewer run the skeptic pass. In that pass, a fresh
-  sub-agent receives every hard-gate finding to refute, as a neutral
-  falsifiable claim. For a security finding, the claim is about
-  exploitability. Skeptics are deliberately one-shot — never a follow-up —
-  so each claim meets genuinely fresh context. Default-keep holds on
-  anything short of a verified refutation.
+Defines safe nested-agent dispatch and fallback.
+
+**Mentions:**
+
+- `cross-model-review`
+- `principle-blind-the-investigator`
+- `principle-deep-agents-narrow-seams`
+- `principle-fail-closed`
+- `principle-generator-evaluator`
+- `principle-optimization-never-dependency`
+- `principle-record-assumptions`
+- `systems-thinking`
 
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
-- **Purpose:** Creating and managing architecture decision records (ADRs).
-- **Loaded by:** planner and orchestrator (per the skill's own
-  self-description. no agent body carries an explicit
-  `Load skills/documenting-decisions/SKILL.md` instruction and no agent
-  declares it through `skills:` frontmatter), and `reviewing-designs` as
-  a review criterion.
-- **Key behaviors:** Capture the decision, its alternatives, and its
-  rationale so later readers understand the "why". Points ADR authors at
-  the seventh-grade prose bar in `writing-prose`.
+Defines ADR structure and lifecycle.
+
+**Mentions:**
+
+- `writing-prose`
 
 ### [technical-design-doc](https://github.com/bostonaholic/team/blob/main/skills/technical-design-doc/SKILL.md)
 
-- **Purpose:** Technical-design / architecture-doc methodology.
-- **Loaded by:** planner (per the skill's own self-description. The
-  `planner` agent body loads `engineering-standards` explicitly but does
-  not carry an explicit `Load skills/technical-design-doc/SKILL.md`
-  instruction), and `reviewing-designs` as a review criterion.
-- **Key behaviors:** Structures the design narrative: current state,
-  desired end state, patterns to follow, and trade-offs. Points design-doc
-  authors at the seventh-grade prose bar in `writing-prose`.
+Defines technical design sections and decision content.
+
+**Mentions:**
+
+- `writing-prose`
 
 ### [product-requirements-doc](https://github.com/bostonaholic/team/blob/main/skills/product-requirements-doc/SKILL.md)
 
-- **Purpose:** Optional product-requirements-document methodology.
-- **Loaded by:** questioner, through `decomposing-intent`'s conditional
-  load, which fires when the request is vague, multi-story, cross-cutting,
-  or replaces existing behavior. Also design-author, through
-  `authoring-designs`, when `1-task.md` references a `3-prd.md`, per the
-  skill's "Consuming a PRD downstream" section.
-- **Key behaviors:** Frames the problem, users, and success criteria when a
-  request warrants a PRD before design. The PRD lands at
-  `docs/plans/<id>/3-prd.md`, referenced from `1-task.md`. Points PRD authors
-  at the seventh-grade prose bar in `writing-prose`.
+Defines when and how to write `3-prd.md`.
+
+**Mentions:**
+
+- `writing-prose`
 
 ### [product-thinking](https://github.com/bostonaholic/team/blob/main/skills/product-thinking/SKILL.md)
 
-- **Purpose:** Product-need reasoning lens for "make something people
-  want", which sharpens framing, design, and slicing so the work serves real
-  users.
-- **Loaded by:** questioner, design-author, structure-planner.
-- **Key behaviors:** A reasoning lens, not a gate: it produces no artifact
-  of its own and blocks nothing. Four lenses (demand evidence, smallest
-  thing people want, named user, talk-to-users mindset) shape the
-  pre-implementation phases.
+Defines product-need lenses.
 
 ### [systems-thinking](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md)
 
-- **Purpose:** System-fit reasoning lens that weighs a change's blast radius
-  (callers, consumers, sibling implementations, conventions) rather than
-  only the diff in front of it.
-- **Loaded by:** researcher, structure-planner, and planner (frontmatter).
-  implementer, code-reviewer, ux-reviewer (inline). Cited by
-  authoring-designs and nested-agents.
-- **Key behaviors:** A reasoning lens, not a gate: it produces no artifact
-  of its own and blocks nothing. Four lenses (blast radius over diff
-  radius, callers and siblings first, conventions are contracts, leave the
-  system consistent) shape per-phase `## When ...` guidance. Reviews cite
-  the `System Fit` checklist item by name. On greenfield targets "none
-  found" is a complete answer.
+Defines system-boundary, feedback, and dependency analysis.
+
+**Mentions:**
+
+- `reviewing-code`
 
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
-- **Purpose:** Plain-language prose quality for authoring and review.
-- **Loaded by:** technical-writer, design-author.
-- **Key behaviors:** One document-level rule sits above the sentence rules,
-  drawn from Kenneth Roman and Joel Raphaelson's *Writing That Works*: a PR
-  description, a design summary, or a review comment addresses one busy
-  reader deciding one thing, so it leads with the recommendation, names the
-  action wanted, and cuts every sentence that describes the document. A
-  seventh-grade reading-level bar governs prose the agent writes as well as
-  prose it assesses: readable, plain language aimed at someone who has not
-  seen the code, clarity over cleverness.
-  ASD-STE100 rules run in two modes — strict for instruction text,
-  STE-flavored for descriptive prose — with three deltas (sentence cap,
-  form, conditional mood) and every ban list shared. A delete-list names
-  words to remove, never replace: marketing adjectives, modal hedges,
-  filler. A `## Self-lint` checklist runs on any governed text before it
-  is final. A bundled scorer, `ste-lint.mjs`, sits next to the skill file
-  and reports violations of the mechanical rules per 100 words. It gates
-  nothing. The technical-writer's review procedure that applies this
-  bar lives in `reviewing-documentation`.
+Defines plain-language prose rules.
+
+**Mentions:**
+
+- `conventional-comments`
+- `reviewing-documentation`
 
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
-- **Purpose:** Documentation-gap review methodology and the
-  REQUIRED/RECOMMENDED doc-change classification.
-- **Loaded by:** technical-writer.
-- **Key behaviors:** Carries the technical-writer's review procedure: it
-  applies the `writing-prose` principles to reviews. Those are to classify
-  by impact, name the failure mode, suggest the direction and not the
-  rewrite, and acknowledge what works. It also carries the
-  documentation-gap review process (inventory, impact analysis, and
-  cross-reference) and the REQUIRED/RECOMMENDED doc-change classification.
+Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
+
+**Mentions:**
+
+- `writing-prose`
 
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
-- **Purpose:** Live application verification procedure for the Implement
-  phase's UX gate.
-- **Loaded by:** ux-reviewer.
-- **Key behaviors:** Detect the project type: UI, API-only, or library.
-  Libraries skip live testing. Boot the application, then check routes and
-  endpoints with real `curl` requests, including error and edge cases.
-  Always stop the server when done.
+Defines live application and screenshot verification.
+
+**Mentions:**
+
+- `team-pr`
 
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
-- **Purpose:** Commit discipline: conventional commits, the 50/72 subject
-  and body rule, and atomic commits.
-- **Loaded by:** team-pr, and implementer (through `implementing-slices`,
-  at the atomic slice-commit step).
-- **Key behaviors:** One logical change per commit with a clear, scoped
-  message. Points commit-body prose at the seventh-grade bar in
-  `writing-prose`.
+Defines Conventional Commit subjects and safe commit procedure.
+
+**Mentions:**
+
+- `writing-prose`
 
 ### [changelog](https://github.com/bostonaholic/team/blob/main/skills/changelog/SKILL.md)
 
-- **Purpose:** Keep a Changelog methodology.
-- **Loaded by:** team, team-pr.
-- **Key behaviors:** Record user-facing changes under the standard
-  Added / Changed / Fixed headings before the PR opens. Points entry
-  authors at the seventh-grade prose bar in `writing-prose`.
+Defines Keep a Changelog updates.
+
+**Mentions:**
+
+- `writing-prose`
 
 ### [tracking-tickets](https://github.com/bostonaholic/team/blob/main/skills/tracking-tickets/SKILL.md)
 
-- **Purpose:** Ticket-lifecycle discipline for tracker-linked runs: the
-  in-progress / in-review timing, the conditional PR closing footer, and
-  the never-close-by-hand rule.
-- **Loaded by:** the PR-opening and pickup hosts just-in-time through
-  pointers (`team`, `team-pr`, `team-fix`). No agent preloads it.
-- **Key behaviors:** Every tracker interaction is best-effort,
-  tracker-agnostic, and never blocks the pipeline. A picked-up ticket moves
-  to in-progress as the run's first action. At PR open, a `Closes` footer
-  links the PR to the ticket as the final line of the PR body. The footer
-  is conditional on `ticketId`, and it is omitted when null, with no
-  placeholder. The interpretation rules are codified at the consumption
-  site. In multi-repo mode, only the home repo's PR carries the closing
-  keyword, and companions get a non-closing qualified reference. The ticket
-  moves to in-review only after someone marks the PR ready for review,
-  never while it is a draft. No one closes the ticket by hand, because the
-  link auto-closes it on merge.
+Defines tracker status transitions and closing rules.
 
 ### [worktree-isolation](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
 
-- **Purpose:** Worktree topology for single- and multi-repo work.
-- **Loaded by:** orchestrator (team, team-worktree).
-- **Key behaviors:** Set up isolated worktrees, so implementation never
-  touches the main checkout. Tear them down only after the PR merges, or on
-  explicit request. A branch thus stays available for iteration while its
-  PR is open. Teardown ends by loading `sweeping-local-state`, so a
-  database or container the worktree provisioned goes with it.
+Defines Team worktree creation, validation, and teardown.
+
+**Mentions:**
+
+- `pr-cleanup`
+- `sweeping-local-state`
+- `team-worktree`
 
 ### [sweeping-local-state](https://github.com/bostonaholic/team/blob/main/skills/sweeping-local-state/SKILL.md)
 
-- **Purpose:** Machine-local teardown for a merged PR, a closed PR, or a
-  completed review.
-- **Loaded by:** `pr-cleanup` (Mode A step 5, Mode B step 5) and
-  `worktree-isolation` (teardown step 8).
-- **Key behaviors:** Removes what git teardown never reaches — provisioned
-  databases, containers, queues, buckets, caches, and recorded temp-directory
-  scratch. It infers nothing: the repo declares its own teardown as one
-  command per line in a `.teamteardown` file at the repo root, and each line
-  runs verbatim with `TEAM_REPO_ROOT`, `TEAM_BRANCH`, and `TEAM_WORKTREE` in
-  its environment. **Only the copy committed to the default branch runs.** The
-  working tree's copy and the finished branch's copy are never read, so a pull
-  request cannot earn code execution on your machine by editing the file you
-  run after reviewing it. A declared line that fails is reported and the
-  remaining lines still run; nothing here blocks the caller's git teardown. A
-  temp path is deleted only when the run recorded it, and never through a
-  wildcard sweep of `$TMPDIR` — the names cannot distinguish a dead run's
-  directory from a live one's. A repo with no `.teamteardown` runs nothing and
-  is told so.
+Defines machine-local teardown.
+
+**Mentions:**
+
+- `pr-cleanup`
+- `principle-never-interpolate`
+- `principle-skip-loudly`
+- `worktree-isolation`
 
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
@@ -903,379 +700,120 @@ lists more than three carries one recorded reason naming that count (see
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
-- **Purpose:** Hand an investigator the question, never the wanted
-  answer — a helper that knows the conclusion anchors to it and verifies
-  nothing.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `qrspi-workflow`, `nested-agents`, `decomposing-intent`,
-  `researching-codebases`, and `why`. No agent preloads it.
-- **Key behaviors:** Research consumes neutral questions, never the task
-  framing; a missing piece of context surfaces as an open question, not a
-  guess at intent. The isolation extends downward: a scout's prompt
-  carries only verbatim question text and stated context. Verification
-  helpers get neutral, falsifiable claims with file:line — never the
-  verdict, severity, or reasoning. One fresh skeptic per claim, and any
-  leakage is a critical defect. The review-gate instance (fresh context,
-  no shared history) and the one-claim-one-fresh-judge rule are owned by
-  `principle-generator-evaluator`.
+Keeps desired outcomes out of research prompts.
+
+**Mentions:**
+
+- `principle-generator-evaluator`
 
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
-- **Purpose:** Every loop carries a declared cap, and hitting the cap is
-  a defined, loud, terminal outcome.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, and
-  `principle-non-blocking-waits`. No agent preloads it.
-- **Key behaviors:** Declare the bound with the loop: watch cycles,
-  retries, poll budgets, helpers in flight. Hitting the cap halts
-  terminally with everything unresolved reported — never silently
-  restart, extend, or soften the exit criteria. A retry budget is small
-  and stated. A loop that ends on a verdict rather than a count is
-  already bounded — the verdict is the bound, the missing number is the
-  design, and a reader never supplies a count the loop deliberately
-  omits. Team's two review loops are that case. The same rule bounds
-  output as size budgets (a ~200-line design, a ≤ 30-line helper reply):
-  over budget means restructure and name what was dropped, never silent
-  truncation.
+Requires explicit retry and watch limits.
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 
-- **Purpose:** Each agent is a deep module behind a narrow interface —
-  the declared predecessor artifacts in, one bounded output back.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `nested-agents` and `team`. No agent preloads it.
-- **Key behaviors:** The declared predecessor artifacts in — one where
-  one suffices — and exactly one bounded output back: an artifact on
-  disk or a returned report the dispatcher persists. An agent never
-  reaches around its declared inputs to peek at another
-  agent's state. Orchestration stays in the orchestrator — a specialist
-  that routes or retries siblings has absorbed a second job. Split a
-  "utility" agent that quietly does five unrelated things. Bound the
-  depth (helpers never spawn further sub-agents) and the reply (a short,
-  stated maximum, with the dispatcher owning everything it relays).
+Keeps agent interfaces narrow and internal work deep.
 
 ### [principle-evidence-over-assertion](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md)
 
-- **Purpose:** A claim earns its verdict only with cited evidence; an
-  unverifiable claim degrades its verdict and says so.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-verify`, `groom-backlog`, `pr-open-comments`,
-  `researching-codebases`, and `why`. No agent preloads it.
-- **Key behaviors:** Verify by re-querying, never by memory — a zero
-  exit means the mutation was accepted, not that the change landed. No
-  PASS without cited evidence; an unverifiable item is reported at its
-  degraded confidence, never rounded up. A third party's claim is never
-  the sole evidence: verify it at a concrete file:line before adopting.
-  Agreement is corroborating signal, never proof.
+Requires evidence for claims and verdicts.
 
 ### [principle-explicit-intent](https://github.com/bostonaholic/team/blob/main/skills/principle-explicit-intent/SKILL.md)
 
-- **Purpose:** An irreversible act — merge, force-push, public close,
-  deletion — fires only on the user's stated intent, never inferred from
-  state.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, and
-  `groom-backlog`. No agent preloads it.
-- **Key behaviors:** Granularity matches irreversibility: one yes per
-  irreversible mutation, and approving an adjacent class of change never
-  carries the irreversible one. The grant is scoped and complete —
-  authorization to act is authorization to finish the verified act, and
-  nothing beyond it. Spend granted authorization; never re-ask it, since
-  confirmation churn erodes the signal a real confirmation carries. A
-  skill whose invocation itself authorizes a side effect states an
-  explicit-intent guard in its description; the strictest also disable
-  model invocation where the host honors it.
+Requires stated intent for irreversible actions.
 
 ### [principle-fail-closed](https://github.com/bostonaholic/team/blob/main/skills/principle-fail-closed/SKILL.md)
 
-- **Purpose:** When a guarantee cannot be evaluated, the answer is no.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `nested-agents`, `team`, `team-design`, `team-structure`, and
-  `principle-optimization-never-dependency`. No agent preloads it.
-- **Key behaviors:** Unknown counts as unsupported, a missing verdict as
-  not passed, and an inconclusive refutation leaves the finding
-  standing. Never advance
-  on a missing or unparseable verdict: retry once with the error, halt
-  loudly on the second failure. A capability check that cannot run counts
-  as unavailable. Refutation passes are default-keep, and severity is
-  never softened on an uncertain reply. An ambiguous instruction about an
-  irreversible step resolves to the safer reading. Governs guarantees
-  only — an enhancement that cannot run degrades loudly instead, per
-  `principle-optimization-never-dependency`.
+Treats unknown guarantees as failures.
+
+**Mentions:**
+
+- `principle-optimization-never-dependency`
 
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
-- **Purpose:** The conversation is ephemeral; the artifact on disk is
-  durable, and steps communicate through files — never shared chat
-  memory.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `qrspi-workflow`, `team`, and `artifact-frontmatter`. No agent preloads
-  it.
-- **Key behaviors:** A step that produced no artifact did not happen:
-  write the file before reporting the step done. Pass a path, not a
-  paraphrase — the consumer reads the artifact itself, never the
-  producer's summary. Rebuild in-session state (ledgers, phase tables) by
-  scanning the artifacts; after any interruption the files are
-  authoritative. Long procedures checkpoint to an append-only log, and
-  decisions, approvals, and pre-images land in the artifact directory so
-  a later run can audit what happened.
+Requires durable files for cross-step state.
 
 ### [principle-fix-root-causes](https://github.com/bostonaholic/team/blob/main/skills/principle-fix-root-causes/SKILL.md)
 
-- **Purpose:** A debugging fix lands at the root cause, never at the
-  symptom — trace every failure to the cause that produced it and
-  correct it there.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `systematic-debugging`, `test-driven-bug-fix`, `implementing-slices`,
-  and `team-fix`. No agent preloads it.
-- **Key behaviors:** Reproduce first — a bug you cannot reproduce is a
-  fix you cannot verify. Ask "why" until the causal chain bottoms out at
-  a cause you can change. Resist guards that silence crashes, and fix
-  the code rather than justify a workaround with a comment. Fix the
-  pattern, not just the instance. When stuck, instrument instead of
-  guessing. On restart bugs, suspect stale persistent state before code.
+Requires diagnosis and repair of root causes.
 
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
-- **Purpose:** The agent that produced the work never evaluates it;
-  judgment comes from fresh context, and the judge holds veto without
-  authorship.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `reviewing-code`, `eng-design-doc-review`, `nested-agents`,
-  `pr-watch-as-reviewer`, `principle-blind-the-investigator`, and `how`.
-  No agent preloads it.
-- **Key behaviors:** The evaluator starts with fresh context: the
-  artifact and the upstream spec, never the discussion that produced
-  them. Intent reaches it through artifacts written before the work
-  existed — isolation withholds narration, not intent. Veto without
-  authorship: the evaluator reports defects and fixes nothing, the
-  producer changes the work and casts no verdict, and neither role closes
-  a review cycle alone. An evaluator needing clarification flags an open
-  question rather than asking the producer. One claim, one fresh judge.
+Separates producers from evaluators.
+
+**Mentions:**
+
+- `reviewing-code`
 
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
-- **Purpose:** Two decisions stay human — what to build and what to
-  ship. Everything between runs autonomously.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `review-severity-tiers` and `qrspi-workflow`. No agent preloads it.
-- **Key behaviors:** Never pause an autonomous run to triage a finding:
-  Blocking and Major work loops the fixer automatically, and
-  Minor-and-below lands in the PR body's review notes — Minor is the
-  human's queue, not a wastebasket. Never land on the system's own
-  judgment; merging is always a human decision. A question
-  that can wait for PR review waits, and a blocked run halts terminally
-  and reports rather than asking permission to continue.
+Reserves goals and shipping decisions for the user.
 
 ### [principle-idempotent-reruns](https://github.com/bostonaholic/team/blob/main/skills/principle-idempotent-reruns/SKILL.md)
 
-- **Purpose:** A re-run converges on the same end state instead of
-  failing or duplicating.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-cleanup`, `groom-backlog`, `team`, `pr-watch-as-author`,
-  `team-design`, and `principle-pre-image-first`. No agent preloads it.
-- **Key behaviors:** Already-done is done, not an error: deleting the
-  already-deleted or closing the already-closed is reported as done, and
-  convergence is never treated as failure. Match by title or content
-  before creating, so a re-run never duplicates an issue or comment.
-  Re-read each item immediately before writing it, and skip-and-report an
-  item whose state changed since the plan. Record landed steps as you go,
-  and run mutations serially with backoff where a rate limit could shred
-  a half-applied plan.
+Requires reruns to converge without duplicate effects.
 
 ### [principle-least-privilege](https://github.com/bostonaholic/team/blob/main/skills/principle-least-privilege/SKILL.md)
 
-- **Purpose:** Enforce a constraint by withholding the capability, not
-  by asking for restraint — the toolset is the guarantee.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `reviewing-code`, `reflect`, `eng-design-doc-review`,
-  `cross-model-review`, and `pr-verify`. No agent preloads it.
-- **Key behaviors:** Reviewers hold no Write/Edit and run in plan mode —
-  a reviewer that can fix what it found can approve its own fix. A child
-  process receives an environment allowlist and its own credential block,
-  never the parent's full environment. Prefer the narrowest dispatch
-  target that can run the errand; a structural guarantee (a read-only
-  lens) refuses a target holding a command sink, and an errand that must
-  ride a full-tool target reports its guarantee as prompt-level, not
-  structural. Match the assurance claim to the mechanism: when work
-  falls back to a full-tool context, say the guarantee no longer applies
-  rather than keeping the claim while losing the mechanism.
+Limits tools, credentials, and environment to the task.
 
 ### [principle-mechanical-gates](https://github.com/bostonaholic/team/blob/main/skills/principle-mechanical-gates/SKILL.md)
 
-- **Purpose:** Where a rule must hold, enforce it with a deterministic
-  check that runs whether or not the model cooperates.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `qrspi-workflow` and `test-first-development`. No agent preloads it.
-- **Key behaviors:** A rule enforced only by good behavior is not
-  enforced at all: a prompt line is a request, a gate is a guarantee, and
-  the deterministic layer outranks the model. Push every check to the
-  cheapest, most deterministic layer that can catch it — a check at the
-  wrong layer is worse than no check. Detect errors early, surface them
-  loudly, never mask them. Prefer a check that makes the violation
-  impossible over one that observes it, and a check on the artifact over
-  a check on the intent.
+Requires deterministic enforcement for reliable rules.
 
 ### [principle-never-interpolate](https://github.com/bostonaholic/team/blob/main/skills/principle-never-interpolate/SKILL.md)
 
-- **Purpose:** Untrusted text never travels through a shell command's
-  text.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`,
-  `decomposing-intent`, and `cross-model-review`. No agent preloads it.
-- **Key behaviors:** Unvalidated prose is never spliced into command
-  text — it goes by file (`--body-file`, `-F body=@-`) or stdin, and
-  allowlisted scalars and guarded `"${VAR:?}"` expansions are the only
-  sanctioned argv forms. Scalars pass a character allowlist first, with
-  `LC_ALL=C` so the class is byte-exact — refuse on failure, never
-  normalize a name to make it pass. Terminate options with `--` where a
-  value could be read as an option. A value whose position already fixes
-  its role needs no terminator when its allowlist excludes a leading
-  `-`; otherwise it gets one. Paths get containment checks before
-  destructive use. Capture, validate, and use in the SAME invocation; a
-  value a destructive command or gate consumes expands as `"${VAR:?}"`
-  so an unset value aborts instead of expanding to empty.
+Keeps external text out of shell syntax.
 
 ### [principle-non-blocking-waits](https://github.com/bostonaholic/team/blob/main/skills/principle-non-blocking-waits/SKILL.md)
 
-- **Purpose:** A wait on anything outside the session is one backgrounded
-  call the harness reports on — never foreground sleeps that occupy the
-  turn.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`,
-  `shipit`, `cross-model-review`, and `pr-rebase`. No agent preloads it.
-- **Key behaviors:** Background the wait with `run_in_background: true`
-  and let the completion notification be the wake-up. Put the poll inside
-  the same backgrounded call (`sleep <interval>; <poll>`) so a cycle costs
-  one turn and returns its result. Never poll a task the harness already
-  tracks — that pays for the notification twice. A foreground wait is
-  capped by the harness (600 s in Claude Code), not by a stated
-  `timeout`, so a foreground `timeout 1800` is a cap that never applies.
-  Bounding is unchanged and still owned by `principle-bounded-loops`.
-  Where a harness has no background execution, say so and chunk the wait
-  under that harness's ceiling — the fallback is named at the call site,
-  never the default. Waits shorter than a turn's overhead stay inline.
+Requires resumable waits for external state.
+
+**Mentions:**
+
+- `principle-bounded-loops`
 
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
-- **Purpose:** An enhancement path improves the work when it runs and
-  costs nothing when it cannot.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`,
-  `reflect`, `principle-fail-closed`, `why`, and `how`. No agent
-  preloads it.
-- **Key behaviors:** On absence, error, or silence: do the work inline
-  with the tools you hold, and proceed — never stall or report failure
-  solely because the enhancement was unavailable. Never soften a verdict
-  because an optional pass did not run; record the skip and its reason
-  where the report format puts it. A malformed enhancement result is
-  discarded and the fallback used, never patched up and trusted. Classify
-  first: a step that carries a guarantee fails closed instead, per
-  `principle-fail-closed`.
+Keeps optional enhancements off the correctness path.
+
+**Mentions:**
+
+- `principle-fail-closed`
+- `principle-skip-loudly`
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
-- **Purpose:** Mutations are planned in writing, presented as questions
-  with one recommendation each, and executed only on the user's answer.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `groom-backlog`, `pr-open-comments`, and `reflect`. No agent preloads
-  it.
-- **Key behaviors:** Write the plan before presenting; the ask and the
-  act are separate turns, and when the approval may outlive the turn or
-  survive compaction the plan goes to a durable file the executing turn
-  re-reads rather than remembers (an in-conversation list is the
-  degenerate form for a same-session punch list). Presentation
-  granularity matches irreversibility: an irreversible mutation is
-  presented as the exact text it would create, one consequential choice
-  per question; a reversible class whose undo is stated may be approved
-  as a class, each item named with its target and evidence. Nothing
-  changes before the user answers, no
-  answer means no mutation, and a partial answer executes only the
-  answered subset. Execution re-validates each step against the approved
-  class — an approval never relaxes a hard rule. An item may skip the
-  wait only above a verified confidence bar and inside every hard rule.
+Requires a written plan and user approval before mutations.
 
 ### [principle-pre-image-first](https://github.com/bostonaholic/team/blob/main/skills/principle-pre-image-first/SKILL.md)
 
-- **Purpose:** Before anything is changed, capture the baseline that
-  classifies the after-state and the pre-image that makes the change
-  recoverable — no pre-image, no destructive write.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-rebase`, `groom-backlog`, and `reflect`. No agent preloads it.
-- **Key behaviors:** Run the checks BEFORE the operation, on the
-  untouched state, so a post-operation failure classifies as pre-existing
-  or introduced. Capture the recovery anchor before anything is
-  rewritten, and report it at every stop — success and failure alike.
-  Cache the pre-image of any body you rewrite, close, or overwrite before
-  composing the replacement; compare against it at write time and skip a
-  drifted target. A baseline that could not run is UNKNOWN, never
-  evidence that behavior was preserved.
+Requires a recoverable baseline before destructive changes.
+
+**Mentions:**
+
+- `principle-idempotent-reruns`
 
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
-- **Purpose:** An autonomous step resolves open questions itself and
-  records each as an explicit, auditable assumption — an unmarked guess
-  is a defect.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `authoring-designs`, `decomposing-intent`, and `nested-agents`. No
-  agent preloads it.
-- **Key behaviors:** Mark it where it governs ("Assumption — chosen
-  without user review", in the artifact the decision shapes), naming the
-  rejected alternative and the trade-off accepted so the audit is a
-  judgment call, not an archaeology dig. Ambiguity absorbs upward, never
-  downward: a helper's surfaced ambiguity is recorded or resolved in YOUR
-  artifact, and asking is never delegated. Park low-stakes items as
-  deferred open questions, and report how many assumptions the artifact
-  carries.
+Records autonomous resolutions as assumptions.
 
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
-- **Purpose:** The approved upstream artifact bounds the work: it
-  authorizes exactly the change it names.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `implementing-slices`, `qrspi-workflow`, `test-first-development`, and
-  `principle-subtract-before-you-add`. No agent preloads it.
-- **Key behaviors:** Do not add steps, slices, or features beyond the
-  plan — a missing piece is documented as a finding, not implemented on
-  the spot. Adjacent code is refactored where the plan calls for it and
-  noted as an opportunity where it does not. An applied fix stays bounded to the anchored file and
-  lines it was approved for. Scope expands by changing the governing
-  artifact (and re-reviewing a material change), never by quietly
-  exceeding it — and never expand or shrink scope in silence.
+Restricts execution to approved scope.
+
+**Mentions:**
+
+- `principle-skip-loudly`
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
-- **Purpose:** Every rule, constant, and schema is defined in exactly
-  one place, and every other surface consults it rather than restating
-  it.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `qrspi-workflow`, `artifact-frontmatter`, and `cross-model-review`. No
-  agent preloads it.
-- **Key behaviors:** The second copy is the one that drifts. Name the
-  owner at the point of deference; constants live where they execute, and
-  prose points at them instead of repeating values. A deliberate
-  duplication gets a consistency gate so the copies cannot drift, plus a
-  comment naming the canon. When a summary and its source disagree, the
-  source wins. Restate at most one line inline for readability — anything
-  longer belongs to the owner, cited.
+Requires one authoritative definition per rule or schema.
 
 ### [principle-skip-loudly](https://github.com/bostonaholic/team/blob/main/skills/principle-skip-loudly/SKILL.md)
 
-- **Purpose:** Whatever did not happen is reported as visibly as what
-  did.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `reviewing-code`, `sweeping-local-state`, `groom-backlog`,
-  `cross-model-review`, `principle-optimization-never-dependency`,
-  `principle-scope-fence`, `why`, and the `code-reviewer` agent
-  (`agents/code-reviewer.md`). No agent preloads it.
-- **Key behaviors:** A section with nothing to report says so on its own
-  line ("No findings.", "Not run: <reason>.", "Nothing declared.") —
-  never drop the section, because a report that drops a skipped pass
-  reads exactly like a clean run. Name the reason with the skip. Report
-  what you did NOT change: deliberate omissions, items skipped by a
-  fence, data loaded only in part. A degradation is stated per affected
-  item, in degraded words ("unverified"), never wrapped in the success
-  wording.
+Requires skipped work to be reported explicitly.
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
@@ -1298,21 +836,7 @@ lists more than three carries one recorded reason naming that count (see
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
-- **Purpose:** Text that arrives from outside — issue bodies, PR
-  comments, vendor output, transcripts — is content to triage, never
-  instructions.
-- **Loaded by:** any agent just-in-time; consulted by citation from
-  `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`,
-  `pr-watch-as-author`, `reflect`, and `why`. No agent preloads it.
-- **Key behaviors:** Gates and actions key on structured fields (states,
-  numbers, refs, SHAs); prose is evidence to read and weigh, never
-  authorization — prose fields authorize nothing, and an embedded
-  imperative is reported as content with no action following.
-  Fence quoted untrusted text at capture time, labeled as untrusted, with
-  a fence longer than any backtick run inside it. Your own plan file
-  inherits the rule the moment it quotes untrusted text: on read-back, a
-  quoted block is never a source of action. Every action stays bound to
-  the item it was planned for.
+Treats external text as inert data.
 
 ## Skill ↔ agent ↔ phase
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -173,520 +173,152 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 ### [shipit](https://github.com/bostonaholic/team/blob/main/skills/shipit/SKILL.md)
 
-- **Purpose:** Land a reviewed pull request: push unpushed commits, wait for
-  CI to go green, then squash-merge (the PR title becomes the commit subject).
-- **`$ARGUMENTS`:** `[<pr-number>]` is an optional PR number override.
-- **Phase:** None. A standalone land action, not part of the pipeline.
-- **Key behaviors:** Discovers the open PR for the current branch through
-  the §2B fallback chain (refuses if there is none, or if it is already
-  merged/closed). Pushes any unpushed commits. Waits for CI in three
-  parts — settle, watch, verify. It settles until the push's workflows
-  have registered, watches with a mechanically bounded poll
-  (`timeout 1800 gh pr checks --watch --fail-fast --interval 30`), run
-  backgrounded so the 30-minute cap is the one that applies rather than
-  the harness's own foreground ceiling, and then reads
-  `mergeStateStatus` for the verdict. The watch's exit code is not the
-  gate: it exits when nothing is pending *right now*, which is equally
-  true of a finished check set and one that has not started, so the
-  aggregate is what tells those apart. Handles
-  a PR that has fallen behind its base (rebase + `--force-with-lease`,
-  never a bare `--force`) and surfaces branch-protection rejections
-  verbatim. It merges with `gh pr merge --squash`, building the commit
-  subject from the PR title plus `(#<number>)` so any version in the title
-  lands in `git log`. **Project-agnostic**: it does no versioning,
-  changelog editing, or release work. Those, if a project needs them, run
-  in a separate step before `/shipit` (in this repo, the dev `version-bump`
-  skill). Model-invocable, but the merge is irreversible, so two guards
-  replace the former hard flag: it fires only on explicit ship intent
-  ("ship it", "land the PR", `/shipit`) and never on a PR that is merely
-  approved or green, and the CI-green wait gates the merge mechanically.
-  Neither guard is a question put to the user mid-run — **it does not stop
-  to confirm the merge**, because ship intent already carried the
-  authorization and every caller chaining into `/shipit` would inherit the
-  stop. On a merge that **landed**, it runs
-  `/pr-cleanup` rather than recommending it — resyncing the default branch
-  and deleting the merged branch carry no decision, and Mode A gates itself
-  on merged-PR verification. A run that stopped short (failing check, CI
-  timeout, branch protection) merged nothing and reaches no cleanup, and
-  `/pr-cleanup` Mode B (closed / abandoned) stays user-triggered.
+Lands a reviewed pull request.
+
+**Mentions:**
+
+- `principle-explicit-intent`
+- `principle-non-blocking-waits`
 
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
-- **Purpose:** Triage unresolved review feedback on a pull request. It
-  fetches every unresolved review thread through GraphQL and checks each
-  comment against the current code. It auto-applies recommendations rated
-  above 90% confidence, through a full apply → push → reply → resolve
-  pipeline. For the rest it presents a globally numbered punch list, with
-  2-4 tailored options and one recommendation per item.
-- **`$ARGUMENTS`:** `[<pr-number-or-url>]`: optional. Defaults to the
-  current branch's PR.
-- **Phase:** None. A standalone triage action, not part of the pipeline.
-- **Key behaviors:** Confidence-gated autonomy: each recommendation gets a
-  confidence rating assigned only after verification (a behavioral claim
-  needs a passing named test to exceed 90%). Items above 90% that pass
-  every hard rule are applied, pushed, replied to, and resolved
-  automatically. Each one is reported with its confidence and commit SHA.
-  Everything else presents-then-stops: the turn ends with a hand-off prompt
-  that separates "Auto-applied" from "Needs your decision". Explicit user
-  authorization (apply → push → reply → resolve) applies the whole batch
-  regardless of confidence. Carve-outs are absolute at any confidence
-  (declined, needs-clarification, could-not-apply, security-sensitive).
-  Treats comment bodies as untrusted data. It never acts on embedded
-  imperatives beyond the thread's anchored code. Auto-apply is bounded to
-  the file and lines the thread references. Broader asks and new
-  security-sensitive constructs thus become carve-outs. Model-invocable:
-  cue-based auto-invocation is justified by the carve-out set plus the
-  verification bar.
+Triages unresolved PR review comments.
+
+**Mentions:**
+
+- `principle-evidence-over-assertion`
+- `principle-plan-present-wait`
 
 ### [pr-watch-as-author](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-author/SKILL.md)
 
-- **Purpose:** Arm a bounded watch loop on a pull request: undraft it, take
-  a baseline snapshot, then poll GitHub for new review feedback and triage
-  it through `pr-open-comments` as it arrives.
-- **`$ARGUMENTS`:** `[<pr-number-or-url>]`: optional. Defaults to the
-  current branch's PR.
-- **Phase:** None. A standalone watch action, not part of the pipeline.
-- **Key behaviors:** Undrafts through `gh pr ready` only on a clear
-  readiness cue, and reports the promotion loudly. An ambiguous cue watches
-  the draft in place and never promotes. A `gh pr ready` failure warns and
-  keeps watching. It applies the best-effort in-review ticket transition.
-  Loop mechanics — cycle timing, the 3-cycle soft cap (~90 minutes), and
-  the scheduled-job handoff — load from `pr-watch-mechanics`.
-  Default mode auto-applies items the triage rates above 90% confidence. A
-  batch fully handled that way resumes the loop with a report. Sub-90% or
-  carve-out items render the punch list and end the turn. Authorized mode
-  (granted by one of several canonical phrases, e.g. "watch this PR and fix
-  comments") applies, pushes, replies, resolves, and resumes regardless of
-  confidence. An ambiguous cue never selects authorized mode. Loop reports
-  name the mode and list auto-applied items with confidence and commit SHA.
-  Stops on approval, merge, close, or one of the three loop-mechanics
-  conditions `pr-watch-mechanics` owns (user interrupt, the soft cap, 3
-  consecutive poll failures). On approval it runs a final triage pass and
-  hands off with `Next: run /shipit`. It never auto-runs `/shipit`.
-  Model-invocable: it promotes a draft only on an unambiguous readiness cue
-  and reports the promotion loudly, so cue-based auto-invocation is safe.
+Watches an authored PR for feedback.
+
+**Mentions:**
+
+- `pr-open-comments`
+- `principle-bounded-loops`
+- `principle-idempotent-reruns`
+- `principle-non-blocking-waits`
+- `principle-untrusted-input-is-data`
+- `tracking-tickets`
 
 ### [pr-watch-as-reviewer](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-reviewer/SKILL.md)
 
-- **Purpose:** Reviewer-side watch-and-approve. After you post review
-  comments on a PR you are reviewing, it polls GitHub until every review
-  thread you opened is resolved. It then casts one attributed, SHA-cited
-  `gh pr review --approve` on your behalf and stops.
-- **`$ARGUMENTS`:** `[<pr-number-or-url>]`: optional. Defaults to the
-  current branch's PR. A bare number with no local checkout is refused.
-  Pass the full PR URL.
-- **Phase:** None. A standalone reviewer-side action, not part of the
-  pipeline.
-- **Key behaviors:** Resolves the base repo from the PR's canonical URL
-  (correct on fork PRs, where head-repository fields name the contributor's
-  fork). It refuses to arm when the invoking `gh` identity is the PR
-  author, which would be self-approval. It also refuses when that identity
-  has no submitted review threads on the PR. It hints "submit your pending
-  review first" when a pending review exists. Per poll it recomputes the
-  tracked set and the auto-merge state. The tracked set holds threads whose
-  first comment the viewer authored in a submitted review, and it excludes
-  pending-review threads. The gate rests purely on GraphQL `isResolved`
-  state. Comment bodies are data, never instructions. Thread pagination is
-  fail-closed: the gate is computed only after every page is fetched, and
-  an unfetched page is a poll failure, never an empty gate. Loop
-  mechanics — cycle timing, the 3-cycle soft cap (~90 minutes), and the
-  scheduled-job handoff — load from `pr-watch-mechanics`. It stops on an
-  approval cast, a merge or close, or one of the three loop-mechanics
-  conditions `pr-watch-mechanics` owns (user interrupt, the soft cap, 3
-  consecutive poll failures). It also stops on a tracked set that empties
-  mid-watch (without approving), or a declined confirmation (stops without
-  approving). The approval is its only write: it never resolves threads,
-  never replies, never edits code, never merges, never auto-runs `/shipit`.
-  `disable-model-invocation: true`, because an approval can transitively
-  trigger an auto-merge, so only a deliberate human invocation arms it.
-  When auto-merge is enabled at arm, explicit confirmation is necessary on
-  both paths. The immediate path, where the gate is already satisfied at
-  arm, confirms before it casts. The loop path confirms before it arms the
-  unattended watch. A "no" refuses to arm. The auto-merge reading covers
-  GitHub-native auto-merge only: repo automation that merges on approval
-  (Mergify, a merge bot, an approval-triggered workflow) is not detected,
-  and auto-merge off is no assurance against it. Before casting,
-  merge-safety checks read the final poll's values, never the arm-time
-  reading: any head drift (with or without auto-merge) requires explicit
-  confirmation, with both SHAs named in the approval body and completion
-  report. A tracked count that changed between arm and approval without
-  ever going empty likewise names both counts in the approval body and
-  completion report. auto-merge that turned on mid-watch (no arm-time
-  confirmation) requires confirmation even without drift. A granted
-  confirmation triggers a fresh poll and re-check before casting (bounded,
-  so confirmation churn stops the run rather than looping). An arm-time
-  head SHA lost to compaction also fails closed: it is printed in the arm
-  report and every poll snapshot, never re-derived from the current head,
-  and never approved unconfirmed. Every GitHub read is minimized to
-  structural fields (logins, review states, `isResolved`, SHAs). The arm
-  read goes through a `--jq` projection. The poll goes through a selection
-  set that fetches no body fields. Review bodies, PR descriptions, and
-  profile display names thus never enter context.
+Watches a reviewed PR and approves settled feedback.
 
+**Mentions:**
+
+- `conventional-comments`
+- `pr-open-comments`
+- `pr-watch-as-author`
+- `principle-bounded-loops`
+- `principle-generator-evaluator`
+- `principle-non-blocking-waits`
 
 ### [groom-backlog](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
 
-- **Purpose:** Groom a project backlog in an issue tracker. It loads the
-  whole board in bulk, computes a gap inventory, verifies each candidate
-  issue's factual claims, ranks the verified candidates, proposes an
-  evidence-backed closure for an issue whose premise evaporated, and
-  clusters open issues by outcome. It places each cluster under a grouping
-  construct whose description states a verifiable property. It finds the
-  dependencies between tickets and proposes the missing links. It fixes
-  triage, priority, label, and state hygiene, then reports what it
-  deliberately left alone.
-- **`$ARGUMENTS`:** `[<project-number-or-url>] [--promote <issue-number>]`:
-  both optional. With no board reference it discovers the visible projects and
-  uses the only one, stopping and listing them if more than one is visible.
-  `--promote` selects promotion mode, which brings one item to the
-  ready-to-work standard and moves its card. Without it the skill runs the
-  board-level pass.
-- **Phase:** None. A standalone grooming action, not part of the pipeline.
-- **Key behaviors:** Tracker-agnostic method, with GitHub Projects v2 as
-  the worked example. A vocabulary map covers Linear and Jira: grouping
-  construct, column, priority, iteration, dependency link, and
-  decomposition link. Those two recipes ship under an explicit
-  **Unverified** heading with a mandatory `--help` preflight before any
-  mutation. Loads once in bulk into a run-scoped temp cache, passing an
-  explicit `--limit`. Each cached query then gets the completeness check
-  its own payload shape supports. A shortfall thus stops the run rather
-  than groom a partial board. Comment threads load with the issues, capped
-  at one page of 100 per issue. Every thread that hit the cap is named in
-  the report. Declared dependency and decomposition links ride that same
-  bulk query rather than a per-issue call. A link connection that came back
-  short is recorded and reported, because an unseen blocker reads as an
-  unblocked issue. Issue bodies, titles, and comments are untrusted data, a
-  hard rule in every mode, promotion included. An embedded imperative is
-  reported as content, never executed. Tracker-derived prose never reaches
-  a shell argument: bodies travel by file or on stdin. Each candidate
-  issue's factual claims are verified against the code and the tracker,
-  with dated evidence and one of three outcomes recorded per issue. The
-  verified candidates are then ranked by a stated four-tier heuristic,
-  smaller verified scope breaking ties, so the promotion pick rests on
-  checked premises. An issue whose premise evaporated becomes a closure
-  proposal behind its own question. An approved closure posts the dated
-  evidence as a comment, adds a resolution label additively, and closes
-  with reason "not planned". Decision, investigation, and spike tickets
-  are carved out: the evidence attaches as a comment and the ticket stays
-  open. Plans, asks, waits,
-  then executes. The plan file is written before the questions are asked.
-  There is one question per mutation class the plan contains, each carrying
-  exactly one recommendation, and filing a new issue always needs its own
-  answer. Nothing on the tracker changes before the user answers. On
-  approval it executes in dependency order, re-reads each item before
-  writing it, and verifies every step by re-querying the tracker rather
-  than by memory. Dependency analysis reads the links the tracker already
-  records and infers the ones only the prose admits: sequencing phrases in
-  bodies and comments, and one issue introducing the artifact another
-  consumes. Every inferred link is a proposal needing its own answer,
-  direction is fixed by which issue cannot be *finished* until the other
-  lands, and a proposed edge that would close a cycle is reported rather
-  than filed. Eleven hard rules hold in every mode. Decision and spike
-  tickets stay open. Label writes are additive. A split ticket's original
-  description is never rewritten. Priority, assignee, and state are left
-  alone on someone else's in-flight work. Promotion mode skips the eleven
-  board steps for a narrow single-issue load. It then brings that item to
-  the ready-to-work standard: check it, rewrite it, prioritize it, then
-  move the card. An open blocker, declared or found in the thread, drops
-  the card move and nothing else: a blocked ticket is still worth
-  clarifying while it waits. It refuses a `bug` outright, because `Bugs` is
-  already its ready-to-pull state. It swaps a card back to `Backlog` rather
-  than exceed the `Ready` WIP limit of 5, the number that
-  [project-tracking.md](project-tracking.md) owns. It reports a
-  pre-existing breach instead of an addition to it. The board pass ends by
-  naming the item most worth promoting and printing that command. It never
-  performs the promotion itself. Model-invocable: the read-and-plan phase
-  mutates nothing and execution requires the user's answer, so those two
-  guards make cue-based auto-invocation safe.
+Grooms a project backlog and proposes tracker changes.
+
+**Mentions:**
+
+- `pr-open-comments`
+- `principle-evidence-over-assertion`
+- `principle-explicit-intent`
+- `principle-idempotent-reruns`
+- `principle-never-interpolate`
+- `principle-plan-present-wait`
+- `principle-pre-image-first`
+- `principle-skip-loudly`
+- `principle-untrusted-input-is-data`
 
 ### [pr-cleanup](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md)
 
-- **Purpose:** Tear down local and remote branch state after a pull
-  request is finished. Mode A (merged) verifies the PR actually merged,
-  removes the branch's worktree, resyncs the default branch, and deletes
-  the local branch. Mode B (closed / abandoned) closes the PR(s), then
-  deletes every trace — worktree, local and remote branches, planning
-  scratch.
-- **`$ARGUMENTS`:** `[<pr-number-or-url-or-branch>]` — a PR number or URL
-  (its head branch is resolved via `gh`), a branch name, or nothing to
-  default to the branch checked out in the invoking directory (captured
-  before commands are anchored to the primary clone, so a run from inside
-  a worktree targets that worktree's branch, not the primary checkout).
-- **Phase:** None. A standalone teardown action, not part of the pipeline.
-- **Key behaviors:** Runs a merged-PR verification gate
-  (`gh pr list --state merged`) before any `git branch -D`, and the gate
-  checks identity and containment, not just a head-branch name match: the
-  merged PR's head repository must be this repo (a fork PR sharing the
-  branch name licenses nothing) and its merge commit must be an ancestor
-  of the default branch. A gate failure halts the run; only the user's
-  explicit delete-anyway confirmation re-enters it. Mode B has no
-  merged check because the user's explicit abandon request is the gate —
-  the skill never infers abandon intent. Refuses protected branch names
-  (the detected default, `master`, `develop`, `release/*`) and a dirty
-  tree with tracked modifications. Every externally sourced branch name
-  must pass a byte-exact (`LC_ALL=C`) character allowlist before it
-  reaches any command. Protected names are refused case-insensitively,
-  and `git branch -D` runs only when a local branch matches the name byte
-  for byte — so `Main` cannot force-delete `main` on a case-insensitive
-  filesystem. No destructive command relies on a variable set in an
-  earlier shell invocation: the primary-clone root and repo slug are
-  re-derived in every invocation that uses them, and destructive
-  expansions abort when a variable is unset. Before any destructive step it resolves
-  AND validates `$PRIMARY_ROOT` (the primary clone, found via
-  `git rev-parse --path-format=absolute --git-common-dir` and cross-checked
-  against the main working tree), then anchors every subsequent command
-  with `git -C "$PRIMARY_ROOT"` — so invoking it from inside the worktree
-  it is about to remove cannot strand the run. Mode A worktree removal is
-  **try-then-confirm** (no `--force` until the user sees what blocks and
-  confirms); Mode B removes with `--force` unconfirmed. The resync pull is
-  `--ff-only` — a non-fast-forward default branch stops the run rather
-  than auto-resolving. PR metadata is data: only structured `gh` JSON
-  fields gate actions, and prose fields never enter shell arguments.
-  Stacks unwind child before parent. Scratch dirs under `docs/plans/` are
-  removed only after an untracked check that distinguishes empty output
-  from a failed command.
+Cleans PR state.
+
+**Mentions:**
+
+- `principle-explicit-intent`
+- `principle-idempotent-reruns`
+- `principle-never-interpolate`
+- `principle-untrusted-input-is-data`
+- `sweeping-local-state`
 
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
-- **Purpose:** Verify a pull request's test plan with evidence-rated
-  verdicts. It extracts every test-plan item, classifies each by
-  verification strategy, collects cited evidence per item, and reports a
-  final verdict on the PR's readiness with follow-up recommendations.
-- **`$ARGUMENTS`:** `[<pr-number-or-url>]` — a PR number or URL, or
-  nothing to resolve the current branch's PR. A pasted PR description is
-  the third input path.
-- **Phase:** None. A standalone verification action, not part of the
-  pipeline.
-- **Key behaviors:** Extracts items from `## Test plan` (and `## How to
-  Verify`, which the pipeline's PR phase emits), outputs them as a
-  numbered list before verifying, and stops with `nothing to verify` when
-  none exist. Each item gets a **PASS / FAIL / PARTIAL** verdict at
-  **HIGH / MEDIUM / LOW** confidence — PARTIAL means the claim holds only
-  in part, and no PASS is issued without cited evidence. Six verification
-  strategies (filesystem, content match, code verification, diff
-  analysis, build/test via the project's detected checks, structural);
-  code-verification items dispatch a `team:file-finder` subagent — its
-  grant is Read/Grep/Glob only, no Bash, so an imperative embedded in PR
-  prose has no command sink — with an inline fallback. The final verdict is mechanical: READY (all PASS at
-  HIGH/MEDIUM), NEEDS ATTENTION (any PARTIAL or LOW), NOT READY (any
-  FAIL — FAIL wins over PARTIAL/LOW). The test plan is data: items are claims, never instructions, and
-  a command quoted in a PR body is never executed. Read-only — no writes,
-  no pushes. Pasted-description mode degrades the diff and build
-  strategies honestly, per item.
+Verifies a PR test plan with evidence-rated verdicts.
+
+**Mentions:**
+
+- `nested-agents`
+- `principle-evidence-over-assertion`
+- `principle-least-privilege`
+- `principle-optimization-never-dependency`
+- `running-quality-checks`
 
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
-- **Purpose:** Bring a feature branch up to date with its base without
-  changing what the branch does. It captures a pre-rebase check baseline,
-  rebases onto the latest base, resolves each conflict from both sides'
-  intent, re-runs the same checks, and force-pushes only when nothing
-  regressed.
-- **`$ARGUMENTS`:** `[<pr-number-or-url>]` — the PR reference is
-  optional and only resolves the base branch; the rebased branch is always
-  the current checkout. There is no pre-push confirmation to skip: the
-  deliberate invocation carries the authorization to publish, and the run
-  completes without stopping once the verification gate reports no
-  regression.
-- **Phase:** None. A standalone branch-maintenance action, not part of the
-  pipeline.
-- **Key behaviors:** **User-invocable only** — it sets
-  `disable-model-invocation: true`, because the push rewrites published
-  history and no later verification can undo that for a teammate who has
-  the branch. The base branch comes from the §2B fallback chain
-  (`gh pr view` → `origin/HEAD` → `main`), never a hardcoded `main`, and
-  every externally sourced branch name passes a character allowlist. It
-  refuses a dirty tree, a detached HEAD, an in-progress
-  rebase/merge/cherry-pick, a protected branch as the rebase target, and a
-  branch someone else has pushed to. Before touching anything it records
-  the recovery anchor (`git reset --hard <ORIG_SHA>`) and runs the
-  project's detected checks (via `running-quality-checks`) as the
-  **baseline**; a check that could not execute is `UNKNOWN` and is barred
-  from counting as post-rebase evidence. Conflicts are resolved by
-  reconstructing both sides' intent from history — the skill flags the
-  rebase inversion (`--ours` is the base, `--theirs` is your commit),
-  forbids wholesale side-picking and `git rebase --skip`, regenerates
-  generated files instead of picking one, delegates a large conflicted
-  file to a read-only subagent, and escalates a genuinely undecidable hunk
-  through `AskUserQuestion` without aborting the rebase. Every resolution
-  is written to `docs/plans/<id>/rebase-<n>.md` (append-only local
-  scratch). Verification re-runs the identical checks and compares at the
-  level of individual test names: PASS→FAIL is a regression and **hard
-  stops before the push**; FAIL→FAIL is pre-existing and does not block.
-  The push is
-  `--force-with-lease=<branch>:<pre-fetch-sha> --force-if-includes`, never
-  a bare `--force` and never an implicit lease — the skill's own `git
-  fetch` advances the remote-tracking ref an implicit lease would read.
-  It does not wait for CI and does not merge; `/shipit` lands the PR.
+Rebases a branch onto its base.
+
+**Mentions:**
+
+- `artifact-frontmatter`
+- `pr-cleanup`
+- `principle-explicit-intent`
+- `principle-never-interpolate`
+- `principle-pre-image-first`
+- `principle-untrusted-input-is-data`
+- `running-quality-checks`
 
 ### [reflect](https://github.com/bostonaholic/team/blob/main/skills/reflect/SKILL.md)
 
-- **Purpose:** Mine the session it was invoked from for learnings that
-  outlive it, and propose each one as a concrete change. It resolves the
-  session's own transcript, sends three read-only lenses over it, and
-  synthesizes one Accepted / Rejected / Backlog list with the evidence
-  behind every item.
-- **`$ARGUMENTS`:** `[skill-name]` — an optional focus that narrows every
-  lens to learnings about one skill. Empty means the whole session. A focus
-  naming no skill stops the run before anything is read and prints its near
-  matches.
-- **Phase:** None. A standalone session-review action, not part of the
-  pipeline.
-- **Key behaviors:** **User-invocable only** — it sets
-  `disable-model-invocation: true`, because a run rewrites `SKILL.md` files
-  every later run reads and files public issues. Resolution is by **marker**,
-  never by content match: the run creates its cache with `mktemp -d` and
-  prints the absolute path, the host records that output inline in the
-  transcript, and a bundled script
-  (`skills/reflect/resources/resolve-transcript.mjs`) finds the one file on disk
-  holding that string. The search returns file names only, so no unmatched
-  session's content reaches a lens. The same script normalizes the
-  transcript: `user` and `assistant` records only (every other type is
-  dropped and counted), each span cut to 4,000 bytes, a tool call carried as
-  its tool name plus its invocation so the tooling lens has an invocation to
-  count, the stream bounded to
-  2,000 records and 4 MB with the newest kept, and malformed lines skipped
-  and counted — so the record classifier, the byte cap, and the rule that
-  the `tool-results/*.txt` sidecars are never opened all run as code. The
-  three lenses — **judgment** (guidance that was absent, ambiguous, or
-  misleading), **tooling** (a command or test that cost unwarranted
-  retries), **divergent** (something no skill describes) — run as parallel
-  `team:file-finder` subagents capped at 30 reply lines each. The dispatch
-  target is chosen for its toolset (`Read, Grep, Glob`, no `Bash` and no
-  `Write`): a lens reads the transcript path it is handed, so an imperative
-  embedded in a transcript span cannot be fenced, and a target holding `Bash`
-  would give it a command sink. `team:researcher` is rejected on the same axis
-  rather than on fit — it holds `Agent`, and its preloaded `nested-agents`
-  authorizes dispatch to `Explore`, which holds `Bash`, or to `general-purpose`,
-  which holds every tool; `team:file-finder` holds no `Agent` at all, so it has
-  no delegation path. Both agents scope themselves to `2-questions.md` and forbid
-  themselves speculation, so each lens prompt states its overrides of the agent
-  body outright: the transcript path is the lens's only input and its scope, the
-  reply shape is the prompt's own, and judgment about the session is the errand.
-  An override cannot bind an agent body, so a reply carrying no finding in the
-  shape the prompt asked for — a `## Found Files` report, a bare path list, an
-  error, or nothing — is **disqualified**: that lens's pass re-runs inline and
-  the report names it, because a disqualified reply and a session that taught
-  nothing both arrive as zero findings and only this check separates them.
-  Where dispatch is unavailable the three passes run sequentially in-session as
-  a named **reduced-assurance mode** — that session holds `Bash` and `Write`, so
-  the toolset guarantee does not carry, and the bound that replaces it is that
-  the spans are the session's own history, already in its context once, under
-  two compensating rules: a pass's only output is findings in the plan file, and
-  no span may cause a tool call. On Codex and Antigravity, which install the
-  skill but cannot dispatch Claude Code agents, that mode is the normal path,
-  and the run's report names which mode it ran in. Transcript spans
-  are untrusted content: proposals paraphrase and cite a file path or a turn
-  index, and never quote a transcript line. Sorting happens once, in
-  synthesis, so one finding cannot be classified three ways; a finding a
-  deterministic check would enforce better is demoted to Backlog, as is any
-  proposal to rewrite `AGENTS.md`, `CLAUDE.md`, or `docs/`. The read-and-plan
-  phase writes only inside its printed run cache — the plan file it leaves
-  there is what the later turns read, and the cache is never deleted so the
-  report stays auditable. Applying the approved edits is a **separate turn**
-  behind one approval for the whole skill-write class, and it reads a plan file
-  only from a run cache this conversation printed. **Write scope is narrow and
-  checked in code** (`skills/reflect/resources/write-target.mjs`): a proposed name must
-  match `^[a-z][a-z0-9-]*$`; an edit lands in the skills root the running host
-  actually loads (`<repo>/skills/` for a repo carrying a plugin marker,
-  `<repo>/.claude/skills/` otherwise); a creation only ever targets
-  `<repo>/.claude/skills/<name>/SKILL.md` and only when that path does not
-  exist; every resolved real path must stay inside the repository, so a
-  symlinked directory cannot carry a write out; and `~/.claude/**`, a sibling
-  repository, and `agents/*.md` are never written. The two modes carry different
-  preconditions, because they have different undos: an **edit** is applied only
-  while its target is **tracked and clean** (`git ls-files --error-unmatch`,
-  `git status --porcelain`) and still matches the pre-image the plan recorded,
-  which is what makes `git restore -- <path>` a true undo; a **creation**
-  targets a path that does not exist, so its precondition is that absence and
-  its undo is deleting the named path. Anything else is skipped with a reason.
-  Authoring guidance is discovered
-  (`.claude/skills/create-team-skill/`, any `create-*skill*` repo skill, an
-  installed host `skill-creator`) with a fixed frontmatter contract as the
-  fallback, since none of those ships with the plugin. After the writes it runs
-  the repo's own check through `running-quality-checks` and reports the
-  verdict; it neither fixes a failure nor reverts. Demoted findings go to
-  **whatever tracker the repo already names**, resolved in three tiers: the
-  repo's own router first (so a repo naming Linear or Jira is not silently
-  fixed to GitHub issues), then an authenticated `gh` with issues enabled, then
-  print-only. Every `gh issue` call passes `--repo` explicitly, resolved from
-  `git remote get-url origin`, because a bare `gh` reads the current
-  directory's remote and a set `GH_REPO` answers from anywhere. Issue creation
-  is public and irreversible, so it takes **one approval question per issue**,
-  and the issue carries the board fields its router states (in this repo, per
-  `docs/project-tracking.md`: on the board, with a `Priority`, and `P0` on a
-  `bug`). A tracker that cannot be reached does not stop the run — the item
-  bodies print verbatim and the summary lists filed and unfiled items
-  separately.
+Mines a session for durable learnings.
+
+**Mentions:**
+
+- `finding-files`
+- `nested-agents`
+- `principle-explicit-intent`
+- `principle-least-privilege`
+- `principle-optimization-never-dependency`
+- `principle-plan-present-wait`
+- `principle-pre-image-first`
+- `principle-untrusted-input-is-data`
+- `running-quality-checks`
 
 ### [why](https://github.com/bostonaholic/team/blob/main/skills/why/SKILL.md)
 
-- **Purpose:** Investigate the design rationale behind code — why it was
-  built this way, what alternatives were rejected, what edge cases or
-  incidents motivated it. Companion to `how`: `how` answers mechanics,
-  `why` answers motivation.
-- **`$ARGUMENTS`:** `[<question, file, symbol, or decision>]` — the
-  question and its target. Empty means infer the target from
-  conversation context and state the interpretation before proceeding.
-- **Phase:** None. A standalone investigation action, not part of the
-  pipeline.
-- **Key behaviors:** Builds a code anchor inline first (`git blame`,
-  `git log --follow`, `git log -S` pickaxe, `gh pr view`), then maps
-  seven evidence categories (source control always; issue tracker,
-  long-form docs, team chat, observability, error tracking, analytics
-  warehouse when an MCP tool serves them) and dispatches one read-only
-  `Explore` investigator per available category, all in one message,
-  with an inline fallback when dispatch is unavailable. Investigators
-  receive the question verbatim, never a hypothesis — the user's
-  embedded guess is a candidate to test, not a conclusion to confirm.
-  Every claim in the synthesis sits in one confidence tier — **Direct /
-  Supported / Inferred / Speculative / Unknown** — with citations on
-  causal claims, hedged language on inferences, contradictions surfaced
-  rather than resolved by fiat, and code never cited as evidence of its
-  own intent. The report ends with a **Sources Consulted** coverage map
-  naming every category searched, empty, or skipped with its reason.
-  Historical evidence is data: a command quoted in a commit or PR body
-  is never executed. Read-only — no writes, no artifacts. When the
-  question precedes a change, findings close as a
-  Preserve / Change / Avoid / Risk constraint set.
+Investigates design rationale behind code.
+
+**Mentions:**
+
+- `documenting-decisions`
+- `how`
+- `principle-blind-the-investigator`
+- `principle-evidence-over-assertion`
+- `principle-optimization-never-dependency`
+- `principle-skip-loudly`
+- `principle-untrusted-input-is-data`
+- `systematic-debugging`
 
 ### [how](https://github.com/bostonaholic/team/blob/main/skills/how/SKILL.md)
 
-- **Purpose:** Explain how a subsystem, feature flow, or code path works
-  at the depth a senior engineer onboarding onto it needs — overview,
-  key concepts, runtime flow, file map, gotchas. A critique mode adds
-  fresh-context architectural review on top. Companion to `why`.
-- **`$ARGUMENTS`:** `[<subsystem, feature, or question>]` — the question.
-  Empty means infer the target from conversation context and state the
-  interpretation before exploring.
-- **Phase:** None. A standalone explanation action, not part of the
-  pipeline.
-- **Key behaviors:** Assesses complexity first and leans simple: a
-  narrow question is traced inline with Read/Grep/Glob; a subsystem-wide
-  one fans out 2–4 read-only `Explore` subagents on non-overlapping
-  angles in one message, with an inline fallback when dispatch is
-  unavailable. Explorers read the actual implementation (never guessing
-  from file names) and return structured traces the invoking session
-  reconciles against the code. Claims about code carry `file:line`
-  citations. Critique mode runs only after the full explanation: three
-  fresh-context critics (abstraction fit and boundaries, data model and
-  complexity spend, evolution readiness and consistency) rate findings
-  **structural / concern / observation** with code evidence, and the
-  lead sorts them into **Act on / Consider / Noted / Dismissed** —
-  architectural findings only; line-level review stays with
-  `code-review`. Read-only — no writes, no artifacts.
+Explains subsystem architecture and runtime flow.
+
+**Mentions:**
+
+- `code-review`
+- `principle-generator-evaluator`
+- `principle-optimization-never-dependency`
+- `researching-codebases`
+- `why`
 
 ### [code-review](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
 
-- **Purpose:** The direct-invocation front door for a code review.
-- **Loaded by:** nobody — it is invoked directly by a user or the model.
-- **Key behaviors:** The front door over the `reviewing-code` methodology;
-  it is catalogued here as a command and never loaded as a building block.
-  Invoked directly, it dispatches the `code-reviewer` agent rather than
-  reviewing inline — the main session holds the conversation history
-  `reviewing-code` forbids — then prints that reviewer's report in full, in
-  the shape `reviewing-code` pins. The review methodology itself lives in
-  `reviewing-code`, which the front door loads by name.
+Reviews a diff with fresh context.
 
+**Mentions:**
+
+- `reviewing-code`
 
 ## Methodology skills
 

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -229,7 +229,7 @@ function deriveMentions(
 }
 
 // ---------------------------------------------------------------------------
-// Read once at module scope: the page, plus 236 `.md` files
+// Read once at module scope: the page, plus every `.md` file under skills/
 // (skillContents and agentContents in tests/methodology.test.ts).
 // ---------------------------------------------------------------------------
 
@@ -292,15 +292,16 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     ); // (5) every parsed body non-empty
 
     // (6) Reference-form axis: at least one edge only the `skills/<x>/SKILL.md`
-    // path form produced (69 today). A broken path pattern drops them silently.
+    // path form produced. A broken path pattern drops them silently.
     const allEdges = edgeSet(ALL_MD_TEXT, BOTH_FORMS);
     const bareEdges = edgeSet(ALL_MD_TEXT, ["bare"]);
     expect([...allEdges].filter((edge) => !bareEdges.has(edge)).length).toBeGreaterThan(0);
 
-    // (7) Depth axis: the edge set over the 84 SKILL.md files alone is a STRICT
-    // subset of the set over all 236 `.md` files (49 edges live only in
-    // references/ and the two prompt templates). An equal pair means the walk
-    // shrank — a shallow glob or a missed references/ directory.
+    // (7) Depth axis: the edge set over the SKILL.md files alone is a STRICT
+    // subset of the set over every `.md` file. Dozens of edges live only in
+    // references/ and the two prompt templates, so the margin is wide; an equal
+    // pair means the walk shrank — a shallow glob or a missed references/
+    // directory.
     const skillMdEdges = edgeSet(SKILL_MD_TEXT, BOTH_FORMS);
     expect([...skillMdEdges].filter((edge) => !allEdges.has(edge))).toEqual([]);
     expect(skillMdEdges.size).toBeLessThan(allEdges.size);
@@ -308,7 +309,7 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // Every skill on disk has an entry. Fails loud rather than skipping.
     expect(SKILL_DIRECTORIES.filter((name) => !ENTRY_BY_NAME.has(name))).toEqual([]);
 
-    // The four sweeps, over all 84 entries.
+    // The four sweeps, over every entry.
     expect(SKILL_DIRECTORIES.flatMap(shapeOffenders)).toEqual([]);
     expect(SKILL_DIRECTORIES.flatMap(sentenceOffenders)).toEqual([]);
     expect(SKILL_DIRECTORIES.flatMap(mentionSetOffenders)).toEqual([]);

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -1,0 +1,390 @@
+// L2 static-invariant tripwire: every `docs/skills.md` entry matches disk.
+//
+// The page is hand-authored, and nothing has ever pinned it to the skills it
+// catalogues. This holds four properties per entry — shape, sentence, mention
+// set, mention order — so a rewritten `description`, or a backticked skill name
+// added to any `.md` under `skills/<name>/`, reds the build with a message
+// naming the skill, the name, and the direction.
+//
+// WHY THE SENTENCE EQUALITY IS NOT A WORDING PIN. docs/testing.md:160-161 sets
+// the test: "if a rewrite that preserves the meaning turns the test red, the
+// test was measuring the wording." This assertion passes it. The page holds no
+// wording of its own here — the entry sentence is a *copy* of the first
+// sentence of that skill's frontmatter `description`. A meaning-preserving
+// rewrite of the description updates both copies in the same commit and stays
+// green. The check reds only when the two copies disagree, which is drift
+// between an artifact and its source, the "collision / drift tripwire" form
+// docs/testing.md sanctions at L2. Same treatment as the recorded exception at
+// tests/skill-budget.test.ts:16-18.
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { description, read, squash } from "./helpers/text";
+import { skillNames } from "./helpers/skill-refs";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const CATALOG = join(REPO_ROOT, "docs", "skills.md");
+const SKILLS_ROOT = join(REPO_ROOT, "skills");
+
+const MENTIONS_HEADER = "**Mentions:**";
+const MENTION_BULLET = /^- `([a-z0-9-]+)`$/;
+
+type Entry = { name: string; section: string; body: string[] };
+
+/** The two encoded skill-to-skill reference forms (docs/architecture.md#6-skills). */
+type ReferenceForm = "bare" | "path";
+
+const BOTH_FORMS: ReferenceForm[] = ["bare", "path"];
+
+// ---------------------------------------------------------------------------
+// Parse and file walk. Scaffolding: no rule lives here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every `### [<name>](…)` entry, tagged with the `## ` section above it and
+ * carrying its body — every line after the heading up to the next `/^#{2,3} /`
+ * or EOF, with blank (trimmed-empty) lines dropped. The heading line is never
+ * part of the body, so it cannot leak into the sentence comparison. Same pass
+ * as tests/methodology-not-user-invocable.test.ts:38-47.
+ */
+function catalogEntries(page: string): Entry[] {
+  const out: Entry[] = [];
+  let section = "";
+  let current: Entry | undefined;
+  for (const line of page.split("\n")) {
+    if (/^#{2,3} /.test(line)) current = undefined;
+    if (line.startsWith("## ")) section = line.trim();
+    const heading = /^### \[([a-z0-9-]+)\]/.exec(line);
+    if (heading) {
+      current = { name: heading[1] as string, section, body: [] };
+      out.push(current);
+      continue;
+    }
+    if (current && line.trim() !== "") current.body.push(line);
+  }
+  return out;
+}
+
+/** Every `.md` file under `dir`, at any depth: references/ and prompt templates included. */
+function markdownFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return markdownFiles(path);
+    return entry.name.endsWith(".md") ? [path] : [];
+  });
+}
+
+/** The names on the entry's mention bullets, in authored order. */
+function mentionBullets(body: string[]): string[] {
+  return body.flatMap((line) => {
+    const bullet = MENTION_BULLET.exec(line.trim());
+    return bullet ? [bullet[1] as string] : [];
+  });
+}
+
+/** True when the body carries the mentions header. */
+function hasMentionsHeader(body: string[]): boolean {
+  return body.some((line) => line.trim() === MENTIONS_HEADER);
+}
+
+/** A body line that is neither the mentions header nor a mention bullet. */
+function isProse(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed !== MENTIONS_HEADER && !MENTION_BULLET.test(trimmed);
+}
+
+// ---------------------------------------------------------------------------
+// The four page-side rules and the scanner, factored as pure functions so the
+// planted-positive test runs the same code the real sweep runs
+// (tests/methodology-not-user-invocable.test.ts:128-182).
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape offenders for one entry body, each naming the offending line. The body
+ * must be one or more prose lines, then optionally the mentions header followed
+ * by one or more mention bullets, and nothing after. Eight offenders: (1) zero
+ * prose lines; (2) a line starting `- ` that is not exactly a mention bullet
+ * (a surviving `**Purpose:**` bullet, a trailing clause after a name); (3) a
+ * prose line after the mentions header; (4) a mentions header with no bullet
+ * under it; (5) a mention bullet with no header above it; (6) a second mentions
+ * header; (7) a duplicate name among the bullets; (8) any body line with
+ * leading whitespace, first line included.
+ */
+function shape(body: string[]): string[] {
+  const offenders: string[] = [];
+  const seen = new Set<string>();
+  let headers = 0;
+  let prose = 0;
+  let bullets = 0;
+
+  for (const line of body) {
+    const trimmed = line.trim();
+    if (line !== trimmed) offenders.push(`indented body line: ${JSON.stringify(line)}`);
+
+    if (trimmed === MENTIONS_HEADER) {
+      headers++;
+      if (headers > 1) offenders.push("second mentions header");
+      continue;
+    }
+
+    const bullet = MENTION_BULLET.exec(trimmed);
+    if (bullet) {
+      const name = bullet[1] as string;
+      bullets++;
+      if (headers === 0) offenders.push(`mention bullet with no header above it: ${name}`);
+      if (seen.has(name)) offenders.push(`duplicate mention: ${name}`);
+      seen.add(name);
+      continue;
+    }
+
+    if (trimmed.startsWith("- ")) {
+      offenders.push(`bullet that is not a bare mention: ${JSON.stringify(trimmed)}`);
+      continue;
+    }
+
+    prose++;
+    if (headers > 0) offenders.push(`prose line after the mentions header: ${JSON.stringify(trimmed)}`);
+  }
+
+  if (prose === 0) offenders.push("no prose line");
+  if (headers > 0 && bullets === 0) offenders.push("mentions header with no bullet under it");
+  return offenders;
+}
+
+/**
+ * Sentence offenders for one entry. Cut `description` at the first period
+ * followed by whitespace, or at a period ending the string; join the body's
+ * prose lines with a space; run squash() then .trim() over BOTH sides; compare.
+ * A missing/empty description and a description with no sentence terminator are
+ * each a named offender — no skip, no vacuous pass.
+ */
+function sentence(body: string[], description: string): string[] {
+  const value = description.trim();
+  if (value === "") return ["description is missing or empty"];
+
+  const cut = /^[\s\S]*?\.(?=\s|$)/.exec(value);
+  if (!cut) return [`description has no sentence terminator: ${JSON.stringify(value)}`];
+
+  const expected = squash(cut[0]).trim();
+  const actual = squash(body.filter(isProse).join(" ")).trim();
+
+  return actual === expected
+    ? []
+    : [`sentence is ${JSON.stringify(actual)}, description's first sentence is ${JSON.stringify(expected)}`];
+}
+
+/**
+ * Mention-set offenders, each naming the offending name: a derived name missing
+ * from the bullets, a listed name absent from the derived set, and a listed name
+ * that is not a real skill at all.
+ */
+function mentionSet(bullets: string[], derived: Set<string>, names: Set<string>): string[] {
+  const listed = new Set(bullets);
+  return [
+    ...[...derived].filter((name) => !listed.has(name)).map((name) => `mentions omit ${name}`),
+    ...bullets.filter((name) => !derived.has(name)).map((name) => `mentions list ${name}, which its files never name`),
+    ...bullets.filter((name) => !names.has(name)).map((name) => `mentions list ${name}, which is not a skill`),
+  ];
+}
+
+/**
+ * Order offenders: the authored bullet names compared to that same array under
+ * `[...names].sort()` — codepoint order, so `pr-verify` precedes
+ * `principle-fail-closed`. Names the first name out of place.
+ */
+function mentionOrder(bullets: string[]): string[] {
+  const sorted = [...bullets].sort();
+  const at = bullets.findIndex((name, index) => name !== sorted[index]);
+  return at === -1 ? [] : [`mentions out of order at ${bullets[at]}, expected ${sorted[at]}`];
+}
+
+/**
+ * The skill names `text` mentions, excluding `self` and filtered by `names`.
+ * Two reference forms: a bare backticked lowercase-kebab token, and the path
+ * `skills/<x>/SKILL.md`. Pure over file text — the file walk stays outside, so
+ * the fixture needs no disk layout. `forms` narrows to one form so the
+ * reference-form vacuity guard can isolate the path-only edges.
+ */
+function deriveMentions(
+  text: string,
+  self: string,
+  names: Set<string>,
+  forms: ReferenceForm[] = BOTH_FORMS,
+): Set<string> {
+  const patterns: Record<ReferenceForm, RegExp> = {
+    bare: /`([a-z0-9][a-z0-9-]*)`/g,
+    path: /skills\/([a-z0-9][a-z0-9-]*)\/SKILL\.md/g,
+  };
+  const found = new Set<string>();
+  for (const form of forms) {
+    for (const match of text.matchAll(patterns[form])) {
+      const name = match[1] as string;
+      if (name !== self && names.has(name)) found.add(name);
+    }
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Read once at module scope: the page, plus 236 `.md` files
+// (tests/methodology.test.ts:1883-1888).
+// ---------------------------------------------------------------------------
+
+const ENTRIES = catalogEntries(read(CATALOG));
+const ENTRY_BY_NAME = new Map(ENTRIES.map((entry) => [entry.name, entry]));
+const NAMES = skillNames(REPO_ROOT);
+const SKILL_DIRECTORIES = [...NAMES].sort();
+const SKILL_MD_TEXT = new Map(
+  SKILL_DIRECTORIES.map((name) => [name, read(join(SKILLS_ROOT, name, "SKILL.md"))]),
+);
+const ALL_MD_TEXT = new Map(
+  SKILL_DIRECTORIES.map((name) => [
+    name,
+    markdownFiles(join(SKILLS_ROOT, name)).map(read).join("\n"),
+  ]),
+);
+
+/** `owner -> mentioned` edges over a name→text map, under the given forms. */
+function edgeSet(texts: Map<string, string>, forms: ReferenceForm[]): Set<string> {
+  return new Set(
+    [...texts].flatMap(([owner, text]) =>
+      [...deriveMentions(text, owner, NAMES, forms)].map((name) => `${owner} -> ${name}`),
+    ),
+  );
+}
+
+// Sweep glue: run one rule over one skill and prefix each offender with the
+// skill, so the failure output names it.
+const bodyOf = (name: string): string[] => ENTRY_BY_NAME.get(name)?.body ?? [];
+
+const shapeOffenders = (name: string): string[] =>
+  shape(bodyOf(name)).map((offender) => `${name}: ${offender}`);
+
+const sentenceOffenders = (name: string): string[] =>
+  sentence(bodyOf(name), description(SKILL_MD_TEXT.get(name) ?? "")).map(
+    (offender) => `${name}: ${offender}`,
+  );
+
+const mentionSetOffenders = (name: string): string[] =>
+  mentionSet(
+    mentionBullets(bodyOf(name)),
+    deriveMentions(ALL_MD_TEXT.get(name) ?? "", name, NAMES),
+    NAMES,
+  ).map((offender) => `${name}: ${offender}`);
+
+const mentionOrderOffenders = (name: string): string[] =>
+  mentionOrder(mentionBullets(bodyOf(name))).map((offender) => `${name}: ${offender}`);
+
+describe("docs/skills.md catalog matches the skills on disk", () => {
+  test("every entry's shape, sentence, mention set, and mention order match disk", () => {
+    // Seven vacuity guards. Each names the property that vanished, because a
+    // mis-scoped haystack makes every sweep below pass for the wrong reason
+    // (docs/testing.md, "Prove a negative check can find a positive").
+    expect(SKILL_DIRECTORIES.length).toBeGreaterThan(60); // (1) skills/ tree parsed
+    expect(ENTRIES.length).toBeGreaterThan(60); // (2) page parsed
+    expect(ENTRIES.filter((entry) => hasMentionsHeader(entry.body)).length).toBeGreaterThan(0); // (3)
+    expect(ENTRIES.filter((entry) => !hasMentionsHeader(entry.body)).length).toBeGreaterThan(0); // (4)
+    expect(ENTRIES.filter((entry) => entry.body.length === 0).map((entry) => entry.name)).toEqual(
+      [],
+    ); // (5) every parsed body non-empty
+
+    // (6) Reference-form axis: at least one edge only the `skills/<x>/SKILL.md`
+    // path form produced (69 today). A broken path pattern drops them silently.
+    const allEdges = edgeSet(ALL_MD_TEXT, BOTH_FORMS);
+    const bareEdges = edgeSet(ALL_MD_TEXT, ["bare"]);
+    expect([...allEdges].filter((edge) => !bareEdges.has(edge)).length).toBeGreaterThan(0);
+
+    // (7) Depth axis: the edge set over the 84 SKILL.md files alone is a STRICT
+    // subset of the set over all 236 `.md` files (49 edges live only in
+    // references/ and the two prompt templates). An equal pair means the walk
+    // shrank — a shallow glob or a missed references/ directory.
+    const skillMdEdges = edgeSet(SKILL_MD_TEXT, BOTH_FORMS);
+    expect([...skillMdEdges].filter((edge) => !allEdges.has(edge))).toEqual([]);
+    expect(skillMdEdges.size).toBeLessThan(allEdges.size);
+
+    // Every skill on disk has an entry. Fails loud rather than skipping.
+    expect(SKILL_DIRECTORIES.filter((name) => !ENTRY_BY_NAME.has(name))).toEqual([]);
+
+    // The four sweeps, over all 84 entries.
+    expect(SKILL_DIRECTORIES.flatMap(shapeOffenders)).toEqual([]);
+    expect(SKILL_DIRECTORIES.flatMap(sentenceOffenders)).toEqual([]);
+    expect(SKILL_DIRECTORIES.flatMap(mentionSetOffenders)).toEqual([]);
+    expect(SKILL_DIRECTORIES.flatMap(mentionOrderOffenders)).toEqual([]);
+  });
+
+  test("the page-side rules each see a planted positive", () => {
+    // A well-formed body, used as the negative control for every rule below.
+    const clean = [
+      "Lands a reviewed PR.",
+      MENTIONS_HEADER,
+      "- `pr-verify`",
+      "- `principle-fail-closed`",
+    ];
+    expect(shape(clean)).toEqual([]);
+
+    // Leftover bullet: a `**Purpose:**` line that survived the rewrite.
+    expect(shape(["Lands a reviewed PR.", "- **Purpose:** Lands a reviewed PR."])).not.toEqual([]);
+
+    // Second mentions header.
+    expect(shape([...clean, MENTIONS_HEADER, "- `shipit`"])).not.toEqual([]);
+
+    // Trailing clause after a name.
+    expect(
+      shape(["Lands a reviewed PR.", MENTIONS_HEADER, "- `pr-verify` for the checks"]),
+    ).not.toEqual([]);
+
+    // Duplicate name among the bullets.
+    expect(
+      shape(["Lands a reviewed PR.", MENTIONS_HEADER, "- `pr-verify`", "- `pr-verify`"]),
+    ).not.toEqual([]);
+
+    // Indented line, as the first line and as a later line.
+    expect(shape(["  Lands a reviewed PR."])).not.toEqual([]);
+    expect(
+      shape(["Lands a reviewed PR.", MENTIONS_HEADER, "- `pr-verify`", "  continued"]),
+    ).not.toEqual([]);
+
+    // Drifted sentence: the page no longer copies the description's first sentence.
+    const description = "Lands a reviewed PR. Use on stated ship intent.";
+    expect(sentence(["Lands a reviewed PR."], description)).toEqual([]);
+    expect(sentence(["Lands a merged PR."], description)).not.toEqual([]);
+
+    // Phantom name: a bullet naming no skill on disk.
+    const derived = new Set(["pr-verify", "principle-fail-closed"]);
+    expect(mentionSet(["pr-verify", "principle-fail-closed"], derived, NAMES)).toEqual([]);
+    expect(
+      mentionSet(["pr-verify", "principle-fail-closed", "not-a-skill"], derived, NAMES),
+    ).not.toEqual([]);
+
+    // Dropped name: a derived name the page omits.
+    expect(mentionSet(["pr-verify"], derived, NAMES)).not.toEqual([]);
+
+    // Correct set, wrong order. Codepoint sort: `pr-verify` precedes
+    // `principle-fail-closed`, which a dictionary sort would reverse.
+    expect(mentionOrder(["pr-verify", "principle-fail-closed"])).toEqual([]);
+    expect(mentionOrder(["principle-fail-closed", "pr-verify"])).not.toEqual([]);
+  });
+
+  test("the scanner returns exactly the two reference forms", () => {
+    // A synthetic source standing in for one skill's `.md`, never a real skill
+    // file: one bare backticked name, one `skills/<x>/SKILL.md` path naming a
+    // different real skill, the fixture skill's own name, and a backticked
+    // token naming no skill. Both real names are real skill directories, since
+    // the skillNames() filter would otherwise drop them and hide a broken
+    // pattern.
+    const fixture = [
+      "# Fixture skill body",
+      "",
+      "Call the Skill tool with `pr-verify` before landing.",
+      "The fail-closed rule is restated at skills/principle-fail-closed/SKILL.md.",
+      "This skill is `shipit`, and it never runs `not-a-real-skill`.",
+    ].join("\n");
+
+    expect([...deriveMentions(fixture, "shipit", NAMES)].sort()).toEqual([
+      "pr-verify",
+      "principle-fail-closed",
+    ]);
+  });
+});

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -6,16 +6,17 @@
 // added to any `.md` under `skills/<name>/`, reds the build with a message
 // naming the skill, the name, and the direction.
 //
-// WHY THE SENTENCE EQUALITY IS NOT A WORDING PIN. docs/testing.md:160-161 sets
-// the test: "if a rewrite that preserves the meaning turns the test red, the
-// test was measuring the wording." This assertion passes it. The page holds no
+// WHY THE SENTENCE EQUALITY IS NOT A WORDING PIN. docs/testing.md, under "A
+// tripwire asserts a contract, never a wording", sets the test: "if a rewrite
+// that preserves the meaning turns the test red, the test was measuring the
+// wording." This assertion passes it. The page holds no
 // wording of its own here — the entry sentence is a *copy* of the first
 // sentence of that skill's frontmatter `description`. A meaning-preserving
 // rewrite of the description updates both copies in the same commit and stays
 // green. The check reds only when the two copies disagree, which is drift
 // between an artifact and its source, the "collision / drift tripwire" form
 // docs/testing.md sanctions at L2. Same treatment as the recorded exception at
-// tests/skill-budget.test.ts:16-18.
+// SKILL_BUDGET_REASONS in tests/skill-budget.test.ts.
 
 import { describe, expect, test } from "bun:test";
 import { readdirSync } from "node:fs";
@@ -47,7 +48,7 @@ const BOTH_FORMS: ReferenceForm[] = ["bare", "path"];
  * carrying its body — every line after the heading up to the next `/^#{2,3} /`
  * or EOF, with blank (trimmed-empty) lines dropped. The heading line is never
  * part of the body, so it cannot leak into the sentence comparison. Same pass
- * as tests/methodology-not-user-invocable.test.ts:38-47.
+ * as catalogEntries() in tests/methodology-not-user-invocable.test.ts.
  */
 function catalogEntries(page: string): Entry[] {
   const out: Entry[] = [];
@@ -98,7 +99,7 @@ function isProse(line: string): boolean {
 // ---------------------------------------------------------------------------
 // The four page-side rules and the scanner, factored as pure functions so the
 // planted-positive test runs the same code the real sweep runs
-// (tests/methodology-not-user-invocable.test.ts:128-182).
+// (the offender rules in tests/methodology-not-user-invocable.test.ts).
 // ---------------------------------------------------------------------------
 
 /**
@@ -229,7 +230,7 @@ function deriveMentions(
 
 // ---------------------------------------------------------------------------
 // Read once at module scope: the page, plus 236 `.md` files
-// (tests/methodology.test.ts:1883-1888).
+// (skillContents and agentContents in tests/methodology.test.ts).
 // ---------------------------------------------------------------------------
 
 const ENTRIES = catalogEntries(read(CATALOG));

--- a/tests/helpers/text.ts
+++ b/tests/helpers/text.ts
@@ -31,3 +31,27 @@ export function frontmatter(text: string): string {
   }
   return out.join("\n");
 }
+
+// The frontmatter `description` value, unquoted and unescaped. Both YAML quote
+// styles are unquoted (`''` and `\"` unescaped); a `>` block scalar folds to
+// spaces and a `|` block scalar keeps its newlines. "" when the field is
+// missing, so dependent assertions fail loud, never vacuously.
+export function description(text: string): string {
+  const lines = frontmatter(text).split("\n");
+  const index = lines.findIndex((line) => line.startsWith("description:"));
+  if (index < 0) return "";
+  const value = lines[index]!.replace(/^description:\s*/, "");
+  if (!/^[|>][-]?$/.test(value)) {
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      return value[0] === '"' ? value.slice(1, -1).replace(/\\([\\"])/g, "$1") : value.slice(1, -1).replace(/''/g, "'");
+    }
+    return value.trim();
+  }
+  const continuation: string[] = [];
+  for (const line of lines.slice(index + 1)) {
+    if (!/^\s/.test(line)) break;
+    continuation.push(line.trim());
+  }
+  const folded = value.startsWith(">") ? continuation.join(" ").replace(/\s+/g, " ") : continuation.join("\n");
+  return value.endsWith("-") ? folded.trimEnd() : `${folded.trim()}\n`;
+}

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -190,12 +190,12 @@ describe("engineering-standards methodology", () => {
   // a property of the code under test, so it is intentionally not covered here.
 
   test("skills.md methodology table includes solid row", () => {
-    const row = filterRows(read(SKILLS_MD), "solid", /^#|^>|\/\/|event/);
+    const row = filterRows(read(SKILLS_MD), "| `solid` |", /^#|^>|\/\/|event/);
     expect(row.length).toBeGreaterThan(0);
   });
 
   test("skills.md methodology table includes refactoring-to-patterns row", () => {
-    const row = filterRows(read(SKILLS_MD), "refactoring-to-patterns", /^#|^>|\/\/|event/);
+    const row = filterRows(read(SKILLS_MD), "| `refactoring-to-patterns` |", /^#|^>|\/\/|event/);
     expect(row.length).toBeGreaterThan(0);
   });
 });
@@ -1873,19 +1873,16 @@ describe("principle-untrusted-input-is-data (L2 content tripwire)", () => {
   });
 });
 
-// The catalog's consumer lists drifted: new bare principle-name citations
-// landed and the docs/skills.md entry did not follow. This gate
-// makes that drift class deterministic: for every principle-* skill, every
-// file under agents/ or skills/ that cites its backticked name must appear
-// in the catalog's `### <name>` entry, and — for the 21 extracted
-// single-invariant principles — in the "Skill ↔ agent ↔ phase" table row.
-// The reverse direction runs where an entry's own wording promises a
-// citer list: the JIT "consulted by citation from" form. A lens-style entry
-// ("Cited by ...") never made that promise — it also names checklist-level
-// consumers a path grep cannot see. All parsing is precomputed once at module level:
-// each file is read once, and each test body is a declarative assertion
-// whose failure value names the skill and the missing or phantom consumer.
-describe("docs/skills.md principle consumer lists match on-disk citations (L2 tripwire)", () => {
+// The "Skill ↔ agent ↔ phase" table drifted: new bare principle-name citations
+// landed and the row did not follow. This gate makes that drift class
+// deterministic: for every principle-* skill, every file under agents/ or
+// skills/ that cites its backticked name must appear in that skill's table
+// row. This is where inbound *agent* citers are covered, since the per-entry
+// Mentions: sweep in tests/docs-skills-catalog.test.ts reads nothing under
+// agents/. All parsing is precomputed once at module level: each file is read
+// once, and each test body is a declarative assertion whose failure value
+// names the skill and the missing consumer.
+describe("docs/skills.md principle table rows match on-disk citations (L2 tripwire)", () => {
   const SKILLS_DIR = join(REPO_ROOT, "skills");
   const AGENTS_DIR = join(REPO_ROOT, "agents");
   const SKILLS_MD = read(join(REPO_ROOT, "docs", "skills.md"));
@@ -1929,27 +1926,6 @@ describe("docs/skills.md principle consumer lists match on-disk citations (L2 tr
     }),
   );
 
-  // The `### <name>` catalog entry, up to the next heading. "" when the
-  // entry is missing, so dependent assertions fail loud, never vacuously.
-  const entrySections = new Map(
-    principleSkills.map((name) => {
-      // Entry headings come in two sanctioned forms: plain `### <name>` and
-      // the linked `### [<name>](<url>)` form docs/skills.md adopted.
-      const plain = `### ${name}\n`;
-      const linked = `### [${name}](`;
-      let start = SKILLS_MD.indexOf(plain);
-      let markerLen = plain.length;
-      if (start === -1) {
-        start = SKILLS_MD.indexOf(linked);
-        markerLen = linked.length;
-      }
-      if (start === -1) return [name, ""] as const;
-      const rest = SKILLS_MD.slice(start + markerLen);
-      const next = rest.search(/\n##+ /);
-      return [name, next === -1 ? rest : rest.slice(0, next)] as const;
-    }),
-  );
-
   // The `| \`<name>\` | ... |` row of the "Skill ↔ agent ↔ phase" table.
   // "" when the row is missing, so the assertion fails loud, never vacuously.
   const tableRows = new Map(
@@ -1969,21 +1945,6 @@ describe("docs/skills.md principle consumer lists match on-disk citations (L2 tr
     expect(principleSkills.length).toBeGreaterThan(20);
   });
 
-  for (const principle of principleSkills) {
-    test(`entry for ${principle} omits no file that cites it by name`, () => {
-      const section = entrySections.get(principle) ?? "";
-      expect(section.length).toBeGreaterThan(0);
-      // Clip at "Key behaviors" so a citer named only in a Key-behaviors
-      // cross-reference cannot satisfy the consumer-list check.
-      const cut = section.indexOf("Key behaviors");
-      const clipped = cut === -1 ? section : section.slice(0, cut);
-      const missing = (citersByPrinciple.get(principle) ?? [])
-        .filter((citer) => !mentions(clipped, citer))
-        .map((citer) => `${principle}: catalog entry omits consumer ${citer}`);
-      expect(missing).toEqual([]);
-    });
-  }
-
   for (const principle of extractedPrinciples) {
     test(`table row for ${principle} omits no file that cites it by name`, () => {
       const row = tableRows.get(principle) ?? "";
@@ -1992,36 +1953,6 @@ describe("docs/skills.md principle consumer lists match on-disk citations (L2 tr
         .filter((citer) => !mentions(row, citer))
         .map((citer) => `${principle}: table row omits consumer ${citer}`);
       expect(missing).toEqual([]);
-    });
-  }
-
-  const jitPrinciples = principleSkills.filter((name) =>
-    squash(entrySections.get(name) ?? "").includes("consulted by citation from"),
-  );
-
-  test("JIT-worded entries exist (the reverse check below cannot go vacuous)", () => {
-    expect(jitPrinciples.length).toBeGreaterThan(0);
-  });
-
-  for (const principle of jitPrinciples) {
-    test(`"consulted by citation from" list for ${principle} names only real citers`, () => {
-      const flat = squash(entrySections.get(principle) ?? "");
-      const list = flat.slice(flat.indexOf("consulted by citation from"));
-      // Clip at the bullet's tail so Key-behavior cross-references (which
-      // legitimately name non-citers) never register as consumers.
-      const ends = ["No agent preloads", "Key behaviors"]
-        .map((m) => list.indexOf(m))
-        .filter((i) => i !== -1);
-      const clipped = ends.length === 0 ? list : list.slice(0, Math.min(...ends));
-      const named = [...clipped.matchAll(/`([a-z0-9-]+)`/g)]
-        .map((m) => m[1] ?? "")
-        .filter((n) => skillNames.includes(n) || agentNames.includes(n));
-      expect(named.length).toBeGreaterThan(0);
-      const citers = new Set(citersByPrinciple.get(principle) ?? []);
-      const phantom = named
-        .filter((n) => !citers.has(n))
-        .map((n) => `${principle}: entry names ${n}, which does not cite it`);
-      expect(phantom).toEqual([]);
     });
   }
 });

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -914,7 +914,7 @@ describe("no mid-run human-gate claims (L2 forbidden-pattern sweep)", () => {
 // gated loci, including every multi-locus row this sweep makes atomic.
 //
 // A red names a file and a phrase. Restate that sentence — never add an
-// allowlist entry. The allowlist takes domain nouns only, and its six entries
+// allowlist entry. The allowlist takes domain nouns only, and its five entries
 // are fixed.
 // ---------------------------------------------------------------------------
 
@@ -942,7 +942,6 @@ describe("exception vocabulary appears in no rule prose", () => {
     "carve-out|skills/pr-watch-as-author/SKILL.md",
     "carve-out|skills/pr-watch-as-reviewer/SKILL.md",
     "carve-out|skills/principle-plan-present-wait/SKILL.md",
-    "carve-out|docs/skills.md",
     "exempt|skills/nested-agents/SKILL.md",
   ]);
 

--- a/tests/reflect-skill.test.ts
+++ b/tests/reflect-skill.test.ts
@@ -632,17 +632,14 @@ describe("Slice 1 — L2: reflect's three reporting lenses", () => {
     // runs in a session holding Bash and Write, so it cannot inherit it. On
     // Codex and Antigravity, which install the skill but cannot dispatch Claude
     // Code agents, the fallback is the only path — so the degradation is named
-    // where the model meets it, in the run's own report, and in the skill
-    // catalog a reader consults. Drift tripwire: all three surfaces or none.
+    // where the model meets it and in the run's own report. Drift tripwire:
+    // both surfaces or neither.
     const lenses = flat(section(LENSES));
     const completion = flat(body());
-    const catalog = flat(read(join(REPO_ROOT, "docs", "skills.md")));
     expect(lenses.length).toBeGreaterThan(0);
     expect(completion.length).toBeGreaterThan(0);
-    expect(catalog.length).toBeGreaterThan(0);
     expect(/reduced-assurance mode/i.test(lenses)).toBe(true);
     expect(/reduced-assurance mode/i.test(completion)).toBe(true);
-    expect(/reduced-assurance mode/i.test(catalog)).toBe(true);
   });
 
   test("the dispatch sweep can see a positive", () => {
@@ -658,22 +655,19 @@ describe("Slice 1 — L2: reflect's three reporting lenses", () => {
   });
 
   test("a disqualified lens reply is a named failure on every surface", () => {
-    // The dispatch path's OTHER degradation mode is named on three surfaces and
+    // The dispatch path's OTHER degradation mode is named on two surfaces and
     // pinned above, and this one needs the same treatment: a prompt cannot bind
     // an agent body, so a lens can follow `agents/file-finder.md` instead and
     // reply with a file list or nothing. Unnamed, that reply is a zero — a run
     // where all three lenses ignored the errand reports as a clean session, and
     // no surface distinguishes it from a session that genuinely taught nothing.
-    // Drift tripwire: all three surfaces or none.
+    // Drift tripwire: both surfaces or neither.
     const lenses = flat(section(LENSES));
     const completion = flat(body());
-    const catalog = flat(read(join(REPO_ROOT, "docs", "skills.md")));
     expect(lenses.length).toBeGreaterThan(0);
     expect(completion.length).toBeGreaterThan(0);
-    expect(catalog.length).toBeGreaterThan(0);
     expect(/disqualified/i.test(lenses)).toBe(true);
     expect(/disqualified/i.test(completion)).toBe(true);
-    expect(/disqualified/i.test(catalog)).toBe(true);
   });
 
   test("a disqualified reply re-runs inline and is never reported as a zero", () => {

--- a/tests/skill-budget.test.ts
+++ b/tests/skill-budget.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { frontmatter, read } from "./helpers/text";
+import { description, frontmatter, read } from "./helpers/text";
 
 const REPO_ROOT = process.cwd();
 const SKILLS_ROOT = join(REPO_ROOT, "skills");
@@ -19,26 +19,6 @@ type BudgetReason = { lineCount?: number; descriptionLength?: number; reason: st
 const SKILL_BUDGET_REASONS: Record<string, BudgetReason> = {};
 
 type SkillBudget = { name: string; tier: SkillTier; lineCount: number; descriptionLength: number };
-
-function description(text: string): string {
-  const lines = frontmatter(text).split("\n");
-  const index = lines.findIndex((line) => line.startsWith("description:"));
-  if (index < 0) return "";
-  const value = lines[index]!.replace(/^description:\s*/, "");
-  if (!/^[|>][-]?$/.test(value)) {
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      return value[0] === '"' ? value.slice(1, -1).replace(/\\([\\"])/g, "$1") : value.slice(1, -1).replace(/''/g, "'");
-    }
-    return value.trim();
-  }
-  const continuation: string[] = [];
-  for (const line of lines.slice(index + 1)) {
-    if (!/^\s/.test(line)) break;
-    continuation.push(line.trim());
-  }
-  const folded = value.startsWith(">") ? continuation.join(" ").replace(/\s+/g, " ") : continuation.join("\n");
-  return value.endsWith("-") ? folded.trimEnd() : `${folded.trim()}\n`;
-}
 
 function tier(name: string, metadata: string): SkillTier {
   if (name.startsWith("principle-")) return "principle";


### PR DESCRIPTION
## Summary
- `docs/skills.md` drops from 118 KB and 1,881 lines to 37 KB and 956 lines. Every one of the 86 entries is now a heading, one sentence, and a `Mentions:` list when the skill names other skills.
- The sentence is the first sentence of the skill's frontmatter `description`, verbatim. The `Mentions:` list is derived from the skill's own `.md` files. A new tripwire, `tests/docs-skills-catalog.test.ts`, holds both to disk in both directions, so the page cannot drift again.
- Four assertions that pinned the deleted prose are retired or narrowed. Nothing under `skills/`, `agents/`, or `hooks/` changes, so this PR carries no version bump and no changelog entry.

## Design Decisions
- **Header word is `Mentions:`, not `Loads:`.** The issue delegated the header word. `docs/architecture.md` §6 already defines "Load" as one specific reference form, and most catalog edges are bare mentions or path citations, so `Loads:` would overclaim. `Mentions:` sub-claims both defined forms and needs no architecture edit.
- **The list is vertical**, one backticked name per bullet in codepoint order, exactly as the issue's format block shows.
- **A mention is any backticked skill name or `skills/<x>/SKILL.md` path in any `.md` under the skill's own directory**, self excluded, filtered to real skill names. That is the same citer rule the existing principle tripwire uses, so both directions of the graph share one definition.
- **The sentence equality is a drift tripwire, not a wording pin.** Both sides derive from disk. A meaning-preserving rewrite edits the `description`, and the catalog entry follows it in the same commit.
- **Retired tests:** the per-entry inbound citer check and the "consulted by citation from" reverse check in `tests/methodology.test.ts` (their inbound coverage survives in the table-row check), the catalog leg of two `tests/reflect-skill.test.ts` drift tripwires, and the `carve-out|docs/skills.md` allowlist entry in `tests/protocol.test.ts`.
- **`description()` moves from `tests/skill-budget.test.ts` into `tests/helpers/text.ts`** so the catalog test and the budget test parse the frontmatter field with one function.
- The full decision record, with every alternative weighed, is in the design document referenced below.

## Changes
- **`docs/skills.md`**: all 86 entries rewritten. `## Contents`, `## Two flavors of skill`, and the three section preambles are cut. Each section keeps one line naming the `argument-hint` flavor marker. The intro defines `Mentions:` and points to `docs/architecture.md#6-skills`. The `## Skill ↔ agent ↔ phase` and `## Name-collision pairs` tables are unchanged apart from one pointer repoint.
- **`tests/docs-skills-catalog.test.ts`** (new): three tests. One sweeps every entry for shape, sentence, mention set, and mention order with seven vacuity guards. One proves each page-side rule fires on a planted positive. One proves the scanner sees both reference forms on a synthetic source.
- **`tests/helpers/text.ts`**: gains `description()`.
- **`tests/methodology.test.ts`**, **`tests/reflect-skill.test.ts`**, **`tests/protocol.test.ts`**, **`tests/skill-budget.test.ts`**: the retirements and narrowings above, plus three `filterRows` call sites re-keyed on the table-row delimiter.
- **`docs/index.md`**, **`docs/architecture.md`**: the "arguments, consumers, and behaviors" promise updated to the new format.
- **`.claude/skills/create-team-skill/SKILL.md`**: the Integrate step states the entry contract (verbatim first sentence, conditional `Mentions:` list, codepoint sort, any-depth file scope) and the fast pre-check gains the new test.

## Screenshots
Captured, not yet uploaded. No authenticated browser session was available, so the images stay local.
- **Skills page top with new one-sentence-plus-Mentions entry format for entry-point skills.** (populated)
  `docs/plans/325-simplified-skill-docs/screenshots/01-skills-populated.png`
- **Skills page scrolled to the #groom-backlog anchor, confirming the fragment resolves to the matching heading.** (populated)
  `docs/plans/325-simplified-skill-docs/screenshots/02-skills-anchor.png`
- **Docs home page, confirming the Skills nav link and index.md description still render correctly.** (populated)
  `docs/plans/325-simplified-skill-docs/screenshots/03-index-populated.png`

## How to Verify
- `bun test` is green, including the three new tests. `bun run typecheck` is clean.
- `wc -c docs/skills.md` reports 37,375 bytes. `grep -c '^### ' docs/skills.md` reports 86, which equals `ls skills | wc -l`.
- `grep -cE '\*\*(Purpose|Key behaviors|Loaded by|Phase):\*\*' docs/skills.md` reports 0.
- `cd docs && bundle exec jekyll build` succeeds, and `_site/skills.html` carries `id="groom-backlog"`.
- To watch the tripwire fire, edit one entry's sentence or add a phantom name under a `Mentions:` list, then run `bun test tests/docs-skills-catalog.test.ts`.

## Review notes
Findings deferred to this review. Nothing here blocked the pipeline.

**Final review round (round 3)**
- [code-reviewer] suggestion: the four sweeps in `tests/docs-skills-catalog.test.ts` run as sequential `expect` calls inside one `test()`, so the first failing sweep hides the other three. The structure fixed the three test names. Splitting the sweeps into four sibling tests would show every offender at once.
- [code-reviewer] nitpick: the `docs/skills.md` frontmatter `description` lists 11 standalone utilities and omits `code-review`, the twelfth. The omission predates this branch.
- [code-reviewer] nitpick: the `bare` regex in the new test duplicates the module-private `NAME` regex in `tests/helpers/skill-refs.ts`. Second copy. A third should trigger extraction.
- [security-reviewer] LOW: the recursive `.md` walk in `tests/docs-skills-catalog.test.ts` reads a symlinked `*.md` file if one existed (none do). Optional hardening: skip `isSymbolicLink()` entries or assert `realpathSync` stays under `skills/`.
- [verifier] PASS on the final round: `git diff --check`, discovery consistency, `bun run typecheck`, `bundle exec jekyll build`, and `bun test` (2,116 pass, 4 skip, 0 fail). The `BUDGET REGRESSIONS` line in the test output is fixture output from a passing eval-store test, not a failure.

**Environment note.** During rounds 1 and 2, `bun test` under heavy concurrent load showed 2 to 12 failures, all 5-second subprocess timeouts in files this branch does not touch (`pre-merge-guard`, `regression-309`, `regression-314`, `dev-install-pull-hooks`, `pr-title-version`), with a different set each run. Each passes in isolation. This is machine load, not a regression, and matches the preflight's prediction for tests that commit to scratch repositories under global `commit.gpgsign`.

**Design review (design-review-7, COMMENT verdict)**
- [design-review-7] suggestion: entry order within each section is contracted but held by prose only, because `docs/testing.md` bans pinning heading order. Recorded, not enforced.
- [design-review-7] suggestion: the claim-survival walk for the deleted `## Two flavors of skill` section was recorded in one clause. Every claim in it survives in `docs/architecture.md` §6 or the authoring guide.
- [design-review-7] suggestion: vacuity guard 6 (path-only edges) overlaps the scanner fixture. Its residual value is defense in depth.
- [design-review-7] suggestion: a temp-directory fixture for the file walk was weighed and not adopted. Guard 7 covers the depth axis against the real tree instead.
- [design-review-7] nitpick: the recorded edge split was 69 path-only and 118 bare. The reviewer's re-derivation gave 67 and 120. The union of 249 and the 62 loads reproduce exactly.

**Cross-model review record** [cross-model-notes]

> **Design round 1**
> ### Cross-model disposition
>
> Nine claims arrived from two second-vendor CLIs. I judged each against files I read myself. No external claim reached Blocking without my own confirmation at a line I checked.
>
> **Verified, and raised as Blocking on my own confirmation (5):**
> - Two claims, one per vendor, that exact equality above the `Loads:` bullet does not obviate a shape assertion. Confirmed at `6-design.md:82-84` and `:96-97`. My Blocking finding 1. I extended it with the empty-bullet contradiction, which neither vendor raised.
> - One claim that the design misses a testing-doctrine constraint on pinning sentences. Confirmed at `docs/testing.md:139-141`, `:151-152`, `:160-161` and `.claude/skills/create-team-skill/SKILL.md:17`, `:91`. My Blocking finding 4. The claim framed it as a missing follow-on edit. I place the defect at the missing decision basis instead, which is where the design actually fails.
> - Two claims, one per vendor, that the scanner scope of 234 files omits two files and the true count is 236. Confirmed by `find skills -name "*.md"`. My Blocking finding 3. I add a fact neither vendor checked: both prompt templates carry no skill citation today, so the derived set does not change now.
> - One claim that only line 84 of the authoring guide is updated and line 83 is missed. Confirmed at `.claude/skills/create-team-skill/SKILL.md:83-84` and corroborated by `5-research.md:40`. My Blocking finding 5.
>
> **Verified in part, folded into Blocking finding 2 (3):**
> - One claim that `squash` never trims. Confirmed at `tests/helpers/text.ts:14-16`. I did not adopt the prediction that the check fails for all 84 skills. That is an implementation forecast, and the design-level defect is the undefined slice.
> - One claim that the 26 zero-citation skills have no slice boundary. I counted 26 myself. The accompanying prediction about an `indexOf` return value is unverifiable, because the design specifies no `indexOf`.
> - One claim that the entry heading is never stripped from the haystack. Confirmed against `6-design.md:63-66` and the heading form of every entry in `docs/skills.md`.
>
> **Partly refuted (2):**
> - One claim that the proposed parser wrongly excludes block scalars that `tests/skill-budget.test.ts:23-41` handles. I checked all 84 `description:` lines. Every one is a single-line single-quoted scalar, which matches `6-design.md:32-33`. No block scalar exists, so the exclusion breaks nothing today. The duplicate-parser half of the claim survives as my non-blocking suggestion on `principle-single-source-of-truth`, not as a blocker.
> - One claim that deleting `## Two flavors of skill` is wrong because `docs/architecture.md:744` defines no flavors. I confirmed the cited lines carry no definition, which is my Blocking finding 6 about the evidence. I refute the conclusion: `docs/architecture.md:632-633` does define the two flavors, so the canonicity claim holds at a different location and the deletion stands. I did not adopt the recommendation to keep a summary line, because the design already keeps one line per surviving section.
>
> **Verified, no finding (1):**
> - One claim agreeing that removing the allowlist entry is correct once the four uses leave the page. I confirmed the four case-insensitive matches at `docs/skills.md:345`, `:350`, `:351`, and `:371`, and checked independently that no description sentence reintroduces a family word. I record one detail the claim missed: line 371 sits in a different entry, which is my second nitpick.
>
> **Skipped:** none. Every claim received a disposition.

> **Design round 2**
> ### Cross-model disposition
>
> One vendor returned claims and one returned a skip. I judged each claim against files I opened myself. No external claim reached Blocking without my own confirmation at a line I checked.
>
> **Verified, raised as Blocking on my own confirmation (3):**
>
> - A claim that the parser treats wrapped continuation lines as prose and so breaks the largest valid list. Confirmed at `6-design.md:100-102`, `:110`, and `:139-141`. My Blocking 1. I extended it with two consequences the claim did not name, the prose join and the single-line name extraction, and with my own measurement of the 409-character `team` bullet.
> - A claim that decision 5 omits a self-exclusion and that six skills self-mention. Confirmed by my own directory scan, which returned the same six names. My Blocking 2. I added the existing self-exclusion precedent at `tests/methodology.test.ts:1897`.
> - Two related claims, one about the `Loads:` label misstating execution for most citations and one about the architecture contract staying unchanged while the catalog pointer moves. Confirmed at `docs/architecture.md:693-720`, `:698-699`, `tests/helpers/skill-refs.ts:3-20`, and `6-design.md:342`. My Blocking 3. My own edge count is 249 including six self-edges, which reconciles with the claim's figure once self-edges are removed. I added the finding the claims missed: decision 5 states the cost as roughly eight mentions.
>
> **Verified in part, reduced to non-blocking (2):**
>
> - A claim that a literal-block description would compare newlines against spaces. Confirmed as an asymmetry at `6-design.md:118` and `tests/skill-budget.test.ts:39`. Refuted as a present defect: I checked all 84 descriptions and every one is a single-line single-quoted scalar, which `6-design.md:33` already states. Non-blocking suggestion.
> - A claim that the loads parser checks only its prefix and names, so a malformed bullet passes. Confirmed at `6-design.md:100` and `:108-113`. Reduced to a suggestion, because the design fixes the authored form at `:189` and no stated gate depends on the gap.
>
> **Verified, no finding raised (1):**
>
> - A suggestion to replace the bare `filterRows` key with an exact table delimiter. I confirmed the neighbouring pattern exists at `tests/methodology.test.ts:154` and `tests/architecture.test.ts:79`. I raise no finding on the recommendation, because implementation choice sits outside design review and `6-design.md:365-369` already records the risk. I raise an adjacent finding instead: the set of bare-key call sites is three, not one.
>
> **Skipped (1):** The second vendor returned no claims. The recorded reason is a vendor timeout with a non-zero exit. Nothing from that vendor entered this review.

> **Design round 3**
> ### Cross-model disposition
>
> Two vendors returned claims. I judged each against files I opened myself. No external claim reached Blocking without my own `file:line` confirmation.
>
> **Verified, raised as Blocking on my own confirmation (2):**
>
> - A claim that the design replaces the issue's fixed list format with an inline bullet. I split it. The header-word half is refuted, because the input contract delegated that word and decision 2 documents the choice with numbers I reproduced. The list-shape half is confirmed at `6-design.md:227-236` against `1-task.md:22` and `:101`. My Blocking 1. I extended it with the defect the claim did not name: the reconciliation sentence at `:262-264` asserts a substitution that does not hold for two of the six lines it cites.
> - A claim that decision 15's follow-on set omits an architecture line asserting how `docs/skills.md` sorts skill flavor. Confirmed at `docs/architecture.md:743-745`, at the deleted source `docs/skills.md:32-33` and `:53`, and at `5-research.md:105`, where the recorded derivation stops short. My Blocking 3.
>
> **Verified, raised as Blocking after reframing (1):**
>
> - A claim that the three entry assertions cannot see retained sections, preambles, or reordered entries. Confirmed at `6-design.md:119-121` and `:131-158`. My Blocking 2. I reframed it, because a design may leave a rule to prose. The defect is the Surfaces table at `:440` naming the new test as the holder for two changes it cannot observe.
>
> **Verified in part, reduced to non-blocking (4):**
>
> - A claim that the entry regex admits a malformed heading. Confirmed as a mechanical fact at `6-design.md:116`. Refuted as blocking, because `tests/methodology-not-user-invocable.test.ts:218-221` already asserts every `### ` heading parses as an entry, and the link target was unpinned before this change. Reduced to a suggestion.
> - A claim that dropping blank lines lets one sentence span two paragraphs. Confirmed at `6-design.md:123` and `:99-102`. Folded into my shape-contract suggestion.
> - A claim that the shape offenders omit a zero-prose-line check. Confirmed at `6-design.md:131-138`. Refuted in part, because the sentence assertion at `:142-148` reds on an empty prose join, so such an entry does not pass. Folded into the same suggestion.
> - A claim that a first body line with leading whitespace has no defined handling. Confirmed as an unenumerated boundary at `6-design.md:122-125`. Reframed from a runtime-error prediction to a missing edge case, because the design states a rule and not an implementation. Raised as a suggestion.
>
> **Verified as a fact, no finding raised (2):**
>
> - A claim that reusing the shared helper cannot fail loud, because the frontmatter reader accepts an opening delimiter with no close. Confirmed as a mechanical fact at `tests/helpers/text.ts:21-32`. Refuted as a design defect, because the extracted parser returns an empty string when no description line exists, and `6-design.md:182-184` turns that into a named loud failure.
> - A claim that duplicate names on the mentions line pass. Confirmed as unspecified at `6-design.md:149-154` and `:266-268`. Raised as a suggestion rather than an accepted claim, because the design never states which compare shape it uses.
>
> **Refuted (3):**
>
> - A claim that a vacuity threshold above 60 permits silent truncation of up to 23 skills. Refuted at `6-design.md:182-184`, which names a missing entry as a loud failure, and at `tests/methodology-not-user-invocable.test.ts:199-209`, which already asserts the catalog-to-disk bijection in both directions.
> - A claim that a reusable scanner should be exported instead of localized. Refuted as a gap, because `6-design.md:429-430` records that exclusion in `## Out of scope` with the retrofit named.
> - A claim of temporary vocabulary divergence against the task artifact. Refuted as a new finding, because `6-design.md:473-477` already records it as a risk with a same-commit landing condition.
>
> **Unverifiable (1):**
>
> - A claim about a leading space surviving a fourteen-character prefix slice. This describes string handling that the design does not specify. `6-design.md:137-138` states a whole-line contract rather than a slice offset, so the claim has no design-level referent. Recorded as unverifiable, no finding.

> **Design round 4**
> ### Cross-model disposition
>
> Twelve external claims, paraphrased only.
>
> **Verified at a line I checked myself, and folded into my findings.** Two claims about bullet order surviving a sorted comparison hold at `6-design.md:175-176` and `:293-297`; I confirmed the ordering standard at `docs/testing.md:118-119` and `:139-141` and raised the first blocking finding. One claim about a second frontmatter description parser holds at `tests/architecture.test.ts:419`; I confirmed the function and raised the third blocking finding. One claim about the narrow verification command holds at `.claude/skills/create-team-skill/SKILL.md:94`; I checked the surrounding block and rated it a suggestion, because line 97 of the same block runs the full suite. One claim about an undefined whitespace-only line holds across `6-design.md:142`, `:145`, and `:165-166`; I rated it a suggestion. One claim about the architecture file already sitting in the edit set holds at `6-design.md:444`; I rated it a nitpick, because the second half of the rejection reason is independent and `## Risks` discloses the residue at `:531-536`.
>
> **Refuted with the line I checked.** One claim treats the header word as a contract violation. The input contract delegated that word, `6-design.md:267-292` records the substitution, and decision 1 now adopts the vertical list `1-task.md:22` states, so it does not block. Two claims call documented exclusions defects. Paragraph joining at `6-design.md:142` is recorded with its cost at `:472-476`, and the unpinned heading link at `:466-471` is recorded as unchanged from today, which I confirmed against `tests/methodology-not-user-invocable.test.ts:218-221`. One claim says the path pattern misses cross-skill `references/` citations. A repo-wide scan of `skills/` for that path form returns zero occurrences, and `1-task.md:23-26` defines the rule as the `SKILL.md` path or a backticked bare name. One claim reports tool markup in the document footer. The file I read ends at line 565 with the single-repo risk bullet.
>
> **Verified in mechanism, refuted as stated remedy, downgraded.** One claim says filtering derived names hides stale references and proposes validating unknown targets first. The filter is real at `6-design.md:346-349`, and the proposed remedy is not implementable, because a backticked lowercase-kebab token that names no skill is an ordinary word. I kept only the unrecorded cost, as a suggestion.
>
> No external claim reached Blocking or Major on its own. Each blocking finding above rests on a line I checked myself.

> **Design round 5**
> ### Cross-model disposition
>
> Two vendors were offered. One returned six claims. One returned a skip.
>
> - **Skip recorded.** The second vendor exited on a timeout and produced no claims. No content from that vendor reached this report.
> - **Claim 1, header rename.** Refuted as stated. The review brief records that the requester delegated the header word to the implementer, so a documented rename is inside the delegated latitude. The claim's supporting count is separately wrong, which I confirmed at `1-task.md:68` and raised as my own blocking finding above.
> - **Claim 2, sentence equality.** Verified in part, downgraded. I checked `6-design.md:425-429` against `:124-127`. The page copy is hand-authored, so a description rewrite does red the build until an author updates the page. The design records that residue at `:429-430`, and `docs/testing.md:120-121` sanctions two-file sync as a drift form, so the claim does not reach blocking on its own reasoning. The authoring-surface half of the problem is my second blocking finding, confirmed at `.claude/skills/create-team-skill/SKILL.md:83-84`.
> - **Claim 3, heading link shape.** Verified at `tests/methodology-not-user-invocable.test.ts:218-221`. The named test does not cover a missing URL. The design records the exclusion deliberately with a reason, so the finding lands as a suggestion, not a blocker.
> - **Claim 4, argument shapes.** Verified in part at `docs/architecture.md:637-655` and `docs/skills.md:115`. Section 6 does state that `argument-hint` documents the shape, so the pointer is not empty. It carries no per-skill shape. Recorded as a suggestion.
> - **Claim 5, missing source fixture.** Verified independently at `6-design.md:241-252` against `docs/testing.md:174-207`. This became my third blocking finding on my own citations.
> - **Claim 6, deleted-coverage prose.** Verified at `tests/methodology.test.ts:1853-1866`. Recorded as a suggestion, matching the vendor's own non-blocking placement.

> **Design round 6**
> ### Cross-model disposition
>
> - **Header rename as a contract breach.** Refuted. The requester delegated the header word, and decision 2 keeps the list and block shapes the issue fixes. I confirmed all nine `Loads:` lines in `1-task.md` at the lines the design names, and each reads with the substituted word. Dropped.
> - **Fixture omits recursive discovery, 49 nested-only edges.** Verified by my own scan, 243 edges over all files against 194 over `SKILL.md` alone. Raised as my first blocking finding on my own evidence, not on the vendor's.
> - **Stale targets are catchable for the path and load forms.** Verified in part at `6-design.md:441-448`. The path form is mechanically distinct from an ordinary word, so the unavoidability argument does not cover it. Recorded as a suggestion, because the design records the residue and the mechanism still works.
> - **Heading exclusion leaves the linked form unenforced.** The underlying fact is verified at `tests/methodology-not-user-invocable.test.ts:218-221`, where a heading with no URL parses and the counts stay equal. Not blocking and not raised: `6-design.md:628-637` states the exclusion, its ground, and the same gap in existing coverage, so this is a recorded decision rather than silence.
> - **Marker retention and architecture revision are not exclusive.** Verified at `6-design.md:393-398` against `:703-708` and `:571-573`. Raised as a suggestion at the vendor's own non-blocking level.
> - **The path-only guard pins repository contents.** Verified at `6-design.md:241-249` and `:257-267`. The scanner fixture does exercise both reference forms, so the guard is defense in depth rather than the only proof. Non-blocking, and I leave the trade-off to the author, so I raise no finding. Removing that guard while the depth axis stays open would widen the first blocking finding.
> - **No planned check measures final bytes.** Verified at `6-design.md:715-722` and in `## Out of scope`. Folded into my size suggestion with my own measurement.
> - **Second-vendor skip.** The `agy` adapter returned a timeout skip, its second in a row, so it produced no claims and stays disabled for later rounds in this invocation. The pass ran with one vendor, and this record is the loud skip.

> **Design round 7**
> ### Cross-model disposition
>
> agy: skipped this round. The prompt records the CLI as disabled for the rest of the run after two consecutive timeouts. No claim to judge.
>
> codex produced seven claims. Three arrived at the highest severity. I confirmed none of them at that severity, so none is promoted.
>
> - Claim one, that the header substitution breaks the acceptance contract. Partly verified, refuted as a breach. The cited lines exist and do state the substitution. The input contract for this review records that the requester delegated the header word to the implementer, so a documented rename sits inside that latitude. Decision 2 records the reasoning, and `## Risks` records the residual divergence with `1-task.md`. Not blocking, and no new finding.
> - Claim two, that the deferred broken-path check lets a renamed skill escape. Verified as a fact and refuted as a blocker. The `skillNames()` filter at `tests/helpers/skill-refs.ts:44-51` does drop an unmatched name. Decision 7 records the gap, splits the verdict by reference form, states why the fix belongs to the reference contract rather than a catalog test, and logs it in `## Open questions (deferred)`. A stated omission is a recorded decision. Not blocking.
> - Claim three, that the new pointer deletes the only correct record of `team-pr`'s fallback. Verified in part and refuted in the load-bearing half. `docs/architecture.md:647-648` does name only `AskUserQuestion`, and `docs/skills.md:102-104` goes away. The fallback is documented at `skills/team-pr/SKILL.md:15-17`, which I read. The design names the loss as a docs-site loss and accepts it. Not blocking. I raised the missing line reference as a nitpick above.
> - Claim four, that the path-only guard duplicates the scanner fixture and pins repository content. Verified at both cited passages and at the design's own concession about which check notices a broken pattern. I raised it myself as a suggestion, so it reaches non-blocking on my confirmation.
> - Claim five, that the depth guard tests current edges and that a temp-directory walker fixture would cover recursion without repository coupling. Verified. The design concedes the walk stays untested by the fixture, and the repository already builds temp directories in ten test files. I raised it myself as a suggestion.
> - Claim six, that decision 12 touches unrelated callers. Verified as a fact and refuted as framed. The three call sites read the file this change rewrites, so they are consumers rather than unrelated work. Decision 12 records two grounds that survive its own measurement. No finding.
> - Claim seven, that the heading parse accepts a missing or malformed link target. Verified. The parse regex has no end anchor, and `tests/methodology-not-user-invocable.test.ts:218-221` stays green on an unlinked heading, which I confirmed against the regex at `:43`. `## Out of scope` already records the exclusion and its ground. No finding.

> ### Cross-model disposition
>
> - `codex` — ran. The courier dispatch failed with the same tmux pane error, so the pass used the skill's inline fallback with the runner's pinned argv. The prompt exceeded the 128 KB cap at 157 KB, so it carried the code and tooling diff at 36 KB and named `docs/skills.md` as dropped, which codex could read from its working directory. One claim returned, about the authoring guide requiring a `Mentions:` list the gate rejects on an empty set. Team confirmed it independently at `.claude/skills/create-team-skill/SKILL.md:85` and `tests/docs-skills-catalog.test.ts:152`, so it is **adopted** and merged into finding 1. No claim reached Blocking on vendor assertion alone.
> - `agy` — `skip: agy unavailable after two consecutive timeouts`. Not called, per this invocation's state. `detect` reported it ready, so the skip is a protocol decision, not a capability gap.
> - Post-pass tree check: `git status --porcelain` is empty. Neither vendor mutated the tree. The one `git stash` entry predates this branch and belongs to an unrelated topic.

> ### Cross-model disposition
>
> **Round 2.**
>
> - **`agy`** — `skip: agy unavailable after two consecutive timeouts`. Not called, per the two-consecutive-timeout rule in `skills/cross-model-review/SKILL.md`. Note that `detect` still reports it ready; the skip is the protocol's, not the CLI's.
> - **`codex`** — ran, exit 0, output present and carrying no claims. **No findings from `codex`.** Nothing to verify, adopt, refute, or record as unverifiable.
> - **Prompt cap.** The full three-dot diff is 158 KB against the 128 KB cap. I trimmed once before calling and named the drop inside the prompt: the `docs/skills.md` diff hunks (123 KB of mechanical per-entry rewrites) were dropped and the resulting `docs/skills.md` was included in full instead, so its content stayed reviewable. Nothing else was dropped. Assembled prompt: 73,913 bytes, one call.
> - **Courier.** `Agent`-tool dispatch of the named `codex-review` courier failed at creation ("no space for new pane"). I used the skill's inline fallback and ran the pinned `external-review.mjs run` command myself as a background task. No flags added, no vendor CLI invoked directly.
> - **Post-pass tree check.** `git status --porcelain` is empty. No vendor mutation to report. (`docs/_site` from my own `jekyll build` is gitignored.)
>
> The pass produced no input that changes the verdict; the blocking finding above is entirely Team's own.

> ### Cross-model disposition
>
> - **codex** — ran, returned nothing to verify. The vendor reported no defects in the material sent, so no claim reached adoption or refutation.
> - **agy** — `skip: agy unavailable after two consecutive timeouts`. Not called, per the two-consecutive-timeout rule, even though `detect` reported it ready.
>
> Prompt handling: the full three-dot diff measures 158090 bytes, over the 128 KB cap. I trimmed to the logic-bearing files (36360 bytes) and named the drop inside the prompt. **Dropped: `docs/skills.md`**, the 123 KB mechanical catalog rewrite, which the vendor could read in full from its working directory. All test files, `tests/helpers/text.ts`, the authoring guide, `docs/architecture.md`, and `docs/index.md` were sent whole.
>
> Courier dispatch failed with `Failed to create teammate pane: no space for new pane`. I used the skill's documented inline fallback and ran the same pinned `external-review.mjs run codex` command myself as a background task. Post-pass tree check: `git status --porcelain` is empty, so no vendor wrote to the repository.


## References
- Design: docs/plans/325-simplified-skill-docs/6-design.md
- Plan:   docs/plans/325-simplified-skill-docs/8-plan.md

Closes https://github.com/bostonaholic/team/issues/325
