### PR TITLE
v0.91.0 feat(reviewing-designs): calibrate the bar to the class of change

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.90.0"
+    "version": "0.91.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.90.0",
+      "version": "0.91.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.91.0] - 2026-09-07
+
 ### Changed
 
 - **[`reviewing-designs`](https://github.com/bostonaholic/team/blob/main/skills/reviewing-designs/SKILL.md) now calibrates the bar to the class of change.** The brief held every design to one standard, so a design for a pure refactor — file moves plus reference updates, zero behavior change — took five review rounds. Rounds 1 and 2 found real defects; by round 3 the findings were defects in the review's own verification commands, and rounds 4 and 5 turned on one internal contradiction and then a wording nit. What made it converge was calibration typed into the review prompt by hand, which meant it depended on whoever was driving noticing the problem. It is in the brief now: a refactor design is legitimately thin on edge cases, concurrency, and authorization because the change adds no behavior there; blocking means acting on the design as written produces a wrong or incomplete result; `COMMENT` is the verdict for a design carrying only non-blocking observations; and a reviewer never manufactures a blocking finding to justify another round. The defects the first two rounds caught — a self-contradiction, a missing edit, a verification command that would reject a correct implementation — stay blocking under the new wording, whatever the class of change. **What this asks of you:** nothing. `/eng-design-doc-review` dispatches the same brief, so it calibrates the same way.
@@ -817,7 +819,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.90.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.91.0...HEAD
+[0.91.0]: https://github.com/bostonaholic/team/compare/v0.90.0...v0.91.0
 [0.90.0]: https://github.com/bostonaholic/team/compare/v0.89.0...v0.90.0
 [0.89.0]: https://github.com/bostonaholic/team/compare/v0.88.0...v0.89.0
 [0.88.0]: https://github.com/bostonaholic/team/compare/v0.87.0...v0.88.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **[`reviewing-designs`](https://github.com/bostonaholic/team/blob/main/skills/reviewing-designs/SKILL.md) now calibrates the bar to the class of change.** The brief held every design to one standard, so a design for a pure refactor — file moves plus reference updates, zero behavior change — took five review rounds. Rounds 1 and 2 found real defects; by round 3 the findings were defects in the review's own verification commands, and rounds 4 and 5 turned on one internal contradiction and then a wording nit. What made it converge was calibration typed into the review prompt by hand, which meant it depended on whoever was driving noticing the problem. It is in the brief now: a refactor design is legitimately thin on edge cases, concurrency, and authorization because the change adds no behavior there; blocking means acting on the design as written produces a wrong or incomplete result; `COMMENT` is the verdict for a design carrying only non-blocking observations; and a reviewer never manufactures a blocking finding to justify another round. The defects the first two rounds caught — a self-contradiction, a missing edit, a verification command that would reject a correct implementation — stay blocking under the new wording, whatever the class of change. **What this asks of you:** nothing. `/eng-design-doc-review` dispatches the same brief, so it calibrates the same way.
+
 ## [0.90.0] - 2026-09-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/reviewing-designs/SKILL.md
+++ b/skills/reviewing-designs/SKILL.md
@@ -46,6 +46,15 @@ section. Call the Skill tool with `conventional-comments` for findings and
 8. **Check scope discipline.** Silent subsystem or multi-repo expansion is
    blocking.
 
+### Calibration
+
+Size the bar to the class of change. A refactor design is legitimately thin on
+edge cases, concurrency, and authorization, because the change adds no behavior
+there. Blocking means one thing: acting on the design as written produces a
+wrong or incomplete result. Prose imprecision, a citation off by a line, and a
+claim resting on vendor documentation outside the repo are not that. Never
+manufacture a blocking finding to justify another round.
+
 ### Output format
 
 Use Conventional Comments for every finding with a `file:line`. When external

--- a/skills/reviewing-designs/references/review-brief.md
+++ b/skills/reviewing-designs/references/review-brief.md
@@ -105,6 +105,30 @@ When you write your findings, also call the Skill tool with
    subsystems implied by the predecessor artifacts? Flag scope creep
    (especially silent multi-repo expansion) as a blocking issue.
 
+### Calibrate to the class of change
+
+Size the bar to what the change is, then judge against it. A design for a
+pure refactor — file moves plus reference updates, no behavior change —
+has legitimately thin edge-case, concurrency, and authorization
+sections, because the change introduces no behavior for those sections to
+describe. Thin there is the right answer, not a gap. Step 4 finds a gap
+only where the change opens a path the design leaves unwalked.
+
+**Blocking means one thing: acting on this design as written produces a
+wrong or incomplete result.** A self-contradiction, a missing edit the
+implementer would have to invent, and a verification command that would
+reject a correct implementation are all blocking, whatever the class of
+change. Prose imprecision, a citation off by a line, and a claim resting
+on vendor documentation outside the repo are not.
+
+Check your own findings before you emit them. A defect in the
+verification commands *you* propose is a defect in your review, not in
+the design.
+
+Never manufacture a blocking finding to justify another round. A round
+that turns up nothing blocking is the gate working, and a design a
+competent implementer can execute as written is approved.
+
 ### Output format
 
 Use Conventional Comments format for every finding. Every comment includes a
@@ -130,7 +154,8 @@ verdict is the **terminal line of your report** — nothing follows it:
   unjustified decision, absent edge-case enumeration, false or unverifiable
   citation, silent scope expansion, a rule that reaches one surface and not
   another with no reason given). The author must revise before the
