### PR TITLE
v0.89.0 feat(team): invert the mechanical gate for a zero-behavior-change refactor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.88.0"
+    "version": "0.89.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.88.0",
+      "version": "0.89.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.89.0] - 2026-09-07
+
 ### Changed
 
 - **The IMPLEMENT phase's mechanical gate now has an answer for a pure refactor.** The gate advanced only when every acceptance test failed with an assertion error, which is correct for a change that adds behavior and wrong for one whose stated contract is zero behavior change. There the acceptance tests already exist — they are the current suite — and their correct state throughout is green, so `test-architect` had nothing to write and writing tests for the mechanics of a file move would add tests the task never asked for. For that class the gate's polarity inverts: the `test-architect` dispatch is skipped with a recorded reason rather than silently, the suite and every static check are captured as a baseline **before** any file moves, and the gate becomes "the checks reproduce that baseline". Structural checks — a `grep` with an exact expected match count, a path that must no longer exist — carry the acceptance criteria the tests cannot express there. **What this asks of you:** nothing. A change that adds behavior runs the same red-tests gate as before.
@@ -805,7 +807,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.88.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.89.0...HEAD
+[0.89.0]: https://github.com/bostonaholic/team/compare/v0.88.0...v0.89.0
 [0.88.0]: https://github.com/bostonaholic/team/compare/v0.87.0...v0.88.0
 [0.87.0]: https://github.com/bostonaholic/team/compare/v0.86.0...v0.87.0
 [0.86.0]: https://github.com/bostonaholic/team/compare/v0.85.0...v0.86.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The IMPLEMENT phase's mechanical gate now has an answer for a pure refactor.** The gate advanced only when every acceptance test failed with an assertion error, which is correct for a change that adds behavior and wrong for one whose stated contract is zero behavior change. There the acceptance tests already exist — they are the current suite — and their correct state throughout is green, so `test-architect` had nothing to write and writing tests for the mechanics of a file move would add tests the task never asked for. For that class the gate's polarity inverts: the `test-architect` dispatch is skipped with a recorded reason rather than silently, the suite and every static check are captured as a baseline **before** any file moves, and the gate becomes "the checks reproduce that baseline". Structural checks — a `grep` with an exact expected match count, a path that must no longer exist — carry the acceptance criteria the tests cannot express there. **What this asks of you:** nothing. A change that adds behavior runs the same red-tests gate as before.
+
 ## [0.88.0] - 2026-09-07
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,7 +276,11 @@ No gate. The plan is mechanically derived from the structure.
 2. **Mechanical gate.** The orchestrator runs the suite and the project's
    static checks. All tests must fail with assertion errors, not crashes,
    and every static check must pass — a runner that transpiles without
-   type-checking leaves a red type checker behind a green suite.
+   type-checking leaves a red type checker behind a green suite. A change
+   whose stated contract is zero behavior change inverts both steps: step 1
+   is skipped with a recorded reason, since the current suite is already the
+   acceptance suite, and the gate becomes "the checks reproduce the baseline
+   captured before any file moved". Green is the correct state throughout.
 3. **Slice execution.** `implementer` works through the plan one slice
    at a time, committing each atomically.
 4. **Code review.** 5 reviewers in parallel: `code-reviewer`,

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -40,6 +40,7 @@ Runs the 8-phase QRSPI feature pipeline.
 - `principle-fail-closed`
 - `principle-files-are-the-contract`
 - `principle-idempotent-reruns`
+- `principle-pre-image-first`
 - `principle-progress-tracking`
 - `principle-skip-loudly`
 - `qrspi-workflow`
@@ -117,6 +118,7 @@ Executes and verifies implementation slices.
 **Mentions:**
 
 - `artifact-frontmatter`
+- `principle-pre-image-first`
 - `principle-progress-tracking`
 - `review-severity-tiers`
 - `running-quality-checks`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/qrspi-workflow/SKILL.md
+++ b/skills/qrspi-workflow/SKILL.md
@@ -25,7 +25,7 @@ WORKTREE -> QUESTION -> RESEARCH -> DESIGN -> STRUCTURE -> PLAN -> IMPLEMENT -> 
 | **IMPLEMENT** | code, passing tests, per-slice commits | AGGREGATE: security, verifier, code-review hard gates |
 | **PR** | GitHub draft PR | terminal: record URL; close ledger |
 
-WORKTREE is router-owned and has no agent; see “Why first” in `skills/worktree-isolation/SKILL.md`. IMPLEMENT has four sub-phases: test-architect writes failing acceptance tests; a mechanical gate requires assertion failures rather than crashes plus passing static checks; implementer commits green slices; 5 parallel code/security/docs/ux/verifier reviews return typed failures until no Blocking/Major remains.
+WORKTREE is router-owned and has no agent; see “Why first” in `skills/worktree-isolation/SKILL.md`. IMPLEMENT has four sub-phases: test-architect writes failing acceptance tests; a mechanical gate requires assertion failures rather than crashes plus passing static checks, inverting to a reproduced green pre-change baseline for a zero-behavior-change refactor, whose test-architect dispatch is skipped with a recorded reason; implementer commits green slices; 5 parallel code/security/docs/ux/verifier reviews return typed failures until no Blocking/Major remains.
 
 ## Artifact and isolation invariants
 

