### PR TITLE
v0.93.0 fix(reflect): resolve the invoking session on Codex and Conductor, not just Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.92.0"
+    "version": "0.93.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.92.0",
+      "version": "0.93.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "keywords": [
     "agents",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **[`/reflect`](https://github.com/bostonaholic/team/blob/main/skills/reflect/SKILL.md) now reads the session it was actually invoked from, on Codex as well as Claude Code.** It looked in one place, `~/.claude/projects/`, and understood one record format, so running it from Codex — including a Codex session inside Conductor — stopped at `no-match` before a single lens read anything. It now resolves the session through the id the host itself exported (`CLAUDE_CODE_SESSION_ID`, `CODEX_THREAD_ID`), which names the transcript file directly, and re-checks that file's own header before reading it. Codex rollouts under `${CODEX_HOME:-~/.codex}/sessions/` normalize into the same bounded records Claude Code transcripts always did: your prompts, the replies, and each tool call with its name and arguments, with the host's own injected preamble kept out of the user-turn count. **Conductor is not a separate case.** It runs Claude Code, Codex, Cursor Agent, or OpenCode in a worktree and the backend writes its own transcript, so a Conductor session resolves as whichever backend it runs — and its two other backends now fail as `unsupported-host` instead of resolving to something plausible. Where two agents' session variables are set in one process, which happens when one launches the other, the run cache path this run printed breaks the tie on evidence; where it settles nothing, the run stops at `ambiguous-host` rather than picking. Every existing safeguard is unchanged — stores are only read, searches return file names only, the record and byte ceilings still bound the stream, findings still paraphrase and cite a path or a turn index, and every skill edit and tracker issue still waits on your approval. What the transcript does not carry is now reported rather than filled in: unreadable records, truncated spans, a bounded read, and the earlier turns a forked Codex thread left in its parent's file. **What this asks of you:** nothing.
+
 ## [0.92.0] - 2026-09-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.93.0] - 2026-09-07
+
 ### Fixed
 
 - **[`/reflect`](https://github.com/bostonaholic/team/blob/main/skills/reflect/SKILL.md) now reads the session it was actually invoked from, on Codex as well as Claude Code.** It looked in one place, `~/.claude/projects/`, and understood one record format, so running it from Codex — including a Codex session inside Conductor — stopped at `no-match` before a single lens read anything. It now resolves the session through the id the host itself exported (`CLAUDE_CODE_SESSION_ID`, `CODEX_THREAD_ID`), which names the transcript file directly, and re-checks that file's own header before reading it. Codex rollouts under `${CODEX_HOME:-~/.codex}/sessions/` normalize into the same bounded records Claude Code transcripts always did: your prompts, the replies, and each tool call with its name and arguments, with the host's own injected preamble kept out of the user-turn count. **Conductor is not a separate case.** It runs Claude Code, Codex, Cursor Agent, or OpenCode in a worktree and the backend writes its own transcript, so a Conductor session resolves as whichever backend it runs — and its two other backends now fail as `unsupported-host` instead of resolving to something plausible. Where two agents' session variables are set in one process, which happens when one launches the other, the run cache path this run printed breaks the tie on evidence; where it settles nothing, the run stops at `ambiguous-host` rather than picking. Every existing safeguard is unchanged — stores are only read, searches return file names only, the record and byte ceilings still bound the stream, findings still paraphrase and cite a path or a turn index, and every skill edit and tracker issue still waits on your approval. What the transcript does not carry is now reported rather than filled in: unreadable records, truncated spans, a bounded read, and the earlier turns a forked Codex thread left in its parent's file. **What this asks of you:** nothing.
@@ -829,7 +831,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.92.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.93.0...HEAD
+[0.93.0]: https://github.com/bostonaholic/team/compare/v0.92.0...v0.93.0
 [0.92.0]: https://github.com/bostonaholic/team/compare/v0.91.0...v0.92.0
 [0.91.0]: https://github.com/bostonaholic/team/compare/v0.90.0...v0.91.0
 [0.90.0]: https://github.com/bostonaholic/team/compare/v0.89.0...v0.90.0

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -136,8 +136,12 @@ nested subagents, and structured returns.
   interpolates it into a runnable command breaks on Codex, where the value is
   empty and the path resolves to `/skills/...`. Document the command with a
   `<skill-dir>` placeholder the caller substitutes, the pattern Codex's own
-  bundled skills use, and keep the script free of relative imports and
-  environment reads so it runs from any install path (`ste-lint.mjs` does both).
+  bundled skills use, and keep the script free of relative imports and of
+  environment reads that resolve its own location, so it runs from any install
+  path (`ste-lint.mjs` does both). Reading the environment for something other
+  than the script's own path is fine and sometimes required — the host a session
+  is running on is knowable no other way, which is how
+  `resolve-transcript.mjs` tells a Claude Code session from a Codex one.
   `skills/nested-agents/SKILL.md:35` still interpolates the variable directly.
   That command is Claude-Code-only today, because the pipeline agents it serves
   cannot dispatch on Codex.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -17,7 +17,10 @@ make it more than "summarize this session":
 - **It reads the session, not its own memory.** Compaction has already
   discarded the early turns from context, and those turns are where the
   corrections live. So the run resolves the session's transcript on disk and
-  works from that file.
+  works from that file — its own, identified by the id the host exported,
+  whether that host is Claude Code or Codex and whether either runs inside
+  Conductor. What the file does not carry is reported as missing, never
+  filled in from memory.
 - **Three lenses, then one list.** The lenses look for different things and
   report what they find. Sorting the findings — accepted, rejected, or handed
   to the tracker — happens once, afterwards, so one finding cannot be

--- a/skills/reflect/references/03-execution.md
+++ b/skills/reflect/references/03-execution.md
@@ -15,10 +15,10 @@ readable only by its owner. The cache holds the normalized transcript and the
 plan file, both of which carry session text. A cache that cannot be created
 stops the run rather than falling back to memory.
 
-That printed path does double duty. It is **this run's marker**: the host
-records command output inline in the transcript, so the path appears in this
-session's records and in no other file on disk. Step 2 resolves the session by
-searching for it.
+That printed path does double duty. It is **this run's fallback marker**: the
+host records command output inline in the transcript, so the path appears in
+this session's records and in no other file on disk. Step 2 searches for it on
+a host that exports no session id of its own.
 
 A **run** is one invocation plus every later turn that answers its approval
 question, named by the one directory whose absolute path this conversation
@@ -39,28 +39,55 @@ a command carrying it breaks on every other host.
 
 The script resolves one absolute transcript path or fails by name, and it
 writes `transcript.jsonl` into the run cache: one classified record per line,
-each span cut to the per-span byte cap. A tool call normalizes to its tool name
-plus its invocation, which is what leaves the tooling lens an invocation to
-count. **The lenses read only that normalized file.** Three rules therefore run
-as code rather than as advice — the record classifier, the byte cap, and never
-opening a `tool-results/*.txt` sidecar.
+each span cut to the per-span byte cap. **The lenses read only that normalized
+file.** Every host's records land in the same shape — real user prompts,
+assistant replies, and tool calls rendered as the tool's name plus its
+invocation, which is what leaves the tooling lens an invocation to count. Four
+rules therefore run as code rather than as advice: the record classifier, the
+byte cap, the record and byte ceilings, and never descending past a
+transcript's own directory level into a `subagents/` or `tool-results/` sidecar.
 
-Its search is a **fixed-string** match for the marker over the transcripts one
-level under `~/.claude/projects`, and it **returns file names only**. So no
-unmatched session's content reaches a lens, a proposal, or this context, which
-is what makes searching wider than one project directory acceptable. Three
-named failures stop the run instead of guessing:
+**Which store it reads.** Claude Code keeps `<session-id>.jsonl` under
+`~/.claude/projects/<project-slug>/`; Codex keeps
+`rollout-<timestamp>-<thread-id>.jsonl` under
+`${CODEX_HOME:-~/.codex}/sessions/<YYYY>/<MM>/<DD>/`. **Conductor is not a
+store.** It runs Claude Code, Codex, Cursor Agent, or OpenCode inside a
+worktree, and the backend writes its transcript in its own place unchanged — so
+a Conductor session resolves as whichever backend it runs, and the two backends
+this skill cannot read fail as `unsupported-host` rather than as something
+plausible.
+
+**How the session is identified.** The host's own exported id first
+(`CLAUDE_CODE_SESSION_ID`, `CODEX_THREAD_ID`), which names the file directly and
+is re-checked against the file's own header. Only where a host exports none does
+the run fall back to a **fixed-string** search for the marker across that host's
+store. Either way the search **returns file names only**, so no unmatched
+session's content reaches a lens, a proposal, or this context — which is what
+makes searching wider than one directory acceptable. Nothing takes the newest
+file, guesses from the working directory, or picks among candidates. Named
+failures stop the run instead:
 
 | Failure | What it means | What to report |
 |---------|---------------|----------------|
-| `no-projects-root` | the host records no transcripts here | the path tried; reflect works on Claude Code only |
-| `no-match` | the marker has not reached disk after one retry | both search patterns tried |
-| `multiple-matches` | an invariant violation, since the marker is unique to this run | every path matched, and no pick |
+| `unsupported-host` | neither supported agent exported a session id here | the host, and that reflect reads Claude Code and Codex stores — Conductor through whichever of the two it runs |
+| `ambiguous-host` | both agents' session variables are set in one process | both hosts named; no pick was made |
+| `invalid-session-id` | the exported id is not a session id shape | the value seen |
+| `no-session-store` | the host records no transcripts here | the path tried |
+| `no-match` | neither the session id nor the marker reached disk after one retry | every pattern tried |
+| `multiple-matches` | an invariant violation, since both signals are unique to this run | every path matched, and no pick |
+| `unsupported-format` | the resolved file holds no records any supported host writes | the path, and the unrecognized-record count |
 
-Read the script's counts into the report: records kept, records dropped per
-type, records dropped to the aggregate ceiling, spans truncated, and malformed
-lines skipped. A session whose transcript was bounded produced a partial read,
-and the summary says so.
+Read the script's counts into the report: the host and whether the session was
+resolved by id or by marker, the format, records kept, records dropped per
+type, records dropped to the aggregate ceiling, spans truncated, malformed
+lines skipped, unrecognized records, and any prior history the file does not
+carry. **A bounded or partial read is stated, never absorbed.** A session
+whose transcript hit a ceiling produced a partial read; a Codex thread forked
+from another one leaves its earlier turns in the parent's file, which this run
+does not read. Say so in the summary either way, and **never substitute your own
+memory of the session for the part the transcript did not carry** — that memory
+is what compaction already discarded, which is the reason the run reads a file
+at all.
 
 ### Step 3 — send the lenses over the normalized file
 

--- a/skills/reflect/references/03-execution.md
+++ b/skills/reflect/references/03-execution.md
@@ -61,16 +61,17 @@ plausible.
 (`CLAUDE_CODE_SESSION_ID`, `CODEX_THREAD_ID`), which names the file directly and
 is re-checked against the file's own header. Only where a host exports none does
 the run fall back to a **fixed-string** search for the marker across that host's
-store. Either way the search **returns file names only**, so no unmatched
-session's content reaches a lens, a proposal, or this context — which is what
-makes searching wider than one directory acceptable. Nothing takes the newest
-file, guesses from the working directory, or picks among candidates. Named
-failures stop the run instead:
+store. **Neither path returns a transcript's content**: the marker search
+returns file names only, and the header check returns only the id it read. So
+no unmatched session's content reaches a lens, a proposal, or this context,
+which is what makes searching wider than one directory acceptable. Nothing takes
+the newest file, guesses from the working directory, or picks among candidates.
+Named failures stop the run instead:
 
 | Failure | What it means | What to report |
 |---------|---------------|----------------|
 | `unsupported-host` | neither supported agent exported a session id here | the host, and that reflect reads Claude Code and Codex stores — Conductor through whichever of the two it runs |
-| `ambiguous-host` | both agents' session variables are set in one process | both hosts named; no pick was made |
+| `ambiguous-host` | two agents claim this process — one is running inside the other's shell — and the marker settled neither transcript | both hosts named; no pick was made |
 | `invalid-session-id` | the exported id is not a session id shape | the value seen |
 | `no-session-store` | the host records no transcripts here | the path tried |
 | `no-match` | neither the session id nor the marker reached disk after one retry | every pattern tried |

--- a/skills/reflect/resources/resolve-transcript.d.mts
+++ b/skills/reflect/resources/resolve-transcript.d.mts
@@ -12,9 +12,15 @@ export const MAX_RECORDS: number;
 /** Aggregate byte ceiling on the normalized stream, newest kept. */
 export const MAX_TOTAL_BYTES: number;
 
+/** The hosts whose session stores this script reads, keyed by host name. */
+export const HOSTS: Record<string, { depth: number; suffixed: boolean }>;
+
+/** A supported host's name, or null when this process is on neither. */
+export type HostName = "claude-code" | "codex";
+
 /** One normalized record: an allowlisted span the lenses may read. */
 export interface NormalizedRecord {
-  /** The record's transcript type — only "user" or "assistant" survive. */
+  /** The record's normalized side of the conversation: "user" or "assistant". */
   type: string;
   /** True only for a real user prompt (no tool result, injection, or meta). */
   isUserTurn: boolean;
@@ -25,22 +31,46 @@ export interface NormalizedRecord {
 /** The normalized stream plus the counts the run summary reports. */
 export interface NormalizedTranscript {
   records: NormalizedRecord[];
+  /** The one host format the stream was in, or "unknown" / "mixed". */
+  format: string;
   /** Dropped non-allowlisted record types, counted per type. */
   droppedByType: Record<string, number>;
   malformedLines: number;
   truncatedSpans: number;
+  /** Well-formed JSON lines no supported host writes. */
+  unrecognizedRecords: number;
+  /** The thread this one was forked from, whose turns are in another file. */
+  priorHistory: string | null;
   /** Records dropped to stay inside MAX_RECORDS / MAX_TOTAL_BYTES. */
   droppedForCeiling: number;
 }
 
+/** One raw record, classified: kept, dropped under a counter key, or unreadable. */
+export interface ClassifiedRecord {
+  /** The host format the record belongs to, or null when no host writes it. */
+  format: string | null;
+  keep?: NormalizedRecord;
+  drop?: string;
+}
+
+/** One host that might hold this session, and the id it exported for it. */
+export interface HostCandidate {
+  host: HostName;
+  sessionId: string | null;
+}
+
 export interface ResolveOptions {
+  /** The host whose store to search. Validated here, so any string is accepted. */
+  host: string | null;
+  /** The host's own id for this session. Present means an exact lookup. */
+  sessionId?: string | null;
+  /** Search root, injected so tests never read a real session store. */
+  storeRoot: string;
   /** The unguessable run-cache path this run printed. Matched fixed-string. */
-  marker: string;
-  /** Search root, injected so tests never read a real ~/.claude/projects. */
-  projectsRoot: string;
-  /** Optional narrow first glob: the start directory's slug. */
+  marker?: string;
+  /** Optional narrow first glob for Claude Code: the start directory's slug. */
   slug?: string;
-  /** Retry delay before the second grep, injectable so tests never sleep. */
+  /** Retry delay before the second search, injectable so tests never sleep. */
   retryDelayMs?: number;
 }
 
@@ -48,14 +78,42 @@ export interface ResolveOptions {
 export interface ResolveResult {
   ok: boolean;
   path?: string;
-  /** "no-projects-root" | "no-match" | "multiple-matches" when ok is false. */
+  host?: HostName | null;
+  /** "session-id" when the host named the session, "marker" otherwise. */
+  via?: string;
+  /**
+   * "unsupported-host" | "ambiguous-host" | "invalid-session-id" |
+   * "no-session-store" | "no-match" | "multiple-matches" when ok is false.
+   */
   failure?: string;
   /** The globs or paths tried, for the failure message. */
   tried?: string[];
 }
 
+export interface ResolveSessionOptions {
+  /** Every host claiming this process, from detectHost. */
+  candidates: readonly HostCandidate[];
+  /** The store root for a given host. Injected so tests never read a real one. */
+  storeRootOf: (host: string) => string;
+  marker?: string;
+  slug?: string;
+  retryDelayMs?: number;
+}
+
+export function detectHost(env: Record<string, string | undefined> | undefined): HostCandidate[];
+
+export function resolveSession(options: ResolveSessionOptions): ResolveResult;
+
+export function storeRootFor(host: string | null, env: Record<string, string | undefined> | undefined): string;
+
 export function resolveTranscript(options: ResolveOptions): ResolveResult;
 
 export function normalizeTranscript(jsonlText: string): NormalizedTranscript;
+
+export function classifyRecord(record: unknown): ClassifiedRecord;
+
+export function declaredSessionId(headText: string): string | null;
+
+export function priorHistoryOf(record: unknown): string | null;
 
 export function isUserTurn(record: unknown): boolean;

--- a/skills/reflect/resources/resolve-transcript.mjs
+++ b/skills/reflect/resources/resolve-transcript.mjs
@@ -246,7 +246,12 @@ export function declaredSessionId(headText) {
   return null;
 }
 
-/** Candidates whose own header agrees they are `sessionId`, dropping any that disagree. */
+/**
+ * Candidates whose own header agrees they are `sessionId`, dropping any that
+ * disagree. Only files the host's own naming already points at are opened, and
+ * only the declared id leaves this function — no span of any transcript, matched
+ * or not, reaches the caller.
+ */
 function confirmed(candidates, sessionId) {
   return candidates.filter((path) => {
     const declared = declaredSessionId(readHead(path));

--- a/skills/reflect/resources/resolve-transcript.mjs
+++ b/skills/reflect/resources/resolve-transcript.mjs
@@ -1,37 +1,48 @@
 #!/usr/bin/env node
 
 /**
- * Resolve the invoking session's transcript by a marker that session printed,
- * and normalize it into a bounded record stream.
+ * Resolve the invoking session's transcript on whichever host is running, and
+ * normalize it into one bounded record stream.
  *
- *     node "<skill-dir>/resolve-transcript.mjs" <run-cache-dir> [projects-root]
+ *     node "<skill-dir>/resolve-transcript.mjs" <run-cache-dir> [store-root]
  *
- * The run cache's absolute path IS the marker: the run printed it, so the host
- * recorded it inline in this session's transcript and in no other file on disk.
+ * TWO HOSTS, ONE CONTRACT. Claude Code and Codex CLI each keep their own
+ * session store in their own record format. Everything downstream — the lenses,
+ * the plan, the report — reads the single normalized shape this file emits, so
+ * a host is added here and nowhere else.
  *
- * The pure halves (`resolveTranscript`, `normalizeTranscript`, `isUserTurn`)
- * are unit-tested at L1; the CLI below is what the skill body runs through
- * Bash. Importing this file has no side effects.
+ * CONDUCTOR IS NOT A HOST HERE. Conductor runs Claude Code, Codex, Cursor
+ * Agent, or OpenCode inside a git worktree; the backend agent writes the
+ * transcript in its own store, unchanged. So a Conductor session resolves as
+ * whichever backend it runs, and the two backends this file cannot read fail by
+ * name rather than resolving to something plausible.
  *
- * `projectsRoot` is a parameter rather than a constant so the tests drive it
- * against synthetic fixtures; the CLI defaults it to `~/.claude/projects`.
+ * HOW THE SESSION IS IDENTIFIED, IN ORDER.
  *
- * WHY TWO GLOBS, WIDE ONE INCLUDED. A session's records live under a slug
- * derived from the directory the session *started* in — and in a worktree that
- * is the parent repository's slug, not the worktree's. Both shapes therefore
- * exist on disk. Nothing a skill can read in-session reports the start
- * directory, so the narrow `<slug>` glob is a guess that usually misses and
- * the wide glob is the normal path. Only file NAMES come back either way, so
- * an unmatched session's content never reaches the caller. Both globs are top
- * level, which is what keeps `<session-uuid>/subagents/*.jsonl` and the
- * `<session-uuid>/tool-results/*.txt` sidecars out of reach by construction
- * rather than by a filter someone can drop.
+ *  1. The id the host itself exported into this process (`CLAUDE_CODE_SESSION_ID`,
+ *     `CODEX_THREAD_ID`). It names the transcript file directly, so resolution is
+ *     a lookup rather than a search, and the file's own header is re-read to
+ *     confirm the match.
+ *  2. Failing that, the run cache's absolute path as a marker: the run printed
+ *     it, so the host recorded it inline in this session's records and in no
+ *     other file on disk. Only file NAMES come back from that search, so an
+ *     unmatched session's content never reaches the caller.
+ *
+ * Neither path ever picks among candidates, guesses from the working directory,
+ * or takes the newest file. Two matches is a named failure.
+ *
+ * The pure halves (`detectHost`, `resolveTranscript`, `normalizeTranscript`,
+ * `isUserTurn`) are unit-tested at L1; the CLI below is what the skill body runs
+ * through Bash. Importing this file has no side effects.
+ *
+ * `storeRoot` is a parameter rather than a constant so the tests drive it
+ * against synthetic fixtures; the CLI derives it from the detected host.
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, readdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 /** Per-span byte cap applied before any lens sees a span. */
@@ -43,21 +54,57 @@ export const MAX_RECORDS = 2000;
 /** Aggregate byte ceiling on the normalized stream, newest kept. */
 export const MAX_TOTAL_BYTES = 4 * 1024 * 1024;
 
-/** The two record types a lens may read. Every other type is dropped. */
-const ALLOWED_TYPES = new Set(["user", "assistant"]);
+/**
+ * The hosts whose stores this file can read, and the shape of each store.
+ *
+ * `depth` is the number of directory levels between the store root and a
+ * transcript, and it is exact. Claude Code keeps `<project-slug>/<id>.jsonl`;
+ * Codex keeps `<YYYY>/<MM>/<DD>/rollout-<timestamp>-<thread-id>.jsonl`. Walking
+ * to exactly that depth is what keeps a session's `subagents/*.jsonl` and its
+ * `tool-results/*.txt` sidecars out of reach by construction rather than by a
+ * filter someone can drop.
+ */
+export const HOSTS = {
+  "claude-code": { depth: 1, suffixed: false },
+  codex: { depth: 3, suffixed: true },
+};
 
-/** Host injections that arrive as `type: "user"` but are not prompts. */
-const INJECTION_TAGS = [
+/** Host injections that arrive as a Claude `type: "user"` record but are not prompts. */
+const CLAUDE_INJECTION_TAGS = [
   "<local-command-caveat>",
   "<local-command-stdout>",
   "<task-notification>",
 ];
+
+/**
+ * Codex injections, which arrive as `role: "user"` messages. Each is a whole
+ * injected block that opens its span, so these are matched as prefixes: a user
+ * who merely mentions one mid-prompt still counts as a user turn.
+ */
+const CODEX_INJECTION_PREFIXES = [
+  "<recommended_plugins>",
+  "<system_instruction>",
+  "<environment_context>",
+  "# AGENTS.md instructions for ",
+];
+
+/** Codex message roles that carry host and project instructions, never a turn. */
+const CODEX_DROPPED_ROLES = new Set(["developer", "system"]);
+
+/** The two Claude record types a lens may read. Every other type is dropped. */
+const CLAUDE_ALLOWED_TYPES = new Set(["user", "assistant"]);
 
 /** Argv chunk size for the fixed-string search — well inside ARG_MAX. */
 const SEARCH_CHUNK = 200;
 
 /** Retry delay before the second search, when the first found nothing. */
 const DEFAULT_RETRY_DELAY_MS = 1000;
+
+/** Bytes of a transcript read to confirm its header names the expected session. */
+const HEADER_PROBE_BYTES = 64 * 1024;
+
+/** A session id is used in path comparisons only, never in a command. */
+const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/;
 
 function sleepSync(milliseconds) {
   if (!(milliseconds > 0)) return;
@@ -66,31 +113,71 @@ function sleepSync(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
-/** Top-level `*.jsonl` files directly inside `directory`. */
-function transcriptFiles(directory) {
-  let entries;
-  try {
-    entries = readdirSync(directory, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  return entries
-    .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".jsonl"))
-    .map((entry) => join(directory, entry.name))
-    .sort();
+// ---------------------------------------------------------------------------
+// Host detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Every host that might hold this session, and the id it exported for each.
+ *
+ * Detection reads the agents' own variables, never Conductor's: a Conductor
+ * workspace sets `CONDUCTOR_*` whichever backend it launched, so those say
+ * nothing about where the transcript is.
+ *
+ * Two candidates is a real state, not a bug: one agent launched from the
+ * other's shell inherits its variables, so a Codex process started by Claude
+ * Code carries `CLAUDE_CODE_SESSION_ID` as well as its own. Precedence would
+ * be a guess there, so `resolveSession` breaks the tie on evidence instead.
+ */
+export function detectHost(env) {
+  const environment = env ?? {};
+  const codexId = environment.CODEX_THREAD_ID || environment.CODEX_SESSION_ID || "";
+  const claudeId = environment.CLAUDE_CODE_SESSION_ID || "";
+  const codex = Boolean(codexId);
+  const claude = Boolean(claudeId) || environment.CLAUDECODE === "1";
+
+  const candidates = [];
+  // CODEX_THREAD_ID names this thread's own rollout. CODEX_SESSION_ID names the
+  // root thread, which is the same file for the top-level session a user invokes
+  // reflect from; the header check below rejects it when it is not.
+  if (codex) candidates.push({ host: "codex", sessionId: codexId });
+  if (claude) candidates.push({ host: "claude-code", sessionId: claudeId || null });
+  return candidates;
 }
 
-/** Every transcript one directory level under `projectsRoot`, and no deeper. */
-function allProjectTranscripts(projectsRoot) {
-  let entries;
+/** The session store `host` keeps, honoring the host's own root override. */
+export function storeRootFor(host, env) {
+  const environment = env ?? {};
+  const home = environment.HOME || homedir();
+  if (host === "codex") return join(environment.CODEX_HOME || join(home, ".codex"), "sessions");
+  if (host === "claude-code") return join(environment.CLAUDE_CONFIG_DIR || join(home, ".claude"), "projects");
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/** Directory entries of `directory`, or [] when it cannot be read. */
+function entriesOf(directory) {
   try {
-    entries = readdirSync(projectsRoot, { withFileTypes: true });
+    return readdirSync(directory, { withFileTypes: true });
   } catch {
     return [];
   }
-  return entries
+}
+
+/** Every `*.jsonl` exactly `depth` directory levels under `root`, and no deeper. */
+function transcriptsUnder(root, depth) {
+  if (depth === 0) {
+    return entriesOf(root)
+      .filter((entry) => !entry.isDirectory() && entry.name.endsWith(".jsonl"))
+      .map((entry) => join(root, entry.name))
+      .sort();
+  }
+  return entriesOf(root)
     .filter((entry) => entry.isDirectory())
-    .flatMap((entry) => transcriptFiles(join(projectsRoot, entry.name)));
+    .flatMap((entry) => transcriptsUnder(join(root, entry.name), depth - 1));
 }
 
 /**
@@ -108,8 +195,8 @@ function filesContaining(files, marker) {
       env: { ...process.env, LC_ALL: "C" },
     });
     // stdout is read whatever the status: grep exits non-zero both for "no
-    // match" and for an unreadable file, and the wide glob crosses project
-    // directories this user may not own. A readable match still counts.
+    // match" and for an unreadable file, and the search crosses directories
+    // this user may not own. A readable match still counts.
     for (const line of (result.stdout ?? "").split("\n")) {
       if (line) found.push(line);
     }
@@ -117,57 +204,194 @@ function filesContaining(files, marker) {
   return found;
 }
 
-/** Narrow glob first, then the wide one. Returns on the first non-empty hit. */
-function searchOnce({ marker, projectsRoot, slug }) {
-  const globs = [];
-  if (slug) {
-    globs.push(join(projectsRoot, slug, "*.jsonl"));
-    const narrow = filesContaining(transcriptFiles(join(projectsRoot, slug)), marker);
-    if (narrow.length > 0) return { matches: narrow, globs };
+/** The transcript `host` would name `sessionId`, as a filename test. */
+function namesSession(host, file, sessionId) {
+  const name = basename(file);
+  return HOSTS[host]?.suffixed ? name.endsWith(`-${sessionId}.jsonl`) : name === `${sessionId}.jsonl`;
+}
+
+/** The first `HEADER_PROBE_BYTES` of a file, without reading a huge transcript whole. */
+function readHead(path) {
+  let fd;
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(HEADER_PROBE_BYTES);
+    const read = readSync(fd, buffer, 0, HEADER_PROBE_BYTES, 0);
+    return buffer.subarray(0, read).toString("utf8");
+  } catch {
+    return "";
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
-  globs.push(join(projectsRoot, "*", "*.jsonl"));
-  return { matches: filesContaining(allProjectTranscripts(projectsRoot), marker), globs };
+}
+
+/**
+ * The session id a transcript's own header declares, or null when it declares
+ * none. Claude Code stamps every record with `sessionId`; Codex opens a rollout
+ * with a `session_meta` whose `payload.id` is the thread the file belongs to.
+ */
+export function declaredSessionId(headText) {
+  for (const line of String(headText ?? "").split("\n")) {
+    if (line.trim() === "") continue;
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      // A truncated final line is expected — the probe cuts at a byte offset.
+      continue;
+    }
+    if (record?.type === "session_meta" && typeof record?.payload?.id === "string") return record.payload.id;
+    if (typeof record?.sessionId === "string") return record.sessionId;
+  }
+  return null;
+}
+
+/** Candidates whose own header agrees they are `sessionId`, dropping any that disagree. */
+function confirmed(candidates, sessionId) {
+  return candidates.filter((path) => {
+    const declared = declaredSessionId(readHead(path));
+    // A store that stamps no id in its header cannot contradict the filename,
+    // which the host derived from the id in the first place.
+    return declared === null || declared === sessionId;
+  });
+}
+
+/** Narrow glob first for Claude Code, then the whole store. Returns the first non-empty hit. */
+function searchByMarker({ host, storeRoot, marker, slug }) {
+  const { depth } = HOSTS[host];
+  const tried = [];
+  if (host === "claude-code" && slug) {
+    tried.push(join(storeRoot, slug, "*.jsonl"));
+    const narrow = filesContaining(transcriptsUnder(join(storeRoot, slug), 0), marker);
+    if (narrow.length > 0) return { matches: narrow, tried };
+  }
+  tried.push(join(storeRoot, ...Array.from({ length: depth }, () => "*"), "*.jsonl"));
+  return { matches: filesContaining(transcriptsUnder(storeRoot, depth), marker), tried };
+}
+
+/** Candidates the session id names, and the pattern tried when it names none. */
+function searchBySessionId({ host, storeRoot, sessionId }) {
+  const { depth, suffixed } = HOSTS[host];
+  const levels = Array.from({ length: depth }, () => "*");
+  const leaf = suffixed ? `*-${sessionId}.jsonl` : `${sessionId}.jsonl`;
+  const candidates = transcriptsUnder(storeRoot, depth).filter((file) => namesSession(host, file, sessionId));
+  return { matches: confirmed(candidates, sessionId), tried: [join(storeRoot, ...levels, leaf)] };
 }
 
 /**
  * One resolved absolute transcript path, or a named failure — never a pick.
- * Two matches is an invariant violation: the marker is unique to this run, so
- * picking one would hand a stranger's session to the caller.
+ * Two matches is an invariant violation: both the session id and the marker are
+ * unique to this run, so picking one would hand a stranger's session to the caller.
  */
 export function resolveTranscript(options) {
-  const { marker, projectsRoot, slug, retryDelayMs } = options ?? {};
+  const { host, sessionId, storeRoot, marker, slug, retryDelayMs } = options ?? {};
 
-  if (!projectsRoot || !existsSync(projectsRoot)) {
-    return { ok: false, failure: "no-projects-root", tried: [String(projectsRoot)] };
+  if (!host || !Object.hasOwn(HOSTS, host)) {
+    return { ok: false, failure: "unsupported-host", tried: [String(host ?? "none")] };
+  }
+  // Empty is absent, not invalid: one truthiness rule decides both this guard
+  // and the id-versus-marker branch below, so they cannot disagree.
+  if (sessionId && !SESSION_ID_PATTERN.test(String(sessionId))) {
+    return { ok: false, failure: "invalid-session-id", tried: [String(sessionId)] };
+  }
+  if (!storeRoot || !existsSync(storeRoot)) {
+    return { ok: false, failure: "no-session-store", tried: [String(storeRoot)] };
   }
 
-  let { matches, globs } = searchOnce({ marker, projectsRoot, slug });
+  // No id and no marker leaves nothing to identify this session with. An empty
+  // marker would reach `grep -F -e ""`, which matches every file in the store.
+  if (!sessionId && !marker) {
+    return { ok: false, failure: "no-match", tried: ["no session id and no marker"], host };
+  }
+
+  // The id the host exported wins outright. A host that named this session and
+  // then has no file for it is a real failure, not a cue to go guessing by
+  // marker: falling back there would search on behalf of an id already known to
+  // be authoritative, and could resolve some other session that mentions the path.
+  const via = sessionId ? "session-id" : "marker";
+  const search = () =>
+    sessionId
+      ? searchBySessionId({ host, storeRoot, sessionId })
+      : searchByMarker({ host, storeRoot, marker, slug });
+
+  let { matches, tried } = search();
   if (matches.length === 0) {
-    // The marker reaches the transcript only once the host has flushed the
-    // record that carries it, so one retry covers a write still in flight.
+    // The record carrying either signal reaches disk only once the host has
+    // flushed it, so one retry covers a write still in flight.
     sleepSync(retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
-    ({ matches, globs } = searchOnce({ marker, projectsRoot, slug }));
+    ({ matches, tried } = search());
   }
 
-  if (matches.length === 0) return { ok: false, failure: "no-match", tried: globs };
-  if (matches.length > 1) return { ok: false, failure: "multiple-matches", tried: matches };
-  return { ok: true, path: matches[0] };
+  if (matches.length === 0) return { ok: false, failure: "no-match", tried, host, via };
+  if (matches.length > 1) return { ok: false, failure: "multiple-matches", tried: matches, host, via };
+  return { ok: true, path: matches[0], host, via };
 }
 
 /**
- * A tool call rendered as the evidence it is. A `tool_use` block carries `name`
- * and `input` and neither `text` nor `content`, so the shape-based reads below
- * would normalize it to the empty string — erasing the repeated invocation that
- * is the whole evidence the tooling lens looks for, while still spending a
- * record of the stream budget on a blank line.
+ * The invoking session's transcript, across every host that claims this process.
+ *
+ * One candidate is the normal case and resolves directly. Two means one agent
+ * is running inside the other's shell, and the tie is broken on **evidence**,
+ * never on precedence: this run printed the marker, so it is in the transcript
+ * of the session that is asking and in no other file on disk. A tie the marker
+ * does not settle — neither transcript carries it, or somehow both do — is
+ * `ambiguous-host`, because picking either would read a stranger's session.
  */
-function toolUseText(block) {
-  const name = typeof block.name === "string" ? block.name : "unknown";
-  const input = typeof block.input === "string" ? block.input : jsonOrEmpty(block.input);
-  return input ? `[tool_use ${name}] ${input}` : `[tool_use ${name}]`;
+export function resolveSession(options) {
+  const { candidates, storeRootOf, marker, slug, retryDelayMs } = options ?? {};
+  const list = candidates ?? [];
+
+  if (list.length === 0) {
+    return { ok: false, failure: "unsupported-host", tried: Object.keys(HOSTS) };
+  }
+
+  const resolved = list.map((candidate) => ({
+    candidate,
+    result: resolveTranscript({
+      ...candidate,
+      storeRoot: storeRootOf(candidate.host),
+      marker,
+      slug,
+      retryDelayMs,
+    }),
+  }));
+
+  if (list.length === 1) return resolved[0].result;
+
+  const found = resolved.filter(({ result }) => result.ok);
+  if (found.length === 0) {
+    return {
+      ok: false,
+      failure: "no-match",
+      tried: resolved.flatMap(({ result }) => result.tried ?? []),
+    };
+  }
+
+  const paths = found.map(({ result }) => result.path);
+  let carrying = filesContaining(paths, marker);
+  if (carrying.length === 0) {
+    // The marker reaches a transcript only once the host has flushed the record
+    // that carries it, so one retry covers a write still in flight.
+    sleepSync(retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+    carrying = filesContaining(paths, marker);
+  }
+
+  if (carrying.length === 1) {
+    const pick = found.find(({ result }) => result.path === carrying[0]);
+    return { ...pick.result, via: "session-id+marker" };
+  }
+  return {
+    ok: false,
+    failure: "ambiguous-host",
+    tried: found.map(({ candidate, result }) => `${candidate.host}: ${result.path}`),
+  };
 }
 
-/** `input` as JSON, or "" for a value JSON cannot carry. */
+// ---------------------------------------------------------------------------
+// Normalization — every supported format down to one record shape
+// ---------------------------------------------------------------------------
+
+/** `value` as JSON, or "" for a value JSON cannot carry. */
 function jsonOrEmpty(value) {
   if (value === undefined) return "";
   try {
@@ -177,18 +401,31 @@ function jsonOrEmpty(value) {
   }
 }
 
-/** The text of one content block, whatever shape the block takes. */
+/**
+ * A tool call rendered as the evidence it is. A tool-call record carries a name
+ * and an invocation and no prose, so the text-shaped reads below would normalize
+ * it to the empty string — erasing the repeated invocation that is the whole
+ * evidence the tooling lens looks for, while still spending a record of the
+ * stream budget on a blank line.
+ */
+function toolUseText(name, invocation) {
+  const toolName = typeof name === "string" && name ? name : "unknown";
+  const input = typeof invocation === "string" ? invocation : jsonOrEmpty(invocation);
+  return input ? `[tool_use ${toolName}] ${input}` : `[tool_use ${toolName}]`;
+}
+
+/** The text of one Claude content block, whatever shape the block takes. */
 function blockText(block) {
   if (typeof block === "string") return block;
   if (block === null || typeof block !== "object") return "";
   if (typeof block.text === "string") return block.text;
-  if (block.type === "tool_use") return toolUseText(block);
+  if (block.type === "tool_use") return toolUseText(block.name, block.input);
   if (typeof block.content === "string") return block.content;
   if (Array.isArray(block.content)) return block.content.map(blockText).join("\n");
   return "";
 }
 
-/** A record's span text: what a lens reads, before the per-span cap. */
+/** A Claude record's span text: what a lens reads, before the per-span cap. */
 function spanText(record) {
   const content = record?.message?.content;
   if (typeof content === "string") return content;
@@ -196,19 +433,123 @@ function spanText(record) {
   return blockText(content);
 }
 
+/** The text of a Codex content array — `input_text` and `output_text` blocks. */
+function codexText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((block) => (typeof block?.text === "string" ? block.text : ""))
+    .filter((text) => text !== "")
+    .join("\n");
+}
+
+/** True when a record carries the Codex rollout envelope rather than a Claude record. */
+function isCodexRecord(record) {
+  return (
+    record !== null &&
+    typeof record === "object" &&
+    typeof record.type === "string" &&
+    record.payload !== null &&
+    typeof record.payload === "object"
+  );
+}
+
 /**
- * True only for a real user prompt. Most `type: "user"` records in a live
- * transcript are tool results, so "the last user message" is not a prompt
- * classifier: a prompt carries no `toolUseResult`, no host-injection tag, and
- * no `isMeta: true`.
+ * True only for a real user prompt. Most user-side records in a live transcript
+ * are tool results and host injections, so "the last user message" is not a
+ * prompt classifier.
  */
 export function isUserTurn(record) {
   if (record === null || typeof record !== "object") return false;
+  if (isCodexRecord(record)) {
+    const { payload } = record;
+    if (record.type !== "response_item" || payload.type !== "message" || payload.role !== "user") return false;
+    const text = codexText(payload.content).trimStart();
+    return !CODEX_INJECTION_PREFIXES.some((prefix) => text.startsWith(prefix));
+  }
   if (record.type !== "user") return false;
   if ("toolUseResult" in record) return false;
   if (record.isMeta === true) return false;
   const text = spanText(record);
-  return !INJECTION_TAGS.some((tag) => text.includes(tag));
+  return !CLAUDE_INJECTION_TAGS.some((tag) => text.includes(tag));
+}
+
+/**
+ * One raw record, classified. `keep` is a normalized record; `drop` is the
+ * counter key an excluded record lands under; a null `format` is a record no
+ * supported host writes.
+ */
+export function classifyRecord(record) {
+  if (record === null || typeof record !== "object") return { format: null };
+
+  if (isCodexRecord(record)) return { format: "codex", ...classifyCodex(record) };
+
+  const type = typeof record.type === "string" ? record.type : null;
+  if (type === null) return { format: null };
+  if (!CLAUDE_ALLOWED_TYPES.has(type)) return { format: "claude-code", drop: type };
+  return {
+    format: "claude-code",
+    keep: { type, isUserTurn: isUserTurn(record), text: spanText(record) },
+  };
+}
+
+/** A Codex rollout record, classified against the shapes Codex writes. */
+function classifyCodex(record) {
+  const { payload } = record;
+  // Everything outside `response_item` is rollout bookkeeping: session headers,
+  // UI events (which restate the assistant messages already kept below), token
+  // accounting, and compaction boundaries. Each is dropped under its own name,
+  // so the report still shows it happened.
+  if (record.type !== "response_item") return { drop: record.type };
+
+  const payloadType = typeof payload.type === "string" ? payload.type : "unknown";
+
+  if (payloadType === "message") {
+    const role = typeof payload.role === "string" ? payload.role : "unknown";
+    if (CODEX_DROPPED_ROLES.has(role)) return { drop: role };
+    if (role === "user") {
+      return { keep: { type: "user", isUserTurn: isUserTurn(record), text: codexText(payload.content) } };
+    }
+    if (role === "assistant") {
+      return { keep: { type: "assistant", isUserTurn: false, text: codexText(payload.content) } };
+    }
+    return { drop: `message:${role}` };
+  }
+
+  // A tool call: a payload naming a tool plus the invocation it was given.
+  // Matched by shape rather than by an enumerated list of call types, so a
+  // rollout that renames one still yields the name and arguments the tooling
+  // lens counts.
+  if (typeof payload.name === "string" && (payload.input !== undefined || payload.arguments !== undefined)) {
+    return {
+      keep: {
+        type: "assistant",
+        isUserTurn: false,
+        text: toolUseText(payload.name, payload.input ?? payload.arguments),
+      },
+    };
+  }
+
+  // A tool result, which is where a command's own stdout lands — including the
+  // marker a fallback resolution searches for.
+  if (payloadType.endsWith("_output")) {
+    return { keep: { type: "user", isUserTurn: false, text: codexText(payload.output) } };
+  }
+
+  return { drop: `${record.type}:${payloadType}` };
+}
+
+/**
+ * The prior history a resolved transcript does not contain, or null. A Codex
+ * thread that was forked or spawned from another one starts its own rollout,
+ * and the turns before the fork live in the parent's file — which this run does
+ * not read, because it is a different session.
+ */
+export function priorHistoryOf(record) {
+  if (!isCodexRecord(record) || record.type !== "session_meta") return null;
+  const { payload } = record;
+  const parent = payload.forked_from_id ?? payload.parent_thread_id ?? null;
+  return typeof parent === "string" && parent ? parent : null;
 }
 
 /**
@@ -218,8 +559,11 @@ export function isUserTurn(record) {
  */
 export function normalizeTranscript(jsonlText) {
   const droppedByType = {};
+  const formats = new Set();
   let malformedLines = 0;
   let truncatedSpans = 0;
+  let unrecognizedRecords = 0;
+  let priorHistory = null;
   const records = [];
 
   for (const line of String(jsonlText ?? "").split("\n")) {
@@ -233,22 +577,44 @@ export function normalizeTranscript(jsonlText) {
       continue;
     }
 
-    const type = typeof record?.type === "string" ? record.type : "unknown";
-    if (!ALLOWED_TYPES.has(type)) {
-      droppedByType[type] = (droppedByType[type] ?? 0) + 1;
+    priorHistory = priorHistory ?? priorHistoryOf(record);
+
+    const classified = classifyRecord(record);
+    if (classified.format === null) {
+      unrecognizedRecords++;
+      continue;
+    }
+    formats.add(classified.format);
+
+    if (classified.drop !== undefined) {
+      droppedByType[classified.drop] = (droppedByType[classified.drop] ?? 0) + 1;
       continue;
     }
 
-    let text = spanText(record);
+    let { text } = classified.keep;
     if (text.length > PER_SPAN_BYTE_CAP) {
       text = text.slice(0, PER_SPAN_BYTE_CAP);
       truncatedSpans++;
     }
 
-    records.push({ type, isUserTurn: isUserTurn(record), text });
+    records.push({ ...classified.keep, text });
   }
 
-  return { ...boundStream(records), droppedByType, malformedLines, truncatedSpans };
+  return {
+    ...boundStream(records),
+    format: formatOf(formats),
+    droppedByType,
+    malformedLines,
+    truncatedSpans,
+    unrecognizedRecords,
+    priorHistory,
+  };
+}
+
+/** The one format a stream is in — or the honest answer when it is not one. */
+function formatOf(formats) {
+  if (formats.size === 1) return [...formats][0];
+  return formats.size === 0 ? "unknown" : "mixed";
 }
 
 /**
@@ -274,32 +640,53 @@ function boundStream(records) {
 // test import has no side effects (the supports-nesting.mjs shape).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const runDir = process.argv[2] ?? "";
-  const projectsRoot = process.argv[3] ?? join(homedir(), ".claude", "projects");
-  const marker = runDir;
+  const storeOverride = process.argv[3] ?? "";
 
   if (!runDir) {
-    process.stderr.write("usage: resolve-transcript.mjs <run-cache-dir> [projects-root]\n");
+    process.stderr.write("usage: resolve-transcript.mjs <run-cache-dir> [store-root]\n");
     process.exit(1);
   }
+
+  const FAILURE_NOTES = {
+    "unsupported-host":
+      "reflect reads Claude Code and Codex session stores; Conductor is supported through whichever of those it runs, and its Cursor Agent and OpenCode backends are not",
+    "ambiguous-host":
+      "two agents' session variables are set in one process and the marker settled neither transcript",
+    "unsupported-format": "the resolved file holds no records a supported host writes",
+  };
+
+  const fail = (failure, tried, note) => {
+    process.stderr.write(`${failure}\n`);
+    for (const line of tried ?? []) process.stderr.write(`  tried: ${line}\n`);
+    if (note) process.stderr.write(`  note: ${note}\n`);
+    process.exit(1);
+  };
 
   // The slug of the directory this command runs in. It matches only when the
   // session also started here, so it is an optimization, never the mechanism.
   const slug = process.cwd().replace(/[/.]/g, "-");
 
-  const resolved = resolveTranscript({ marker, projectsRoot, slug });
-  if (!resolved.ok) {
-    process.stderr.write(`${resolved.failure}\n`);
-    for (const tried of resolved.tried ?? []) process.stderr.write(`  tried: ${tried}\n`);
-    process.exit(1);
-  }
+  const resolved = resolveSession({
+    candidates: detectHost(process.env),
+    storeRootOf: (host) => storeOverride || storeRootFor(host, process.env),
+    marker: runDir,
+    slug,
+  });
+  if (!resolved.ok) fail(resolved.failure, resolved.tried, FAILURE_NOTES[resolved.failure]);
 
   const raw = readFileSync(resolved.path, "utf8");
   const normalized = normalizeTranscript(raw);
+  if (normalized.format === "unknown" || normalized.format === "mixed") {
+    fail("unsupported-format", [resolved.path], `${FAILURE_NOTES["unsupported-format"]} (format: ${normalized.format}, unrecognized records: ${normalized.unrecognizedRecords})`);
+  }
 
   mkdirSync(runDir, { recursive: true });
   const outPath = join(runDir, "transcript.jsonl");
   writeFileSync(outPath, normalized.records.map((r) => JSON.stringify(r)).join("\n"), "utf8");
 
+  process.stdout.write(`host: ${resolved.host}\n`);
+  process.stdout.write(`resolved by: ${resolved.via}\n`);
+  process.stdout.write(`format: ${normalized.format}\n`);
   process.stdout.write(`transcript: ${resolved.path}\n`);
   process.stdout.write(`bytes: ${raw.length}\n`);
   process.stdout.write(`normalized: ${outPath}\n`);
@@ -309,4 +696,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   process.stdout.write(`dropped for ceiling: ${normalized.droppedForCeiling}\n`);
   process.stdout.write(`truncated spans: ${normalized.truncatedSpans}\n`);
   process.stdout.write(`malformed lines: ${normalized.malformedLines}\n`);
+  process.stdout.write(`unrecognized records: ${normalized.unrecognizedRecords}\n`);
+  process.stdout.write(`prior history unavailable: ${normalized.priorHistory ?? "none"}\n`);
 }

--- a/tests/reflect-skill.test.ts
+++ b/tests/reflect-skill.test.ts
@@ -580,6 +580,18 @@ describe("Slice 1 — L1: the session id the host exported resolves the transcri
     expect(result.path).toBe(join(store, rolloutPath(id)));
   });
 
+  test("a header probe that lands mid-record still reads the id above it", () => {
+    // The header is read as a bounded byte probe, so its last line is routinely
+    // a truncated record. A parser that gave up there would reject every large
+    // transcript it was asked to confirm.
+    const id = "01a07c7b-16e9-73a2-8f5b-7638fd286088";
+    const store = tree("id-codex-truncated-probe", {
+      [rolloutPath(id)]: `${JSON.stringify(codexMeta(id))}\n${JSON.stringify(codexUser("hi")).slice(0, 40)}`,
+    });
+
+    expect(resolveIn("codex", store, { sessionId: id }).path).toBe(join(store, rolloutPath(id)));
+  });
+
   test("a rollout whose own header names a different thread is not this session", () => {
     // The filename is the host's claim; the header is the file's. A file that
     // was renamed, copied, or restored under another id must not resolve.

--- a/tests/reflect-skill.test.ts
+++ b/tests/reflect-skill.test.ts
@@ -7,12 +7,13 @@
 //
 // L1 (pure unit, hermetic): the two bundled scripts,
 // skills/reflect/resources/resolve-transcript.mjs and skills/reflect/resources/write-target.mjs.
-// Resolution, record classification, the byte/record bounds, the untrusted
-// name pattern, <repo> containment, and the two-root tie-break are all
-// `f(input) -> output`, so docs/testing.md ("L1: Pure unit") puts them here
-// rather than in prose. Every fixture is synthetic JSONL written into a temp
-// dir keyed by pid+timestamp and removed afterwards — no test ever reads a real
-// ~/.claude/projects/.
+// Host detection, resolution, record classification, the byte/record bounds,
+// the untrusted name pattern, <repo> containment, and the two-root tie-break are
+// all `f(input) -> output`, so docs/testing.md ("L1: Pure unit") puts them here
+// rather than in prose. Every fixture is synthetic JSONL — sanitized values in
+// the record shapes each host really writes — written into a temp dir keyed by
+// pid+timestamp and removed afterwards. No test ever reads a real
+// ~/.claude/projects/ or ~/.codex/sessions/, and no test spawns an agent.
 //
 // L2 (static-invariant tripwires): the load-bearing rules of
 // skills/reflect/SKILL.md. These assert CONTRACTS — frontmatter keys and
@@ -46,9 +47,12 @@ import {
   MAX_RECORDS,
   MAX_TOTAL_BYTES,
   PER_SPAN_BYTE_CAP,
+  detectHost,
   isUserTurn,
   normalizeTranscript,
+  resolveSession,
   resolveTranscript,
+  storeRootFor,
 } from "../skills/reflect/resources/resolve-transcript.mjs";
 import {
   hasPluginMarker,
@@ -93,8 +97,10 @@ afterAll(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Synthetic transcript records. Every shape here was measured from real
-// transcript files under ~/.claude/projects/.
+// Synthetic transcript records. Every shape here was measured from a real
+// transcript: Claude Code's under ~/.claude/projects/, Codex's under
+// ~/.codex/sessions/. Values are sanitized; the KEYS and nesting are verbatim,
+// because those are what the classifier reads.
 // ---------------------------------------------------------------------------
 
 const jsonl = (...records: unknown[]): string =>
@@ -152,6 +158,94 @@ function assistantStream(count: number, spanBytes: number): string {
 function totalSpanBytes(records: { text?: string }[]): number {
   return records.reduce((sum, record) => sum + (record.text ?? "").length, 0);
 }
+
+// ---------------------------------------------------------------------------
+// Codex rollout records. A rollout wraps every record in `{type, payload}`;
+// `session_meta` opens the file and `response_item` carries the conversation.
+// ---------------------------------------------------------------------------
+
+const codexMeta = (id: string, extra: Record<string, unknown> = {}) => ({
+  timestamp: "2026-09-07T15:27:17.620Z",
+  ordinal: 0,
+  type: "session_meta",
+  payload: {
+    session_id: id,
+    id,
+    cwd: "/w/repo",
+    originator: "codex_sdk_ts",
+    cli_version: "0.153.4",
+    source: "exec",
+    thread_source: "user",
+    ...extra,
+  },
+});
+
+const codexMessage = (role: string, blockType: string, text: string) => ({
+  type: "response_item",
+  payload: { type: "message", id: `msg_${role}`, role, content: [{ type: blockType, text }] },
+});
+
+const codexUser = (text: string) => codexMessage("user", "input_text", text);
+const codexDeveloper = (text: string) => codexMessage("developer", "input_text", text);
+const codexAssistant = (text: string) => codexMessage("assistant", "output_text", text);
+
+const codexToolCall = (name: string, input: string) => ({
+  type: "response_item",
+  payload: { type: "custom_tool_call", id: "ctc_1", call_id: "call_1", status: "completed", name, input },
+});
+
+const codexFunctionCall = (name: string, args: string) => ({
+  type: "response_item",
+  payload: { type: "function_call", id: "fc_1", call_id: "call_2", name, arguments: args },
+});
+
+const codexToolOutput = (text: string) => ({
+  type: "response_item",
+  payload: { type: "custom_tool_call_output", id: "ctco_1", call_id: "call_1", output: [{ type: "input_text", text }] },
+});
+
+const codexReasoning = () => ({
+  type: "response_item",
+  payload: { type: "reasoning", id: "rs_1", encrypted_content: "gAAAA-redacted", summary: [] },
+});
+
+// The UI event stream restates each assistant message, so keeping it would
+// double every reply the lenses read.
+const codexEvent = (message: string) => ({
+  type: "event_msg",
+  payload: { type: "agent_message", message, phase: "commentary" },
+});
+
+const codexTokens = () => ({ type: "token_usage_record", payload: { total_tokens: 9794 } });
+
+const codexCompacted = () => ({
+  type: "compacted",
+  payload: { message: "", window_number: 1, replacement_history: [] },
+});
+
+/** A rollout's path inside a Codex store: `<YYYY>/<MM>/<DD>/rollout-<ts>-<id>.jsonl`. */
+const rolloutPath = (id: string, day = "07"): string =>
+  `2026/09/${day}/rollout-2026-09-${day}T09-27-16-${id}.jsonl`;
+
+// ---------------------------------------------------------------------------
+// Resolution helpers. Every host goes through the same entry point, so these
+// only supply the host wiring each test would otherwise repeat.
+// ---------------------------------------------------------------------------
+
+type ResolveArgs = { marker?: string; sessionId?: string; retryDelayMs?: number };
+
+const resolveIn = (host: string, storeRoot: string, args: ResolveArgs = {}) =>
+  resolveTranscript({ host, storeRoot, retryDelayMs: 0, ...args });
+
+/** Claude Code, the host the pre-existing behavior below was written against. */
+const resolveClaude = (options: { marker?: string; projectsRoot: string; sessionId?: string; retryDelayMs?: number }) =>
+  resolveTranscript({
+    host: "claude-code",
+    storeRoot: options.projectsRoot,
+    marker: options.marker,
+    sessionId: options.sessionId,
+    retryDelayMs: options.retryDelayMs,
+  });
 
 // ---------------------------------------------------------------------------
 // L2 readers. A missing file reads as "" so content assertions FAIL, never
@@ -251,7 +345,7 @@ function fencedLines(): string[] {
 // Slice 1 — L1: resolution
 // ===========================================================================
 
-describe("Slice 1 — L1: resolve-transcript finds the invoking session by its own marker", () => {
+describe("Slice 1 — L1: Claude Code sessions resolve by marker", () => {
   test("a project file holding the marker resolves to that absolute path", () => {
     const marker = "/tmp/reflect-cache-a1b2c3";
     const projectsRoot = tree("resolve-hit", {
@@ -262,7 +356,7 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
       "-Users-dev-other/session-two.jsonl": jsonl(userPrompt("unrelated work")),
     });
 
-    const result = resolveTranscript({ marker, projectsRoot });
+    const result = resolveClaude({ marker, projectsRoot });
 
     expect(result.ok).toBe(true);
     expect(result.path).toBe(join(projectsRoot, "-Users-dev-team", "session-one.jsonl"));
@@ -273,7 +367,7 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
       "-Users-dev-team/session-one.jsonl": jsonl(userPrompt("reflect on this session")),
     });
 
-    const result = resolveTranscript({
+    const result = resolveClaude({
       marker: "/tmp/reflect-cache-never-written",
       projectsRoot,
       retryDelayMs: 0,
@@ -290,7 +384,7 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
       "-Users-dev-team-worktrees-x/session-two.jsonl": jsonl(toolResult(marker)),
     });
 
-    const result = resolveTranscript({ marker, projectsRoot });
+    const result = resolveClaude({ marker, projectsRoot });
 
     expect(result.failure).toBe("multiple-matches");
     expect(result.path).toBeUndefined();
@@ -306,7 +400,7 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
       "-Users-dev-other/session-two.jsonl": jsonl(toolResult("/tmp/reflectXaab1")),
     });
 
-    const result = resolveTranscript({ marker, projectsRoot });
+    const result = resolveClaude({ marker, projectsRoot });
 
     expect(result.ok).toBe(true);
     expect(result.path).toBe(join(projectsRoot, "-Users-dev-team", "session-one.jsonl"));
@@ -325,12 +419,12 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
 
     // Positive control: the same tree resolves a top-level marker, so a
     // resolver that finds nothing at all cannot pass the exclusion below.
-    expect(resolveTranscript({ marker: topLevelMarker, projectsRoot }).path).toBe(
+    expect(resolveClaude({ marker: topLevelMarker, projectsRoot }).path).toBe(
       join(projectsRoot, "-Users-dev-team", "9aec38dc.jsonl"),
     );
 
     expect(
-      resolveTranscript({ marker: subagentMarker, projectsRoot, retryDelayMs: 0 }).failure,
+      resolveClaude({ marker: subagentMarker, projectsRoot, retryDelayMs: 0 }).failure,
     ).toBe("no-match");
   });
 
@@ -347,29 +441,29 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
     });
 
     // Positive control, same tree.
-    expect(resolveTranscript({ marker: topLevelMarker, projectsRoot }).path).toBe(
+    expect(resolveClaude({ marker: topLevelMarker, projectsRoot }).path).toBe(
       join(projectsRoot, "-Users-dev-team", "9aec38dc.jsonl"),
     );
 
     expect(
-      resolveTranscript({ marker: sidecarMarker, projectsRoot, retryDelayMs: 0 }).failure,
+      resolveClaude({ marker: sidecarMarker, projectsRoot, retryDelayMs: 0 }).failure,
     ).toBe("no-match");
   });
 
-  test("a missing projects root is a named failure that states the path tried", () => {
-    // A non-Claude host has no ~/.claude/projects at all. Failing with
-    // "no-match" there would send the user hunting for a session that was
-    // never recorded, so the two failures are distinct and each names what it
-    // looked for.
+  test("a missing session store is a named failure that states the path tried", () => {
+    // A host that keeps no store at the path tried has recorded nothing.
+    // Failing with "no-match" there would send the user hunting for a session
+    // that was never recorded, so the two failures are distinct and each names
+    // what it looked for.
     const missingRoot = join(scratch("resolve-no-root"), "claude-projects-absent");
 
-    const result = resolveTranscript({
+    const result = resolveClaude({
       marker: "/tmp/reflect-cache-a1b2c3",
       projectsRoot: missingRoot,
       retryDelayMs: 0,
     });
 
-    expect(result.failure).toBe("no-projects-root");
+    expect(result.failure).toBe("no-session-store");
     expect((result.tried ?? []).join(" ")).toContain(missingRoot);
   });
 
@@ -386,10 +480,306 @@ describe("Slice 1 — L1: resolve-transcript finds the invoking session by its o
       ),
     });
 
-    const result = resolveTranscript({ marker, projectsRoot });
+    const result = resolveClaude({ marker, projectsRoot });
 
     expect(result.ok).toBe(true);
     expect(result.path).toBe(join(projectsRoot, "-Users-dev-team", "session-one.jsonl"));
+  });
+});
+
+// ===========================================================================
+// Slice 1 — L1: host detection and multi-host resolution
+// ===========================================================================
+
+describe("Slice 1 — L1: detectHost names every host claiming this process", () => {
+  test("Claude Code is detected from the session id it exports", () => {
+    expect(detectHost({ CLAUDECODE: "1", CLAUDE_CODE_SESSION_ID: "df48a6dc-3bfa-4bc1-94b5-799582807858" })).toEqual([
+      { host: "claude-code", sessionId: "df48a6dc-3bfa-4bc1-94b5-799582807858" },
+    ]);
+  });
+
+  test("Codex is detected from its thread id, which names the rollout file", () => {
+    // CODEX_THREAD_ID is this thread's own id. CODEX_SESSION_ID names the root
+    // thread and is the same value for a top-level session, so it is only the
+    // fallback.
+    expect(detectHost({ CODEX_THREAD_ID: "01a07c7b-16e9-73a2-8f5b-7638fd286088" })).toEqual([
+      { host: "codex", sessionId: "01a07c7b-16e9-73a2-8f5b-7638fd286088" },
+    ]);
+    expect(detectHost({ CODEX_SESSION_ID: "01a07c7b-16e9-73a2-8f5b-7638fd286088" })).toEqual([
+      { host: "codex", sessionId: "01a07c7b-16e9-73a2-8f5b-7638fd286088" },
+    ]);
+  });
+
+  test("Conductor's own variables never decide the host — the backend's do", () => {
+    // Conductor runs Claude Code, Codex, Cursor Agent, or OpenCode. It sets the
+    // same CONDUCTOR_* variables whichever it launched, so a resolver that read
+    // them would resolve the same way for a backend it cannot read at all.
+    const conductor = {
+      CONDUCTOR_WORKSPACE_NAME: "monaco",
+      CONDUCTOR_WORKSPACE_PATH: "/Users/dev/conductor/workspaces/team/monaco",
+      CONDUCTOR_SESSION_ID: "b18ebf27-14fe-41af-bec5-9110bcb92478",
+      CONDUCTOR_IS_LOCAL: "1",
+    };
+
+    expect(detectHost({ ...conductor, CLAUDE_CODE_SESSION_ID: "df48a6dc" })).toEqual([
+      { host: "claude-code", sessionId: "df48a6dc" },
+    ]);
+    expect(detectHost({ ...conductor, CODEX_THREAD_ID: "01a07c7b" })).toEqual([
+      { host: "codex", sessionId: "01a07c7b" },
+    ]);
+    // A Conductor workspace running a backend reflect cannot read resolves to
+    // no host at all, rather than to whichever store happens to exist.
+    expect(detectHost(conductor)).toEqual([]);
+  });
+
+  test("both agents' variables in one process yields both candidates, not a pick", () => {
+    // Real state, not a bug: a Codex process launched from a Claude Code shell
+    // inherits CLAUDE_CODE_SESSION_ID. Precedence would be a guess, so the tie
+    // is broken on evidence in resolveSession.
+    expect(detectHost({ CLAUDE_CODE_SESSION_ID: "df48a6dc", CODEX_THREAD_ID: "01a07c7b" }).length).toBe(2);
+  });
+
+  test("each host's store root follows that host's own override variable", () => {
+    const env = { HOME: "/home/dev", CODEX_HOME: "/home/dev/.codex-alt", CLAUDE_CONFIG_DIR: "/home/dev/.claude-alt" };
+
+    expect(storeRootFor("codex", env)).toBe(join("/home/dev/.codex-alt", "sessions"));
+    expect(storeRootFor("claude-code", env)).toBe(join("/home/dev/.claude-alt", "projects"));
+    expect(storeRootFor("codex", { HOME: "/home/dev" })).toBe(join("/home/dev", ".codex", "sessions"));
+    expect(storeRootFor("claude-code", { HOME: "/home/dev" })).toBe(join("/home/dev", ".claude", "projects"));
+  });
+});
+
+describe("Slice 1 — L1: the session id the host exported resolves the transcript", () => {
+  test("Claude Code resolves <session-id>.jsonl without searching content", () => {
+    const projectsRoot = tree("id-claude", {
+      "-Users-dev-team/df48a6dc-3bfa-4bc1-94b5-799582807858.jsonl": jsonl(userPrompt("reflect on this session")),
+      "-Users-dev-other/9aec38dc-0000-4000-8000-000000000002.jsonl": jsonl(userPrompt("unrelated work")),
+    });
+
+    const result = resolveClaude({ projectsRoot, sessionId: "df48a6dc-3bfa-4bc1-94b5-799582807858" });
+
+    expect(result.ok).toBe(true);
+    expect(result.via).toBe("session-id");
+    expect(result.path).toBe(join(projectsRoot, "-Users-dev-team", "df48a6dc-3bfa-4bc1-94b5-799582807858.jsonl"));
+  });
+
+  test("Codex resolves rollout-<timestamp>-<thread-id>.jsonl three levels down", () => {
+    const id = "01a07c7b-16e9-73a2-8f5b-7638fd286088";
+    const store = tree("id-codex", {
+      [rolloutPath(id)]: jsonl(codexMeta(id), codexUser("reflect on this session")),
+      [rolloutPath("01a07c68-3b6a-7f31-85dd-9c4b6e04b97c", "06")]: jsonl(
+        codexMeta("01a07c68-3b6a-7f31-85dd-9c4b6e04b97c"),
+        codexUser("unrelated work"),
+      ),
+    });
+
+    const result = resolveIn("codex", store, { sessionId: id });
+
+    expect(result.ok).toBe(true);
+    expect(result.via).toBe("session-id");
+    expect(result.path).toBe(join(store, rolloutPath(id)));
+  });
+
+  test("a rollout whose own header names a different thread is not this session", () => {
+    // The filename is the host's claim; the header is the file's. A file that
+    // was renamed, copied, or restored under another id must not resolve.
+    const id = "01a07c7b-16e9-73a2-8f5b-7638fd286088";
+    const store = tree("id-codex-header-mismatch", {
+      [rolloutPath(id)]: jsonl(codexMeta("01a06c22-7c2a-73d2-b559-bc5ba98ea18c"), codexUser("someone else")),
+    });
+
+    expect(resolveIn("codex", store, { sessionId: id }).failure).toBe("no-match");
+  });
+
+  test("an exported id with no transcript fails by name and never falls back to a search", () => {
+    // Falling back to the marker here would search on behalf of an id already
+    // known to be authoritative, and could land on any session that happens to
+    // mention the run cache path.
+    const marker = "/tmp/reflect-cache-a1b2c3";
+    const projectsRoot = tree("id-claude-miss", {
+      "-Users-dev-other/9aec38dc-0000-4000-8000-000000000002.jsonl": jsonl(toolResult(marker)),
+    });
+
+    // Positive control: the same marker in the same tree does resolve when no
+    // session id is exported, so the failure below is the id path refusing.
+    expect(resolveClaude({ projectsRoot, marker }).ok).toBe(true);
+
+    const result = resolveClaude({ projectsRoot, marker, sessionId: "df48a6dc-3bfa-4bc1-94b5-799582807858" });
+    expect(result.failure).toBe("no-match");
+    expect(result.path).toBeUndefined();
+  });
+
+  test("an exported id that is not a session id shape is refused before any lookup", () => {
+    const store = tree("id-invalid", { [rolloutPath("01a07c7b")]: jsonl(codexMeta("01a07c7b")) });
+
+    expect(resolveIn("codex", store, { sessionId: "../../etc/passwd" }).failure).toBe("invalid-session-id");
+    // Empty is absent, not invalid — and with no marker either there is nothing
+    // left to identify the session with. An empty marker would reach
+    // `grep -F -e ""`, which matches every transcript in the store.
+    expect(resolveIn("codex", store, { sessionId: "" }).failure).toBe("no-match");
+    expect(resolveIn("codex", store, { sessionId: "", marker: "" }).failure).toBe("no-match");
+    expect(resolveIn("codex", store, { marker: "" }).path).toBeUndefined();
+  });
+
+  test("a host reflect cannot read is a named failure, never a resolved transcript", () => {
+    const store = tree("unsupported", { "sessions/whatever.jsonl": jsonl(userPrompt("hi")) });
+
+    expect(resolveIn("cursor-agent", store, { marker: "/tmp/x" }).failure).toBe("unsupported-host");
+    expect(resolveIn("opencode", store, { marker: "/tmp/x" }).failure).toBe("unsupported-host");
+    expect(resolveTranscript({ host: null, storeRoot: store, marker: "/tmp/x" }).failure).toBe("unsupported-host");
+  });
+});
+
+describe("Slice 1 — L1: concurrent sessions in one workspace never cross", () => {
+  test("two Claude sessions in one project slug are told apart by the exported id", () => {
+    // Two Conductor workspaces on one repo, or two windows on one worktree,
+    // put several live transcripts in the same project directory.
+    const mine = "df48a6dc-3bfa-4bc1-94b5-799582807858";
+    const theirs = "9aec38dc-0000-4000-8000-000000000002";
+    const projectsRoot = tree("concurrent-claude", {
+      [`-Users-dev-team/${mine}.jsonl`]: jsonl(userPrompt("reflect on this session")),
+      [`-Users-dev-team/${theirs}.jsonl`]: jsonl(userPrompt("a different session, same workspace")),
+    });
+
+    expect(resolveClaude({ projectsRoot, sessionId: mine }).path).toBe(
+      join(projectsRoot, "-Users-dev-team", `${mine}.jsonl`),
+    );
+    expect(resolveClaude({ projectsRoot, sessionId: theirs }).path).toBe(
+      join(projectsRoot, "-Users-dev-team", `${theirs}.jsonl`),
+    );
+  });
+
+  test("two Codex threads recorded the same day are told apart by the exported id", () => {
+    const mine = "01a07c7b-16e9-73a2-8f5b-7638fd286088";
+    const theirs = "01a07c68-3b6a-7f31-85dd-9c4b6e04b97c";
+    const store = tree("concurrent-codex", {
+      [rolloutPath(mine)]: jsonl(codexMeta(mine), codexUser("reflect on this session")),
+      [rolloutPath(theirs)]: jsonl(codexMeta(theirs), codexUser("a different session, same workspace")),
+    });
+
+    expect(resolveIn("codex", store, { sessionId: mine }).path).toBe(join(store, rolloutPath(mine)));
+    expect(resolveIn("codex", store, { sessionId: theirs }).path).toBe(join(store, rolloutPath(theirs)));
+  });
+
+  test("a neighbouring session that merely mentions the run cache path is not selected", () => {
+    // Two sessions in one workspace can both name the same path — one printed
+    // it, the other read the report. The id is what decides, and where there is
+    // no id, two marker hits are an ambiguity failure rather than a pick.
+    const marker = "/tmp/reflect.A0DYJB9o";
+    const mine = "df48a6dc-3bfa-4bc1-94b5-799582807858";
+    const projectsRoot = tree("concurrent-mention", {
+      [`-Users-dev-team/${mine}.jsonl`]: jsonl(toolResult(`run cache: ${marker}`)),
+      "-Users-dev-team/9aec38dc-0000-4000-8000-000000000002.jsonl": jsonl(
+        userPrompt(`did the other window write ${marker}?`),
+      ),
+    });
+
+    expect(resolveClaude({ projectsRoot, marker, sessionId: mine }).path).toBe(
+      join(projectsRoot, "-Users-dev-team", `${mine}.jsonl`),
+    );
+    expect(resolveClaude({ projectsRoot, marker }).failure).toBe("multiple-matches");
+  });
+
+  test("a Codex subagent thread's own rollout is never resolved for its parent", () => {
+    // A subagent gets its own thread id and its own file. Resolving the parent
+    // must return the parent's file, whatever the child's contains.
+    const parent = "01a0676d-0eca-7791-b069-436d26e7eec8";
+    const child = "01a06c22-7c2a-73d2-b559-bc5ba98ea18c";
+    const store = tree("codex-subagent", {
+      [rolloutPath(parent)]: jsonl(codexMeta(parent), codexUser("reflect on this session")),
+      [rolloutPath(child)]: jsonl(
+        codexMeta(child, { session_id: parent, parent_thread_id: parent, thread_source: "subagent" }),
+        codexUser("scout the callers"),
+      ),
+    });
+
+    expect(resolveIn("codex", store, { sessionId: parent }).path).toBe(join(store, rolloutPath(parent)));
+    expect(resolveIn("codex", store, { sessionId: child }).path).toBe(join(store, rolloutPath(child)));
+  });
+});
+
+describe("Slice 1 — L1: resolveSession breaks a two-host tie on evidence", () => {
+  const claudeId = "df48a6dc-3bfa-4bc1-94b5-799582807858";
+  const codexId = "01a07c7b-16e9-73a2-8f5b-7638fd286088";
+  const bothHosts = [
+    { host: "codex", sessionId: codexId },
+    { host: "claude-code", sessionId: claudeId },
+  ] as const;
+
+  function twoStores(label: string, options: { markerInClaude: boolean; markerInCodex: boolean; marker: string }) {
+    const claudeRoot = tree(`${label}-claude`, {
+      [`-Users-dev-team/${claudeId}.jsonl`]: jsonl(
+        userPrompt("reflect on this session"),
+        ...(options.markerInClaude ? [toolResult(`run cache: ${options.marker}`)] : []),
+      ),
+    });
+    const codexRoot = tree(`${label}-codex`, {
+      [rolloutPath(codexId)]: jsonl(
+        codexMeta(codexId),
+        codexUser("reflect on this session"),
+        ...(options.markerInCodex ? [codexToolOutput(`run cache: ${options.marker}`)] : []),
+      ),
+    });
+    return { claudeRoot, codexRoot, storeRootOf: (host: string) => (host === "codex" ? codexRoot : claudeRoot) };
+  }
+
+  test("the host whose transcript carries this run's marker wins", () => {
+    const marker = "/tmp/reflect.Vl7d3fCN";
+    const { codexRoot, storeRootOf } = twoStores("tie-codex", { marker, markerInCodex: true, markerInClaude: false });
+
+    const result = resolveSession({ candidates: bothHosts, storeRootOf, marker, retryDelayMs: 0 });
+
+    expect(result.ok).toBe(true);
+    expect(result.host).toBe("codex");
+    expect(result.via).toBe("session-id+marker");
+    expect(result.path).toBe(join(codexRoot, rolloutPath(codexId)));
+  });
+
+  test("the tie-break is symmetric — the inherited variable does not win by order", () => {
+    const marker = "/tmp/reflect.A0DYJB9o";
+    const { claudeRoot, storeRootOf } = twoStores("tie-claude", { marker, markerInCodex: false, markerInClaude: true });
+
+    const result = resolveSession({ candidates: bothHosts, storeRootOf, marker, retryDelayMs: 0 });
+
+    expect(result.host).toBe("claude-code");
+    expect(result.path).toBe(join(claudeRoot, "-Users-dev-team", `${claudeId}.jsonl`));
+  });
+
+  test("a marker in neither transcript is ambiguous-host, and picks neither", () => {
+    const marker = "/tmp/reflect.NotFlushedYet";
+    const { storeRootOf } = twoStores("tie-none", { marker, markerInCodex: false, markerInClaude: false });
+
+    const result = resolveSession({ candidates: bothHosts, storeRootOf, marker, retryDelayMs: 0 });
+
+    expect(result.failure).toBe("ambiguous-host");
+    expect(result.path).toBeUndefined();
+    expect((result.tried ?? []).join(" ")).toContain("codex");
+    expect((result.tried ?? []).join(" ")).toContain("claude-code");
+  });
+
+  test("a marker in both transcripts is ambiguous-host, and picks neither", () => {
+    const marker = "/tmp/reflect.InBoth";
+    const { storeRootOf } = twoStores("tie-both", { marker, markerInCodex: true, markerInClaude: true });
+
+    expect(resolveSession({ candidates: bothHosts, storeRootOf, marker, retryDelayMs: 0 }).failure).toBe(
+      "ambiguous-host",
+    );
+  });
+
+  test("one candidate resolves directly, and no candidate is unsupported-host", () => {
+    const marker = "/tmp/reflect.Solo";
+    const { codexRoot, storeRootOf } = twoStores("tie-solo", { marker, markerInCodex: true, markerInClaude: false });
+
+    const single = resolveSession({
+      candidates: [{ host: "codex", sessionId: codexId }] as const,
+      storeRootOf,
+      marker,
+      retryDelayMs: 0,
+    });
+    expect(single.path).toBe(join(codexRoot, rolloutPath(codexId)));
+    expect(single.via).toBe("session-id");
+
+    expect(resolveSession({ candidates: [], storeRootOf, marker, retryDelayMs: 0 }).failure).toBe("unsupported-host");
   });
 });
 
@@ -505,6 +895,152 @@ describe("Slice 1 — L1: normalizeTranscript classifies records and bounds the 
 
     expect(normalized.malformedLines).toBe(1);
     expect(normalized.records.length).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Slice 1 — L1: Codex normalization into the same bounded contract
+// ===========================================================================
+
+describe("Slice 1 — L1: a Codex rollout normalizes into the same record shape", () => {
+  test("prompts, replies, and tool calls survive with their names and arguments", () => {
+    const normalized = normalizeTranscript(
+      jsonl(
+        codexMeta("01a07c7b-16e9-73a2-8f5b-7638fd286088"),
+        codexUser("reflect on this session"),
+        codexToolCall("exec", 'text(await tools.exec_command({cmd:"bun test"}));'),
+        codexToolOutput("Script completed\nOutput:\n42 pass"),
+        codexAssistant("every check is green"),
+      ),
+    );
+
+    expect(normalized.format).toBe("codex");
+    expect(normalized.records.map((record) => record.type)).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(normalized.records[0]?.isUserTurn).toBe(true);
+    expect(normalized.records[0]?.text).toBe("reflect on this session");
+    // The tooling lens's evidence is the invocation, so the tool's name and its
+    // arguments both have to reach the normalized file.
+    expect(normalized.records[1]?.text).toContain("exec");
+    expect(normalized.records[1]?.text).toContain("bun test");
+    expect(normalized.records[2]?.text).toContain("42 pass");
+    expect(normalized.records[3]?.text).toBe("every check is green");
+    expect(normalized.unrecognizedRecords).toBe(0);
+  });
+
+  test("a function_call carries its name and arguments the same way a custom_tool_call does", () => {
+    // Codex writes tool calls two ways. Both are the same evidence, so both
+    // normalize to the same rendering rather than one of them vanishing.
+    const normalized = normalizeTranscript(jsonl(codexFunctionCall("wait", '{"cell_id":"18"}')));
+
+    expect(normalized.records.length).toBe(1);
+    expect(normalized.records[0]?.text).toContain("wait");
+    expect(normalized.records[0]?.text).toContain("cell_id");
+  });
+
+  test("rollout bookkeeping is dropped under its own name and counted", () => {
+    // event_msg restates each assistant message, so keeping it would double
+    // every reply. Reasoning is encrypted. The rest is accounting. Each drop is
+    // counted, because a silent drop reads exactly like a parser that never saw
+    // the record.
+    const normalized = normalizeTranscript(
+      jsonl(
+        codexMeta("01a07c7b-16e9-73a2-8f5b-7638fd286088"),
+        codexDeveloper("<skills_instructions>"),
+        codexReasoning(),
+        codexEvent("every check is green"),
+        codexTokens(),
+        codexAssistant("every check is green"),
+      ),
+    );
+
+    expect(normalized.droppedByType).toEqual({
+      session_meta: 1,
+      developer: 1,
+      "response_item:reasoning": 1,
+      event_msg: 1,
+      token_usage_record: 1,
+    });
+    expect(normalized.records.length).toBe(1);
+  });
+
+  test("a Codex host injection is kept as a record but is not a user turn", () => {
+    // Codex delivers project instructions and Conductor's own preamble as
+    // role: "user" messages. Counting those as prompts would make every session
+    // look like it opened with three turns nobody typed.
+    expect(isUserTurn(codexUser("reflect on this session"))).toBe(true);
+    expect(isUserTurn(codexUser("# AGENTS.md instructions for /w/repo\n\n<INSTRUCTIONS>"))).toBe(false);
+    expect(isUserTurn(codexUser("\n<system_instruction>\nYou are working inside Conductor"))).toBe(false);
+    expect(isUserTurn(codexUser("<recommended_plugins>\nHere is a list of plugins"))).toBe(false);
+    // A prompt that merely mentions an injection mid-sentence is still a prompt:
+    // the wrappers open their span, so the test is a prefix, not a substring.
+    expect(isUserTurn(codexUser("why does <system_instruction> show up in the transcript?"))).toBe(true);
+  });
+
+  test("the byte cap, record ceiling, and malformed-line count apply to Codex too", () => {
+    const capped = normalizeTranscript(jsonl(codexAssistant("y".repeat(10_000))));
+    expect((capped.records[0]?.text ?? "").length).toBe(PER_SPAN_BYTE_CAP);
+    expect(capped.truncatedSpans).toBe(1);
+
+    const bounded = normalizeTranscript(
+      jsonl(...Array.from({ length: MAX_RECORDS + 1 }, (_, index) => codexUser(`turn-${index}`))),
+    );
+    expect(bounded.records.length).toBe(MAX_RECORDS);
+    expect(bounded.droppedForCeiling).toBe(1);
+
+    const malformed = normalizeTranscript(
+      `${JSON.stringify(codexUser("reflect"))}\n{"type":"response_item",\n${JSON.stringify(codexAssistant("ok"))}\n`,
+    );
+    expect(malformed.malformedLines).toBe(1);
+    expect(malformed.records.length).toBe(2);
+  });
+
+  test("a forked thread reports the prior history this file does not carry", () => {
+    // A forked or spawned Codex thread starts its own rollout, and the turns
+    // before the fork stay in the parent's file — which this run does not read,
+    // because it is a different session. Reporting the gap is the alternative
+    // to filling it in from memory.
+    const parent = "01a073aa-6b96-7221-a294-a4008eacc046";
+    const forked = normalizeTranscript(
+      jsonl(
+        codexMeta("01a074fd-169c-70d3-823d-dbc2318360e8", { forked_from_id: parent, history_mode: "paginated" }),
+        codexUser("carry on from there"),
+      ),
+    );
+
+    expect(forked.priorHistory).toBe(parent);
+    // A session that was never forked reports no gap, so the field can tell the
+    // two apart.
+    expect(normalizeTranscript(jsonl(codexMeta("01a07c7b"), codexUser("hi"))).priorHistory).toBeNull();
+  });
+
+  test("a compaction boundary is reported rather than absorbed", () => {
+    // Codex writes a `compacted` record where it replaced earlier turns in
+    // context. The raw records stay in the file, so the read is still complete —
+    // the count is what tells a reader the session had one.
+    const normalized = normalizeTranscript(
+      jsonl(codexUser("a long session"), codexCompacted(), codexAssistant("carrying on")),
+    );
+
+    expect(normalized.droppedByType.compacted).toBe(1);
+    expect(normalized.records.length).toBe(2);
+  });
+
+  test("records no supported host writes are counted, and the stream reports unknown", () => {
+    // The alternative to a named failure here is three lenses reading an empty
+    // file and reporting, truthfully and uselessly, that the session taught
+    // nothing.
+    const normalized = normalizeTranscript(
+      jsonl({ id: "1", role: "user", parts: [{ text: "some other agent's format" }] }, { foo: "bar" }),
+    );
+
+    expect(normalized.format).toBe("unknown");
+    expect(normalized.unrecognizedRecords).toBe(2);
+    expect(normalized.records.length).toBe(0);
+  });
+
+  test("each host's own format is reported, so a caller can tell them apart", () => {
+    expect(normalizeTranscript(jsonl(userPrompt("hi"))).format).toBe("claude-code");
+    expect(normalizeTranscript(jsonl(codexUser("hi"))).format).toBe("codex");
   });
 });
 
@@ -710,6 +1246,52 @@ describe("Slice 1 — L2: reflect's three reporting lenses", () => {
     // Guard: an empty corpus would make the sweep pass vacuously.
     expect(fenced.length).toBeGreaterThan(0);
     expect(fenced.filter((line) => /\brm\s+-[rRf]/.test(line))).toEqual([]);
+  });
+
+  test("step 2 names the store each supported host keeps, and Conductor as neither", () => {
+    // Conductor runs Claude Code, Codex, Cursor Agent, or OpenCode inside a
+    // worktree; the backend writes the transcript. A body that named a
+    // "Conductor transcript" would send a reader looking for a file that does
+    // not exist.
+    const step = section(/^##\s+Execution\s*$/) || prose();
+    expect(step.length).toBeGreaterThan(0);
+
+    const flattened = flat(step);
+    expect(flattened).toContain("~/.claude/projects");
+    expect(flattened).toContain("${CODEX_HOME:-~/.codex}/sessions");
+    expect(flattened).toContain("CLAUDE_CODE_SESSION_ID");
+    expect(flattened).toContain("CODEX_THREAD_ID");
+  });
+
+  test("every failure the resolver can emit is documented in the skill body", () => {
+    // A drift tripwire between the script and the prose that tells the model
+    // what to report. A new failure name that reaches a user with no entry here
+    // stops a run with a word nothing explains.
+    const script = read(join(REPO_ROOT, "skills", "reflect", "resources", "resolve-transcript.mjs"));
+    const failures = [...script.matchAll(/failure:\s*"([a-z-]+)"/g)].map((match) => match[1]);
+    const unique = [...new Set(failures)].sort();
+
+    // Positive control: the sweep must actually find the names it is checking.
+    expect(unique).toContain("no-match");
+    expect(unique).toContain("multiple-matches");
+    expect(unique.length).toBeGreaterThanOrEqual(6);
+
+    const documented = flat(body());
+    expect(documented.length).toBeGreaterThan(0);
+    expect(unique.filter((failure) => !documented.includes(`\`${failure}\``))).toEqual([]);
+    // unsupported-format is raised by the format check rather than by a
+    // `failure:` literal, so it is asserted by name.
+    expect(documented).toContain("`unsupported-format`");
+  });
+
+  test("a bounded or missing read is reported, never filled in from memory", () => {
+    // The whole reason the run reads a file is that context already lost the
+    // early turns. A partial read that gets topped up from memory reintroduces
+    // exactly the source the skill exists to avoid.
+    const step = section(/^##\s+Execution\s*$/);
+    expect(step.length).toBeGreaterThan(0);
+    expect(flat(step)).toContain("unrecognized records");
+    expect(flat(step)).toContain("prior history");
   });
 
   test("nothing in the skill depends on the frog binary the plugin does not install", () => {


### PR DESCRIPTION
## Problem

`/reflect` resolves the invoking session through
`skills/reflect/resources/resolve-transcript.mjs`. That script searched one
directory level under `~/.claude/projects/` and understood one record format.
Invoking `team:reflect` from Codex inside Conductor therefore returned
`no-match`, and the skill's own execution instructions stop the run there —
before a single lens reads anything.

Reproduced against the pre-fix script on both halves:

```
A. resolve against a Codex store  -> {"ok":false,"failure":"no-match", ...}
B. normalize Codex records        -> records: []  droppedByType: {"response_item":3}
```

Even handed the right file, every Codex record was dropped.

## What changed

**Resolution now prefers the id the host itself exported.**
`CLAUDE_CODE_SESSION_ID` names `<project-slug>/<id>.jsonl`; `CODEX_THREAD_ID`
names `sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<id>.jsonl`. The filename is the
host's claim, so the file's own header (`session_meta.payload.id`, or a record's
`sessionId`) is re-read and has to agree. The fixed-string marker search is kept
as the fallback for a host that exports no id. Nothing takes the newest file,
guesses from the working directory, or picks among candidates.

**Conductor is not a store.** It launches Claude Code, Codex, Cursor Agent, or
OpenCode in a worktree and the backend writes its own transcript, so detection
reads the agents' variables and never `CONDUCTOR_*`. A Conductor session
resolves as whichever backend it runs; the two backends this script cannot read
fail as `unsupported-host` rather than resolving to something plausible.

**Two hosts in one process is a real state, handled on evidence.** `codex exec`
launched from a Claude Code shell inherits `CLAUDE_CODE_SESSION_ID` — observed
live during this work. Precedence would be a guess, so the run cache path this
run printed breaks the tie; where it settles neither transcript, the run stops
at `ambiguous-host`.

**Codex records normalize into the existing bounded contract.** User messages,
assistant messages, and both tool-call shapes (`custom_tool_call`,
`function_call`) rendered as the tool's name plus its invocation. Rollout
bookkeeping drops under its own name and is counted. Codex's injected preamble
(`# AGENTS.md instructions for `, `<system_instruction>`,
`<recommended_plugins>`, `<environment_context>`) is kept as a record but not
counted as a user turn — matched as a prefix, so a prompt that merely mentions
one still counts.

**Partial reads are reported, not filled in.** The stream now also reports its
format, unrecognized records, and the prior history a forked Codex thread left
in its parent's file. The skill body says explicitly never to substitute the
agent's memory for the part the transcript did not carry.

Unchanged: stores are only read, the marker search returns file names only, the
header check returns only the id it read, the record and byte ceilings and
exclusion rules stand, findings still paraphrase and cite a path or a turn
index, and every skill edit and tracker issue still waits on approval.

## Verified live vs. fixture-only

| Host / backend | Evidence |
| --- | --- |
| **Conductor + Claude Code** | **LIVE.** End-to-end CLI run from this very session: `host: claude-code`, `resolved by: session-id`, `format: claude-code`, 142 records. |
| **Codex CLI, in-agent** | **LIVE.** Two real turns via `codex exec` + `codex exec resume`, with `CLAUDE_*` stripped so the env matches Conductor + Codex. Reported `host: codex`, `resolved by: session-id`, 7 records, 2 user turns, and resolved its own rollout. |
| **Codex CLI, real on-disk store** | **LIVE.** A real rollout written by a real Codex session, resolved by its real `CODEX_THREAD_ID` through the CLI: correct classification of the `<recommended_plugins>` injection (not a user turn), the real prompt (a user turn), the `exec` tool call with its invocation, the tool output, and the reply. |
| **Codex resumed session** | **LIVE.** `codex exec resume` appends to the same rollout, so the resumed turn resolved the same file with turn 1's history intact and `prior history unavailable: none`. |
| **Both hosts set in one process** | **LIVE for the failure, fixture-only for the tie-break.** The inherited-`CLAUDE_CODE_SESSION_ID` case was reproduced live and returned `ambiguous-host`. The marker tie-break that now resolves it is covered by fixtures only. |
| **Conductor + Codex specifically** | **NOT verified live.** The env shape was taken from a real Conductor-launched Codex rollout's own recorded `env` dump (`CODEX_THREAD_ID`, `CODEX_SESSION_ID`, `CONDUCTOR_*`, and no `CLAUDE_*`), and the store, file naming, format, and id mechanism are identical to the Codex CLI path verified live above. |
| **Conductor + Cursor Agent / OpenCode** | **Fixture-only.** Asserted to fail as `unsupported-host`. |
| **Antigravity CLI** | **Not covered.** No session id or store is known for it, so it now fails as `unsupported-host` — a named failure instead of the previous silent `no-match`. |

## Tests

`tests/reflect-skill.test.ts`, +25 tests (69 -> 94). Fixtures are sanitized
values in the record shapes each host really writes, measured from
`~/.claude/projects` and `~/.codex/sessions`. No test reads a real store or
spawns an agent.

Covers: existing Claude Code marker behavior (unchanged), Codex resolution by
thread id, header-mismatch rejection, a header probe landing mid-record,
Conductor resolving as its backend, concurrent sessions in one workspace (both
hosts), a neighbouring session that merely mentions the run cache path,
subagent threads, ambiguity in both directions, an authoritative id refusing to
fall back to a search, malformed records, the record and byte ceilings,
forked-thread history gaps, compaction boundaries, unsupported formats, and a
drift tripwire between the resolver's failure names and the prose that explains
them (proved to go red on an undocumented name).

## Test plan

- [x] `bun test` — 2153 pass, 4 skip, 0 fail
- [x] `tsc --noEmit` — clean
- [x] Reproduced the bug against the pre-fix script (both resolution and normalization)
- [x] Live: Claude Code inside Conductor, end-to-end through the CLI
- [x] Live: Codex, in-agent, across two turns including a resume
- [x] Live: a real Codex rollout resolved from the real `~/.codex/sessions` store
- [x] Negative control: the failure-name drift tripwire goes red on an undocumented name
- [x] Re-verified after rebasing onto `main` (0.92.0): `bun test` 2153 pass / 0 fail, `tsc --noEmit` clean

## Design note, raised for review and settled by the land decision

Where two agents claim one process and the marker settles neither transcript,
the run stops at `ambiguous-host` rather than picking. That is fail-closed by
design. It is also the one place a user can dead-end, so it was flagged as an
open question on the draft; landing this PR is the decision to keep that
behavior. Changing it later means choosing a tiebreaker, which is a new
decision, not a fix.

## Pre-merge

- [x] Version bump at land time (runtime change — `skills/` ships) — 0.92.0 → 0.93.0 (minor: a user running `/reflect` on Codex went from `no-match` to a working run)