-  design can advance.
+  design can advance. A finding that is not blocking never reaches this
+  verdict, however many of them there are.
 - **COMMENT** — Non-blocking suggestions and nitpicks only. Document is
   acceptable but could be improved.
 


### PR DESCRIPTION
## What this is

The design-review brief held every design to one standard. A design for a **pure refactor** — file moves plus reference updates, zero behavior change, with an ADR attached — went through **five** review rounds:

- Rounds 1 and 2 found real defects and were worth it.
- By round 3 the findings were defects in the review's **own verification commands** — self-check greps that would have rejected a correct implementation.
- Rounds 4 and 5 turned on one internal contradiction and then a wording nit.

What made it converge was calibration typed into the review prompt **by hand** from round 3 onward. That guidance was not in the skill, which means convergence depended on whoever was driving noticing the problem.

## What the brief now says

- **Size the bar to the class of change.** A refactor design is legitimately thin on edge cases, concurrency, and authorization *because the change adds no behavior for those sections to describe*. Under the old brief that read as a gap and drew findings.
- **Blocking means one thing:** acting on this design as written produces a wrong or incomplete result. Prose imprecision, a citation off by a line, and a claim resting on vendor documentation outside the repo are not that.
- **Check your own findings first.** A defect in the verification commands *you* propose is a defect in your review, not in the design.
- **`COMMENT` is the verdict for a design carrying only non-blocking observations.** In the observed run the reviewer defaulted toward `REQUEST CHANGES` while any finding at all remained; the verdict bullet now says a non-blocking finding never reaches that verdict, however many there are.
- **Never manufacture a blocking finding to justify another round.**

## Guarding against over-correction

This must not become a rubber stamp. Every defect the first two rounds caught — the self-contradiction about path aliases, the missing import edit, the test-runner glob that would have matched nothing — is **still blocking** under "produces a wrong or incomplete result," whatever the class of change. That phrasing was chosen precisely so those keep landing.

## Test plan

- [x] `bun test` — 2118 pass / 4 skip / 0 fail (rebased onto v0.88.0)
- [x] `bun run typecheck` — clean
- [x] `bash .claude/scripts/check-discovery-consistency.sh` — all assertions passed
- [x] `skills/reviewing-designs/SKILL.md` at 78 lines — under the 80-line methodology budget, no `SKILL_BUDGET_REASONS` entry needed
- [x] `/eng-design-doc-review` dispatches this brief by reference and restates no verdict criteria — it picks the calibration up with no change
- [x] Commit signed (verified good ED25519)
- [x] No version bump — runtime change, versioned at land time per `docs/versioning.md`

## What I deliberately did not add

**No test.** The addition is prose a reviewer weighs, with no command, number, path, or name underneath it. Per `docs/testing.md` ("a tripwire asserts a contract, never a wording") a regex over it would pin the phrasing and go red on every honest edit. The layer that *can* judge it is L5/L6 — and `tests/eng-design-doc-review.evals.ts` exists — but a proportionality case is a false-positive test with **zero** planted bugs, which `outcomeJudge` (`minimum_detection` over an empty `bugs[]`) does not express today. That is a real coverage gap; extending the judge is a follow-up worth filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