--- a/skills/team-implement/references/03-execution.md
+++ b/skills/team-implement/references/03-execution.md
@@ -6,7 +6,10 @@
    mode it derives acceptance criteria from `$ARGUMENTS/1-task.md` instead
    of `7-structure.md`. If those tests already exist, skip this dispatch.
    When the slice commits are on the branch too, resume at step 5.
-   Otherwise, resume at step 4.
+   Otherwise, resume at step 4. A change whose stated contract is zero
+   behavior change has nothing to write either — the current suite is the
+   acceptance suite — so skip this dispatch, record the reason on a named
+   line, and run step 3 in its inverted form.
 3. **Mechanical gate** — confirm all tests fail with assertion errors
    (not crashes), **and** that every static check the project defines
    passes (typecheck, lint, format, build — call the Skill tool with
@@ -18,6 +21,13 @@
    the next actor to notice is the `verifier`, a full review round later.
    This gate applies to a fresh `test-architect` run only. A resumed run
    that skips step 2 skips this gate too.
+   **Inverted for a zero-behavior-change refactor:** capture the suite and
+   the static checks as a baseline **before** any file moves
+   (`principle-pre-image-first`), and advance only when they reproduce it —
+   green is the correct state throughout, and a new failure is a
+   regression. Structural checks carry what the tests cannot express here:
+   a `grep` with an exact expected match count, a path that must no longer
+   exist.
 4. Dispatch `implementer` → executes slices with per-slice commits. In
    standalone mode it works from `$ARGUMENTS/1-task.md` and the failing
    tests.

--- a/skills/team/references/03-the-phase-loop.md
+++ b/skills/team/references/03-the-phase-loop.md
@@ -25,7 +25,8 @@ loop:
        REQUEST CHANGES, re-dispatch design-author with the findings
        verbatim and `revision: <n+1>`; a fresh review round follows.
      - MECHANICAL (tests-failing): run the suite; on assertion-only
-       failure, advance.
+       failure, advance. For a zero-behavior-change refactor this gate
+       inverts — see "Mechanical Gate (test confirmation)" below.
      - ROUTER-EMIT (worktree, PR): perform the action.
      - AGGREGATE (5 reviewers): dispatch in parallel, collect results,
        sort findings into severity tiers; auto-loop while any Blocking or
@@ -54,6 +55,11 @@ For RESEARCH, dispatch `file-finder` and `researcher` in parallel passing
 each only the `docs/plans/<id>/2-questions.md` path. Combine their returned
 content into a single `docs/plans/<id>/5-research.md` artifact (with the
 frontmatter the researcher's documentation specifies) before advancing.
+
+For IMPLEMENT, the `test-architect` dispatch is conditional. A change whose
+stated contract is zero behavior change has nothing to write — the current
+suite is the acceptance suite — so that dispatch is skipped with a recorded
+reason and the mechanical gate runs in its inverted form.
 
 `skills/team/registry.json` is an inventory of the 13 specialist agents
 for documentation purposes only. The orchestrator dispatches based on

--- a/skills/team/references/11-mechanical-gate-test-confirmation.md
+++ b/skills/team/references/11-mechanical-gate-test-confirmation.md
@@ -18,3 +18,27 @@ type checker is red — and the first actor to notice is otherwise the
 fix round to learn something a static check answers in seconds. Test-first
 deliberately produces incomplete stubs, which is exactly the state that
 type-checks badly, so this gate is where that shows up.
+
+#### The refactor case — the gate inverts
+
+A change whose stated contract is **zero behavior change** has no test to
+write. The acceptance tests already exist: they are the current suite, and
+their correct state throughout is green, not red. Writing new tests for the
+mechanics of a file move would add tests the task never asked for. So the
+gate's polarity inverts:
+
+1. Capture the baseline — the suite and every static check — **before** any
+   file moves. A baseline taken after the first move measures the change
+   rather than the pre-image (`principle-pre-image-first`), and a check that
+   could not run at all is UNKNOWN, never a pass.
+2. Skip the `test-architect` dispatch and record the reason on a named line
+   (`principle-skip-loudly`). A silent skip is indistinguishable from a
+   forgotten one.
+3. Advance only when the checks **reproduce that baseline**. A check red
+   before the change stays red; a new failure is a regression, not an
+   assertion the implementer is about to satisfy.
+
+Structural checks carry the acceptance criteria the tests cannot express
+here: a `grep` with an exact expected match count, a path that must no longer
+exist, an import graph with no surviving reference to the old name. State the
+expected count before running the command, so the check can fail.

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1555,3 +1555,34 @@ describe("the TodoWrite fallback names one ledger path (L2 tripwire)", () => {
     expect(setup).not.toContain(FALLBACK_LEDGER);
   });
 });
