### PR TITLE
docs(skills): make the catalog a load graph, not a mention list

### DIFF
--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,8 +82,8 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by a `**Mentions:**` list only when the skill's own `.md` files name at least one other skill; omit the block entirely when they name none. Rewriting a `description` updates that entry in the same commit.
-- Sort `Mentions:` in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`), and list every backticked skill name in any `.md` under `skills/<name>/`, references and prompt templates included. `tests/docs-skills-catalog.test.ts` is the gate.
+- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by a `**Loads:**` list only when the skill's own `.md` files instruct a load of at least one other skill; omit the block entirely when they load none. Rewriting a `description` updates that entry in the same commit.
+- List under `Loads:` only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a load, so a skill it merely names by path or in prose stays off the list — the list is a directed dependency edge, not a cross-reference. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.
 - For runtime behavior, update `CHANGELOG.md` under `Unreleased`; version only at land time.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -818,7 +818,8 @@ a building block. The two front-door pairs are how a composed methodology
 keeps a user-facing entry point without becoming one.)
 
 For the full per-skill reference (all skills, each with the skills it
-mentions), see [skills.md](skills.md).
+loads, which is the skill-to-skill dependency graph), see
+[skills.md](skills.md).
 
 ### Design guidelines
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: "The Team plugin's skills: pipeline entry-point slash commands, standalone utilities (shipit, pr-open-comments, pr-watch-as-author, pr-watch-as-reviewer, groom-backlog, pr-cleanup, pr-verify, pr-rebase, reflect, why, how), and methodology skills loaded by agents, each with the skills it mentions."
+description: "The Team plugin's skills: pipeline entry-point slash commands, standalone utilities (shipit, pr-open-comments, pr-watch-as-author, pr-watch-as-reviewer, groom-backlog, pr-cleanup, pr-verify, pr-rebase, reflect, why, how), and methodology skills loaded by agents, each with the skills it loads."
 audience: [user, developer]
 nav_order: 5
 nav_label: skills
@@ -17,10 +17,26 @@ nav_label: skills
 > `SKILL.md`, the `SKILL.md` wins.
 
 Each entry is one sentence, copied from that skill's frontmatter
-`description`. A `**Mentions:**` list follows it when the skill's own `.md`
-files name other skills — a load, a citation, and a passing mention alike.
-For what separates a load from a citation, and for how a skill is loaded at
-all, see [architecture.md §6](architecture.md#6-skills).
+`description`. A `**Loads:**` list follows it when the skill's own `.md`
+files instruct a load of another skill — ``Call the Skill tool with `<name>` ``,
+the one form that makes a reader go execute it. Naming a skill any other way
+is a citation, and a citation is not an edge: `team-structure` restates a
+`principle-fail-closed` rule inline and never loads it, so it has no edge to
+it.
+
+The edges are therefore **directed**, and reading them transitively gives the
+graph. `team-implement` loads `team-pr`, which loads `git-commit`, which
+loads `writing-prose`. None of the three loads back. An entry with no
+`**Loads:**` block is a leaf: it loads nothing, which is the normal shape for
+a `principle-*` skill and for a methodology skill that states one rule and
+stops.
+
+Loads are collected across every `.md` file in the skill's directory, so a
+load written in a `references/` file counts the same as one in `SKILL.md`.
+This page carries skill-to-skill edges only. For which *agent* loads a skill,
+see [the table below](#skill--agent--phase); for what separates a load from a
+citation, and for how a skill is loaded at all, see
+[architecture.md §6](architecture.md#6-skills).
 
 ## Entry-point skills
 
@@ -31,23 +47,13 @@ full run or drives one phase of the QRSPI pipeline.
 
 Runs the 8-phase QRSPI feature pipeline.
 
-**Mentions:**
+**Loads:**
 
-- `artifact-frontmatter`
 - `changelog`
 - `cross-model-review`
-- `principle-deep-agents-narrow-seams`
-- `principle-fail-closed`
-- `principle-files-are-the-contract`
-- `principle-idempotent-reruns`
-- `principle-pre-image-first`
-- `principle-progress-tracking`
-- `principle-skip-loudly`
-- `qrspi-workflow`
 - `review-severity-tiers`
 - `reviewing-designs`
 - `running-quality-checks`
-- `team-implement`
 - `team-pr`
 - `team-worktree`
 - `tracking-tickets`
@@ -57,84 +63,49 @@ Runs the 8-phase QRSPI feature pipeline.
 
 Decomposes a feature into task and question artifacts.
 
-**Mentions:**
-
-- `decomposing-intent`
-- `product-requirements-doc`
-- `qrspi-workflow`
-
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
 Researches a codebase area before changes.
-
-**Mentions:**
-
-- `team`
 
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
 Drafts and adversarially reviews a design.
 
-**Mentions:**
+**Loads:**
 
-- `artifact-frontmatter`
 - `cross-model-review`
-- `principle-fail-closed`
-- `principle-idempotent-reruns`
 - `reviewing-designs`
-- `team`
 
 ### [team-structure](https://github.com/bostonaholic/team/blob/main/skills/team-structure/SKILL.md)
 
 Breaks a reviewed design into verified slices.
 
-**Mentions:**
-
-- `principle-fail-closed`
-- `team`
-
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
 Produces the tactical implementation plan.
-
-**Mentions:**
-
-- `team`
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
 Prepares isolated git worktrees.
 
-**Mentions:**
-
-- `qrspi-workflow`
-- `team`
-- `worktree-isolation`
-
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
 Executes and verifies implementation slices.
 
-**Mentions:**
+**Loads:**
 
-- `artifact-frontmatter`
-- `principle-pre-image-first`
-- `principle-progress-tracking`
 - `review-severity-tiers`
 - `running-quality-checks`
-- `team`
 - `team-pr`
 
 ### [team-pr](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md)
 
 Opens a pull request after verification.
 
-**Mentions:**
+**Loads:**
 
 - `changelog`
 - `git-commit`
-- `principle-optimization-never-dependency`
-- `team`
 - `tracking-tickets`
 - `verifying-ux`
 - `worktree-isolation`
@@ -144,11 +115,8 @@ Opens a pull request after verification.
 
 Runs the compressed bug-fix pipeline.
 
-**Mentions:**
+**Loads:**
 
-- `principle-explicit-intent`
-- `principle-fix-root-causes`
-- `principle-progress-tracking`
 - `systematic-debugging`
 - `team-worktree`
 - `test-driven-bug-fix`
@@ -160,13 +128,10 @@ Runs the compressed bug-fix pipeline.
 
 Reviews a technical design document with fresh context.
 
-**Mentions:**
+**Loads:**
 
 - `cross-model-review`
-- `principle-generator-evaluator`
-- `principle-least-privilege`
 - `reviewing-designs`
-- `team`
 - `writing-prose`
 
 ## Standalone utilities
@@ -178,151 +143,81 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 Lands a reviewed pull request.
 
-**Mentions:**
-
-- `principle-explicit-intent`
-- `principle-non-blocking-waits`
-
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
 Triages unresolved PR review comments.
-
-**Mentions:**
-
-- `principle-evidence-over-assertion`
-- `principle-plan-present-wait`
 
 ### [pr-watch-as-author](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-author/SKILL.md)
 
 Watches an authored PR for feedback.
 
-**Mentions:**
+**Loads:**
 
 - `pr-open-comments`
 - `pr-watch-mechanics`
-- `principle-bounded-loops`
-- `principle-idempotent-reruns`
-- `principle-non-blocking-waits`
-- `principle-untrusted-input-is-data`
 - `tracking-tickets`
 
 ### [pr-watch-as-reviewer](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-reviewer/SKILL.md)
 
 Watches a reviewed PR and approves settled feedback.
 
-**Mentions:**
+**Loads:**
 
-- `conventional-comments`
-- `pr-open-comments`
-- `pr-watch-as-author`
 - `pr-watch-mechanics`
-- `principle-bounded-loops`
-- `principle-generator-evaluator`
-- `principle-non-blocking-waits`
 
 ### [groom-backlog](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
 
 Grooms a project backlog and proposes tracker changes.
 
-**Mentions:**
-
-- `pr-open-comments`
-- `principle-evidence-over-assertion`
-- `principle-explicit-intent`
-- `principle-idempotent-reruns`
-- `principle-never-interpolate`
-- `principle-plan-present-wait`
-- `principle-pre-image-first`
-- `principle-skip-loudly`
-- `principle-untrusted-input-is-data`
-
 ### [pr-cleanup](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md)
 
 Cleans PR state.
-
-**Mentions:**
-
-- `principle-explicit-intent`
-- `principle-idempotent-reruns`
-- `principle-never-interpolate`
-- `principle-untrusted-input-is-data`
-- `sweeping-local-state`
 
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
 Verifies a PR test plan with evidence-rated verdicts.
 
-**Mentions:**
+**Loads:**
 
-- `nested-agents`
-- `principle-evidence-over-assertion`
-- `principle-least-privilege`
-- `principle-optimization-never-dependency`
 - `running-quality-checks`
 
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
 Rebases a branch onto its base.
 
-**Mentions:**
+**Loads:**
 
-- `artifact-frontmatter`
-- `pr-cleanup`
-- `principle-explicit-intent`
-- `principle-never-interpolate`
-- `principle-non-blocking-waits`
-- `principle-pre-image-first`
-- `principle-untrusted-input-is-data`
 - `running-quality-checks`
 
 ### [reflect](https://github.com/bostonaholic/team/blob/main/skills/reflect/SKILL.md)
 
 Mines a session for durable learnings.
 
-**Mentions:**
+**Loads:**
 
-- `finding-files`
-- `nested-agents`
-- `principle-explicit-intent`
-- `principle-least-privilege`
-- `principle-optimization-never-dependency`
-- `principle-plan-present-wait`
-- `principle-pre-image-first`
-- `principle-untrusted-input-is-data`
 - `running-quality-checks`
 
 ### [why](https://github.com/bostonaholic/team/blob/main/skills/why/SKILL.md)
 
 Investigates design rationale behind code.
 
-**Mentions:**
+**Loads:**
 
-- `documenting-decisions`
-- `how`
-- `principle-blind-the-investigator`
-- `principle-evidence-over-assertion`
-- `principle-optimization-never-dependency`
-- `principle-skip-loudly`
-- `principle-untrusted-input-is-data`
 - `systematic-debugging`
 
 ### [how](https://github.com/bostonaholic/team/blob/main/skills/how/SKILL.md)
 
 Explains subsystem architecture and runtime flow.
 
-**Mentions:**
+**Loads:**
 
-- `code-review`
-- `principle-generator-evaluator`
-- `principle-optimization-never-dependency`
-- `researching-codebases`
 - `why`
 
 ### [code-review](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
 
 Reviews a diff with fresh context.
 
-**Mentions:**
+**Loads:**
 
 - `reviewing-code`
 
@@ -335,40 +230,13 @@ them.
 
 Defines QRSPI phases, artifacts, gates, and state transitions.
 
-**Mentions:**
-
-- `artifact-frontmatter`
-- `principle-blind-the-investigator`
-- `principle-files-are-the-contract`
-- `principle-human-owns-the-ends`
-- `principle-mechanical-gates`
-- `principle-scope-fence`
-- `principle-single-source-of-truth`
-- `review-severity-tiers`
-- `slicing-work`
-- `team`
-- `worktree-isolation`
-
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
 Defines pipeline artifact schemas.
 
-**Mentions:**
-
-- `principle-files-are-the-contract`
-- `principle-single-source-of-truth`
-- `product-requirements-doc`
-- `qrspi-workflow`
-- `worktree-isolation`
-
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
 Defines evidence-only codebase research and `5-research.md`.
-
-**Mentions:**
-
-- `principle-blind-the-investigator`
-- `principle-evidence-over-assertion`
 
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
@@ -378,27 +246,17 @@ Locates files by naming, structure, and imports.
 
 Defines task and question artifacts plus multi-repo detection.
 
-**Mentions:**
+**Loads:**
 
-- `artifact-frontmatter`
-- `principle-blind-the-investigator`
-- `principle-never-interpolate`
-- `principle-record-assumptions`
 - `product-requirements-doc`
 
 ### [authoring-designs](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md)
 
 Defines the design-document procedure.
 
-**Mentions:**
+**Loads:**
 
-- `artifact-frontmatter`
-- `how`
-- `principle-record-assumptions`
-- `principle-subtract-before-you-add`
-- `product-requirements-doc`
 - `systems-thinking`
-- `why`
 - `writing-prose`
 
 ### [slicing-work](https://github.com/bostonaholic/team/blob/main/skills/slicing-work/SKILL.md)
@@ -413,17 +271,10 @@ Defines the tactical plan schema.
 
 Defines adversarial code review and evidence-based findings.
 
-**Mentions:**
+**Loads:**
 
-- `conventional-comments`
-- `cross-model-review`
 - `engineering-standards`
-- `principle-generator-evaluator`
-- `principle-least-privilege`
-- `principle-skip-loudly`
 - `review-severity-tiers`
-- `reviewing-security`
-- `solid`
 - `test-style`
 - `why`
 - `writing-prose`
@@ -432,15 +283,13 @@ Defines adversarial code review and evidence-based findings.
 
 Defines adversarial design review and verdicts.
 
-**Mentions:**
+**Loads:**
 
 - `conventional-comments`
 - `cross-model-review`
 - `documenting-decisions`
-- `eng-design-doc-review`
 - `engineering-standards`
 - `reviewing-code`
-- `team`
 - `technical-design-doc`
 - `writing-prose`
 
@@ -456,66 +305,28 @@ Defines threat and OWASP review with evidence-rated findings.
 
 Runs second-vendor reviews through machine-only CLI adapters.
 
-**Mentions:**
-
-- `artifact-frontmatter`
-- `nested-agents`
-- `principle-least-privilege`
-- `principle-never-interpolate`
-- `principle-non-blocking-waits`
-- `principle-optimization-never-dependency`
-- `principle-single-source-of-truth`
-- `principle-skip-loudly`
-- `principle-untrusted-input-is-data`
-- `review-severity-tiers`
-- `reviewing-code`
-- `team`
-
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
 Maps reviewer findings to Blocking, Major, or Minor actions.
-
-**Mentions:**
-
-- `principle-human-owns-the-ends`
-- `reviewing-code`
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
 Defines code design, comment, and review standards.
 
-**Mentions:**
-
-- `conventional-comments`
-- `principle-subtract-before-you-add`
-- `solid`
-
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
 Defines acceptance tests as the implementation scope contract.
-
-**Mentions:**
-
-- `principle-mechanical-gates`
-- `principle-scope-fence`
-- `test-style`
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
 Defines deterministic behavioral tests and flaky-test red flags.
 
-**Mentions:**
-
-- `reviewing-code`
-- `test-first-development`
-
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
 Defines reproduce-red-green-refactor bug fixes.
 
-**Mentions:**
+**Loads:**
 
-- `principle-fix-root-causes`
 - `systematic-debugging`
 
 ### [solid](https://github.com/bostonaholic/team/blob/main/skills/solid/SKILL.md)
@@ -526,69 +337,37 @@ Defines SOLID design and review rules.
 
 Maps code smells to behavior-preserving refactorings.
 
-**Mentions:**
-
-- `principle-subtract-before-you-add`
-
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
 Defines test-first slice execution, commits, and review fixes.
 
-**Mentions:**
+**Loads:**
 
 - `git-commit`
 - `principle-fix-root-causes`
-- `principle-scope-fence`
-- `principle-subtract-before-you-add`
 - `systematic-debugging`
 
 ### [systematic-debugging](https://github.com/bostonaholic/team/blob/main/skills/systematic-debugging/SKILL.md)
 
 Defines reproduce, hypothesize, isolate, and fix workflow.
 
-**Mentions:**
-
-- `principle-fix-root-causes`
-- `test-driven-bug-fix`
-- `why`
-
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
 Runs project-native tests, static checks, builds, and linters.
-
-**Mentions:**
-
-- `principle-pre-image-first`
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
 Requires one live ledger for ordered procedures.
 
-**Mentions:**
-
-- `qrspi-workflow`
-- `team-fix`
-
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
 Defines safe nested-agent dispatch and fallback.
-
-**Mentions:**
-
-- `cross-model-review`
-- `principle-blind-the-investigator`
-- `principle-deep-agents-narrow-seams`
-- `principle-fail-closed`
-- `principle-generator-evaluator`
-- `principle-optimization-never-dependency`
-- `principle-record-assumptions`
-- `systems-thinking`
 
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
 Defines ADR structure and lifecycle.
 
-**Mentions:**
+**Loads:**
 
 - `writing-prose`
 
@@ -596,7 +375,7 @@ Defines ADR structure and lifecycle.
 
 Defines technical design sections and decision content.
 
-**Mentions:**
+**Loads:**
 
 - `writing-prose`
 
@@ -604,7 +383,7 @@ Defines technical design sections and decision content.
 
 Defines when and how to write `3-prd.md`.
 
-**Mentions:**
+**Loads:**
 
 - `writing-prose`
 
@@ -616,40 +395,23 @@ Defines product-need lenses.
 
 Defines system-boundary, feedback, and dependency analysis.
 
-**Mentions:**
-
-- `reviewing-code`
-
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
 Defines plain-language prose rules.
-
-**Mentions:**
-
-- `conventional-comments`
-- `reviewing-documentation`
 
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
 Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
 
-**Mentions:**
-
-- `writing-prose`
-
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
 Defines live application and screenshot verification.
-
-**Mentions:**
-
-- `team-pr`
 
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
 Defines Conventional Commit subjects and safe commit procedure.
 
-**Mentions:**
+**Loads:**
 
 - `writing-prose`
 
@@ -657,7 +419,7 @@ Defines Conventional Commit subjects and safe commit procedure.
 
 Defines Keep a Changelog updates.
 
-**Mentions:**
+**Loads:**
 
 - `writing-prose`
 
@@ -669,41 +431,21 @@ Defines tracker status transitions and closing rules.
 
 Defines Team worktree creation, validation, and teardown.
 
-**Mentions:**
+**Loads:**
 
-- `pr-cleanup`
-- `sweeping-local-state`
 - `team-worktree`
 
 ### [sweeping-local-state](https://github.com/bostonaholic/team/blob/main/skills/sweeping-local-state/SKILL.md)
 
 Defines machine-local teardown.
 
-**Mentions:**
-
-- `pr-cleanup`
-- `principle-never-interpolate`
-- `principle-skip-loudly`
-- `worktree-isolation`
-
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
 Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
 
-**Mentions:**
-
-- `pr-watch-as-author`
-- `pr-watch-as-reviewer`
-- `principle-bounded-loops`
-- `principle-non-blocking-waits`
-
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
 Keeps desired outcomes out of research prompts.
-
-**Mentions:**
-
-- `principle-generator-evaluator`
 
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
@@ -725,10 +467,6 @@ Requires stated intent for irreversible actions.
 
 Treats unknown guarantees as failures.
 
-**Mentions:**
-
-- `principle-optimization-never-dependency`
-
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
 Requires durable files for cross-step state.
@@ -740,10 +478,6 @@ Requires diagnosis and repair of root causes.
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
 Separates producers from evaluators.
-
-**Mentions:**
-
-- `reviewing-code`
 
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
@@ -769,18 +503,9 @@ Keeps external text out of shell syntax.
 
 Requires resumable waits for external state.
 
-**Mentions:**
-
-- `principle-bounded-loops`
-
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
 Keeps optional enhancements off the correctness path.
-
-**Mentions:**
-
-- `principle-fail-closed`
-- `principle-skip-loudly`
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
@@ -790,10 +515,6 @@ Requires a written plan and user approval before mutations.
 
 Requires a recoverable baseline before destructive changes.
 
-**Mentions:**
-
-- `principle-idempotent-reruns`
-
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
 Records autonomous resolutions as assumptions.
@@ -801,10 +522,6 @@ Records autonomous resolutions as assumptions.
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
 Restricts execution to approved scope.
-
-**Mentions:**
-
-- `principle-skip-loudly`
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
@@ -817,10 +534,6 @@ Requires skipped work to be reported explicitly.
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
 Requires removal before addition.
-
-**Mentions:**
-
-- `principle-scope-fence`
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -1,10 +1,20 @@
 // L2 static-invariant tripwire: every `docs/skills.md` entry matches disk.
 //
 // The page is hand-authored, and nothing has ever pinned it to the skills it
-// catalogues. This holds four properties per entry — shape, sentence, mention
-// set, mention order — so a rewritten `description`, or a backticked skill name
-// added to any `.md` under `skills/<name>/`, reds the build with a message
-// naming the skill, the name, and the direction.
+// catalogues. This holds four properties per entry — shape, sentence, load
+// set, load order — so a rewritten `description`, or a Skill-tool load added
+// to any `.md` under `skills/<name>/`, reds the build with a message naming
+// the skill, the name, and the direction.
+//
+// WHY LOADS AND NOT MENTIONS. The page's edges are the skill-to-skill
+// dependency graph: A loads B loads C, read transitively. Only the load form
+// — ``Call the Skill tool with `<name>` `` — is an edge, because only it sends
+// the reader to go execute that skill. Every other way of naming a skill is a
+// citation, and a citation carries no direction: a skill that restates a rule
+// from `why` does not depend on `why`, and counting that as an edge invents a
+// back-edge the graph does not have. `loadedSkills()` in
+// tests/helpers/skill-refs.ts owns the extraction, so the page and
+// tests/skill-tool-invocation.test.ts read the same edges.
 //
 // WHY THE SENTENCE EQUALITY IS NOT A WORDING PIN. docs/testing.md, under "A
 // tripwire asserts a contract, never a wording", sets the test: "if a rewrite
@@ -23,21 +33,16 @@ import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { description, read, squash } from "./helpers/text";
-import { skillNames } from "./helpers/skill-refs";
+import { loadedSkills, skillNames } from "./helpers/skill-refs";
 
 const REPO_ROOT = join(import.meta.dir, "..");
 const CATALOG = join(REPO_ROOT, "docs", "skills.md");
 const SKILLS_ROOT = join(REPO_ROOT, "skills");
 
-const MENTIONS_HEADER = "**Mentions:**";
-const MENTION_BULLET = /^- `([a-z0-9-]+)`$/;
+const LOADS_HEADER = "**Loads:**";
+const LOAD_BULLET = /^- `([a-z0-9-]+)`$/;
 
 type Entry = { name: string; section: string; body: string[] };
-
-/** The two encoded skill-to-skill reference forms (docs/architecture.md#6-skills). */
-type ReferenceForm = "bare" | "path";
-
-const BOTH_FORMS: ReferenceForm[] = ["bare", "path"];
 
 // ---------------------------------------------------------------------------
 // Parse and file walk. Scaffolding: no rule lives here.
@@ -77,23 +82,23 @@ function markdownFiles(dir: string): string[] {
   });
 }
 
-/** The names on the entry's mention bullets, in authored order. */
-function mentionBullets(body: string[]): string[] {
+/** The names on the entry's load bullets, in authored order. */
+function loadBullets(body: string[]): string[] {
   return body.flatMap((line) => {
-    const bullet = MENTION_BULLET.exec(line.trim());
+    const bullet = LOAD_BULLET.exec(line.trim());
     return bullet ? [bullet[1] as string] : [];
   });
 }
 
-/** True when the body carries the mentions header. */
-function hasMentionsHeader(body: string[]): boolean {
-  return body.some((line) => line.trim() === MENTIONS_HEADER);
+/** True when the body carries the loads header. */
+function hasLoadsHeader(body: string[]): boolean {
+  return body.some((line) => line.trim() === LOADS_HEADER);
 }
 
-/** A body line that is neither the mentions header nor a mention bullet. */
+/** A body line that is neither the loads header nor a load bullet. */
 function isProse(line: string): boolean {
   const trimmed = line.trim();
-  return trimmed !== MENTIONS_HEADER && !MENTION_BULLET.test(trimmed);
+  return trimmed !== LOADS_HEADER && !LOAD_BULLET.test(trimmed);
 }
 
 // ---------------------------------------------------------------------------
@@ -104,12 +109,12 @@ function isProse(line: string): boolean {
 
 /**
  * Shape offenders for one entry body, each naming the offending line. The body
- * must be one or more prose lines, then optionally the mentions header followed
- * by one or more mention bullets, and nothing after. Eight offenders: (1) zero
- * prose lines; (2) a line starting `- ` that is not exactly a mention bullet
+ * must be one or more prose lines, then optionally the loads header followed
+ * by one or more load bullets, and nothing after. Eight offenders: (1) zero
+ * prose lines; (2) a line starting `- ` that is not exactly a load bullet
  * (a surviving `**Purpose:**` bullet, a trailing clause after a name); (3) a
- * prose line after the mentions header; (4) a mentions header with no bullet
- * under it; (5) a mention bullet with no header above it; (6) a second mentions
+ * prose line after the loads header; (4) a loads header with no bullet
+ * under it; (5) a load bullet with no header above it; (6) a second loads
  * header; (7) a duplicate name among the bullets; (8) any body line with
  * leading whitespace, first line included.
  */
@@ -124,33 +129,33 @@ function shape(body: string[]): string[] {
     const trimmed = line.trim();
     if (line !== trimmed) offenders.push(`indented body line: ${JSON.stringify(line)}`);
 
-    if (trimmed === MENTIONS_HEADER) {
+    if (trimmed === LOADS_HEADER) {
       headers++;
-      if (headers > 1) offenders.push("second mentions header");
+      if (headers > 1) offenders.push("second loads header");
       continue;
     }
 
-    const bullet = MENTION_BULLET.exec(trimmed);
+    const bullet = LOAD_BULLET.exec(trimmed);
     if (bullet) {
       const name = bullet[1] as string;
       bullets++;
-      if (headers === 0) offenders.push(`mention bullet with no header above it: ${name}`);
-      if (seen.has(name)) offenders.push(`duplicate mention: ${name}`);
+      if (headers === 0) offenders.push(`load bullet with no header above it: ${name}`);
+      if (seen.has(name)) offenders.push(`duplicate load: ${name}`);
       seen.add(name);
       continue;
     }
 
     if (trimmed.startsWith("- ")) {
-      offenders.push(`bullet that is not a bare mention: ${JSON.stringify(trimmed)}`);
+      offenders.push(`bullet that is not a bare load: ${JSON.stringify(trimmed)}`);
       continue;
     }
 
     prose++;
-    if (headers > 0) offenders.push(`prose line after the mentions header: ${JSON.stringify(trimmed)}`);
+    if (headers > 0) offenders.push(`prose line after the loads header: ${JSON.stringify(trimmed)}`);
   }
 
   if (prose === 0) offenders.push("no prose line");
-  if (headers > 0 && bullets === 0) offenders.push("mentions header with no bullet under it");
+  if (headers > 0 && bullets === 0) offenders.push("loads header with no bullet under it");
   return offenders;
 }
 
@@ -177,16 +182,18 @@ function sentence(body: string[], description: string): string[] {
 }
 
 /**
- * Mention-set offenders, each naming the offending name: a derived name missing
+ * Load-set offenders, each naming the offending name: a derived name missing
  * from the bullets, a listed name absent from the derived set, and a listed name
- * that is not a real skill at all.
+ * that is not a real skill at all. The second one is the direction check — a
+ * skill that only *names* another skill has no edge to it, so listing it here
+ * would draw an arrow the source never authorized.
  */
-function mentionSet(bullets: string[], derived: Set<string>, names: Set<string>): string[] {
+function loadSet(bullets: string[], derived: Set<string>, names: Set<string>): string[] {
   const listed = new Set(bullets);
   return [
-    ...[...derived].filter((name) => !listed.has(name)).map((name) => `mentions omit ${name}`),
-    ...bullets.filter((name) => !derived.has(name)).map((name) => `mentions list ${name}, which its files never name`),
-    ...bullets.filter((name) => !names.has(name)).map((name) => `mentions list ${name}, which is not a skill`),
+    ...[...derived].filter((name) => !listed.has(name)).map((name) => `loads omit ${name}`),
+    ...bullets.filter((name) => !derived.has(name)).map((name) => `loads list ${name}, which its files never load`),
+    ...bullets.filter((name) => !names.has(name)).map((name) => `loads list ${name}, which is not a skill`),
   ];
 }
 
@@ -195,32 +202,35 @@ function mentionSet(bullets: string[], derived: Set<string>, names: Set<string>)
  * `[...names].sort()` — codepoint order, so `pr-verify` precedes
  * `principle-fail-closed`. Names the first name out of place.
  */
-function mentionOrder(bullets: string[]): string[] {
+function loadOrder(bullets: string[]): string[] {
   const sorted = [...bullets].sort();
   const at = bullets.findIndex((name, index) => name !== sorted[index]);
-  return at === -1 ? [] : [`mentions out of order at ${bullets[at]}, expected ${sorted[at]}`];
+  return at === -1 ? [] : [`loads out of order at ${bullets[at]}, expected ${sorted[at]}`];
 }
 
 /**
- * The skill names `text` mentions, excluding `self` and filtered by `names`.
- * Two reference forms: a bare backticked lowercase-kebab token, and the path
- * `skills/<x>/SKILL.md`. Pure over file text — the file walk stays outside, so
- * the fixture needs no disk layout. `forms` narrows to one form so the
- * reference-form vacuity guard can isolate the path-only edges.
+ * The skills `text` instructs a load of, excluding `self` and filtered by
+ * `names`. Delegates the extraction to loadedSkills(), so this page and
+ * tests/skill-tool-invocation.test.ts can never disagree about what an edge is.
+ * Pure over file text — the file walk stays outside, so the fixture needs no
+ * disk layout.
  */
-function deriveMentions(
-  text: string,
-  self: string,
-  names: Set<string>,
-  forms: ReferenceForm[] = BOTH_FORMS,
-): Set<string> {
-  const patterns: Record<ReferenceForm, RegExp> = {
-    bare: /`([a-z0-9][a-z0-9-]*)`/g,
-    path: /skills\/([a-z0-9][a-z0-9-]*)\/SKILL\.md/g,
-  };
+function deriveLoads(text: string, self: string, names: Set<string>): Set<string> {
+  return new Set(loadedSkills(text).filter((name) => name !== self && names.has(name)));
+}
+
+/**
+ * The skill names `text` NAMES, by either reference form: a bare backticked
+ * lowercase-kebab token, or the path `skills/<x>/SKILL.md`. This is the old,
+ * wider relation, and it exists here for exactly one purpose — the
+ * discrimination guard below, which proves the load extractor is narrower than
+ * it. Nothing on the page is derived from it.
+ */
+function namedSkills(text: string, self: string, names: Set<string>): Set<string> {
+  const patterns = [/`([a-z0-9][a-z0-9-]*)`/g, /skills\/([a-z0-9][a-z0-9-]*)\/SKILL\.md/g];
   const found = new Set<string>();
-  for (const form of forms) {
-    for (const match of text.matchAll(patterns[form])) {
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
       const name = match[1] as string;
       if (name !== self && names.has(name)) found.add(name);
     }
@@ -247,11 +257,11 @@ const ALL_MD_TEXT = new Map(
   ]),
 );
 
-/** `owner -> mentioned` edges over a name→text map, under the given forms. */
-function edgeSet(texts: Map<string, string>, forms: ReferenceForm[]): Set<string> {
+/** `owner -> loaded` edges over a name→text map. */
+function edgeSet(texts: Map<string, string>): Set<string> {
   return new Set(
     [...texts].flatMap(([owner, text]) =>
-      [...deriveMentions(text, owner, NAMES, forms)].map((name) => `${owner} -> ${name}`),
+      [...deriveLoads(text, owner, NAMES)].map((name) => `${owner} -> ${name}`),
     ),
   );
 }
@@ -268,41 +278,49 @@ const sentenceOffenders = (name: string): string[] =>
     (offender) => `${name}: ${offender}`,
   );
 
-const mentionSetOffenders = (name: string): string[] =>
-  mentionSet(
-    mentionBullets(bodyOf(name)),
-    deriveMentions(ALL_MD_TEXT.get(name) ?? "", name, NAMES),
+const loadSetOffenders = (name: string): string[] =>
+  loadSet(
+    loadBullets(bodyOf(name)),
+    deriveLoads(ALL_MD_TEXT.get(name) ?? "", name, NAMES),
     NAMES,
   ).map((offender) => `${name}: ${offender}`);
 
-const mentionOrderOffenders = (name: string): string[] =>
-  mentionOrder(mentionBullets(bodyOf(name))).map((offender) => `${name}: ${offender}`);
+const loadOrderOffenders = (name: string): string[] =>
+  loadOrder(loadBullets(bodyOf(name))).map((offender) => `${name}: ${offender}`);
 
 describe("docs/skills.md catalog matches the skills on disk", () => {
-  test("every entry's shape, sentence, mention set, and mention order match disk", () => {
+  test("every entry's shape, sentence, load set, and load order match disk", () => {
     // Seven vacuity guards. Each names the property that vanished, because a
     // mis-scoped haystack makes every sweep below pass for the wrong reason
     // (docs/testing.md, "Prove a negative check can find a positive").
     expect(SKILL_DIRECTORIES.length).toBeGreaterThan(60); // (1) skills/ tree parsed
     expect(ENTRIES.length).toBeGreaterThan(60); // (2) page parsed
-    expect(ENTRIES.filter((entry) => hasMentionsHeader(entry.body)).length).toBeGreaterThan(0); // (3)
-    expect(ENTRIES.filter((entry) => !hasMentionsHeader(entry.body)).length).toBeGreaterThan(0); // (4)
+    expect(ENTRIES.filter((entry) => hasLoadsHeader(entry.body)).length).toBeGreaterThan(0); // (3)
+    expect(ENTRIES.filter((entry) => !hasLoadsHeader(entry.body)).length).toBeGreaterThan(0); // (4)
     expect(ENTRIES.filter((entry) => entry.body.length === 0).map((entry) => entry.name)).toEqual(
       [],
     ); // (5) every parsed body non-empty
 
-    // (6) Reference-form axis: at least one edge only the `skills/<x>/SKILL.md`
-    // path form produced. A broken path pattern drops them silently.
-    const allEdges = edgeSet(ALL_MD_TEXT, BOTH_FORMS);
-    const bareEdges = edgeSet(ALL_MD_TEXT, ["bare"]);
-    expect([...allEdges].filter((edge) => !bareEdges.has(edge)).length).toBeGreaterThan(0);
+    // (6) Discrimination axis: a load is STRICTLY narrower than a mention. Every
+    // load edge is also a mention edge, and dozens of mention edges are not load
+    // edges — a `principle-*` citation, a "see also", a name in prose. An equal
+    // pair means the extractor collapsed back into a name grep, which is exactly
+    // the wrong relation: it would draw `b -> a` from `b` merely naming `a`.
+    const allEdges = edgeSet(ALL_MD_TEXT);
+    const namedEdges = new Set(
+      [...ALL_MD_TEXT].flatMap(([owner, text]) =>
+        [...namedSkills(text, owner, NAMES)].map((name) => `${owner} -> ${name}`),
+      ),
+    );
+    expect([...allEdges].filter((edge) => !namedEdges.has(edge))).toEqual([]);
+    expect(allEdges.size).toBeLessThan(namedEdges.size);
 
     // (7) Depth axis: the edge set over the SKILL.md files alone is a STRICT
     // subset of the set over every `.md` file. Dozens of edges live only in
     // references/ and the two prompt templates, so the margin is wide; an equal
     // pair means the walk shrank — a shallow glob or a missed references/
     // directory.
-    const skillMdEdges = edgeSet(SKILL_MD_TEXT, BOTH_FORMS);
+    const skillMdEdges = edgeSet(SKILL_MD_TEXT);
     expect([...skillMdEdges].filter((edge) => !allEdges.has(edge))).toEqual([]);
     expect(skillMdEdges.size).toBeLessThan(allEdges.size);
 
@@ -312,15 +330,15 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // The four sweeps, over every entry.
     expect(SKILL_DIRECTORIES.flatMap(shapeOffenders)).toEqual([]);
     expect(SKILL_DIRECTORIES.flatMap(sentenceOffenders)).toEqual([]);
-    expect(SKILL_DIRECTORIES.flatMap(mentionSetOffenders)).toEqual([]);
-    expect(SKILL_DIRECTORIES.flatMap(mentionOrderOffenders)).toEqual([]);
+    expect(SKILL_DIRECTORIES.flatMap(loadSetOffenders)).toEqual([]);
+    expect(SKILL_DIRECTORIES.flatMap(loadOrderOffenders)).toEqual([]);
   });
 
   test("the page-side rules each see a planted positive", () => {
     // A well-formed body, used as the negative control for every rule below.
     const clean = [
       "Lands a reviewed PR.",
-      MENTIONS_HEADER,
+      LOADS_HEADER,
       "- `pr-verify`",
       "- `principle-fail-closed`",
     ];
@@ -329,23 +347,23 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // Leftover bullet: a `**Purpose:**` line that survived the rewrite.
     expect(shape(["Lands a reviewed PR.", "- **Purpose:** Lands a reviewed PR."])).not.toEqual([]);
 
-    // Second mentions header.
-    expect(shape([...clean, MENTIONS_HEADER, "- `shipit`"])).not.toEqual([]);
+    // Second loads header.
+    expect(shape([...clean, LOADS_HEADER, "- `shipit`"])).not.toEqual([]);
 
     // Trailing clause after a name.
     expect(
-      shape(["Lands a reviewed PR.", MENTIONS_HEADER, "- `pr-verify` for the checks"]),
+      shape(["Lands a reviewed PR.", LOADS_HEADER, "- `pr-verify` for the checks"]),
     ).not.toEqual([]);
 
     // Duplicate name among the bullets.
     expect(
-      shape(["Lands a reviewed PR.", MENTIONS_HEADER, "- `pr-verify`", "- `pr-verify`"]),
+      shape(["Lands a reviewed PR.", LOADS_HEADER, "- `pr-verify`", "- `pr-verify`"]),
     ).not.toEqual([]);
 
     // Indented line, as the first line and as a later line.
     expect(shape(["  Lands a reviewed PR."])).not.toEqual([]);
     expect(
-      shape(["Lands a reviewed PR.", MENTIONS_HEADER, "- `pr-verify`", "  continued"]),
+      shape(["Lands a reviewed PR.", LOADS_HEADER, "- `pr-verify`", "  continued"]),
     ).not.toEqual([]);
 
     // Drifted sentence: the page no longer copies the description's first sentence.
@@ -355,36 +373,47 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
 
     // Phantom name: a bullet naming no skill on disk.
     const derived = new Set(["pr-verify", "principle-fail-closed"]);
-    expect(mentionSet(["pr-verify", "principle-fail-closed"], derived, NAMES)).toEqual([]);
+    expect(loadSet(["pr-verify", "principle-fail-closed"], derived, NAMES)).toEqual([]);
     expect(
-      mentionSet(["pr-verify", "principle-fail-closed", "not-a-skill"], derived, NAMES),
+      loadSet(["pr-verify", "principle-fail-closed", "not-a-skill"], derived, NAMES),
     ).not.toEqual([]);
 
     // Dropped name: a derived name the page omits.
-    expect(mentionSet(["pr-verify"], derived, NAMES)).not.toEqual([]);
+    expect(loadSet(["pr-verify"], derived, NAMES)).not.toEqual([]);
+
+    // Invented edge: a name the skill only mentions, listed as if it loaded it.
+    // This is the direction rule — `b` naming `a` is not `b -> a`.
+    expect(loadSet(["pr-verify", "principle-fail-closed", "shipit"], derived, NAMES)).not.toEqual(
+      [],
+    );
 
     // Correct set, wrong order. Codepoint sort: `pr-verify` precedes
     // `principle-fail-closed`, which a dictionary sort would reverse.
-    expect(mentionOrder(["pr-verify", "principle-fail-closed"])).toEqual([]);
-    expect(mentionOrder(["principle-fail-closed", "pr-verify"])).not.toEqual([]);
+    expect(loadOrder(["pr-verify", "principle-fail-closed"])).toEqual([]);
+    expect(loadOrder(["principle-fail-closed", "pr-verify"])).not.toEqual([]);
   });
 
-  test("the scanner returns exactly the two reference forms", () => {
+  test("the scanner takes loads and leaves every other reference behind", () => {
     // A synthetic source standing in for one skill's `.md`, never a real skill
-    // file: one bare backticked name, one `skills/<x>/SKILL.md` path naming a
-    // different real skill, the fixture skill's own name, and a backticked
-    // token naming no skill. Both real names are real skill directories, since
-    // the skillNames() filter would otherwise drop them and hide a broken
-    // pattern.
+    // file. It carries all four reference shapes a body can hold: a load, a
+    // path citation, a bare backticked name in ordinary prose, and the fixture
+    // skill's own name. Only the load is an edge. Every name here is a real
+    // skill directory, since the skillNames() filter would otherwise drop it
+    // and hide a broken pattern.
     const fixture = [
       "# Fixture skill body",
       "",
       "Call the Skill tool with `pr-verify` before landing.",
       "The fail-closed rule is restated at skills/principle-fail-closed/SKILL.md.",
-      "This skill is `shipit`, and it never runs `not-a-real-skill`.",
+      "This is not a `git-commit`, and `shipit` never runs `not-a-real-skill`.",
     ].join("\n");
 
-    expect([...deriveMentions(fixture, "shipit", NAMES)].sort()).toEqual([
+    expect([...deriveLoads(fixture, "shipit", NAMES)].sort()).toEqual(["pr-verify"]);
+
+    // The wider relation over the same text, for contrast: three names, and
+    // two of them are references the graph must not turn into edges.
+    expect([...namedSkills(fixture, "shipit", NAMES)].sort()).toEqual([
+      "git-commit",
       "pr-verify",
       "principle-fail-closed",
     ]);


### PR DESCRIPTION
## What this is

`docs/skills.md` listed, under each skill, every other skill its `.md` files **named** — a load, a citation, and a passing mention alike. That relation is not a dependency, and it is not even directed: `b` restating a rule from `a` produced a `b -> a` entry indistinguishable from `b` actually loading `a`. The page read as a graph and was not one.

It now lists only what the skill **loads**, through the one form that sends a reader to go execute another skill:

```
Call the Skill tool with `<name>`
```

Everything else stays a citation and draws no edge. `team-structure` restates a `principle-fail-closed` rule inline and now has no edge to it, because it does not load it. 26 of 92 skills carry edges; the rest are leaves, which is the honest shape for a `principle-*` skill.

Chains read transitively, which is the point: `team-implement` loads `team-pr`, which loads `git-commit`, which loads `writing-prose`. None of the three loads back.

## The test

`tests/docs-skills-catalog.test.ts` derives the set from `loadedSkills()` in `tests/helpers/skill-refs.ts` — the same extractor `tests/skill-tool-invocation.test.ts` uses, so the page and the load contract cannot disagree about what an edge is.

Vacuity guard (6) checked that the `skills/<x>/SKILL.md` path form still produced edges, which is meaningless once paths are citations. It is replaced with a **discrimination guard**: the load edges must be a STRICT subset of the name-mention edges. An equal pair means the extractor collapsed back into a name grep — the exact defect this PR removes. `namedSkills()` survives only to be the wider side of that comparison; nothing on the page derives from it.

Added a planted positive for the direction rule (listing a merely-named skill is an offender) and a fixture proving the scanner takes the load and leaves the path citation, the prose name, and self behind.

## Test plan

- [x] `bun test` — 2120 pass / 4 skip / 0 fail (rebased onto v0.92.0)
- [x] `bun run typecheck` — clean
- [x] `bash .claude/scripts/check-discovery-consistency.sh` — all assertions passed
- [x] Every derived edge cross-checked against `grep -ri "call the Skill tool" skills/`; the two illustrative claims in the new intro prose (the `team-implement → team-pr → git-commit → writing-prose` chain, and `team-structure` citing but not loading `principle-fail-closed`) verified against the files rather than asserted
- [x] Rebase brought in #342's new `**Mentions:**` block on the `running-quality-checks` entry; that skill loads nothing, so the block is gone. Its row in the `principle-pre-image-first` consumer table — hand-maintained, citation-based, out of scope here — is untouched
- [x] Commit signed (verified good ED25519)
- [x] No version bump — dev-only change (`docs/`, `tests/`, `.claude/`), no runtime file touched, per the runtime-vs-development split in `AGENTS.md`

## Scope I deliberately left out

**No `**Loaded by:**` reverse index.** It would make the graph navigable in both directions, and it is derivable from the same edge set, but traversing A → B → C only needs the forward edges. Easy to add later if the reverse lookup is wanted.

**The `Skill ↔ agent ↔ phase` table is unchanged.** It carries agent→skill loads and principle citations, which are different relations from the skill→skill edges this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)