### PR TITLE
v0.92.0 feat(running-quality-checks): warn where two checks poison each other

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.91.0"
+    "version": "0.92.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.91.0",
+      "version": "0.92.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.91.0",
+  "version": "0.92.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.91.0",
+  "version": "0.92.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **[`running-quality-checks`](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md) now warns that two checks can poison each other.** The skill detected a project's checks and ordered them by speed, and said nothing about checks that interfere. Running a production build immediately before a dev-server-backed browser suite, in one sequential loop, left the shared build directory in a state the dev server did not recover from: two browser tests failed on assertions that looked exactly like real regressions — a form control that never appeared, page metadata with the wrong value — and clearing the build directory and running the suite alone returned it to green, twice. The skill now states the hazard, the mitigation (clear the build directory, run the browser suite alone, never beside another agent's dev server), and the stronger rule for baselines: a before/after comparison is valid only when both sides ran under the same isolation. That last one is the expensive case — the observed run was capturing a baseline for a rebase, so it nearly recorded a false red as the pre-change state, which would have reclassified a later regression as pre-existing. **What this asks of you:** nothing.
+
 ## [0.91.0] - 2026-09-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.92.0] - 2026-09-07
+
 ### Changed
 
 - **[`running-quality-checks`](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md) now warns that two checks can poison each other.** The skill detected a project's checks and ordered them by speed, and said nothing about checks that interfere. Running a production build immediately before a dev-server-backed browser suite, in one sequential loop, left the shared build directory in a state the dev server did not recover from: two browser tests failed on assertions that looked exactly like real regressions — a form control that never appeared, page metadata with the wrong value — and clearing the build directory and running the suite alone returned it to green, twice. The skill now states the hazard, the mitigation (clear the build directory, run the browser suite alone, never beside another agent's dev server), and the stronger rule for baselines: a before/after comparison is valid only when both sides ran under the same isolation. That last one is the expensive case — the observed run was capturing a baseline for a rebase, so it nearly recorded a false red as the pre-change state, which would have reclassified a later regression as pre-existing. **What this asks of you:** nothing.
@@ -823,7 +825,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.91.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.92.0...HEAD
+[0.92.0]: https://github.com/bostonaholic/team/compare/v0.91.0...v0.92.0
 [0.91.0]: https://github.com/bostonaholic/team/compare/v0.90.0...v0.91.0
 [0.90.0]: https://github.com/bostonaholic/team/compare/v0.89.0...v0.90.0
 [0.89.0]: https://github.com/bostonaholic/team/compare/v0.88.0...v0.89.0

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -556,6 +556,10 @@ Defines reproduce, hypothesize, isolate, and fix workflow.
 
 Runs project-native tests, static checks, builds, and linters.
 
+**Mentions:**
+
+- `principle-pre-image-first`
+
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
 Requires one live ledger for ordered procedures.
@@ -913,7 +917,7 @@ skill. For the `$ARGUMENTS` shapes and the three-tier discovery, see
 | `principle-non-blocking-waits` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-optimization-never-dependency` | cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-plan-present-wait` | cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-pre-image-first` | cited by `pr-rebase`, `groom-backlog`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
+| `principle-pre-image-first` | cited by `pr-rebase`, `groom-backlog`, `reflect`, `running-quality-checks`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-record-assumptions` | cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-scope-fence` | cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time) | Any (cross-cutting principle) |
 | `principle-single-source-of-truth` | cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time) | Any (cross-cutting principle) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.91.0",
+  "version": "0.92.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.91.0",
+  "version": "0.92.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/running-quality-checks/SKILL.md
+++ b/skills/running-quality-checks/SKILL.md
@@ -26,6 +26,13 @@ them in speed order, and report evidence. No opinions — just evidence.
    4. **Build** — Production build command
    5. **Test** — Test suite execution
 
+   Checks interfere. A production build and a dev-server-backed browser suite
+   share one build directory in most frameworks that have one, so back-to-back
+   in a single sequence the second reads state the first wrote and fails on
+   assertions that read exactly like regressions. Clear the build directory and
+   run the browser suite alone. A suite that boots its own servers is unsafe
+   beside anything else, another agent's dev server included.
+
 3. **Capture results.** For each check, record:
    - The exact command run
    - The exit code
@@ -57,6 +64,11 @@ them in speed order, and report evidence. No opinions — just evidence.
   (`### Notes — Intermittent: testFoo passed on retry, the underlying race condition is unresolved`).
   Reruns that turn red → green without a code change are evidence of a
   flake or a real intermittent bug, not a verdict of PASS.
+- **A baseline is comparable only under the same isolation.** When this run is
+  the before side of a before/after comparison (`principle-pre-image-first`),
+  run both sides the same way. A false red recorded as the pre-change state
+  reclassifies a later regression as pre-existing — a failure in the safe
+  direction, which is why it goes unnoticed.
 - **Coverage is reported, not gated.** If the project has a coverage tool
   configured, run it and report the coverage delta for changed files
   (e.g., "coverage on changed files: 73% → 78%"). Do NOT gate on an


### PR DESCRIPTION
## What this is

`running-quality-checks` detects a project's checks and gives a speed order. It said nothing about checks that **interfere with each other**.

Observed: running a production build immediately before a dev-server-backed browser suite, in one sequential loop, left the shared build directory in a state the dev server did not recover from. Two browser tests failed on plausible-looking assertions — a form control that never appeared, and page metadata that came back as the wrong value. **Both looked exactly like real regressions.** Clearing the build directory and running the suite alone returned it to green, twice.

## The cost is not just a rerun

This happened while capturing a **baseline** for a rebase, so it nearly recorded a false red as the pre-change state. That fails in the *safe* direction, which is why it goes unnoticed: a genuine regression later would have been classified as pre-existing and waved through.

So the skill now states three things:

1. **The hazard** — a production build and a dev-server-backed browser suite share one build directory in most frameworks that have one, so back-to-back in a single sequence the second reads state the first wrote.
2. **The mitigation** — clear the build directory, run the browser suite alone.
3. **The stronger rule for baselines** — a before/after comparison is valid only when both sides ran under the same isolation (`principle-pre-image-first`).

Also written down, because nothing else stated it: a browser suite that boots its own servers is not safe to run beside anything else, **including another agent's dev server**.

## Test plan

- [x] `bun test` — 2117 pass / 4 skip / 0 fail (rebased onto v0.88.0)
- [x] `bun run typecheck` — clean
- [x] `bash .claude/scripts/check-discovery-consistency.sh` — all assertions passed
- [x] `skills/running-quality-checks/SKILL.md` at 78 lines — under the 80-line methodology budget, no `SKILL_BUDGET_REASONS` entry needed
- [x] `docs/skills.md` updated both ways the catalog tests require: a new `**Mentions:**` block on the entry, and `running-quality-checks` added as a consumer on the `principle-pre-image-first` table row
- [x] Commit signed (verified good ED25519)
- [x] No version bump — runtime change, versioned at land time per `docs/versioning.md`

## What I deliberately did not add

**No test.** The addition is prose about run ordering, with no command, number, path, or name a tripwire could pin without pinning the wording (`docs/testing.md`, "a tripwire asserts a contract, never a wording").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

