### PR TITLE
v0.90.0 fix(pr-rebase): sweep the files the base ADDED, not only what conflicted

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.89.0"
+    "version": "0.90.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.89.0",
+      "version": "0.90.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **[`/pr-rebase`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)'s semantic sweep now also reads what the base branch *added*.** The sweep already covered a file this branch still cites after the base renamed or moved something. The mirror case is sharper and it went unhandled: the base creates a brand-new file citing paths this branch had moved, and it merges perfectly cleanly — not because the merge was smart, but because this branch never touched that file, so there was nothing to conflict. No marker, no stop, nothing in the conflicted-path list to review, and the new file lands on the default branch stale the day it was written. The sweep now enumerates the base's additions across the replayed range with `git diff --name-only --diff-filter=A`, reads each for the paths and symbols this branch moved, and stages the fixups into the replayed commit like any other resolution. **What this asks of you:** nothing.
+
 ## [0.89.0] - 2026-09-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.90.0] - 2026-09-07
+
 ### Changed
 
 - **[`/pr-rebase`](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)'s semantic sweep now also reads what the base branch *added*.** The sweep already covered a file this branch still cites after the base renamed or moved something. The mirror case is sharper and it went unhandled: the base creates a brand-new file citing paths this branch had moved, and it merges perfectly cleanly — not because the merge was smart, but because this branch never touched that file, so there was nothing to conflict. No marker, no stop, nothing in the conflicted-path list to review, and the new file lands on the default branch stale the day it was written. The sweep now enumerates the base's additions across the replayed range with `git diff --name-only --diff-filter=A`, reads each for the paths and symbols this branch moved, and stages the fixups into the replayed commit like any other resolution. **What this asks of you:** nothing.
@@ -811,7 +813,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.89.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.90.0...HEAD
+[0.90.0]: https://github.com/bostonaholic/team/compare/v0.89.0...v0.90.0
 [0.89.0]: https://github.com/bostonaholic/team/compare/v0.88.0...v0.89.0
 [0.88.0]: https://github.com/bostonaholic/team/compare/v0.87.0...v0.88.0
 [0.87.0]: https://github.com/bostonaholic/team/compare/v0.86.0...v0.87.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/pr-rebase/references/10-step-5-resolve-conflicts-from-both-sides-intent.md
+++ b/skills/pr-rebase/references/10-step-5-resolve-conflicts-from-both-sides-intent.md
@@ -149,5 +149,21 @@ push. Apply such fixups now, stage them into the replayed commit beside
 the conflict resolutions, and record each in the step 2 log with the
 base change that forced it.
 
+The mirror case is sharper, and the conflicted-path list will never
+surface it: a file the base **added** that cites a path this branch
+moved. Nothing conflicts, because this branch never touched that file —
+so the merge is clean for the wrong reason and the new file lands stale
+the day it was written. Enumerate the candidates from what the base
+contributed across the range being replayed, not from what conflicted:
+
+```sh
+git diff --name-only --diff-filter=A "${MERGE_BASE:?}..${BASE_REMOTE:?}/${BASE:?}"
+```
+
+Read each one for the paths, symbols, and directories this branch moved
+or renamed. Fix them the same way: staged into the replayed commit beside
+the conflict resolutions, and recorded in the step 2 log with the base
+change that forced them.
+
 **To abandon mid-rebase**, `git rebase --abort` restores the pre-rebase
 state exactly. Never `git rebase --skip` (Hard Rule 3).

--- a/tests/pr-rebase-skill.test.ts
+++ b/tests/pr-rebase-skill.test.ts
@@ -267,6 +267,18 @@ describe("pr-rebase skill: conflict resolution", () => {
     expect(continueLine ?? "").toContain("GIT_EDITOR=true");
   });
 
+  test("the semantic sweep enumerates what the BASE added, not only what conflicted", () => {
+    // The mirror of the rename case: a file the base CREATED that cites a
+    // path this branch moved merges clean, because this branch never touched
+    // it. No marker, no stop, nothing in --diff-filter=U to review — so the
+    // sweep has to read what the base contributed across the replayed range.
+    const added = fencedLines().find((line) => /--diff-filter=A/.test(line));
+    expect(added).toBeDefined();
+    expect(added ?? "").toContain("${MERGE_BASE:?}");
+    expect(added ?? "").toContain("${BASE_REMOTE:?}");
+    expect(added ?? "").toContain("${BASE:?}");
+  });
+
   test("the marker check runs before git add, which runs before --continue", () => {
     // Ordering tripwire: `git diff --cached --check` ahead of `git add`
     // inspects an empty staged diff and passes vacuously.


### PR DESCRIPTION
## What this is

`pr-rebase`'s section **"A clean git merge is not a semantic merge"** already sweeps for a file *this branch* still cites after the base renamed or moved something. The mirror case is sharper, and it had no answer:

**The base branch creates a brand-new file that cites paths this branch had moved.** It merges perfectly cleanly — not because the merge was smart, but because this branch never touched that file, so there was nothing to conflict. No marker, no stop, nothing in the conflicted-path list to review. It lands on the default branch stale on the day it was added.

The observed case: the base added an architecture document whose source table pointed at five paths, and the branch under rebase was the one that had moved all five.

## The detection is different, which is the point

A conflicted-path list (`git diff --diff-filter=U`) can **never** surface this. The sweep has to read what the base *contributed* across the range being replayed:

```sh
git diff --name-only --diff-filter=A "${MERGE_BASE:?}..${BASE_REMOTE:?}/${BASE:?}"
```

Fixups stay under the existing rule: staged into the replayed commit beside the conflict resolutions, and recorded in the step 2 log with the base change that forced them.

## Test plan

- [x] `bun test` — 2118 pass / 4 skip / 0 fail (rebased onto v0.88.0)
- [x] `bun run typecheck` — clean
- [x] `bash .claude/scripts/check-discovery-consistency.sh` — all assertions passed
- [x] `bun test tests/pr-rebase-skill.test.ts` — 43 pass / 0 fail (42 on `main` + this PR's 1)
- [x] Extended tripwire pins the command contract: `--diff-filter=A` plus all three `:?`-guarded range variables (`MERGE_BASE`, `BASE_REMOTE`, `BASE`) — a rewrite that keeps the command correct stays green
- [x] Commit signed (verified good ED25519)
- [x] No version bump — runtime change, versioned at land time per `docs/versioning.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