+
+// -------------------------------------------------------------------------
+// The inverted mechanical gate keeps its baseline rule on both dispatch
+// surfaces — free L2 drift tripwire (docs/testing.md §2, name form). The gate
+// advances on tests that go red, which is right for a change that adds
+// behavior and has no answer for a pure refactor: there the acceptance tests
+// are the current suite and green is correct throughout, so the gate becomes
+// "the checks reproduce a pre-change baseline". That inversion is worthless
+// without the ordering it rests on — the baseline is captured BEFORE anything
+// moves. Two surfaces dispatch `test-architect` and so must both carry it: the
+// orchestrator's gate reference and the standalone /team-implement procedure.
+// A skip path added to one alone is a surface that inverts the gate with no
+// baseline to compare against.
+// ---------------------------------------------------------------------------
+
+describe("the inverted mechanical gate cites its baseline rule (L2 tripwire)", () => {
+  const DISPATCH_SURFACES = [
+    join("skills", "team", "references", "11-mechanical-gate-test-confirmation.md"),
+    join("skills", "team-implement", "references", "03-execution.md"),
+  ];
+
+  test("both test-architect dispatch surfaces name principle-pre-image-first", () => {
+    for (const relative of DISPATCH_SURFACES) {
+      const text = read(join(REPO_ROOT, relative));
+      // Guard: a renamed or deleted surface must fail, not vacuously pass.
+      expect(text.length).toBeGreaterThan(0);
+      expect(text).toContain("test-architect");
+      expect(text).toContain("principle-pre-image-first");
+    }
+  });
+});


### PR DESCRIPTION
## What this is

The IMPLEMENT phase's mechanical gate advances only when **every acceptance test fails with an assertion error** and every static check passes. That is correct for a change that adds behavior. It has no answer for a **pure refactor** — a change whose stated contract is zero behavior change.

There the acceptance tests already exist: they are the current suite, and the correct state for them throughout is **green**, not red. `test-architect` has nothing to write, and writing new tests for the mechanics of a file move would add tests the task never asked for. So the gate's polarity inverts:

1. **Capture the baseline** — the suite and every static check — *before* any file moves (`principle-pre-image-first`). A baseline taken after the first move measures the change, not the pre-image; a check that could not run is UNKNOWN, never a pass.
2. **Skip the `test-architect` dispatch with a recorded reason** (`principle-skip-loudly`), never silently.
3. **Advance only when the checks reproduce that baseline.** A check red before stays red; a new failure is a regression, not an assertion the implementer is about to satisfy.

Structural checks carry the acceptance criteria the tests cannot express here: a `grep` with an exact expected match count, a path that must no longer exist, an import graph with no surviving reference to the old name — with the expected count stated *before* the command runs, so the check can fail.

## The surfaces that would have contradicted it

The phase table dispatched `test-architect` unconditionally, so a skip path in the gate alone would have left the table contradicting it. Four surfaces now agree: the phase table (dispatch marked conditional), the standalone `/team-implement` procedure, the QRSPI summary, and `docs/architecture.md` §3.

## Test plan

- [x] `bun test` — 2118 pass / 4 skip / 0 fail on re-run (rebased onto v0.88.0). One run hit a pre-existing flake — see **Known flake** below
- [x] `bun run typecheck` — clean
- [x] `bash .claude/scripts/check-discovery-consistency.sh` — all assertions passed
- [x] New L2 tripwire: **both** `test-architect` dispatch surfaces cite `principle-pre-image-first` — an inversion without the baseline rule compares against nothing (guarded against vacuous pass)
- [x] Commit signed (verified good ED25519)
- [x] No version bump — runtime change, versioned at land time per `docs/versioning.md`

## Known flake (not introduced here)

Three separate test files in this suite fail intermittently on wall-clock margin, on clean `main` as well as here:

- `tests/dev-install-pull-hooks.test.ts` → "a rebase inside a linked worktree neither reruns the installer nor fails"
- `tests/pre-merge-guard.test.ts` → "the gate script is read from the PR head (#232)" (two tests, 4043ms and 5023ms against a hardcoded `timeout: 4000`)
- `tests/regression-309-idempotent-install.test.ts` (5012ms against a 5000ms limit)

Each passes in isolation and on re-run. Evidence it is not this change:

- This branch touches no path the test exercises — the diff is `CHANGELOG.md`, `docs/`, three `skills/**` files, and `tests/protocol.test.ts`. Nothing under `script/`, `hooks/`, or that test file.
- The test is hermetic: it builds its own fixture repo and its own linked worktree under a temp root.
- Run in isolation on clean `origin/main`, 5/5 green. They only misbehave inside a full-suite run.
- A full-suite control on clean `origin/main` with **zero** changes reproduced it: run 1 green, run 2 green, run 3 red with the two `pre-merge-guard` failures.

**Update — CI settled it:** `Validate harness + fixtures` passed on this PR and on all four siblings, and a full-suite control run on clean `origin/main` was also green. The flake does not reproduce in CI. Nothing to change here; if it recurs locally it is worth its own issue.

## Notes for review

- No existing invariant weakened. The red-tests gate is unchanged for any change that adds behavior; the refactor case is a named, separate class.
- The `/team-implement` reference restates the inverted gate rather than citing `skills/team/references/11-…`, matching the shape that file already had — it condenses the whole mechanical gate inline today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


