### PR TITLE
docs(skills): embed relationship metadata

### DIFF
--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,9 +82,9 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, one `**Callers:**` line, then one `**Calls:**` line. Use comma-separated backticked names, or `None`. Rewriting a `description` updates that entry in the same commit.
-- `Callers` lists, in codepoint order, every skill whose `Calls` list names this skill.
-- `Calls` lists only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a call, so a skill it merely names by path or in prose stays off the list. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
+- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, one `**Used by:**` line, then one `**Uses:**` line. Use comma-separated backticked names, or `None`. Rewriting a `description` updates that entry in the same commit.
+- `Used by` lists, in codepoint order, every skill whose `Uses` list names this skill.
+- `Uses` lists only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a use, so a skill it merely names by path or in prose stays off the list. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.
 - For runtime behavior, update `CHANGELOG.md` under `Unreleased`; version only at land time.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,9 +82,9 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, one `**Callers:**` line, then an optional `**Calls:**` list. Rewriting a `description` updates that entry in the same commit.
-- Set `**Callers:**` to `None` when no other skill loads it. Otherwise list, in codepoint order, every skill whose `**Calls:**` list names it.
-- List under `Calls:` only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a call, so a skill it merely names by path or in prose stays off the list. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
+- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, one `**Callers:**` line, then one `**Calls:**` line. Use comma-separated backticked names, or `None`. Rewriting a `description` updates that entry in the same commit.
+- `Callers` lists, in codepoint order, every skill whose `Calls` list names this skill.
+- `Calls` lists only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a call, so a skill it merely names by path or in prose stays off the list. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.
 - For runtime behavior, update `CHANGELOG.md` under `Unreleased`; version only at land time.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,7 +82,7 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by a `**Loads:**` list only when the skill's own `.md` files instruct a load of at least one other skill; omit the block entirely when they load none. Rewriting a `description` updates that entry in the same commit.
+- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by one non-empty `**Invoked / loaded by:**` line, then one non-empty `**Phase / context:**` line, then a `**Loads:**` list only when the skill's own `.md` files instruct a load of at least one other skill; omit the block entirely when they load none. Rewriting a `description` updates that entry in the same commit.
 - List under `Loads:` only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a load, so a skill it merely names by path or in prose stays off the list — the list is a directed dependency edge, not a cross-reference. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,8 +82,9 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by one non-empty `**Consumers:**` line, then one non-empty `**Context:**` line, then a `**Loads:**` list only when the skill's own `.md` files instruct a load of at least one other skill; omit the block entirely when they load none. Rewriting a `description` updates that entry in the same commit.
-- List under `Loads:` only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a load, so a skill it merely names by path or in prose stays off the list — the list is a directed dependency edge, not a cross-reference. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
+- Write every `docs/skills.md` entry as its heading, the verbatim first sentence of the frontmatter `description`, one `**Callers:**` line, then an optional `**Calls:**` list. Rewriting a `description` updates that entry in the same commit.
+- Set `**Callers:**` to `None` when no other skill loads it. Otherwise list, in codepoint order, every skill whose `**Calls:**` list names it.
+- List under `Calls:` only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a call, so a skill it merely names by path or in prose stays off the list. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.
 - For runtime behavior, update `CHANGELOG.md` under `Unreleased`; version only at land time.

--- a/.claude/skills/create-team-skill/SKILL.md
+++ b/.claude/skills/create-team-skill/SKILL.md
@@ -82,7 +82,7 @@ Never put `$` followed by a digit in `SKILL.md`; hosts may substitute it as an a
 
 - Add entry points to the `AGENTS.md` routing table and `docs/skills.md`.
 - Add methodology and principles to `docs/skills.md`.
-- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by one non-empty `**Invoked / loaded by:**` line, then one non-empty `**Phase / context:**` line, then a `**Loads:**` list only when the skill's own `.md` files instruct a load of at least one other skill; omit the block entirely when they load none. Rewriting a `description` updates that entry in the same commit.
+- Write every `docs/skills.md` entry as its heading and the verbatim first sentence of the frontmatter `description`, followed by one non-empty `**Consumers:**` line, then one non-empty `**Context:**` line, then a `**Loads:**` list only when the skill's own `.md` files instruct a load of at least one other skill; omit the block entirely when they load none. Rewriting a `description` updates that entry in the same commit.
 - List under `Loads:` only the skills the files load through ``Call the Skill tool with `<name>` ``, in any `.md` under `skills/<name>/`, references and prompt templates included. A citation is not a load, so a skill it merely names by path or in prose stays off the list — the list is a directed dependency edge, not a cross-reference. Sort in codepoint order (plain `sort`, so `pr-verify` precedes `principle-fail-closed`). `tests/docs-skills-catalog.test.ts` is the gate.
 - Add one TodoWrite item per ordered step by applying `principle-progress-tracking`; do not copy its banner into the skill.
 - Update `agents/openai.yaml` whenever the description changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The skills catalog now lists each skill's consumers and runtime context with its description.** The separate relationship table is gone, so each entry holds its purpose, consumers, context, and direct loads. **What this asks of you:** nothing.
+- **The skills catalog now lists each skill's callers and calls with its description.** The separate relationship table is gone, so each entry shows both directions of every skill call. **What this asks of you:** nothing.
 
 ## [0.96.0] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The skills catalog now lists each skill's consumers and runtime context with its description.** The separate relationship table is gone, so each entry holds its purpose, consumers, context, and direct loads. **What this asks of you:** nothing.
+
 ## [0.96.0] - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The skills catalog now lists each skill's callers and calls with its description.** The separate relationship table is gone, so each entry shows both directions of every skill call. **What this asks of you:** nothing.
+- **The skills catalog now shows which skills use each skill and which skills it uses.** The separate relationship table is gone, so each entry shows both directions of every skill load. **What this asks of you:** nothing.
 
 ## [0.96.0] - 2026-09-08
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,8 +17,8 @@ nav_label: skills
 > `SKILL.md`, the `SKILL.md` wins.
 
 Each entry starts with one sentence copied from that skill's frontmatter
-`description`. `**Calls:**` lists the skills it loads. `**Callers:**` lists
-the inverse: skills that load it. Both use comma-separated lists, or `None`.
+`description`. `**Uses:**` lists the skills it loads. `**Used by:**` lists
+the skills that load it. Both use comma-separated lists, or `None`.
 The load form is
 ``Call the Skill tool with `<name>` ``. Naming a skill another way is a
 citation, not an edge. For example, `team-structure` restates a
@@ -26,7 +26,7 @@ citation, not an edge. For example, `team-structure` restates a
 
 The edges are therefore **directed**, and reading them transitively gives the
 graph. `team-implement` loads `team-pr`, which loads `git-commit`, which
-loads `writing-prose`. None of the three loads back. `**Calls:** None` marks a
+loads `writing-prose`. None of the three loads back. `**Uses:** None` marks a
 leaf, which is the normal shape for
 a `principle-*` skill and for a methodology skill that states one rule and
 stops.
@@ -46,89 +46,89 @@ full run or drives one phase of the QRSPI pipeline.
 
 Runs the 8-phase QRSPI feature pipeline.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `changelog`, `cross-model-review`, `review-severity-tiers`, `reviewing-designs`, `running-quality-checks`, `team-pr`, `team-worktree`, `tracking-tickets`, `worktree-isolation`
+**Uses:** `changelog`, `cross-model-review`, `review-severity-tiers`, `reviewing-designs`, `running-quality-checks`, `team-pr`, `team-worktree`, `tracking-tickets`, `worktree-isolation`
 
 ### [team-question](https://github.com/bostonaholic/team/blob/main/skills/team-question/SKILL.md)
 
 Decomposes a feature into task and question artifacts.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
 Researches a codebase area before changes.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
 Drafts and adversarially reviews a design.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `cross-model-review`, `reviewing-designs`
+**Uses:** `cross-model-review`, `reviewing-designs`
 
 ### [team-structure](https://github.com/bostonaholic/team/blob/main/skills/team-structure/SKILL.md)
 
 Breaks a reviewed design into verified slices.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
 Produces the tactical implementation plan.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
 Prepares isolated git worktrees.
 
-**Callers:** `team`, `team-fix`, `worktree-isolation`
+**Used by:** `team`, `team-fix`, `worktree-isolation`
 
-**Calls:** None
+**Uses:** None
 
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
 Executes and verifies implementation slices.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `review-severity-tiers`, `running-quality-checks`, `team-pr`
+**Uses:** `review-severity-tiers`, `running-quality-checks`, `team-pr`
 
 ### [team-pr](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md)
 
 Opens a pull request after verification.
 
-**Callers:** `team`, `team-implement`
+**Used by:** `team`, `team-implement`
 
-**Calls:** `changelog`, `git-commit`, `pr-screenshots`, `tracking-tickets`, `verifying-ux`, `worktree-isolation`, `writing-prose`
+**Uses:** `changelog`, `git-commit`, `pr-screenshots`, `tracking-tickets`, `verifying-ux`, `worktree-isolation`, `writing-prose`
 
 ### [team-fix](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md)
 
 Runs the compressed bug-fix pipeline.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `systematic-debugging`, `team-worktree`, `test-driven-bug-fix`, `tracking-tickets`, `why`, `worktree-isolation`
+**Uses:** `systematic-debugging`, `team-worktree`, `test-driven-bug-fix`, `tracking-tickets`, `why`, `worktree-isolation`
 
 ### [eng-design-doc-review](https://github.com/bostonaholic/team/blob/main/skills/eng-design-doc-review/SKILL.md)
 
 Reviews a technical design document with fresh context.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `cross-model-review`, `reviewing-designs`, `writing-prose`
+**Uses:** `cross-model-review`, `reviewing-designs`, `writing-prose`
 
 ## Standalone utilities
 
@@ -139,113 +139,113 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 Lands a reviewed pull request.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
 Triages unresolved PR review comments.
 
-**Callers:** `pr-watch-as-author`
+**Used by:** `pr-watch-as-author`
 
-**Calls:** `decision-making`
+**Uses:** `decision-making`
 
 ### [pr-watch-as-author](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-author/SKILL.md)
 
 Watches an authored PR for feedback.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `pr-open-comments`, `pr-watch-mechanics`, `tracking-tickets`
+**Uses:** `pr-open-comments`, `pr-watch-mechanics`, `tracking-tickets`
 
 ### [pr-watch-as-reviewer](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-reviewer/SKILL.md)
 
 Watches a reviewed PR and approves settled feedback.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `pr-watch-mechanics`
+**Uses:** `pr-watch-mechanics`
 
 ### [groom-backlog](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
 
 Grooms a project backlog and proposes tracker changes.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `decision-making`
+**Uses:** `decision-making`
 
 ### [pr-cleanup](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md)
 
 Cleans PR state.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
 Verifies a PR test plan with evidence-rated verdicts.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `running-quality-checks`
+**Uses:** `running-quality-checks`
 
 ### [pr-screenshots](https://github.com/bostonaholic/team/blob/main/skills/pr-screenshots/SKILL.md)
 
 Attaches local images to a PR body.
 
-**Callers:** `team-pr`
+**Used by:** `team-pr`
 
-**Calls:** None
+**Uses:** None
 
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
 Rebases a branch onto its base.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `running-quality-checks`
+**Uses:** `running-quality-checks`
 
 ### [reflect](https://github.com/bostonaholic/team/blob/main/skills/reflect/SKILL.md)
 
 Mines a session for durable learnings.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `running-quality-checks`
+**Uses:** `running-quality-checks`
 
 ### [why](https://github.com/bostonaholic/team/blob/main/skills/why/SKILL.md)
 
 Investigates design rationale behind code.
 
-**Callers:** `how`, `reviewing-code`, `team-fix`
+**Used by:** `how`, `reviewing-code`, `team-fix`
 
-**Calls:** `systematic-debugging`
+**Uses:** `systematic-debugging`
 
 ### [how](https://github.com/bostonaholic/team/blob/main/skills/how/SKILL.md)
 
 Explains subsystem architecture and runtime flow.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `why`
+**Uses:** `why`
 
 ### [code-review](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
 
 Reviews a diff with fresh context.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `reviewing-code`
+**Uses:** `reviewing-code`
 
 ### [no-comments](https://github.com/bostonaholic/team/blob/main/skills/no-comments/SKILL.md)
 
 Removes low-value source comments and encodes valid constraints.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `principle-fix-root-causes`, `principle-progress-tracking`, `reviewing-comments`, `running-quality-checks`
+**Uses:** `principle-fix-root-causes`, `principle-progress-tracking`, `reviewing-comments`, `running-quality-checks`
 
 ## Methodology skills
 
@@ -256,521 +256,521 @@ them.
 
 Defines QRSPI phases, artifacts, gates, and state transitions.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
 Defines pipeline artifact schemas.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
 Defines evidence-only codebase research and `5-research.md`.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
 Locates files by naming, structure, and imports.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [decomposing-intent](https://github.com/bostonaholic/team/blob/main/skills/decomposing-intent/SKILL.md)
 
 Defines task and question artifacts plus multi-repo detection.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `product-requirements-doc`
+**Uses:** `product-requirements-doc`
 
 ### [authoring-designs](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md)
 
 Defines the design-document procedure.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `decision-making`, `systems-thinking`, `writing-prose`
+**Uses:** `decision-making`, `systems-thinking`, `writing-prose`
 
 ### [slicing-work](https://github.com/bostonaholic/team/blob/main/skills/slicing-work/SKILL.md)
 
 Defines vertical slices and verification checkpoints.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `decision-making`
+**Uses:** `decision-making`
 
 ### [planning-implementation](https://github.com/bostonaholic/team/blob/main/skills/planning-implementation/SKILL.md)
 
 Defines the tactical plan schema.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [reviewing-code](https://github.com/bostonaholic/team/blob/main/skills/reviewing-code/SKILL.md)
 
 Defines adversarial code review and evidence-based findings.
 
-**Callers:** `code-review`, `reviewing-designs`
+**Used by:** `code-review`, `reviewing-designs`
 
-**Calls:** `engineering-standards`, `review-severity-tiers`, `test-style`, `why`, `writing-prose`
+**Uses:** `engineering-standards`, `review-severity-tiers`, `test-style`, `why`, `writing-prose`
 
 ### [reviewing-comments](https://github.com/bostonaholic/team/blob/main/skills/reviewing-comments/SKILL.md)
 
 Defines fresh-context source-comment review and findings.
 
-**Callers:** `no-comments`
+**Used by:** `no-comments`
 
-**Calls:** `engineering-standards`
+**Uses:** `engineering-standards`
 
 ### [reviewing-designs](https://github.com/bostonaholic/team/blob/main/skills/reviewing-designs/SKILL.md)
 
 Defines adversarial design review and verdicts.
 
-**Callers:** `eng-design-doc-review`, `team`, `team-design`
+**Used by:** `eng-design-doc-review`, `team`, `team-design`
 
-**Calls:** `conventional-comments`, `cross-model-review`, `documenting-decisions`, `engineering-standards`, `reviewing-code`, `technical-design-doc`, `writing-prose`
+**Uses:** `conventional-comments`, `cross-model-review`, `documenting-decisions`, `engineering-standards`, `reviewing-code`, `technical-design-doc`, `writing-prose`
 
 ### [conventional-comments](https://github.com/bostonaholic/team/blob/main/skills/conventional-comments/SKILL.md)
 
 Defines review labels and decorations.
 
-**Callers:** `reviewing-designs`
+**Used by:** `reviewing-designs`
 
-**Calls:** None
+**Uses:** None
 
 ### [reviewing-security](https://github.com/bostonaholic/team/blob/main/skills/reviewing-security/SKILL.md)
 
 Defines threat and OWASP review with evidence-rated findings.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [cross-model-review](https://github.com/bostonaholic/team/blob/main/skills/cross-model-review/SKILL.md)
 
 Runs second-vendor reviews through machine-only CLI adapters.
 
-**Callers:** `eng-design-doc-review`, `reviewing-designs`, `team`, `team-design`
+**Used by:** `eng-design-doc-review`, `reviewing-designs`, `team`, `team-design`
 
-**Calls:** None
+**Uses:** None
 
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
 Maps reviewer findings to Blocking, Major, or Minor actions.
 
-**Callers:** `reviewing-code`, `team`, `team-implement`
+**Used by:** `reviewing-code`, `team`, `team-implement`
 
-**Calls:** None
+**Uses:** None
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
 Defines code design, comment, and review standards.
 
-**Callers:** `reviewing-code`, `reviewing-comments`, `reviewing-designs`
+**Used by:** `reviewing-code`, `reviewing-comments`, `reviewing-designs`
 
-**Calls:** None
+**Uses:** None
 
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
 Defines acceptance tests as the implementation scope contract.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
 Defines deterministic behavioral tests and flaky-test red flags.
 
-**Callers:** `reviewing-code`
+**Used by:** `reviewing-code`
 
-**Calls:** None
+**Uses:** None
 
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
 Defines reproduce-red-green-refactor bug fixes.
 
-**Callers:** `team-fix`
+**Used by:** `team-fix`
 
-**Calls:** `systematic-debugging`
+**Uses:** `systematic-debugging`
 
 ### [solid](https://github.com/bostonaholic/team/blob/main/skills/solid/SKILL.md)
 
 Defines SOLID design and review rules.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [refactoring-to-patterns](https://github.com/bostonaholic/team/blob/main/skills/refactoring-to-patterns/SKILL.md)
 
 Maps code smells to behavior-preserving refactorings.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
 Defines test-first slice execution, commits, and review fixes.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** `git-commit`, `principle-fix-root-causes`, `systematic-debugging`
+**Uses:** `git-commit`, `principle-fix-root-causes`, `systematic-debugging`
 
 ### [systematic-debugging](https://github.com/bostonaholic/team/blob/main/skills/systematic-debugging/SKILL.md)
 
 Defines reproduce, hypothesize, isolate, and fix workflow.
 
-**Callers:** `implementing-slices`, `team-fix`, `test-driven-bug-fix`, `why`
+**Used by:** `implementing-slices`, `team-fix`, `test-driven-bug-fix`, `why`
 
-**Calls:** None
+**Uses:** None
 
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
 Runs project-native tests, static checks, builds, and linters.
 
-**Callers:** `no-comments`, `pr-rebase`, `pr-verify`, `reflect`, `team`, `team-implement`
+**Used by:** `no-comments`, `pr-rebase`, `pr-verify`, `reflect`, `team`, `team-implement`
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
 Requires one live ledger for ordered procedures.
 
-**Callers:** `no-comments`
+**Used by:** `no-comments`
 
-**Calls:** None
+**Uses:** None
 
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
 Defines safe nested-agent dispatch and fallback.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [decision-making](https://github.com/bostonaholic/team/blob/main/skills/decision-making/SKILL.md)
 
 Defines a decision method based on reversibility and risk.
 
-**Callers:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
+**Used by:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
 
-**Calls:** None
+**Uses:** None
 
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
 Defines ADR structure and lifecycle.
 
-**Callers:** `reviewing-designs`
+**Used by:** `reviewing-designs`
 
-**Calls:** `decision-making`, `writing-prose`
+**Uses:** `decision-making`, `writing-prose`
 
 ### [technical-design-doc](https://github.com/bostonaholic/team/blob/main/skills/technical-design-doc/SKILL.md)
 
 Defines technical design sections and decision content.
 
-**Callers:** `reviewing-designs`
+**Used by:** `reviewing-designs`
 
-**Calls:** `decision-making`, `writing-prose`
+**Uses:** `decision-making`, `writing-prose`
 
 ### [product-requirements-doc](https://github.com/bostonaholic/team/blob/main/skills/product-requirements-doc/SKILL.md)
 
 Defines when and how to write `3-prd.md`.
 
-**Callers:** `decomposing-intent`
+**Used by:** `decomposing-intent`
 
-**Calls:** `writing-prose`
+**Uses:** `writing-prose`
 
 ### [product-thinking](https://github.com/bostonaholic/team/blob/main/skills/product-thinking/SKILL.md)
 
 Defines product-need lenses.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [systems-thinking](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md)
 
 Defines system-boundary, feedback, and dependency analysis.
 
-**Callers:** `authoring-designs`
+**Used by:** `authoring-designs`
 
-**Calls:** None
+**Uses:** None
 
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
 Defines plain-language prose rules.
 
-**Callers:** `authoring-designs`, `changelog`, `documenting-decisions`, `eng-design-doc-review`, `git-commit`, `product-requirements-doc`, `reviewing-code`, `reviewing-designs`, `team-pr`, `technical-design-doc`
+**Used by:** `authoring-designs`, `changelog`, `documenting-decisions`, `eng-design-doc-review`, `git-commit`, `product-requirements-doc`, `reviewing-code`, `reviewing-designs`, `team-pr`, `technical-design-doc`
 
-**Calls:** None
+**Uses:** None
 
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
 Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
 Defines live application and screenshot verification.
 
-**Callers:** `team-pr`
+**Used by:** `team-pr`
 
-**Calls:** None
+**Uses:** None
 
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
 Defines Conventional Commit subjects and safe commit procedure.
 
-**Callers:** `implementing-slices`, `team-pr`
+**Used by:** `implementing-slices`, `team-pr`
 
-**Calls:** `writing-prose`
+**Uses:** `writing-prose`
 
 ### [changelog](https://github.com/bostonaholic/team/blob/main/skills/changelog/SKILL.md)
 
 Defines Keep a Changelog updates.
 
-**Callers:** `team`, `team-pr`
+**Used by:** `team`, `team-pr`
 
-**Calls:** `writing-prose`
+**Uses:** `writing-prose`
 
 ### [tracking-tickets](https://github.com/bostonaholic/team/blob/main/skills/tracking-tickets/SKILL.md)
 
 Defines tracker status transitions and closing rules.
 
-**Callers:** `pr-watch-as-author`, `team`, `team-fix`, `team-pr`
+**Used by:** `pr-watch-as-author`, `team`, `team-fix`, `team-pr`
 
-**Calls:** None
+**Uses:** None
 
 ### [worktree-isolation](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
 
 Defines Team worktree creation, validation, and teardown.
 
-**Callers:** `team`, `team-fix`, `team-pr`
+**Used by:** `team`, `team-fix`, `team-pr`
 
-**Calls:** `team-worktree`
+**Uses:** `team-worktree`
 
 ### [sweeping-local-state](https://github.com/bostonaholic/team/blob/main/skills/sweeping-local-state/SKILL.md)
 
 Defines machine-local teardown.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
 Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
 
-**Callers:** `pr-watch-as-author`, `pr-watch-as-reviewer`
+**Used by:** `pr-watch-as-author`, `pr-watch-as-reviewer`
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
 Keeps desired outcomes out of research prompts.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
 Requires explicit retry and watch limits.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 
 Keeps agent interfaces narrow and internal work deep.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-evidence-over-assertion](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md)
 
 Requires evidence for claims and verdicts.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-explicit-intent](https://github.com/bostonaholic/team/blob/main/skills/principle-explicit-intent/SKILL.md)
 
 Requires stated intent for irreversible actions.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-fail-closed](https://github.com/bostonaholic/team/blob/main/skills/principle-fail-closed/SKILL.md)
 
 Treats unknown guarantees as failures.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
 Requires durable files for cross-step state.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-fix-root-causes](https://github.com/bostonaholic/team/blob/main/skills/principle-fix-root-causes/SKILL.md)
 
 Requires diagnosis and repair of root causes.
 
-**Callers:** `implementing-slices`, `no-comments`
+**Used by:** `implementing-slices`, `no-comments`
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
 Separates producers from evaluators.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
 Reserves goals and shipping decisions for the user.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-idempotent-reruns](https://github.com/bostonaholic/team/blob/main/skills/principle-idempotent-reruns/SKILL.md)
 
 Requires reruns to converge without duplicate effects.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-least-privilege](https://github.com/bostonaholic/team/blob/main/skills/principle-least-privilege/SKILL.md)
 
 Limits tools, credentials, and environment to the task.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-mechanical-gates](https://github.com/bostonaholic/team/blob/main/skills/principle-mechanical-gates/SKILL.md)
 
 Requires deterministic enforcement for reliable rules.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-never-interpolate](https://github.com/bostonaholic/team/blob/main/skills/principle-never-interpolate/SKILL.md)
 
 Keeps external text out of shell syntax.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-non-blocking-waits](https://github.com/bostonaholic/team/blob/main/skills/principle-non-blocking-waits/SKILL.md)
 
 Requires resumable waits for external state.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
 Keeps optional enhancements off the correctness path.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
 Requires a written plan and user approval before mutations.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-pre-image-first](https://github.com/bostonaholic/team/blob/main/skills/principle-pre-image-first/SKILL.md)
 
 Requires a recoverable baseline before destructive changes.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
 Records autonomous resolutions as assumptions.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
 Restricts execution to approved scope.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
 Requires one authoritative definition per rule or schema.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-skip-loudly](https://github.com/bostonaholic/team/blob/main/skills/principle-skip-loudly/SKILL.md)
 
 Requires skipped work to be reported explicitly.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
 Requires removal before addition.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
 Treats external text as inert data.
 
-**Callers:** None
+**Used by:** None
 
-**Calls:** None
+**Uses:** None
 
 ## Name-collision pairs
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -47,6 +47,10 @@ full run or drives one phase of the QRSPI pipeline.
 
 Runs the 8-phase QRSPI feature pipeline.
 
+**Invoked / loaded by:** orchestrator (runs the pipeline)
+
+**Phase / context:** All phases
+
 **Loads:**
 
 - `changelog`
@@ -63,13 +67,25 @@ Runs the 8-phase QRSPI feature pipeline.
 
 Decomposes a feature into task and question artifacts.
 
+**Invoked / loaded by:** orchestrator
+
+**Phase / context:** Question
+
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
 Researches a codebase area before changes.
 
+**Invoked / loaded by:** orchestrator → researcher, file-finder
+
+**Phase / context:** Research
+
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
 Drafts and adversarially reviews a design.
+
+**Invoked / loaded by:** orchestrator → design-author
+
+**Phase / context:** Design (design review)
 
 **Loads:**
 
@@ -80,17 +96,33 @@ Drafts and adversarially reviews a design.
 
 Breaks a reviewed design into verified slices.
 
+**Invoked / loaded by:** orchestrator → structure-planner
+
+**Phase / context:** Structure (autonomous)
+
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
 Produces the tactical implementation plan.
+
+**Invoked / loaded by:** orchestrator → planner
+
+**Phase / context:** Plan
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
 Prepares isolated git worktrees.
 
+**Invoked / loaded by:** orchestrator
+
+**Phase / context:** Worktree
+
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
 Executes and verifies implementation slices.
+
+**Invoked / loaded by:** orchestrator → implementer + reviewers
+
+**Phase / context:** Implement
 
 **Loads:**
 
@@ -101,6 +133,10 @@ Executes and verifies implementation slices.
 ### [team-pr](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md)
 
 Opens a pull request after verification.
+
+**Invoked / loaded by:** orchestrator
+
+**Phase / context:** PR
 
 **Loads:**
 
@@ -116,6 +152,10 @@ Opens a pull request after verification.
 
 Runs the compressed bug-fix pipeline.
 
+**Invoked / loaded by:** user or model (direct invocation, on explicit pipeline intent)
+
+**Phase / context:** Compressed bug-fix flow (outside QRSPI)
+
 **Loads:**
 
 - `systematic-debugging`
@@ -128,6 +168,10 @@ Runs the compressed bug-fix pipeline.
 ### [eng-design-doc-review](https://github.com/bostonaholic/team/blob/main/skills/eng-design-doc-review/SKILL.md)
 
 Reviews a technical design document with fresh context.
+
+**Invoked / loaded by:** user (direct invocation)
+
+**Phase / context:** Front door over the `reviewing-designs` brief: standalone audit. Dispatches a read-only Explore subagent
 
 **Loads:**
 
@@ -144,9 +188,17 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 Lands a reviewed pull request.
 
+**Invoked / loaded by:** user or model (direct invocation, on explicit ship intent)
+
+**Phase / context:** Standalone: land a reviewed PR (not a QRSPI phase)
+
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
 Triages unresolved PR review comments.
+
+**Invoked / loaded by:** user or model (direct invocation)
+
+**Phase / context:** Standalone: triage unresolved PR review feedback (not a QRSPI phase)
 
 **Loads:**
 
@@ -155,6 +207,10 @@ Triages unresolved PR review comments.
 ### [pr-watch-as-author](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-author/SKILL.md)
 
 Watches an authored PR for feedback.
+
+**Invoked / loaded by:** user or model (direct invocation)
+
+**Phase / context:** Standalone: bounded PR review watch loop (not a QRSPI phase)
 
 **Loads:**
 
@@ -166,6 +222,10 @@ Watches an authored PR for feedback.
 
 Watches a reviewed PR and approves settled feedback.
 
+**Invoked / loaded by:** user (direct invocation)
+
+**Phase / context:** Standalone: reviewer-side watch-and-approve (not a QRSPI phase)
+
 **Loads:**
 
 - `pr-watch-mechanics`
@@ -173,6 +233,10 @@ Watches a reviewed PR and approves settled feedback.
 ### [groom-backlog](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
 
 Grooms a project backlog and proposes tracker changes.
+
+**Invoked / loaded by:** user or model (direct invocation)
+
+**Phase / context:** Standalone: groom a project backlog (not a QRSPI phase)
 
 **Loads:**
 
@@ -182,9 +246,17 @@ Grooms a project backlog and proposes tracker changes.
 
 Cleans PR state.
 
+**Invoked / loaded by:** user or model (direct invocation; Mode B only on explicit abandon intent)
+
+**Phase / context:** Standalone: post-PR teardown (not a QRSPI phase)
+
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
 Verifies a PR test plan with evidence-rated verdicts.
+
+**Invoked / loaded by:** user or model (direct invocation)
+
+**Phase / context:** Standalone: test-plan verification (not a QRSPI phase)
 
 **Loads:**
 
@@ -194,9 +266,17 @@ Verifies a PR test plan with evidence-rated verdicts.
 
 Attaches local images to a PR body.
 
+**Invoked / loaded by:** user or model (direct invocation, on explicit intent)
+
+**Phase / context:** Standalone: attach local images to a PR body (not a QRSPI phase)
+
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
 Rebases a branch onto its base.
+
+**Invoked / loaded by:** user (direct invocation, on explicit rebase intent; model invocation disabled)
+
+**Phase / context:** Standalone: rebase a branch onto its base (not a QRSPI phase)
 
 **Loads:**
 
@@ -206,6 +286,10 @@ Rebases a branch onto its base.
 
 Mines a session for durable learnings.
 
+**Invoked / loaded by:** user (direct invocation, on explicit reflection intent; model invocation disabled)
+
+**Phase / context:** Standalone: mine the session transcript for durable learnings (not a QRSPI phase)
+
 **Loads:**
 
 - `running-quality-checks`
@@ -213,6 +297,10 @@ Mines a session for durable learnings.
 ### [why](https://github.com/bostonaholic/team/blob/main/skills/why/SKILL.md)
 
 Investigates design rationale behind code.
+
+**Invoked / loaded by:** user or model (direct invocation). `team-fix` and `reviewing-code` (conditional load)
+
+**Phase / context:** Standalone: design-rationale investigation (not a QRSPI phase). Dispatches read-only Explore investigators
 
 **Loads:**
 
@@ -222,6 +310,10 @@ Investigates design rationale behind code.
 
 Explains subsystem architecture and runtime flow.
 
+**Invoked / loaded by:** user or model (direct invocation)
+
+**Phase / context:** Standalone: architectural explanation + optional critique (not a QRSPI phase). Dispatches read-only Explore explorers
+
 **Loads:**
 
 - `why`
@@ -230,6 +322,10 @@ Explains subsystem architecture and runtime flow.
 
 Reviews a diff with fresh context.
 
+**Invoked / loaded by:** user or model (direct invocation)
+
+**Phase / context:** Standalone: dispatch a fresh-context code review (not a QRSPI phase)
+
 **Loads:**
 
 - `reviewing-code`
@@ -237,6 +333,10 @@ Reviews a diff with fresh context.
 ### [no-comments](https://github.com/bostonaholic/team/blob/main/skills/no-comments/SKILL.md)
 
 Removes low-value source comments and encodes valid constraints.
+
+**Invoked / loaded by:** user (direct invocation; model invocation disabled)
+
+**Phase / context:** Standalone: comment cleanup (not a QRSPI phase)
 
 **Loads:**
 
@@ -254,21 +354,41 @@ them.
 
 Defines QRSPI phases, artifacts, gates, and state transitions.
 
+**Invoked / loaded by:** orchestrator skills
+
+**Phase / context:** All phases
+
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
 Defines pipeline artifact schemas.
+
+**Invoked / loaded by:** orchestrator skills. Artifact authors (just-in-time through pointers)
+
+**Phase / context:** All phases: artifact schema
 
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
 Defines evidence-only codebase research and `5-research.md`.
 
+**Invoked / loaded by:** researcher
+
+**Phase / context:** Research
+
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
 Locates files by naming, structure, and imports.
 
+**Invoked / loaded by:** file-finder
+
+**Phase / context:** Research
+
 ### [decomposing-intent](https://github.com/bostonaholic/team/blob/main/skills/decomposing-intent/SKILL.md)
 
 Defines task and question artifacts plus multi-repo detection.
+
+**Invoked / loaded by:** questioner
+
+**Phase / context:** Question
 
 **Loads:**
 
@@ -277,6 +397,10 @@ Defines task and question artifacts plus multi-repo detection.
 ### [authoring-designs](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md)
 
 Defines the design-document procedure.
+
+**Invoked / loaded by:** design-author
+
+**Phase / context:** Design
 
 **Loads:**
 
@@ -288,6 +412,10 @@ Defines the design-document procedure.
 
 Defines vertical slices and verification checkpoints.
 
+**Invoked / loaded by:** structure-planner
+
+**Phase / context:** Structure
+
 **Loads:**
 
 - `decision-making`
@@ -296,9 +424,17 @@ Defines vertical slices and verification checkpoints.
 
 Defines the tactical plan schema.
 
+**Invoked / loaded by:** planner
+
+**Phase / context:** Plan
+
 ### [reviewing-code](https://github.com/bostonaholic/team/blob/main/skills/reviewing-code/SKILL.md)
 
 Defines adversarial code review and evidence-based findings.
+
+**Invoked / loaded by:** code-reviewer, security-reviewer, ux-reviewer, technical-writer. `code-review` (front door). `reviewing-designs` read-only Explore reviewer
+
+**Phase / context:** Implement (verify), and Design (review gate)
 
 **Loads:**
 
@@ -312,6 +448,10 @@ Defines adversarial code review and evidence-based findings.
 
 Defines fresh-context source-comment review and findings.
 
+**Invoked / loaded by:** `no-comments` (direct load for read-only Explore review)
+
+**Phase / context:** Standalone: source-comment review methodology
+
 **Loads:**
 
 - `engineering-standards`
@@ -319,6 +459,10 @@ Defines fresh-context source-comment review and findings.
 ### [reviewing-designs](https://github.com/bostonaholic/team/blob/main/skills/reviewing-designs/SKILL.md)
 
 Defines adversarial design review and verdicts.
+
+**Invoked / loaded by:** orchestrator or invoking session (team, team-design, eng-design-doc-review) — the brief a read-only Explore subagent runs
+
+**Phase / context:** Design (review-gate brief)
 
 **Loads:**
 
@@ -334,33 +478,65 @@ Defines adversarial design review and verdicts.
 
 Defines review labels and decorations.
 
+**Invoked / loaded by:** code-reviewer, security-reviewer, technical-writer. `reviewing-designs` read-only Explore reviewer
+
+**Phase / context:** Implement (verify): finding format, and Design (review gate): finding format
+
 ### [reviewing-security](https://github.com/bostonaholic/team/blob/main/skills/reviewing-security/SKILL.md)
 
 Defines threat and OWASP review with evidence-rated findings.
+
+**Invoked / loaded by:** security-reviewer
+
+**Phase / context:** Implement (verify)
 
 ### [cross-model-review](https://github.com/bostonaholic/team/blob/main/skills/cross-model-review/SKILL.md)
 
 Runs second-vendor reviews through machine-only CLI adapters.
 
+**Invoked / loaded by:** code-reviewer. Orchestrator or invoking session (team, team-design, eng-design-doc-review) through `## Design-review pass`. Design-review brief (conditional, on `## External review input`). `reviewing-designs` read-only Explore reviewer (conditional, on `## External review input`)
+
+**Phase / context:** Implement (verify), and Design (review gate)
+
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
 Maps reviewer findings to Blocking, Major, or Minor actions.
+
+**Invoked / loaded by:** orchestrator (team, team-implement, qrspi-workflow)
+
+**Phase / context:** Implement (aggregate review gate)
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
 Defines code design, comment, and review standards.
 
+**Invoked / loaded by:** planner, implementer, code-reviewer. `reviewing-designs` read-only Explore reviewer
+
+**Phase / context:** Plan, Implement, and Design (review gate)
+
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
 Defines acceptance tests as the implementation scope contract.
+
+**Invoked / loaded by:** test-architect, code-reviewer. Orchestrator
+
+**Phase / context:** Implement
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
 Defines deterministic behavioral tests and flaky-test red flags.
 
+**Invoked / loaded by:** test-architect, code-reviewer (just-in-time through pointers)
+
+**Phase / context:** Implement
+
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
 Defines reproduce-red-green-refactor bug fixes.
+
+**Invoked / loaded by:** team-fix
+
+**Phase / context:** Bug-fix flow
 
 **Loads:**
 
@@ -370,13 +546,25 @@ Defines reproduce-red-green-refactor bug fixes.
 
 Defines SOLID design and review rules.
 
+**Invoked / loaded by:** implementer, code-reviewer. `engineering-standards`, `reviewing-code` (citing skills)
+
+**Phase / context:** Implement
+
 ### [refactoring-to-patterns](https://github.com/bostonaholic/team/blob/main/skills/refactoring-to-patterns/SKILL.md)
 
 Maps code smells to behavior-preserving refactorings.
 
+**Invoked / loaded by:** implementer
+
+**Phase / context:** Implement
+
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
 Defines test-first slice execution, commits, and review fixes.
+
+**Invoked / loaded by:** implementer
+
+**Phase / context:** Implement
 
 **Loads:**
 
@@ -388,25 +576,49 @@ Defines test-first slice execution, commits, and review fixes.
 
 Defines reproduce, hypothesize, isolate, and fix workflow.
 
+**Invoked / loaded by:** implementer (inline Load on non-obvious failures). Other agents when debugging (advisory)
+
+**Phase / context:** Implement, and Any (debugging)
+
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
 Runs project-native tests, static checks, builds, and linters.
+
+**Invoked / loaded by:** verifier. reflect (after the writes)
+
+**Phase / context:** Implement (verify), and Any (reflect)
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
 Requires one live ledger for ordered procedures.
 
+**Invoked / loaded by:** every multi-step agent; cited by `team`, `team-implement`, `team-fix`, `pr-screenshots`, `no-comments`
+
+**Phase / context:** Any (multi-step procedure)
+
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
 Defines safe nested-agent dispatch and fallback.
+
+**Invoked / loaded by:** researcher, implementer, code-reviewer, security-reviewer
+
+**Phase / context:** Research, Implement (scouts + skeptic passes)
 
 ### [decision-making](https://github.com/bostonaholic/team/blob/main/skills/decision-making/SKILL.md)
 
 Defines a decision method based on reversibility and risk.
 
+**Invoked / loaded by:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
+
+**Phase / context:** Design, Structure, Plan, and standalone recommendations
+
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
 Defines ADR structure and lifecycle.
+
+**Invoked / loaded by:** planner, orchestrator (advisory). `reviewing-designs` read-only Explore reviewer
+
+**Phase / context:** Any (when decisions are recorded), and Design (review gate)
 
 **Loads:**
 
@@ -417,6 +629,10 @@ Defines ADR structure and lifecycle.
 
 Defines technical design sections and decision content.
 
+**Invoked / loaded by:** planner. `reviewing-designs` read-only Explore reviewer
+
+**Phase / context:** Plan, and Design (review gate)
+
 **Loads:**
 
 - `decision-making`
@@ -426,6 +642,10 @@ Defines technical design sections and decision content.
 
 Defines when and how to write `3-prd.md`.
 
+**Invoked / loaded by:** questioner (through `decomposing-intent`, conditional). Design-author (through `authoring-designs`)
+
+**Phase / context:** Question, Design
+
 **Loads:**
 
 - `writing-prose`
@@ -434,25 +654,49 @@ Defines when and how to write `3-prd.md`.
 
 Defines product-need lenses.
 
+**Invoked / loaded by:** questioner, design-author, structure-planner
+
+**Phase / context:** Question, Design, Structure
+
 ### [systems-thinking](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md)
 
 Defines system-boundary, feedback, and dependency analysis.
+
+**Invoked / loaded by:** researcher, structure-planner, planner (frontmatter). Implementer, code-reviewer, ux-reviewer (inline). Authoring-designs, nested-agents (citing skills)
+
+**Phase / context:** Research, Design, Structure, Plan, Implement (incl. verify)
 
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
 Defines plain-language prose rules.
 
+**Invoked / loaded by:** technical-writer, design-author. `reviewing-designs` read-only Explore reviewer
+
+**Phase / context:** Design (authoring bar), and Implement (verify): bar for prose it writes and prose it assesses. Design (review gate): prose bar
+
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
 Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
+
+**Invoked / loaded by:** technical-writer
+
+**Phase / context:** Implement (verify): doc-gap review process + classification
 
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
 Defines live application and screenshot verification.
 
+**Invoked / loaded by:** ux-reviewer
+
+**Phase / context:** Implement (verify)
+
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
 Defines Conventional Commit subjects and safe commit procedure.
+
+**Invoked / loaded by:** team-pr. Implementer (through `implementing-slices`)
+
+**Phase / context:** PR, and Implement (slice commits)
 
 **Loads:**
 
@@ -462,6 +706,10 @@ Defines Conventional Commit subjects and safe commit procedure.
 
 Defines Keep a Changelog updates.
 
+**Invoked / loaded by:** team, team-pr
+
+**Phase / context:** PR
+
 **Loads:**
 
 - `writing-prose`
@@ -470,9 +718,17 @@ Defines Keep a Changelog updates.
 
 Defines tracker status transitions and closing rules.
 
+**Invoked / loaded by:** orchestrator (team, team-pr, team-fix, just-in-time through pointers)
+
+**Phase / context:** Setup (ticket pickup), and PR (ticket link + state)
+
 ### [worktree-isolation](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
 
 Defines Team worktree creation, validation, and teardown.
+
+**Invoked / loaded by:** orchestrator (team, team-worktree)
+
+**Phase / context:** Worktree
 
 **Loads:**
 
@@ -482,105 +738,209 @@ Defines Team worktree creation, validation, and teardown.
 
 Defines machine-local teardown.
 
+**Invoked / loaded by:** `pr-cleanup`, `worktree-isolation` (both inline)
+
+**Phase / context:** Standalone: teardown after a merged PR, a closed PR, or a completed review (not a QRSPI phase)
+
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
 Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
+
+**Invoked / loaded by:** `pr-watch-as-author`, `pr-watch-as-reviewer` (both through the bounded-cycle-mechanics reference)
+
+**Phase / context:** Standalone: bounded watch-loop mechanics (not a QRSPI phase)
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
 Keeps desired outcomes out of research prompts.
 
+**Invoked / loaded by:** cited by `qrspi-workflow`, `nested-agents`, `decomposing-intent`, `researching-codebases`, `why`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
 Requires explicit retry and watch limits.
+
+**Invoked / loaded by:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `principle-non-blocking-waits`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 
 Keeps agent interfaces narrow and internal work deep.
 
+**Invoked / loaded by:** cited by `nested-agents`, `team`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-evidence-over-assertion](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md)
 
 Requires evidence for claims and verdicts.
+
+**Invoked / loaded by:** cited by `pr-verify`, `groom-backlog`, `pr-open-comments`, `researching-codebases`, `why`, `pr-screenshots`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-explicit-intent](https://github.com/bostonaholic/team/blob/main/skills/principle-explicit-intent/SKILL.md)
 
 Requires stated intent for irreversible actions.
 
+**Invoked / loaded by:** cited by `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, `groom-backlog`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-fail-closed](https://github.com/bostonaholic/team/blob/main/skills/principle-fail-closed/SKILL.md)
 
 Treats unknown guarantees as failures.
+
+**Invoked / loaded by:** cited by `nested-agents`, `team`, `team-design`, `team-structure`, `principle-optimization-never-dependency`, `pr-screenshots`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
 Requires durable files for cross-step state.
 
+**Invoked / loaded by:** cited by `qrspi-workflow`, `team`, `artifact-frontmatter`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-fix-root-causes](https://github.com/bostonaholic/team/blob/main/skills/principle-fix-root-causes/SKILL.md)
 
 Requires diagnosis and repair of root causes.
+
+**Invoked / loaded by:** cited by `systematic-debugging`, `test-driven-bug-fix`, `implementing-slices`, `team-fix`, `no-comments`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
 Separates producers from evaluators.
 
+**Invoked / loaded by:** cited by `reviewing-code`, `eng-design-doc-review`, `nested-agents`, `pr-watch-as-reviewer`, `principle-blind-the-investigator`, `how`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
 Reserves goals and shipping decisions for the user.
+
+**Invoked / loaded by:** cited by `review-severity-tiers`, `qrspi-workflow`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-idempotent-reruns](https://github.com/bostonaholic/team/blob/main/skills/principle-idempotent-reruns/SKILL.md)
 
 Requires reruns to converge without duplicate effects.
 
+**Invoked / loaded by:** cited by `pr-cleanup`, `groom-backlog`, `team`, `pr-watch-as-author`, `team-design`, `principle-pre-image-first`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-least-privilege](https://github.com/bostonaholic/team/blob/main/skills/principle-least-privilege/SKILL.md)
 
 Limits tools, credentials, and environment to the task.
+
+**Invoked / loaded by:** cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-mechanical-gates](https://github.com/bostonaholic/team/blob/main/skills/principle-mechanical-gates/SKILL.md)
 
 Requires deterministic enforcement for reliable rules.
 
+**Invoked / loaded by:** cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-never-interpolate](https://github.com/bostonaholic/team/blob/main/skills/principle-never-interpolate/SKILL.md)
 
 Keeps external text out of shell syntax.
+
+**Invoked / loaded by:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`, `pr-screenshots`, `team-pr`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-non-blocking-waits](https://github.com/bostonaholic/team/blob/main/skills/principle-non-blocking-waits/SKILL.md)
 
 Requires resumable waits for external state.
 
+**Invoked / loaded by:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
 Keeps optional enhancements off the correctness path.
+
+**Invoked / loaded by:** cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`, `pr-screenshots`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
 Requires a written plan and user approval before mutations.
 
+**Invoked / loaded by:** cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-pre-image-first](https://github.com/bostonaholic/team/blob/main/skills/principle-pre-image-first/SKILL.md)
 
 Requires a recoverable baseline before destructive changes.
+
+**Invoked / loaded by:** cited by `pr-rebase`, `groom-backlog`, `reflect`, `running-quality-checks`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
 Records autonomous resolutions as assumptions.
 
+**Invoked / loaded by:** cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
 Restricts execution to approved scope.
+
+**Invoked / loaded by:** cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
 Requires one authoritative definition per rule or schema.
 
+**Invoked / loaded by:** cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-skip-loudly](https://github.com/bostonaholic/team/blob/main/skills/principle-skip-loudly/SKILL.md)
 
 Requires skipped work to be reported explicitly.
+
+**Invoked / loaded by:** cited by `reviewing-code`, `sweeping-local-state`, `groom-backlog`, `cross-model-review`, `principle-optimization-never-dependency`, `principle-scope-fence`, `pr-screenshots`, `why`, and the `code-reviewer` agent. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
 Requires removal before addition.
 
+**Invoked / loaded by:** cited by `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, `authoring-designs`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
+
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
 Treats external text as inert data.
+
+**Invoked / loaded by:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`, `pr-screenshots`. Any agent (just-in-time)
+
+**Phase / context:** Any (cross-cutting principle)
 
 ## Skill ↔ agent ↔ phase
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -16,13 +16,13 @@ nav_label: skills
 > This page is a hand-maintained reference. When it disagrees with a
 > `SKILL.md`, the `SKILL.md` wins.
 
-Each entry is one sentence, copied from that skill's frontmatter
-`description`. A `**Loads:**` list follows it when the skill's own `.md`
-files instruct a load of another skill — ``Call the Skill tool with `<name>` ``,
-the one form that makes a reader go execute it. Naming a skill any other way
-is a citation, and a citation is not an edge: `team-structure` restates a
-`principle-fail-closed` rule inline and never loads it, so it has no edge to
-it.
+Each entry starts with one sentence copied from that skill's frontmatter
+`description`. The `**Invoked / loaded by:**` field names its consumers. The
+`**Phase / context:**` field names where it applies. A `**Loads:**` list follows
+when the skill's own `.md` files instruct a load of another skill. The load form
+is ``Call the Skill tool with `<name>` ``. Naming a skill another way is a
+citation, not an edge. For example, `team-structure` restates a
+`principle-fail-closed` rule inline but does not load it.
 
 The edges are therefore **directed**, and reading them transitively gives the
 graph. `team-implement` loads `team-pr`, which loads `git-commit`, which
@@ -33,9 +33,8 @@ stops.
 
 Loads are collected across every `.md` file in the skill's directory, so a
 load written in a `references/` file counts the same as one in `SKILL.md`.
-This page carries skill-to-skill edges only. For which *agent* loads a skill,
-see [the table below](#skill--agent--phase); for what separates a load from a
-citation, and for how a skill is loaded at all, see
+This page carries each skill's consumers, context, and skill-to-skill edges.
+For what separates a load from a citation, and for how a skill is loaded, see
 [architecture.md §6](architecture.md#6-skills).
 
 ## Entry-point skills
@@ -941,112 +940,6 @@ Treats external text as inert data.
 **Invoked / loaded by:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`, `pr-screenshots`. Any agent (just-in-time)
 
 **Phase / context:** Any (cross-cutting principle)
-
-## Skill ↔ agent ↔ phase
-
-This table ties each skill to the agents or orchestrator skills that load
-it and the phase where that happens. The `Invoked / loaded by` column
-carries two meanings depending on the row: for **entry-point skills** it
-names who *invokes* the skill (you directly, or the orchestrator running a
-phase). For **methodology skills** it names the agent(s) that *load* the
-skill. For the `$ARGUMENTS` shapes and the three-tier discovery, see
-[architecture.md §6](architecture.md#6-skills) rather than repeating them here.
-
-| Skill | Invoked / loaded by | Phase / context |
-|---|---|---|
-| `team` | orchestrator (runs the pipeline) | All phases |
-| `team-question` | orchestrator | Question |
-| `team-research` | orchestrator → researcher, file-finder | Research |
-| `team-design` | orchestrator → design-author | Design (design review) |
-| `team-structure` | orchestrator → structure-planner | Structure (autonomous) |
-| `team-plan` | orchestrator → planner | Plan |
-| `team-worktree` | orchestrator | Worktree |
-| `team-implement` | orchestrator → implementer + reviewers | Implement |
-| `team-pr` | orchestrator | PR |
-| `team-fix` | user or model (direct invocation, on explicit pipeline intent) | Compressed bug-fix flow (outside QRSPI) |
-| `eng-design-doc-review` | user (direct invocation) | Front door over the `reviewing-designs` brief: standalone audit. Dispatches a read-only Explore subagent |
-| `shipit` | user or model (direct invocation, on explicit ship intent) | Standalone: land a reviewed PR (not a QRSPI phase) |
-| `pr-open-comments` | user or model (direct invocation) | Standalone: triage unresolved PR review feedback (not a QRSPI phase) |
-| `pr-watch-as-author` | user or model (direct invocation) | Standalone: bounded PR review watch loop (not a QRSPI phase) |
-| `pr-watch-as-reviewer` | user (direct invocation) | Standalone: reviewer-side watch-and-approve (not a QRSPI phase) |
-| `groom-backlog` | user or model (direct invocation) | Standalone: groom a project backlog (not a QRSPI phase) |
-| `pr-cleanup` | user or model (direct invocation; Mode B only on explicit abandon intent) | Standalone: post-PR teardown (not a QRSPI phase) |
-| `pr-verify` | user or model (direct invocation) | Standalone: test-plan verification (not a QRSPI phase) |
-| `pr-screenshots` | user or model (direct invocation, on explicit intent) | Standalone: attach local images to a PR body (not a QRSPI phase) |
-| `pr-rebase` | user (direct invocation, on explicit rebase intent; model invocation disabled) | Standalone: rebase a branch onto its base (not a QRSPI phase) |
-| `reflect` | user (direct invocation, on explicit reflection intent; model invocation disabled) | Standalone: mine the session transcript for durable learnings (not a QRSPI phase) |
-| `why` | user or model (direct invocation). `team-fix` and `reviewing-code` (conditional load) | Standalone: design-rationale investigation (not a QRSPI phase). Dispatches read-only Explore investigators |
-| `how` | user or model (direct invocation) | Standalone: architectural explanation + optional critique (not a QRSPI phase). Dispatches read-only Explore explorers |
-| `qrspi-workflow` | orchestrator skills | All phases |
-| `artifact-frontmatter` | orchestrator skills. Artifact authors (just-in-time through pointers) | All phases: artifact schema |
-| `code-review` | user or model (direct invocation) | Standalone: dispatch a fresh-context code review (not a QRSPI phase) |
-| `reviewing-code` | code-reviewer, security-reviewer, ux-reviewer, technical-writer. `code-review` (front door) | Implement (verify) |
-| `conventional-comments` | code-reviewer, security-reviewer, technical-writer | Implement (verify): finding format |
-| `review-severity-tiers` | orchestrator (team, team-implement, qrspi-workflow) | Implement (aggregate review gate) |
-| `reviewing-security` | security-reviewer | Implement (verify) |
-| `reviewing-designs` | orchestrator or invoking session (team, team-design, eng-design-doc-review) — the brief a read-only Explore subagent runs | Design (review-gate brief) |
-| `cross-model-review` | code-reviewer. Orchestrator or invoking session (team, team-design, eng-design-doc-review) through `## Design-review pass`. Design-review brief (conditional, on `## External review input`) | Implement (verify), and Design (review gate) |
-| `decomposing-intent` | questioner | Question |
-| `authoring-designs` | design-author | Design |
-| `researching-codebases` | researcher | Research |
-| `finding-files` | file-finder | Research |
-| `slicing-work` | structure-planner | Structure |
-| `planning-implementation` | planner | Plan |
-| `engineering-standards` | planner, implementer, code-reviewer | Plan, Implement |
-| `test-first-development` | test-architect, code-reviewer. Orchestrator | Implement |
-| `test-style` | test-architect, code-reviewer (just-in-time through pointers) | Implement |
-| `test-driven-bug-fix` | team-fix | Bug-fix flow |
-| `solid` | implementer, code-reviewer. `engineering-standards`, `reviewing-code` (citing skills) | Implement |
-| `refactoring-to-patterns` | implementer | Implement |
-| `implementing-slices` | implementer | Implement |
-| `running-quality-checks` | verifier. reflect (after the writes) | Implement (verify), and Any (reflect) |
-| `verifying-ux` | ux-reviewer | Implement (verify) |
-| `systematic-debugging` | implementer (inline Load on non-obvious failures). Other agents when debugging (advisory) | Implement, and Any (debugging) |
-| `principle-progress-tracking` | every multi-step agent; cited by `team`, `team-implement`, `team-fix`, `pr-screenshots`, `no-comments` | Any (multi-step procedure) |
-| `nested-agents` | researcher, implementer, code-reviewer, security-reviewer | Research, Implement (scouts + skeptic passes) |
-| `decision-making` | `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc` | Design, Structure, Plan, and standalone recommendations |
-| `documenting-decisions` | planner, orchestrator (advisory) | Any (when decisions are recorded) |
-| `technical-design-doc` | planner | Plan |
-| `product-requirements-doc` | questioner (through `decomposing-intent`, conditional). Design-author (through `authoring-designs`) | Question, Design |
-| `product-thinking` | questioner, design-author, structure-planner | Question, Design, Structure |
-| `systems-thinking` | researcher, structure-planner, planner (frontmatter). Implementer, code-reviewer, ux-reviewer (inline). Authoring-designs, nested-agents (citing skills) | Research, Design, Structure, Plan, Implement (incl. verify) |
-| `writing-prose` | technical-writer, design-author | Design (authoring bar), and Implement (verify): bar for prose it writes and prose it assesses |
-| `reviewing-documentation` | technical-writer | Implement (verify): doc-gap review process + classification |
-| `git-commit` | team-pr. Implementer (through `implementing-slices`) | PR, and Implement (slice commits) |
-| `changelog` | team, team-pr | PR |
-| `tracking-tickets` | orchestrator (team, team-pr, team-fix, just-in-time through pointers) | Setup (ticket pickup), and PR (ticket link + state) |
-| `worktree-isolation` | orchestrator (team, team-worktree) | Worktree |
-| `sweeping-local-state` | `pr-cleanup`, `worktree-isolation` (both inline) | Standalone: teardown after a merged PR, a closed PR, or a completed review (not a QRSPI phase) |
-| `pr-watch-mechanics` | `pr-watch-as-author`, `pr-watch-as-reviewer` (both through the bounded-cycle-mechanics reference) | Standalone: bounded watch-loop mechanics (not a QRSPI phase) |
-| `principle-blind-the-investigator` | cited by `qrspi-workflow`, `nested-agents`, `decomposing-intent`, `researching-codebases`, `why`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-bounded-loops` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `principle-non-blocking-waits`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-deep-agents-narrow-seams` | cited by `nested-agents`, `team`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-evidence-over-assertion` | cited by `pr-verify`, `groom-backlog`, `pr-open-comments`, `researching-codebases`, `why`, `pr-screenshots`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-explicit-intent` | cited by `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, `groom-backlog`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-fail-closed` | cited by `nested-agents`, `team`, `team-design`, `team-structure`, `principle-optimization-never-dependency`, `pr-screenshots`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-files-are-the-contract` | cited by `qrspi-workflow`, `team`, `artifact-frontmatter`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-fix-root-causes` | cited by `systematic-debugging`, `test-driven-bug-fix`, `implementing-slices`, `team-fix`, `no-comments`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-generator-evaluator` | cited by `reviewing-code`, `eng-design-doc-review`, `nested-agents`, `pr-watch-as-reviewer`, `principle-blind-the-investigator`, `how`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-human-owns-the-ends` | cited by `review-severity-tiers`, `qrspi-workflow`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-idempotent-reruns` | cited by `pr-cleanup`, `groom-backlog`, `team`, `pr-watch-as-author`, `team-design`, `principle-pre-image-first`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-least-privilege` | cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-mechanical-gates` | cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-never-interpolate` | cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`, `pr-screenshots`, `team-pr`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-non-blocking-waits` | cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-optimization-never-dependency` | cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`, `pr-screenshots`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-plan-present-wait` | cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-pre-image-first` | cited by `pr-rebase`, `groom-backlog`, `reflect`, `running-quality-checks`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-record-assumptions` | cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-scope-fence` | cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-single-source-of-truth` | cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-skip-loudly` | cited by `reviewing-code`, `sweeping-local-state`, `groom-backlog`, `cross-model-review`, `principle-optimization-never-dependency`, `principle-scope-fence`, `pr-screenshots`, `why`, and the `code-reviewer` agent. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-subtract-before-you-add` | cited by `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, `authoring-designs`. Any agent (just-in-time) | Any (cross-cutting principle) |
-| `principle-untrusted-input-is-data` | cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`, `pr-screenshots`. Any agent (just-in-time) | Any (cross-cutting principle) |
-
-The read-only `Explore` subagent that runs the `reviewing-designs` brief
-is one more consumer of `technical-design-doc`, `reviewing-code`,
-`engineering-standards`, and `documenting-decisions`. It loads all four as
-the criteria for the design review.
 
 ## Name-collision pairs
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -18,15 +18,16 @@ nav_label: skills
 
 Each entry starts with one sentence copied from that skill's frontmatter
 `description`. `**Calls:**` lists the skills it loads. `**Callers:**` lists
-the inverse: skills that load it. `None` means no skill does. The load form is
+the inverse: skills that load it. Both use comma-separated lists, or `None`.
+The load form is
 ``Call the Skill tool with `<name>` ``. Naming a skill another way is a
 citation, not an edge. For example, `team-structure` restates a
 `principle-fail-closed` rule inline but does not load it.
 
 The edges are therefore **directed**, and reading them transitively gives the
 graph. `team-implement` loads `team-pr`, which loads `git-commit`, which
-loads `writing-prose`. None of the three loads back. An entry with no
-`**Calls:**` block is a leaf: it loads nothing, which is the normal shape for
+loads `writing-prose`. None of the three loads back. `**Calls:** None` marks a
+leaf, which is the normal shape for
 a `principle-*` skill and for a methodology skill that states one rule and
 stops.
 
@@ -47,17 +48,7 @@ Runs the 8-phase QRSPI feature pipeline.
 
 **Callers:** None
 
-**Calls:**
-
-- `changelog`
-- `cross-model-review`
-- `review-severity-tiers`
-- `reviewing-designs`
-- `running-quality-checks`
-- `team-pr`
-- `team-worktree`
-- `tracking-tickets`
-- `worktree-isolation`
+**Calls:** `changelog`, `cross-model-review`, `review-severity-tiers`, `reviewing-designs`, `running-quality-checks`, `team-pr`, `team-worktree`, `tracking-tickets`, `worktree-isolation`
 
 ### [team-question](https://github.com/bostonaholic/team/blob/main/skills/team-question/SKILL.md)
 
@@ -65,11 +56,15 @@ Decomposes a feature into task and question artifacts.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
 Researches a codebase area before changes.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
@@ -77,10 +72,7 @@ Drafts and adversarially reviews a design.
 
 **Callers:** None
 
-**Calls:**
-
-- `cross-model-review`
-- `reviewing-designs`
+**Calls:** `cross-model-review`, `reviewing-designs`
 
 ### [team-structure](https://github.com/bostonaholic/team/blob/main/skills/team-structure/SKILL.md)
 
@@ -88,11 +80,15 @@ Breaks a reviewed design into verified slices.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
 Produces the tactical implementation plan.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
@@ -100,17 +96,15 @@ Prepares isolated git worktrees.
 
 **Callers:** `team`, `team-fix`, `worktree-isolation`
 
+**Calls:** None
+
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
 Executes and verifies implementation slices.
 
 **Callers:** None
 
-**Calls:**
-
-- `review-severity-tiers`
-- `running-quality-checks`
-- `team-pr`
+**Calls:** `review-severity-tiers`, `running-quality-checks`, `team-pr`
 
 ### [team-pr](https://github.com/bostonaholic/team/blob/main/skills/team-pr/SKILL.md)
 
@@ -118,15 +112,7 @@ Opens a pull request after verification.
 
 **Callers:** `team`, `team-implement`
 
-**Calls:**
-
-- `changelog`
-- `git-commit`
-- `pr-screenshots`
-- `tracking-tickets`
-- `verifying-ux`
-- `worktree-isolation`
-- `writing-prose`
+**Calls:** `changelog`, `git-commit`, `pr-screenshots`, `tracking-tickets`, `verifying-ux`, `worktree-isolation`, `writing-prose`
 
 ### [team-fix](https://github.com/bostonaholic/team/blob/main/skills/team-fix/SKILL.md)
 
@@ -134,14 +120,7 @@ Runs the compressed bug-fix pipeline.
 
 **Callers:** None
 
-**Calls:**
-
-- `systematic-debugging`
-- `team-worktree`
-- `test-driven-bug-fix`
-- `tracking-tickets`
-- `why`
-- `worktree-isolation`
+**Calls:** `systematic-debugging`, `team-worktree`, `test-driven-bug-fix`, `tracking-tickets`, `why`, `worktree-isolation`
 
 ### [eng-design-doc-review](https://github.com/bostonaholic/team/blob/main/skills/eng-design-doc-review/SKILL.md)
 
@@ -149,11 +128,7 @@ Reviews a technical design document with fresh context.
 
 **Callers:** None
 
-**Calls:**
-
-- `cross-model-review`
-- `reviewing-designs`
-- `writing-prose`
+**Calls:** `cross-model-review`, `reviewing-designs`, `writing-prose`
 
 ## Standalone utilities
 
@@ -166,15 +141,15 @@ Lands a reviewed pull request.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
 Triages unresolved PR review comments.
 
 **Callers:** `pr-watch-as-author`
 
-**Calls:**
-
-- `decision-making`
+**Calls:** `decision-making`
 
 ### [pr-watch-as-author](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-author/SKILL.md)
 
@@ -182,11 +157,7 @@ Watches an authored PR for feedback.
 
 **Callers:** None
 
-**Calls:**
-
-- `pr-open-comments`
-- `pr-watch-mechanics`
-- `tracking-tickets`
+**Calls:** `pr-open-comments`, `pr-watch-mechanics`, `tracking-tickets`
 
 ### [pr-watch-as-reviewer](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-as-reviewer/SKILL.md)
 
@@ -194,9 +165,7 @@ Watches a reviewed PR and approves settled feedback.
 
 **Callers:** None
 
-**Calls:**
-
-- `pr-watch-mechanics`
+**Calls:** `pr-watch-mechanics`
 
 ### [groom-backlog](https://github.com/bostonaholic/team/blob/main/skills/groom-backlog/SKILL.md)
 
@@ -204,9 +173,7 @@ Grooms a project backlog and proposes tracker changes.
 
 **Callers:** None
 
-**Calls:**
-
-- `decision-making`
+**Calls:** `decision-making`
 
 ### [pr-cleanup](https://github.com/bostonaholic/team/blob/main/skills/pr-cleanup/SKILL.md)
 
@@ -214,15 +181,15 @@ Cleans PR state.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
 Verifies a PR test plan with evidence-rated verdicts.
 
 **Callers:** None
 
-**Calls:**
-
-- `running-quality-checks`
+**Calls:** `running-quality-checks`
 
 ### [pr-screenshots](https://github.com/bostonaholic/team/blob/main/skills/pr-screenshots/SKILL.md)
 
@@ -230,15 +197,15 @@ Attaches local images to a PR body.
 
 **Callers:** `team-pr`
 
+**Calls:** None
+
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
 Rebases a branch onto its base.
 
 **Callers:** None
 
-**Calls:**
-
-- `running-quality-checks`
+**Calls:** `running-quality-checks`
 
 ### [reflect](https://github.com/bostonaholic/team/blob/main/skills/reflect/SKILL.md)
 
@@ -246,9 +213,7 @@ Mines a session for durable learnings.
 
 **Callers:** None
 
-**Calls:**
-
-- `running-quality-checks`
+**Calls:** `running-quality-checks`
 
 ### [why](https://github.com/bostonaholic/team/blob/main/skills/why/SKILL.md)
 
@@ -256,9 +221,7 @@ Investigates design rationale behind code.
 
 **Callers:** `how`, `reviewing-code`, `team-fix`
 
-**Calls:**
-
-- `systematic-debugging`
+**Calls:** `systematic-debugging`
 
 ### [how](https://github.com/bostonaholic/team/blob/main/skills/how/SKILL.md)
 
@@ -266,9 +229,7 @@ Explains subsystem architecture and runtime flow.
 
 **Callers:** None
 
-**Calls:**
-
-- `why`
+**Calls:** `why`
 
 ### [code-review](https://github.com/bostonaholic/team/blob/main/skills/code-review/SKILL.md)
 
@@ -276,9 +237,7 @@ Reviews a diff with fresh context.
 
 **Callers:** None
 
-**Calls:**
-
-- `reviewing-code`
+**Calls:** `reviewing-code`
 
 ### [no-comments](https://github.com/bostonaholic/team/blob/main/skills/no-comments/SKILL.md)
 
@@ -286,12 +245,7 @@ Removes low-value source comments and encodes valid constraints.
 
 **Callers:** None
 
-**Calls:**
-
-- `principle-fix-root-causes`
-- `principle-progress-tracking`
-- `reviewing-comments`
-- `running-quality-checks`
+**Calls:** `principle-fix-root-causes`, `principle-progress-tracking`, `reviewing-comments`, `running-quality-checks`
 
 ## Methodology skills
 
@@ -304,11 +258,15 @@ Defines QRSPI phases, artifacts, gates, and state transitions.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
 Defines pipeline artifact schemas.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
@@ -316,11 +274,15 @@ Defines evidence-only codebase research and `5-research.md`.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
 Locates files by naming, structure, and imports.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [decomposing-intent](https://github.com/bostonaholic/team/blob/main/skills/decomposing-intent/SKILL.md)
 
@@ -328,9 +290,7 @@ Defines task and question artifacts plus multi-repo detection.
 
 **Callers:** None
 
-**Calls:**
-
-- `product-requirements-doc`
+**Calls:** `product-requirements-doc`
 
 ### [authoring-designs](https://github.com/bostonaholic/team/blob/main/skills/authoring-designs/SKILL.md)
 
@@ -338,11 +298,7 @@ Defines the design-document procedure.
 
 **Callers:** None
 
-**Calls:**
-
-- `decision-making`
-- `systems-thinking`
-- `writing-prose`
+**Calls:** `decision-making`, `systems-thinking`, `writing-prose`
 
 ### [slicing-work](https://github.com/bostonaholic/team/blob/main/skills/slicing-work/SKILL.md)
 
@@ -350,9 +306,7 @@ Defines vertical slices and verification checkpoints.
 
 **Callers:** None
 
-**Calls:**
-
-- `decision-making`
+**Calls:** `decision-making`
 
 ### [planning-implementation](https://github.com/bostonaholic/team/blob/main/skills/planning-implementation/SKILL.md)
 
@@ -360,19 +314,15 @@ Defines the tactical plan schema.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [reviewing-code](https://github.com/bostonaholic/team/blob/main/skills/reviewing-code/SKILL.md)
 
 Defines adversarial code review and evidence-based findings.
 
 **Callers:** `code-review`, `reviewing-designs`
 
-**Calls:**
-
-- `engineering-standards`
-- `review-severity-tiers`
-- `test-style`
-- `why`
-- `writing-prose`
+**Calls:** `engineering-standards`, `review-severity-tiers`, `test-style`, `why`, `writing-prose`
 
 ### [reviewing-comments](https://github.com/bostonaholic/team/blob/main/skills/reviewing-comments/SKILL.md)
 
@@ -380,9 +330,7 @@ Defines fresh-context source-comment review and findings.
 
 **Callers:** `no-comments`
 
-**Calls:**
-
-- `engineering-standards`
+**Calls:** `engineering-standards`
 
 ### [reviewing-designs](https://github.com/bostonaholic/team/blob/main/skills/reviewing-designs/SKILL.md)
 
@@ -390,15 +338,7 @@ Defines adversarial design review and verdicts.
 
 **Callers:** `eng-design-doc-review`, `team`, `team-design`
 
-**Calls:**
-
-- `conventional-comments`
-- `cross-model-review`
-- `documenting-decisions`
-- `engineering-standards`
-- `reviewing-code`
-- `technical-design-doc`
-- `writing-prose`
+**Calls:** `conventional-comments`, `cross-model-review`, `documenting-decisions`, `engineering-standards`, `reviewing-code`, `technical-design-doc`, `writing-prose`
 
 ### [conventional-comments](https://github.com/bostonaholic/team/blob/main/skills/conventional-comments/SKILL.md)
 
@@ -406,11 +346,15 @@ Defines review labels and decorations.
 
 **Callers:** `reviewing-designs`
 
+**Calls:** None
+
 ### [reviewing-security](https://github.com/bostonaholic/team/blob/main/skills/reviewing-security/SKILL.md)
 
 Defines threat and OWASP review with evidence-rated findings.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [cross-model-review](https://github.com/bostonaholic/team/blob/main/skills/cross-model-review/SKILL.md)
 
@@ -418,11 +362,15 @@ Runs second-vendor reviews through machine-only CLI adapters.
 
 **Callers:** `eng-design-doc-review`, `reviewing-designs`, `team`, `team-design`
 
+**Calls:** None
+
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
 Maps reviewer findings to Blocking, Major, or Minor actions.
 
 **Callers:** `reviewing-code`, `team`, `team-implement`
+
+**Calls:** None
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
@@ -430,11 +378,15 @@ Defines code design, comment, and review standards.
 
 **Callers:** `reviewing-code`, `reviewing-comments`, `reviewing-designs`
 
+**Calls:** None
+
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
 Defines acceptance tests as the implementation scope contract.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
@@ -442,15 +394,15 @@ Defines deterministic behavioral tests and flaky-test red flags.
 
 **Callers:** `reviewing-code`
 
+**Calls:** None
+
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
 Defines reproduce-red-green-refactor bug fixes.
 
 **Callers:** `team-fix`
 
-**Calls:**
-
-- `systematic-debugging`
+**Calls:** `systematic-debugging`
 
 ### [solid](https://github.com/bostonaholic/team/blob/main/skills/solid/SKILL.md)
 
@@ -458,11 +410,15 @@ Defines SOLID design and review rules.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [refactoring-to-patterns](https://github.com/bostonaholic/team/blob/main/skills/refactoring-to-patterns/SKILL.md)
 
 Maps code smells to behavior-preserving refactorings.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
@@ -470,11 +426,7 @@ Defines test-first slice execution, commits, and review fixes.
 
 **Callers:** None
 
-**Calls:**
-
-- `git-commit`
-- `principle-fix-root-causes`
-- `systematic-debugging`
+**Calls:** `git-commit`, `principle-fix-root-causes`, `systematic-debugging`
 
 ### [systematic-debugging](https://github.com/bostonaholic/team/blob/main/skills/systematic-debugging/SKILL.md)
 
@@ -482,11 +434,15 @@ Defines reproduce, hypothesize, isolate, and fix workflow.
 
 **Callers:** `implementing-slices`, `team-fix`, `test-driven-bug-fix`, `why`
 
+**Calls:** None
+
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
 Runs project-native tests, static checks, builds, and linters.
 
 **Callers:** `no-comments`, `pr-rebase`, `pr-verify`, `reflect`, `team`, `team-implement`
+
+**Calls:** None
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
@@ -494,11 +450,15 @@ Requires one live ledger for ordered procedures.
 
 **Callers:** `no-comments`
 
+**Calls:** None
+
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
 Defines safe nested-agent dispatch and fallback.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [decision-making](https://github.com/bostonaholic/team/blob/main/skills/decision-making/SKILL.md)
 
@@ -506,16 +466,15 @@ Defines a decision method based on reversibility and risk.
 
 **Callers:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
 
+**Calls:** None
+
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
 Defines ADR structure and lifecycle.
 
 **Callers:** `reviewing-designs`
 
-**Calls:**
-
-- `decision-making`
-- `writing-prose`
+**Calls:** `decision-making`, `writing-prose`
 
 ### [technical-design-doc](https://github.com/bostonaholic/team/blob/main/skills/technical-design-doc/SKILL.md)
 
@@ -523,10 +482,7 @@ Defines technical design sections and decision content.
 
 **Callers:** `reviewing-designs`
 
-**Calls:**
-
-- `decision-making`
-- `writing-prose`
+**Calls:** `decision-making`, `writing-prose`
 
 ### [product-requirements-doc](https://github.com/bostonaholic/team/blob/main/skills/product-requirements-doc/SKILL.md)
 
@@ -534,9 +490,7 @@ Defines when and how to write `3-prd.md`.
 
 **Callers:** `decomposing-intent`
 
-**Calls:**
-
-- `writing-prose`
+**Calls:** `writing-prose`
 
 ### [product-thinking](https://github.com/bostonaholic/team/blob/main/skills/product-thinking/SKILL.md)
 
@@ -544,11 +498,15 @@ Defines product-need lenses.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [systems-thinking](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md)
 
 Defines system-boundary, feedback, and dependency analysis.
 
 **Callers:** `authoring-designs`
+
+**Calls:** None
 
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
@@ -556,11 +514,15 @@ Defines plain-language prose rules.
 
 **Callers:** `authoring-designs`, `changelog`, `documenting-decisions`, `eng-design-doc-review`, `git-commit`, `product-requirements-doc`, `reviewing-code`, `reviewing-designs`, `team-pr`, `technical-design-doc`
 
+**Calls:** None
+
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
 Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
@@ -568,15 +530,15 @@ Defines live application and screenshot verification.
 
 **Callers:** `team-pr`
 
+**Calls:** None
+
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
 Defines Conventional Commit subjects and safe commit procedure.
 
 **Callers:** `implementing-slices`, `team-pr`
 
-**Calls:**
-
-- `writing-prose`
+**Calls:** `writing-prose`
 
 ### [changelog](https://github.com/bostonaholic/team/blob/main/skills/changelog/SKILL.md)
 
@@ -584,9 +546,7 @@ Defines Keep a Changelog updates.
 
 **Callers:** `team`, `team-pr`
 
-**Calls:**
-
-- `writing-prose`
+**Calls:** `writing-prose`
 
 ### [tracking-tickets](https://github.com/bostonaholic/team/blob/main/skills/tracking-tickets/SKILL.md)
 
@@ -594,15 +554,15 @@ Defines tracker status transitions and closing rules.
 
 **Callers:** `pr-watch-as-author`, `team`, `team-fix`, `team-pr`
 
+**Calls:** None
+
 ### [worktree-isolation](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
 
 Defines Team worktree creation, validation, and teardown.
 
 **Callers:** `team`, `team-fix`, `team-pr`
 
-**Calls:**
-
-- `team-worktree`
+**Calls:** `team-worktree`
 
 ### [sweeping-local-state](https://github.com/bostonaholic/team/blob/main/skills/sweeping-local-state/SKILL.md)
 
@@ -610,11 +570,15 @@ Defines machine-local teardown.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
 Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
 
 **Callers:** `pr-watch-as-author`, `pr-watch-as-reviewer`
+
+**Calls:** None
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
@@ -622,11 +586,15 @@ Keeps desired outcomes out of research prompts.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
 Requires explicit retry and watch limits.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 
@@ -634,11 +602,15 @@ Keeps agent interfaces narrow and internal work deep.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-evidence-over-assertion](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md)
 
 Requires evidence for claims and verdicts.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-explicit-intent](https://github.com/bostonaholic/team/blob/main/skills/principle-explicit-intent/SKILL.md)
 
@@ -646,11 +618,15 @@ Requires stated intent for irreversible actions.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-fail-closed](https://github.com/bostonaholic/team/blob/main/skills/principle-fail-closed/SKILL.md)
 
 Treats unknown guarantees as failures.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
@@ -658,11 +634,15 @@ Requires durable files for cross-step state.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-fix-root-causes](https://github.com/bostonaholic/team/blob/main/skills/principle-fix-root-causes/SKILL.md)
 
 Requires diagnosis and repair of root causes.
 
 **Callers:** `implementing-slices`, `no-comments`
+
+**Calls:** None
 
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
@@ -670,11 +650,15 @@ Separates producers from evaluators.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
 Reserves goals and shipping decisions for the user.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-idempotent-reruns](https://github.com/bostonaholic/team/blob/main/skills/principle-idempotent-reruns/SKILL.md)
 
@@ -682,11 +666,15 @@ Requires reruns to converge without duplicate effects.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-least-privilege](https://github.com/bostonaholic/team/blob/main/skills/principle-least-privilege/SKILL.md)
 
 Limits tools, credentials, and environment to the task.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-mechanical-gates](https://github.com/bostonaholic/team/blob/main/skills/principle-mechanical-gates/SKILL.md)
 
@@ -694,11 +682,15 @@ Requires deterministic enforcement for reliable rules.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-never-interpolate](https://github.com/bostonaholic/team/blob/main/skills/principle-never-interpolate/SKILL.md)
 
 Keeps external text out of shell syntax.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-non-blocking-waits](https://github.com/bostonaholic/team/blob/main/skills/principle-non-blocking-waits/SKILL.md)
 
@@ -706,11 +698,15 @@ Requires resumable waits for external state.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
 Keeps optional enhancements off the correctness path.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
@@ -718,11 +714,15 @@ Requires a written plan and user approval before mutations.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-pre-image-first](https://github.com/bostonaholic/team/blob/main/skills/principle-pre-image-first/SKILL.md)
 
 Requires a recoverable baseline before destructive changes.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
@@ -730,11 +730,15 @@ Records autonomous resolutions as assumptions.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
 Restricts execution to approved scope.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
@@ -742,11 +746,15 @@ Requires one authoritative definition per rule or schema.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-skip-loudly](https://github.com/bostonaholic/team/blob/main/skills/principle-skip-loudly/SKILL.md)
 
 Requires skipped work to be reported explicitly.
 
 **Callers:** None
+
+**Calls:** None
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
@@ -754,11 +762,15 @@ Requires removal before addition.
 
 **Callers:** None
 
+**Calls:** None
+
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
 Treats external text as inert data.
 
 **Callers:** None
+
+**Calls:** None
 
 ## Name-collision pairs
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,8 +17,8 @@ nav_label: skills
 > `SKILL.md`, the `SKILL.md` wins.
 
 Each entry starts with one sentence copied from that skill's frontmatter
-`description`. The `**Invoked / loaded by:**` field names its consumers. The
-`**Phase / context:**` field names where it applies. A `**Loads:**` list follows
+`description`. `**Consumers:**` lists its consumers. `**Context:**` names where
+it applies. A `**Loads:**` list follows
 when the skill's own `.md` files instruct a load of another skill. The load form
 is ``Call the Skill tool with `<name>` ``. Naming a skill another way is a
 citation, not an edge. For example, `team-structure` restates a
@@ -46,9 +46,9 @@ full run or drives one phase of the QRSPI pipeline.
 
 Runs the 8-phase QRSPI feature pipeline.
 
-**Invoked / loaded by:** orchestrator (runs the pipeline)
+**Consumers:** orchestrator (runs the pipeline)
 
-**Phase / context:** All phases
+**Context:** All phases
 
 **Loads:**
 
@@ -66,25 +66,25 @@ Runs the 8-phase QRSPI feature pipeline.
 
 Decomposes a feature into task and question artifacts.
 
-**Invoked / loaded by:** orchestrator
+**Consumers:** orchestrator
 
-**Phase / context:** Question
+**Context:** Question
 
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
 Researches a codebase area before changes.
 
-**Invoked / loaded by:** orchestrator → researcher, file-finder
+**Consumers:** orchestrator → researcher, file-finder
 
-**Phase / context:** Research
+**Context:** Research
 
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
 Drafts and adversarially reviews a design.
 
-**Invoked / loaded by:** orchestrator → design-author
+**Consumers:** orchestrator → design-author
 
-**Phase / context:** Design (design review)
+**Context:** Design (design review)
 
 **Loads:**
 
@@ -95,33 +95,33 @@ Drafts and adversarially reviews a design.
 
 Breaks a reviewed design into verified slices.
 
-**Invoked / loaded by:** orchestrator → structure-planner
+**Consumers:** orchestrator → structure-planner
 
-**Phase / context:** Structure (autonomous)
+**Context:** Structure (autonomous)
 
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
 Produces the tactical implementation plan.
 
-**Invoked / loaded by:** orchestrator → planner
+**Consumers:** orchestrator → planner
 
-**Phase / context:** Plan
+**Context:** Plan
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
 Prepares isolated git worktrees.
 
-**Invoked / loaded by:** orchestrator
+**Consumers:** orchestrator
 
-**Phase / context:** Worktree
+**Context:** Worktree
 
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
 Executes and verifies implementation slices.
 
-**Invoked / loaded by:** orchestrator → implementer + reviewers
+**Consumers:** orchestrator → implementer + reviewers
 
-**Phase / context:** Implement
+**Context:** Implement
 
 **Loads:**
 
@@ -133,9 +133,9 @@ Executes and verifies implementation slices.
 
 Opens a pull request after verification.
 
-**Invoked / loaded by:** orchestrator
+**Consumers:** orchestrator
 
-**Phase / context:** PR
+**Context:** PR
 
 **Loads:**
 
@@ -151,9 +151,9 @@ Opens a pull request after verification.
 
 Runs the compressed bug-fix pipeline.
 
-**Invoked / loaded by:** user or model (direct invocation, on explicit pipeline intent)
+**Consumers:** user or model (direct invocation, on explicit pipeline intent)
 
-**Phase / context:** Compressed bug-fix flow (outside QRSPI)
+**Context:** Compressed bug-fix flow (outside QRSPI)
 
 **Loads:**
 
@@ -168,9 +168,9 @@ Runs the compressed bug-fix pipeline.
 
 Reviews a technical design document with fresh context.
 
-**Invoked / loaded by:** user (direct invocation)
+**Consumers:** user (direct invocation)
 
-**Phase / context:** Front door over the `reviewing-designs` brief: standalone audit. Dispatches a read-only Explore subagent
+**Context:** Front door over the `reviewing-designs` brief: standalone audit. Dispatches a read-only Explore subagent
 
 **Loads:**
 
@@ -187,17 +187,17 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 Lands a reviewed pull request.
 
-**Invoked / loaded by:** user or model (direct invocation, on explicit ship intent)
+**Consumers:** user or model (direct invocation, on explicit ship intent)
 
-**Phase / context:** Standalone: land a reviewed PR (not a QRSPI phase)
+**Context:** Standalone: land a reviewed PR
 
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
 Triages unresolved PR review comments.
 
-**Invoked / loaded by:** user or model (direct invocation)
+**Consumers:** user or model (direct invocation)
 
-**Phase / context:** Standalone: triage unresolved PR review feedback (not a QRSPI phase)
+**Context:** Standalone: triage unresolved PR review feedback
 
 **Loads:**
 
@@ -207,9 +207,9 @@ Triages unresolved PR review comments.
 
 Watches an authored PR for feedback.
 
-**Invoked / loaded by:** user or model (direct invocation)
+**Consumers:** user or model (direct invocation)
 
-**Phase / context:** Standalone: bounded PR review watch loop (not a QRSPI phase)
+**Context:** Standalone: bounded PR review watch loop
 
 **Loads:**
 
@@ -221,9 +221,9 @@ Watches an authored PR for feedback.
 
 Watches a reviewed PR and approves settled feedback.
 
-**Invoked / loaded by:** user (direct invocation)
+**Consumers:** user (direct invocation)
 
-**Phase / context:** Standalone: reviewer-side watch-and-approve (not a QRSPI phase)
+**Context:** Standalone: reviewer-side watch-and-approve
 
 **Loads:**
 
@@ -233,9 +233,9 @@ Watches a reviewed PR and approves settled feedback.
 
 Grooms a project backlog and proposes tracker changes.
 
-**Invoked / loaded by:** user or model (direct invocation)
+**Consumers:** user or model (direct invocation)
 
-**Phase / context:** Standalone: groom a project backlog (not a QRSPI phase)
+**Context:** Standalone: groom a project backlog
 
 **Loads:**
 
@@ -245,17 +245,17 @@ Grooms a project backlog and proposes tracker changes.
 
 Cleans PR state.
 
-**Invoked / loaded by:** user or model (direct invocation; Mode B only on explicit abandon intent)
+**Consumers:** user or model (direct invocation; Mode B only on explicit abandon intent)
 
-**Phase / context:** Standalone: post-PR teardown (not a QRSPI phase)
+**Context:** Standalone: post-PR teardown
 
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
 Verifies a PR test plan with evidence-rated verdicts.
 
-**Invoked / loaded by:** user or model (direct invocation)
+**Consumers:** user or model (direct invocation)
 
-**Phase / context:** Standalone: test-plan verification (not a QRSPI phase)
+**Context:** Standalone: test-plan verification
 
 **Loads:**
 
@@ -265,17 +265,17 @@ Verifies a PR test plan with evidence-rated verdicts.
 
 Attaches local images to a PR body.
 
-**Invoked / loaded by:** user or model (direct invocation, on explicit intent)
+**Consumers:** user or model (direct invocation, on explicit intent)
 
-**Phase / context:** Standalone: attach local images to a PR body (not a QRSPI phase)
+**Context:** Standalone: attach local images to a PR body
 
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
 Rebases a branch onto its base.
 
-**Invoked / loaded by:** user (direct invocation, on explicit rebase intent; model invocation disabled)
+**Consumers:** user (direct invocation, on explicit rebase intent; model invocation disabled)
 
-**Phase / context:** Standalone: rebase a branch onto its base (not a QRSPI phase)
+**Context:** Standalone: rebase a branch onto its base
 
 **Loads:**
 
@@ -285,9 +285,9 @@ Rebases a branch onto its base.
 
 Mines a session for durable learnings.
 
-**Invoked / loaded by:** user (direct invocation, on explicit reflection intent; model invocation disabled)
+**Consumers:** user (direct invocation, on explicit reflection intent; model invocation disabled)
 
-**Phase / context:** Standalone: mine the session transcript for durable learnings (not a QRSPI phase)
+**Context:** Standalone: mine the session transcript for durable learnings
 
 **Loads:**
 
@@ -297,9 +297,9 @@ Mines a session for durable learnings.
 
 Investigates design rationale behind code.
 
-**Invoked / loaded by:** user or model (direct invocation). `team-fix` and `reviewing-code` (conditional load)
+**Consumers:** user or model (direct invocation). `team-fix` and `reviewing-code` (conditional load)
 
-**Phase / context:** Standalone: design-rationale investigation (not a QRSPI phase). Dispatches read-only Explore investigators
+**Context:** Standalone: design-rationale investigation. Dispatches read-only Explore investigators
 
 **Loads:**
 
@@ -309,9 +309,9 @@ Investigates design rationale behind code.
 
 Explains subsystem architecture and runtime flow.
 
-**Invoked / loaded by:** user or model (direct invocation)
+**Consumers:** user or model (direct invocation)
 
-**Phase / context:** Standalone: architectural explanation + optional critique (not a QRSPI phase). Dispatches read-only Explore explorers
+**Context:** Standalone: architectural explanation + optional critique. Dispatches read-only Explore explorers
 
 **Loads:**
 
@@ -321,9 +321,9 @@ Explains subsystem architecture and runtime flow.
 
 Reviews a diff with fresh context.
 
-**Invoked / loaded by:** user or model (direct invocation)
+**Consumers:** user or model (direct invocation)
 
-**Phase / context:** Standalone: dispatch a fresh-context code review (not a QRSPI phase)
+**Context:** Standalone: dispatch a fresh-context code review
 
 **Loads:**
 
@@ -333,9 +333,9 @@ Reviews a diff with fresh context.
 
 Removes low-value source comments and encodes valid constraints.
 
-**Invoked / loaded by:** user (direct invocation; model invocation disabled)
+**Consumers:** user (direct invocation; model invocation disabled)
 
-**Phase / context:** Standalone: comment cleanup (not a QRSPI phase)
+**Context:** Standalone: comment cleanup
 
 **Loads:**
 
@@ -353,41 +353,41 @@ them.
 
 Defines QRSPI phases, artifacts, gates, and state transitions.
 
-**Invoked / loaded by:** orchestrator skills
+**Consumers:** orchestrator skills
 
-**Phase / context:** All phases
+**Context:** All phases
 
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
 Defines pipeline artifact schemas.
 
-**Invoked / loaded by:** orchestrator skills. Artifact authors (just-in-time through pointers)
+**Consumers:** orchestrator skills. Artifact authors (just-in-time through pointers)
 
-**Phase / context:** All phases: artifact schema
+**Context:** All phases: artifact schema
 
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
 Defines evidence-only codebase research and `5-research.md`.
 
-**Invoked / loaded by:** researcher
+**Consumers:** researcher
 
-**Phase / context:** Research
+**Context:** Research
 
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
 Locates files by naming, structure, and imports.
 
-**Invoked / loaded by:** file-finder
+**Consumers:** file-finder
 
-**Phase / context:** Research
+**Context:** Research
 
 ### [decomposing-intent](https://github.com/bostonaholic/team/blob/main/skills/decomposing-intent/SKILL.md)
 
 Defines task and question artifacts plus multi-repo detection.
 
-**Invoked / loaded by:** questioner
+**Consumers:** questioner
 
-**Phase / context:** Question
+**Context:** Question
 
 **Loads:**
 
@@ -397,9 +397,9 @@ Defines task and question artifacts plus multi-repo detection.
 
 Defines the design-document procedure.
 
-**Invoked / loaded by:** design-author
+**Consumers:** design-author
 
-**Phase / context:** Design
+**Context:** Design
 
 **Loads:**
 
@@ -411,9 +411,9 @@ Defines the design-document procedure.
 
 Defines vertical slices and verification checkpoints.
 
-**Invoked / loaded by:** structure-planner
+**Consumers:** structure-planner
 
-**Phase / context:** Structure
+**Context:** Structure
 
 **Loads:**
 
@@ -423,17 +423,17 @@ Defines vertical slices and verification checkpoints.
 
 Defines the tactical plan schema.
 
-**Invoked / loaded by:** planner
+**Consumers:** planner
 
-**Phase / context:** Plan
+**Context:** Plan
 
 ### [reviewing-code](https://github.com/bostonaholic/team/blob/main/skills/reviewing-code/SKILL.md)
 
 Defines adversarial code review and evidence-based findings.
 
-**Invoked / loaded by:** code-reviewer, security-reviewer, ux-reviewer, technical-writer. `code-review` (front door). `reviewing-designs` read-only Explore reviewer
+**Consumers:** code-reviewer, security-reviewer, ux-reviewer, technical-writer. `code-review` (front door). `reviewing-designs` read-only Explore reviewer
 
-**Phase / context:** Implement (verify), and Design (review gate)
+**Context:** Implement (verify), and Design (review gate)
 
 **Loads:**
 
@@ -447,9 +447,9 @@ Defines adversarial code review and evidence-based findings.
 
 Defines fresh-context source-comment review and findings.
 
-**Invoked / loaded by:** `no-comments` (direct load for read-only Explore review)
+**Consumers:** `no-comments` (direct load for read-only Explore review)
 
-**Phase / context:** Standalone: source-comment review methodology
+**Context:** Standalone: source-comment review methodology
 
 **Loads:**
 
@@ -459,9 +459,9 @@ Defines fresh-context source-comment review and findings.
 
 Defines adversarial design review and verdicts.
 
-**Invoked / loaded by:** orchestrator or invoking session (team, team-design, eng-design-doc-review) — the brief a read-only Explore subagent runs
+**Consumers:** orchestrator or invoking session (team, team-design, eng-design-doc-review) — the brief a read-only Explore subagent runs
 
-**Phase / context:** Design (review-gate brief)
+**Context:** Design (review-gate brief)
 
 **Loads:**
 
@@ -477,65 +477,65 @@ Defines adversarial design review and verdicts.
 
 Defines review labels and decorations.
 
-**Invoked / loaded by:** code-reviewer, security-reviewer, technical-writer. `reviewing-designs` read-only Explore reviewer
+**Consumers:** code-reviewer, security-reviewer, technical-writer. `reviewing-designs` read-only Explore reviewer
 
-**Phase / context:** Implement (verify): finding format, and Design (review gate): finding format
+**Context:** Implement (verify): finding format, and Design (review gate): finding format
 
 ### [reviewing-security](https://github.com/bostonaholic/team/blob/main/skills/reviewing-security/SKILL.md)
 
 Defines threat and OWASP review with evidence-rated findings.
 
-**Invoked / loaded by:** security-reviewer
+**Consumers:** security-reviewer
 
-**Phase / context:** Implement (verify)
+**Context:** Implement (verify)
 
 ### [cross-model-review](https://github.com/bostonaholic/team/blob/main/skills/cross-model-review/SKILL.md)
 
 Runs second-vendor reviews through machine-only CLI adapters.
 
-**Invoked / loaded by:** code-reviewer. Orchestrator or invoking session (team, team-design, eng-design-doc-review) through `## Design-review pass`. Design-review brief (conditional, on `## External review input`). `reviewing-designs` read-only Explore reviewer (conditional, on `## External review input`)
+**Consumers:** code-reviewer. Orchestrator or invoking session (team, team-design, eng-design-doc-review) through `## Design-review pass`. Design-review brief (conditional, on `## External review input`). `reviewing-designs` read-only Explore reviewer (conditional, on `## External review input`)
 
-**Phase / context:** Implement (verify), and Design (review gate)
+**Context:** Implement (verify), and Design (review gate)
 
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
 Maps reviewer findings to Blocking, Major, or Minor actions.
 
-**Invoked / loaded by:** orchestrator (team, team-implement, qrspi-workflow)
+**Consumers:** orchestrator (team, team-implement, qrspi-workflow)
 
-**Phase / context:** Implement (aggregate review gate)
+**Context:** Implement (aggregate review gate)
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
 Defines code design, comment, and review standards.
 
-**Invoked / loaded by:** planner, implementer, code-reviewer. `reviewing-designs` read-only Explore reviewer
+**Consumers:** planner, implementer, code-reviewer. `reviewing-designs` read-only Explore reviewer
 
-**Phase / context:** Plan, Implement, and Design (review gate)
+**Context:** Plan, Implement, and Design (review gate)
 
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
 Defines acceptance tests as the implementation scope contract.
 
-**Invoked / loaded by:** test-architect, code-reviewer. Orchestrator
+**Consumers:** test-architect, code-reviewer. Orchestrator
 
-**Phase / context:** Implement
+**Context:** Implement
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
 Defines deterministic behavioral tests and flaky-test red flags.
 
-**Invoked / loaded by:** test-architect, code-reviewer (just-in-time through pointers)
+**Consumers:** test-architect, code-reviewer (just-in-time through pointers)
 
-**Phase / context:** Implement
+**Context:** Implement
 
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
 Defines reproduce-red-green-refactor bug fixes.
 
-**Invoked / loaded by:** team-fix
+**Consumers:** team-fix
 
-**Phase / context:** Bug-fix flow
+**Context:** Bug-fix flow
 
 **Loads:**
 
@@ -545,25 +545,25 @@ Defines reproduce-red-green-refactor bug fixes.
 
 Defines SOLID design and review rules.
 
-**Invoked / loaded by:** implementer, code-reviewer. `engineering-standards`, `reviewing-code` (citing skills)
+**Consumers:** implementer, code-reviewer. `engineering-standards`, `reviewing-code` (citing skills)
 
-**Phase / context:** Implement
+**Context:** Implement
 
 ### [refactoring-to-patterns](https://github.com/bostonaholic/team/blob/main/skills/refactoring-to-patterns/SKILL.md)
 
 Maps code smells to behavior-preserving refactorings.
 
-**Invoked / loaded by:** implementer
+**Consumers:** implementer
 
-**Phase / context:** Implement
+**Context:** Implement
 
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
 Defines test-first slice execution, commits, and review fixes.
 
-**Invoked / loaded by:** implementer
+**Consumers:** implementer
 
-**Phase / context:** Implement
+**Context:** Implement
 
 **Loads:**
 
@@ -575,49 +575,49 @@ Defines test-first slice execution, commits, and review fixes.
 
 Defines reproduce, hypothesize, isolate, and fix workflow.
 
-**Invoked / loaded by:** implementer (inline Load on non-obvious failures). Other agents when debugging (advisory)
+**Consumers:** implementer (inline Load on non-obvious failures). Other agents when debugging (advisory)
 
-**Phase / context:** Implement, and Any (debugging)
+**Context:** Implement, and Any (debugging)
 
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
 Runs project-native tests, static checks, builds, and linters.
 
-**Invoked / loaded by:** verifier. reflect (after the writes)
+**Consumers:** verifier. reflect (after the writes)
 
-**Phase / context:** Implement (verify), and Any (reflect)
+**Context:** Implement (verify), and Any (reflect)
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
 Requires one live ledger for ordered procedures.
 
-**Invoked / loaded by:** every multi-step agent; cited by `team`, `team-implement`, `team-fix`, `pr-screenshots`, `no-comments`
+**Consumers:** every multi-step agent; cited by `team`, `team-implement`, `team-fix`, `pr-screenshots`, `no-comments`
 
-**Phase / context:** Any (multi-step procedure)
+**Context:** Any (multi-step procedure)
 
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
 Defines safe nested-agent dispatch and fallback.
 
-**Invoked / loaded by:** researcher, implementer, code-reviewer, security-reviewer
+**Consumers:** researcher, implementer, code-reviewer, security-reviewer
 
-**Phase / context:** Research, Implement (scouts + skeptic passes)
+**Context:** Research, Implement (scouts + skeptic passes)
 
 ### [decision-making](https://github.com/bostonaholic/team/blob/main/skills/decision-making/SKILL.md)
 
 Defines a decision method based on reversibility and risk.
 
-**Invoked / loaded by:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
+**Consumers:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
 
-**Phase / context:** Design, Structure, Plan, and standalone recommendations
+**Context:** Design, Structure, Plan, and standalone recommendations
 
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
 Defines ADR structure and lifecycle.
 
-**Invoked / loaded by:** planner, orchestrator (advisory). `reviewing-designs` read-only Explore reviewer
+**Consumers:** planner, orchestrator (advisory). `reviewing-designs` read-only Explore reviewer
 
-**Phase / context:** Any (when decisions are recorded), and Design (review gate)
+**Context:** Any (when decisions are recorded), and Design (review gate)
 
 **Loads:**
 
@@ -628,9 +628,9 @@ Defines ADR structure and lifecycle.
 
 Defines technical design sections and decision content.
 
-**Invoked / loaded by:** planner. `reviewing-designs` read-only Explore reviewer
+**Consumers:** planner. `reviewing-designs` read-only Explore reviewer
 
-**Phase / context:** Plan, and Design (review gate)
+**Context:** Plan, and Design (review gate)
 
 **Loads:**
 
@@ -641,9 +641,9 @@ Defines technical design sections and decision content.
 
 Defines when and how to write `3-prd.md`.
 
-**Invoked / loaded by:** questioner (through `decomposing-intent`, conditional). Design-author (through `authoring-designs`)
+**Consumers:** questioner (through `decomposing-intent`, conditional). Design-author (through `authoring-designs`)
 
-**Phase / context:** Question, Design
+**Context:** Question, Design
 
 **Loads:**
 
@@ -653,49 +653,49 @@ Defines when and how to write `3-prd.md`.
 
 Defines product-need lenses.
 
-**Invoked / loaded by:** questioner, design-author, structure-planner
+**Consumers:** questioner, design-author, structure-planner
 
-**Phase / context:** Question, Design, Structure
+**Context:** Question, Design, Structure
 
 ### [systems-thinking](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md)
 
 Defines system-boundary, feedback, and dependency analysis.
 
-**Invoked / loaded by:** researcher, structure-planner, planner (frontmatter). Implementer, code-reviewer, ux-reviewer (inline). Authoring-designs, nested-agents (citing skills)
+**Consumers:** researcher, structure-planner, planner (frontmatter). Implementer, code-reviewer, ux-reviewer (inline). Authoring-designs, nested-agents (citing skills)
 
-**Phase / context:** Research, Design, Structure, Plan, Implement (incl. verify)
+**Context:** Research, Design, Structure, Plan, Implement (incl. verify)
 
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
 Defines plain-language prose rules.
 
-**Invoked / loaded by:** technical-writer, design-author. `reviewing-designs` read-only Explore reviewer
+**Consumers:** technical-writer, design-author. `reviewing-designs` read-only Explore reviewer
 
-**Phase / context:** Design (authoring bar), and Implement (verify): bar for prose it writes and prose it assesses. Design (review gate): prose bar
+**Context:** Design (authoring bar), and Implement (verify): bar for prose it writes and prose it assesses. Design (review gate): prose bar
 
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
 Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
 
-**Invoked / loaded by:** technical-writer
+**Consumers:** technical-writer
 
-**Phase / context:** Implement (verify): doc-gap review process + classification
+**Context:** Implement (verify): doc-gap review process + classification
 
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
 Defines live application and screenshot verification.
 
-**Invoked / loaded by:** ux-reviewer
+**Consumers:** ux-reviewer
 
-**Phase / context:** Implement (verify)
+**Context:** Implement (verify)
 
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
 Defines Conventional Commit subjects and safe commit procedure.
 
-**Invoked / loaded by:** team-pr. Implementer (through `implementing-slices`)
+**Consumers:** team-pr. Implementer (through `implementing-slices`)
 
-**Phase / context:** PR, and Implement (slice commits)
+**Context:** PR, and Implement (slice commits)
 
 **Loads:**
 
@@ -705,9 +705,9 @@ Defines Conventional Commit subjects and safe commit procedure.
 
 Defines Keep a Changelog updates.
 
-**Invoked / loaded by:** team, team-pr
+**Consumers:** team, team-pr
 
-**Phase / context:** PR
+**Context:** PR
 
 **Loads:**
 
@@ -717,17 +717,17 @@ Defines Keep a Changelog updates.
 
 Defines tracker status transitions and closing rules.
 
-**Invoked / loaded by:** orchestrator (team, team-pr, team-fix, just-in-time through pointers)
+**Consumers:** orchestrator (team, team-pr, team-fix, just-in-time through pointers)
 
-**Phase / context:** Setup (ticket pickup), and PR (ticket link + state)
+**Context:** Setup (ticket pickup), and PR (ticket link + state)
 
 ### [worktree-isolation](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
 
 Defines Team worktree creation, validation, and teardown.
 
-**Invoked / loaded by:** orchestrator (team, team-worktree)
+**Consumers:** orchestrator (team, team-worktree)
 
-**Phase / context:** Worktree
+**Context:** Worktree
 
 **Loads:**
 
@@ -737,209 +737,209 @@ Defines Team worktree creation, validation, and teardown.
 
 Defines machine-local teardown.
 
-**Invoked / loaded by:** `pr-cleanup`, `worktree-isolation` (both inline)
+**Consumers:** `pr-cleanup`, `worktree-isolation` (both inline)
 
-**Phase / context:** Standalone: teardown after a merged PR, a closed PR, or a completed review (not a QRSPI phase)
+**Context:** Standalone: teardown after a merged PR, a closed PR, or a completed review
 
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
 Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
 
-**Invoked / loaded by:** `pr-watch-as-author`, `pr-watch-as-reviewer` (both through the bounded-cycle-mechanics reference)
+**Consumers:** `pr-watch-as-author`, `pr-watch-as-reviewer` (both through the bounded-cycle-mechanics reference)
 
-**Phase / context:** Standalone: bounded watch-loop mechanics (not a QRSPI phase)
+**Context:** Standalone: bounded watch-loop mechanics
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
 Keeps desired outcomes out of research prompts.
 
-**Invoked / loaded by:** cited by `qrspi-workflow`, `nested-agents`, `decomposing-intent`, `researching-codebases`, `why`. Any agent (just-in-time)
+**Consumers:** cited by `qrspi-workflow`, `nested-agents`, `decomposing-intent`, `researching-codebases`, `why`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
 Requires explicit retry and watch limits.
 
-**Invoked / loaded by:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `principle-non-blocking-waits`. Any agent (just-in-time)
+**Consumers:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `principle-non-blocking-waits`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 
 Keeps agent interfaces narrow and internal work deep.
 
-**Invoked / loaded by:** cited by `nested-agents`, `team`. Any agent (just-in-time)
+**Consumers:** cited by `nested-agents`, `team`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-evidence-over-assertion](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md)
 
 Requires evidence for claims and verdicts.
 
-**Invoked / loaded by:** cited by `pr-verify`, `groom-backlog`, `pr-open-comments`, `researching-codebases`, `why`, `pr-screenshots`. Any agent (just-in-time)
+**Consumers:** cited by `pr-verify`, `groom-backlog`, `pr-open-comments`, `researching-codebases`, `why`, `pr-screenshots`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-explicit-intent](https://github.com/bostonaholic/team/blob/main/skills/principle-explicit-intent/SKILL.md)
 
 Requires stated intent for irreversible actions.
 
-**Invoked / loaded by:** cited by `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, `groom-backlog`. Any agent (just-in-time)
+**Consumers:** cited by `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, `groom-backlog`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-fail-closed](https://github.com/bostonaholic/team/blob/main/skills/principle-fail-closed/SKILL.md)
 
 Treats unknown guarantees as failures.
 
-**Invoked / loaded by:** cited by `nested-agents`, `team`, `team-design`, `team-structure`, `principle-optimization-never-dependency`, `pr-screenshots`. Any agent (just-in-time)
+**Consumers:** cited by `nested-agents`, `team`, `team-design`, `team-structure`, `principle-optimization-never-dependency`, `pr-screenshots`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
 Requires durable files for cross-step state.
 
-**Invoked / loaded by:** cited by `qrspi-workflow`, `team`, `artifact-frontmatter`. Any agent (just-in-time)
+**Consumers:** cited by `qrspi-workflow`, `team`, `artifact-frontmatter`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-fix-root-causes](https://github.com/bostonaholic/team/blob/main/skills/principle-fix-root-causes/SKILL.md)
 
 Requires diagnosis and repair of root causes.
 
-**Invoked / loaded by:** cited by `systematic-debugging`, `test-driven-bug-fix`, `implementing-slices`, `team-fix`, `no-comments`. Any agent (just-in-time)
+**Consumers:** cited by `systematic-debugging`, `test-driven-bug-fix`, `implementing-slices`, `team-fix`, `no-comments`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
 Separates producers from evaluators.
 
-**Invoked / loaded by:** cited by `reviewing-code`, `eng-design-doc-review`, `nested-agents`, `pr-watch-as-reviewer`, `principle-blind-the-investigator`, `how`. Any agent (just-in-time)
+**Consumers:** cited by `reviewing-code`, `eng-design-doc-review`, `nested-agents`, `pr-watch-as-reviewer`, `principle-blind-the-investigator`, `how`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
 Reserves goals and shipping decisions for the user.
 
-**Invoked / loaded by:** cited by `review-severity-tiers`, `qrspi-workflow`. Any agent (just-in-time)
+**Consumers:** cited by `review-severity-tiers`, `qrspi-workflow`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-idempotent-reruns](https://github.com/bostonaholic/team/blob/main/skills/principle-idempotent-reruns/SKILL.md)
 
 Requires reruns to converge without duplicate effects.
 
-**Invoked / loaded by:** cited by `pr-cleanup`, `groom-backlog`, `team`, `pr-watch-as-author`, `team-design`, `principle-pre-image-first`. Any agent (just-in-time)
+**Consumers:** cited by `pr-cleanup`, `groom-backlog`, `team`, `pr-watch-as-author`, `team-design`, `principle-pre-image-first`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-least-privilege](https://github.com/bostonaholic/team/blob/main/skills/principle-least-privilege/SKILL.md)
 
 Limits tools, credentials, and environment to the task.
 
-**Invoked / loaded by:** cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time)
+**Consumers:** cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-mechanical-gates](https://github.com/bostonaholic/team/blob/main/skills/principle-mechanical-gates/SKILL.md)
 
 Requires deterministic enforcement for reliable rules.
 
-**Invoked / loaded by:** cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time)
+**Consumers:** cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-never-interpolate](https://github.com/bostonaholic/team/blob/main/skills/principle-never-interpolate/SKILL.md)
 
 Keeps external text out of shell syntax.
 
-**Invoked / loaded by:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`, `pr-screenshots`, `team-pr`. Any agent (just-in-time)
+**Consumers:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`, `pr-screenshots`, `team-pr`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-non-blocking-waits](https://github.com/bostonaholic/team/blob/main/skills/principle-non-blocking-waits/SKILL.md)
 
 Requires resumable waits for external state.
 
-**Invoked / loaded by:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time)
+**Consumers:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
 Keeps optional enhancements off the correctness path.
 
-**Invoked / loaded by:** cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`, `pr-screenshots`. Any agent (just-in-time)
+**Consumers:** cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`, `pr-screenshots`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
 Requires a written plan and user approval before mutations.
 
-**Invoked / loaded by:** cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time)
+**Consumers:** cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-pre-image-first](https://github.com/bostonaholic/team/blob/main/skills/principle-pre-image-first/SKILL.md)
 
 Requires a recoverable baseline before destructive changes.
 
-**Invoked / loaded by:** cited by `pr-rebase`, `groom-backlog`, `reflect`, `running-quality-checks`. Any agent (just-in-time)
+**Consumers:** cited by `pr-rebase`, `groom-backlog`, `reflect`, `running-quality-checks`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
 Records autonomous resolutions as assumptions.
 
-**Invoked / loaded by:** cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time)
+**Consumers:** cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
 Restricts execution to approved scope.
 
-**Invoked / loaded by:** cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time)
+**Consumers:** cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
 Requires one authoritative definition per rule or schema.
 
-**Invoked / loaded by:** cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time)
+**Consumers:** cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-skip-loudly](https://github.com/bostonaholic/team/blob/main/skills/principle-skip-loudly/SKILL.md)
 
 Requires skipped work to be reported explicitly.
 
-**Invoked / loaded by:** cited by `reviewing-code`, `sweeping-local-state`, `groom-backlog`, `cross-model-review`, `principle-optimization-never-dependency`, `principle-scope-fence`, `pr-screenshots`, `why`, and the `code-reviewer` agent. Any agent (just-in-time)
+**Consumers:** cited by `reviewing-code`, `sweeping-local-state`, `groom-backlog`, `cross-model-review`, `principle-optimization-never-dependency`, `principle-scope-fence`, `pr-screenshots`, `why`, and the `code-reviewer` agent. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
 Requires removal before addition.
 
-**Invoked / loaded by:** cited by `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, `authoring-designs`. Any agent (just-in-time)
+**Consumers:** cited by `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, `authoring-designs`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
 Treats external text as inert data.
 
-**Invoked / loaded by:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`, `pr-screenshots`. Any agent (just-in-time)
+**Consumers:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`, `pr-screenshots`. Any agent (just-in-time)
 
-**Phase / context:** Any (cross-cutting principle)
+**Context:** Any (cross-cutting principle)
 
 ## Name-collision pairs
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,23 +17,22 @@ nav_label: skills
 > `SKILL.md`, the `SKILL.md` wins.
 
 Each entry starts with one sentence copied from that skill's frontmatter
-`description`. `**Consumers:**` lists its consumers. `**Context:**` names where
-it applies. A `**Loads:**` list follows
-when the skill's own `.md` files instruct a load of another skill. The load form
-is ``Call the Skill tool with `<name>` ``. Naming a skill another way is a
+`description`. `**Calls:**` lists the skills it loads. `**Callers:**` lists
+the inverse: skills that load it. `None` means no skill does. The load form is
+``Call the Skill tool with `<name>` ``. Naming a skill another way is a
 citation, not an edge. For example, `team-structure` restates a
 `principle-fail-closed` rule inline but does not load it.
 
 The edges are therefore **directed**, and reading them transitively gives the
 graph. `team-implement` loads `team-pr`, which loads `git-commit`, which
 loads `writing-prose`. None of the three loads back. An entry with no
-`**Loads:**` block is a leaf: it loads nothing, which is the normal shape for
+`**Calls:**` block is a leaf: it loads nothing, which is the normal shape for
 a `principle-*` skill and for a methodology skill that states one rule and
 stops.
 
 Loads are collected across every `.md` file in the skill's directory, so a
 load written in a `references/` file counts the same as one in `SKILL.md`.
-This page carries each skill's consumers, context, and skill-to-skill edges.
+This page carries both directions of each skill-to-skill load edge.
 For what separates a load from a citation, and for how a skill is loaded, see
 [architecture.md §6](architecture.md#6-skills).
 
@@ -46,11 +45,9 @@ full run or drives one phase of the QRSPI pipeline.
 
 Runs the 8-phase QRSPI feature pipeline.
 
-**Consumers:** orchestrator (runs the pipeline)
+**Callers:** None
 
-**Context:** All phases
-
-**Loads:**
+**Calls:**
 
 - `changelog`
 - `cross-model-review`
@@ -66,27 +63,21 @@ Runs the 8-phase QRSPI feature pipeline.
 
 Decomposes a feature into task and question artifacts.
 
-**Consumers:** orchestrator
-
-**Context:** Question
+**Callers:** None
 
 ### [team-research](https://github.com/bostonaholic/team/blob/main/skills/team-research/SKILL.md)
 
 Researches a codebase area before changes.
 
-**Consumers:** orchestrator → researcher, file-finder
-
-**Context:** Research
+**Callers:** None
 
 ### [team-design](https://github.com/bostonaholic/team/blob/main/skills/team-design/SKILL.md)
 
 Drafts and adversarially reviews a design.
 
-**Consumers:** orchestrator → design-author
+**Callers:** None
 
-**Context:** Design (design review)
-
-**Loads:**
+**Calls:**
 
 - `cross-model-review`
 - `reviewing-designs`
@@ -95,35 +86,27 @@ Drafts and adversarially reviews a design.
 
 Breaks a reviewed design into verified slices.
 
-**Consumers:** orchestrator → structure-planner
-
-**Context:** Structure (autonomous)
+**Callers:** None
 
 ### [team-plan](https://github.com/bostonaholic/team/blob/main/skills/team-plan/SKILL.md)
 
 Produces the tactical implementation plan.
 
-**Consumers:** orchestrator → planner
-
-**Context:** Plan
+**Callers:** None
 
 ### [team-worktree](https://github.com/bostonaholic/team/blob/main/skills/team-worktree/SKILL.md)
 
 Prepares isolated git worktrees.
 
-**Consumers:** orchestrator
-
-**Context:** Worktree
+**Callers:** `team`, `team-fix`, `worktree-isolation`
 
 ### [team-implement](https://github.com/bostonaholic/team/blob/main/skills/team-implement/SKILL.md)
 
 Executes and verifies implementation slices.
 
-**Consumers:** orchestrator → implementer + reviewers
+**Callers:** None
 
-**Context:** Implement
-
-**Loads:**
+**Calls:**
 
 - `review-severity-tiers`
 - `running-quality-checks`
@@ -133,11 +116,9 @@ Executes and verifies implementation slices.
 
 Opens a pull request after verification.
 
-**Consumers:** orchestrator
+**Callers:** `team`, `team-implement`
 
-**Context:** PR
-
-**Loads:**
+**Calls:**
 
 - `changelog`
 - `git-commit`
@@ -151,11 +132,9 @@ Opens a pull request after verification.
 
 Runs the compressed bug-fix pipeline.
 
-**Consumers:** user or model (direct invocation, on explicit pipeline intent)
+**Callers:** None
 
-**Context:** Compressed bug-fix flow (outside QRSPI)
-
-**Loads:**
+**Calls:**
 
 - `systematic-debugging`
 - `team-worktree`
@@ -168,11 +147,9 @@ Runs the compressed bug-fix pipeline.
 
 Reviews a technical design document with fresh context.
 
-**Consumers:** user (direct invocation)
+**Callers:** None
 
-**Context:** Front door over the `reviewing-designs` brief: standalone audit. Dispatches a read-only Explore subagent
-
-**Loads:**
+**Calls:**
 
 - `cross-model-review`
 - `reviewing-designs`
@@ -187,19 +164,15 @@ QRSPI phase: a self-contained action a user runs on demand.
 
 Lands a reviewed pull request.
 
-**Consumers:** user or model (direct invocation, on explicit ship intent)
-
-**Context:** Standalone: land a reviewed PR
+**Callers:** None
 
 ### [pr-open-comments](https://github.com/bostonaholic/team/blob/main/skills/pr-open-comments/SKILL.md)
 
 Triages unresolved PR review comments.
 
-**Consumers:** user or model (direct invocation)
+**Callers:** `pr-watch-as-author`
 
-**Context:** Standalone: triage unresolved PR review feedback
-
-**Loads:**
+**Calls:**
 
 - `decision-making`
 
@@ -207,11 +180,9 @@ Triages unresolved PR review comments.
 
 Watches an authored PR for feedback.
 
-**Consumers:** user or model (direct invocation)
+**Callers:** None
 
-**Context:** Standalone: bounded PR review watch loop
-
-**Loads:**
+**Calls:**
 
 - `pr-open-comments`
 - `pr-watch-mechanics`
@@ -221,11 +192,9 @@ Watches an authored PR for feedback.
 
 Watches a reviewed PR and approves settled feedback.
 
-**Consumers:** user (direct invocation)
+**Callers:** None
 
-**Context:** Standalone: reviewer-side watch-and-approve
-
-**Loads:**
+**Calls:**
 
 - `pr-watch-mechanics`
 
@@ -233,11 +202,9 @@ Watches a reviewed PR and approves settled feedback.
 
 Grooms a project backlog and proposes tracker changes.
 
-**Consumers:** user or model (direct invocation)
+**Callers:** None
 
-**Context:** Standalone: groom a project backlog
-
-**Loads:**
+**Calls:**
 
 - `decision-making`
 
@@ -245,19 +212,15 @@ Grooms a project backlog and proposes tracker changes.
 
 Cleans PR state.
 
-**Consumers:** user or model (direct invocation; Mode B only on explicit abandon intent)
-
-**Context:** Standalone: post-PR teardown
+**Callers:** None
 
 ### [pr-verify](https://github.com/bostonaholic/team/blob/main/skills/pr-verify/SKILL.md)
 
 Verifies a PR test plan with evidence-rated verdicts.
 
-**Consumers:** user or model (direct invocation)
+**Callers:** None
 
-**Context:** Standalone: test-plan verification
-
-**Loads:**
+**Calls:**
 
 - `running-quality-checks`
 
@@ -265,19 +228,15 @@ Verifies a PR test plan with evidence-rated verdicts.
 
 Attaches local images to a PR body.
 
-**Consumers:** user or model (direct invocation, on explicit intent)
-
-**Context:** Standalone: attach local images to a PR body
+**Callers:** `team-pr`
 
 ### [pr-rebase](https://github.com/bostonaholic/team/blob/main/skills/pr-rebase/SKILL.md)
 
 Rebases a branch onto its base.
 
-**Consumers:** user (direct invocation, on explicit rebase intent; model invocation disabled)
+**Callers:** None
 
-**Context:** Standalone: rebase a branch onto its base
-
-**Loads:**
+**Calls:**
 
 - `running-quality-checks`
 
@@ -285,11 +244,9 @@ Rebases a branch onto its base.
 
 Mines a session for durable learnings.
 
-**Consumers:** user (direct invocation, on explicit reflection intent; model invocation disabled)
+**Callers:** None
 
-**Context:** Standalone: mine the session transcript for durable learnings
-
-**Loads:**
+**Calls:**
 
 - `running-quality-checks`
 
@@ -297,11 +254,9 @@ Mines a session for durable learnings.
 
 Investigates design rationale behind code.
 
-**Consumers:** user or model (direct invocation). `team-fix` and `reviewing-code` (conditional load)
+**Callers:** `how`, `reviewing-code`, `team-fix`
 
-**Context:** Standalone: design-rationale investigation. Dispatches read-only Explore investigators
-
-**Loads:**
+**Calls:**
 
 - `systematic-debugging`
 
@@ -309,11 +264,9 @@ Investigates design rationale behind code.
 
 Explains subsystem architecture and runtime flow.
 
-**Consumers:** user or model (direct invocation)
+**Callers:** None
 
-**Context:** Standalone: architectural explanation + optional critique. Dispatches read-only Explore explorers
-
-**Loads:**
+**Calls:**
 
 - `why`
 
@@ -321,11 +274,9 @@ Explains subsystem architecture and runtime flow.
 
 Reviews a diff with fresh context.
 
-**Consumers:** user or model (direct invocation)
+**Callers:** None
 
-**Context:** Standalone: dispatch a fresh-context code review
-
-**Loads:**
+**Calls:**
 
 - `reviewing-code`
 
@@ -333,11 +284,9 @@ Reviews a diff with fresh context.
 
 Removes low-value source comments and encodes valid constraints.
 
-**Consumers:** user (direct invocation; model invocation disabled)
+**Callers:** None
 
-**Context:** Standalone: comment cleanup
-
-**Loads:**
+**Calls:**
 
 - `principle-fix-root-causes`
 - `principle-progress-tracking`
@@ -353,43 +302,33 @@ them.
 
 Defines QRSPI phases, artifacts, gates, and state transitions.
 
-**Consumers:** orchestrator skills
-
-**Context:** All phases
+**Callers:** None
 
 ### [artifact-frontmatter](https://github.com/bostonaholic/team/blob/main/skills/artifact-frontmatter/SKILL.md)
 
 Defines pipeline artifact schemas.
 
-**Consumers:** orchestrator skills. Artifact authors (just-in-time through pointers)
-
-**Context:** All phases: artifact schema
+**Callers:** None
 
 ### [researching-codebases](https://github.com/bostonaholic/team/blob/main/skills/researching-codebases/SKILL.md)
 
 Defines evidence-only codebase research and `5-research.md`.
 
-**Consumers:** researcher
-
-**Context:** Research
+**Callers:** None
 
 ### [finding-files](https://github.com/bostonaholic/team/blob/main/skills/finding-files/SKILL.md)
 
 Locates files by naming, structure, and imports.
 
-**Consumers:** file-finder
-
-**Context:** Research
+**Callers:** None
 
 ### [decomposing-intent](https://github.com/bostonaholic/team/blob/main/skills/decomposing-intent/SKILL.md)
 
 Defines task and question artifacts plus multi-repo detection.
 
-**Consumers:** questioner
+**Callers:** None
 
-**Context:** Question
-
-**Loads:**
+**Calls:**
 
 - `product-requirements-doc`
 
@@ -397,11 +336,9 @@ Defines task and question artifacts plus multi-repo detection.
 
 Defines the design-document procedure.
 
-**Consumers:** design-author
+**Callers:** None
 
-**Context:** Design
-
-**Loads:**
+**Calls:**
 
 - `decision-making`
 - `systems-thinking`
@@ -411,11 +348,9 @@ Defines the design-document procedure.
 
 Defines vertical slices and verification checkpoints.
 
-**Consumers:** structure-planner
+**Callers:** None
 
-**Context:** Structure
-
-**Loads:**
+**Calls:**
 
 - `decision-making`
 
@@ -423,19 +358,15 @@ Defines vertical slices and verification checkpoints.
 
 Defines the tactical plan schema.
 
-**Consumers:** planner
-
-**Context:** Plan
+**Callers:** None
 
 ### [reviewing-code](https://github.com/bostonaholic/team/blob/main/skills/reviewing-code/SKILL.md)
 
 Defines adversarial code review and evidence-based findings.
 
-**Consumers:** code-reviewer, security-reviewer, ux-reviewer, technical-writer. `code-review` (front door). `reviewing-designs` read-only Explore reviewer
+**Callers:** `code-review`, `reviewing-designs`
 
-**Context:** Implement (verify), and Design (review gate)
-
-**Loads:**
+**Calls:**
 
 - `engineering-standards`
 - `review-severity-tiers`
@@ -447,11 +378,9 @@ Defines adversarial code review and evidence-based findings.
 
 Defines fresh-context source-comment review and findings.
 
-**Consumers:** `no-comments` (direct load for read-only Explore review)
+**Callers:** `no-comments`
 
-**Context:** Standalone: source-comment review methodology
-
-**Loads:**
+**Calls:**
 
 - `engineering-standards`
 
@@ -459,11 +388,9 @@ Defines fresh-context source-comment review and findings.
 
 Defines adversarial design review and verdicts.
 
-**Consumers:** orchestrator or invoking session (team, team-design, eng-design-doc-review) — the brief a read-only Explore subagent runs
+**Callers:** `eng-design-doc-review`, `team`, `team-design`
 
-**Context:** Design (review-gate brief)
-
-**Loads:**
+**Calls:**
 
 - `conventional-comments`
 - `cross-model-review`
@@ -477,67 +404,51 @@ Defines adversarial design review and verdicts.
 
 Defines review labels and decorations.
 
-**Consumers:** code-reviewer, security-reviewer, technical-writer. `reviewing-designs` read-only Explore reviewer
-
-**Context:** Implement (verify): finding format, and Design (review gate): finding format
+**Callers:** `reviewing-designs`
 
 ### [reviewing-security](https://github.com/bostonaholic/team/blob/main/skills/reviewing-security/SKILL.md)
 
 Defines threat and OWASP review with evidence-rated findings.
 
-**Consumers:** security-reviewer
-
-**Context:** Implement (verify)
+**Callers:** None
 
 ### [cross-model-review](https://github.com/bostonaholic/team/blob/main/skills/cross-model-review/SKILL.md)
 
 Runs second-vendor reviews through machine-only CLI adapters.
 
-**Consumers:** code-reviewer. Orchestrator or invoking session (team, team-design, eng-design-doc-review) through `## Design-review pass`. Design-review brief (conditional, on `## External review input`). `reviewing-designs` read-only Explore reviewer (conditional, on `## External review input`)
-
-**Context:** Implement (verify), and Design (review gate)
+**Callers:** `eng-design-doc-review`, `reviewing-designs`, `team`, `team-design`
 
 ### [review-severity-tiers](https://github.com/bostonaholic/team/blob/main/skills/review-severity-tiers/SKILL.md)
 
 Maps reviewer findings to Blocking, Major, or Minor actions.
 
-**Consumers:** orchestrator (team, team-implement, qrspi-workflow)
-
-**Context:** Implement (aggregate review gate)
+**Callers:** `reviewing-code`, `team`, `team-implement`
 
 ### [engineering-standards](https://github.com/bostonaholic/team/blob/main/skills/engineering-standards/SKILL.md)
 
 Defines code design, comment, and review standards.
 
-**Consumers:** planner, implementer, code-reviewer. `reviewing-designs` read-only Explore reviewer
-
-**Context:** Plan, Implement, and Design (review gate)
+**Callers:** `reviewing-code`, `reviewing-comments`, `reviewing-designs`
 
 ### [test-first-development](https://github.com/bostonaholic/team/blob/main/skills/test-first-development/SKILL.md)
 
 Defines acceptance tests as the implementation scope contract.
 
-**Consumers:** test-architect, code-reviewer. Orchestrator
-
-**Context:** Implement
+**Callers:** None
 
 ### [test-style](https://github.com/bostonaholic/team/blob/main/skills/test-style/SKILL.md)
 
 Defines deterministic behavioral tests and flaky-test red flags.
 
-**Consumers:** test-architect, code-reviewer (just-in-time through pointers)
-
-**Context:** Implement
+**Callers:** `reviewing-code`
 
 ### [test-driven-bug-fix](https://github.com/bostonaholic/team/blob/main/skills/test-driven-bug-fix/SKILL.md)
 
 Defines reproduce-red-green-refactor bug fixes.
 
-**Consumers:** team-fix
+**Callers:** `team-fix`
 
-**Context:** Bug-fix flow
-
-**Loads:**
+**Calls:**
 
 - `systematic-debugging`
 
@@ -545,27 +456,21 @@ Defines reproduce-red-green-refactor bug fixes.
 
 Defines SOLID design and review rules.
 
-**Consumers:** implementer, code-reviewer. `engineering-standards`, `reviewing-code` (citing skills)
-
-**Context:** Implement
+**Callers:** None
 
 ### [refactoring-to-patterns](https://github.com/bostonaholic/team/blob/main/skills/refactoring-to-patterns/SKILL.md)
 
 Maps code smells to behavior-preserving refactorings.
 
-**Consumers:** implementer
-
-**Context:** Implement
+**Callers:** None
 
 ### [implementing-slices](https://github.com/bostonaholic/team/blob/main/skills/implementing-slices/SKILL.md)
 
 Defines test-first slice execution, commits, and review fixes.
 
-**Consumers:** implementer
+**Callers:** None
 
-**Context:** Implement
-
-**Loads:**
+**Calls:**
 
 - `git-commit`
 - `principle-fix-root-causes`
@@ -575,51 +480,39 @@ Defines test-first slice execution, commits, and review fixes.
 
 Defines reproduce, hypothesize, isolate, and fix workflow.
 
-**Consumers:** implementer (inline Load on non-obvious failures). Other agents when debugging (advisory)
-
-**Context:** Implement, and Any (debugging)
+**Callers:** `implementing-slices`, `team-fix`, `test-driven-bug-fix`, `why`
 
 ### [running-quality-checks](https://github.com/bostonaholic/team/blob/main/skills/running-quality-checks/SKILL.md)
 
 Runs project-native tests, static checks, builds, and linters.
 
-**Consumers:** verifier. reflect (after the writes)
-
-**Context:** Implement (verify), and Any (reflect)
+**Callers:** `no-comments`, `pr-rebase`, `pr-verify`, `reflect`, `team`, `team-implement`
 
 ### [principle-progress-tracking](https://github.com/bostonaholic/team/blob/main/skills/principle-progress-tracking/SKILL.md)
 
 Requires one live ledger for ordered procedures.
 
-**Consumers:** every multi-step agent; cited by `team`, `team-implement`, `team-fix`, `pr-screenshots`, `no-comments`
-
-**Context:** Any (multi-step procedure)
+**Callers:** `no-comments`
 
 ### [nested-agents](https://github.com/bostonaholic/team/blob/main/skills/nested-agents/SKILL.md)
 
 Defines safe nested-agent dispatch and fallback.
 
-**Consumers:** researcher, implementer, code-reviewer, security-reviewer
-
-**Context:** Research, Implement (scouts + skeptic passes)
+**Callers:** None
 
 ### [decision-making](https://github.com/bostonaholic/team/blob/main/skills/decision-making/SKILL.md)
 
 Defines a decision method based on reversibility and risk.
 
-**Consumers:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
-
-**Context:** Design, Structure, Plan, and standalone recommendations
+**Callers:** `authoring-designs`, `documenting-decisions`, `groom-backlog`, `pr-open-comments`, `slicing-work`, `technical-design-doc`
 
 ### [documenting-decisions](https://github.com/bostonaholic/team/blob/main/skills/documenting-decisions/SKILL.md)
 
 Defines ADR structure and lifecycle.
 
-**Consumers:** planner, orchestrator (advisory). `reviewing-designs` read-only Explore reviewer
+**Callers:** `reviewing-designs`
 
-**Context:** Any (when decisions are recorded), and Design (review gate)
-
-**Loads:**
+**Calls:**
 
 - `decision-making`
 - `writing-prose`
@@ -628,11 +521,9 @@ Defines ADR structure and lifecycle.
 
 Defines technical design sections and decision content.
 
-**Consumers:** planner. `reviewing-designs` read-only Explore reviewer
+**Callers:** `reviewing-designs`
 
-**Context:** Plan, and Design (review gate)
-
-**Loads:**
+**Calls:**
 
 - `decision-making`
 - `writing-prose`
@@ -641,11 +532,9 @@ Defines technical design sections and decision content.
 
 Defines when and how to write `3-prd.md`.
 
-**Consumers:** questioner (through `decomposing-intent`, conditional). Design-author (through `authoring-designs`)
+**Callers:** `decomposing-intent`
 
-**Context:** Question, Design
-
-**Loads:**
+**Calls:**
 
 - `writing-prose`
 
@@ -653,51 +542,39 @@ Defines when and how to write `3-prd.md`.
 
 Defines product-need lenses.
 
-**Consumers:** questioner, design-author, structure-planner
-
-**Context:** Question, Design, Structure
+**Callers:** None
 
 ### [systems-thinking](https://github.com/bostonaholic/team/blob/main/skills/systems-thinking/SKILL.md)
 
 Defines system-boundary, feedback, and dependency analysis.
 
-**Consumers:** researcher, structure-planner, planner (frontmatter). Implementer, code-reviewer, ux-reviewer (inline). Authoring-designs, nested-agents (citing skills)
-
-**Context:** Research, Design, Structure, Plan, Implement (incl. verify)
+**Callers:** `authoring-designs`
 
 ### [writing-prose](https://github.com/bostonaholic/team/blob/main/skills/writing-prose/SKILL.md)
 
 Defines plain-language prose rules.
 
-**Consumers:** technical-writer, design-author. `reviewing-designs` read-only Explore reviewer
-
-**Context:** Design (authoring bar), and Implement (verify): bar for prose it writes and prose it assesses. Design (review gate): prose bar
+**Callers:** `authoring-designs`, `changelog`, `documenting-decisions`, `eng-design-doc-review`, `git-commit`, `product-requirements-doc`, `reviewing-code`, `reviewing-designs`, `team-pr`, `technical-design-doc`
 
 ### [reviewing-documentation](https://github.com/bostonaholic/team/blob/main/skills/reviewing-documentation/SKILL.md)
 
 Defines documentation-gap review and REQUIRED/RECOMMENDED findings.
 
-**Consumers:** technical-writer
-
-**Context:** Implement (verify): doc-gap review process + classification
+**Callers:** None
 
 ### [verifying-ux](https://github.com/bostonaholic/team/blob/main/skills/verifying-ux/SKILL.md)
 
 Defines live application and screenshot verification.
 
-**Consumers:** ux-reviewer
-
-**Context:** Implement (verify)
+**Callers:** `team-pr`
 
 ### [git-commit](https://github.com/bostonaholic/team/blob/main/skills/git-commit/SKILL.md)
 
 Defines Conventional Commit subjects and safe commit procedure.
 
-**Consumers:** team-pr. Implementer (through `implementing-slices`)
+**Callers:** `implementing-slices`, `team-pr`
 
-**Context:** PR, and Implement (slice commits)
-
-**Loads:**
+**Calls:**
 
 - `writing-prose`
 
@@ -705,11 +582,9 @@ Defines Conventional Commit subjects and safe commit procedure.
 
 Defines Keep a Changelog updates.
 
-**Consumers:** team, team-pr
+**Callers:** `team`, `team-pr`
 
-**Context:** PR
-
-**Loads:**
+**Calls:**
 
 - `writing-prose`
 
@@ -717,19 +592,15 @@ Defines Keep a Changelog updates.
 
 Defines tracker status transitions and closing rules.
 
-**Consumers:** orchestrator (team, team-pr, team-fix, just-in-time through pointers)
-
-**Context:** Setup (ticket pickup), and PR (ticket link + state)
+**Callers:** `pr-watch-as-author`, `team`, `team-fix`, `team-pr`
 
 ### [worktree-isolation](https://github.com/bostonaholic/team/blob/main/skills/worktree-isolation/SKILL.md)
 
 Defines Team worktree creation, validation, and teardown.
 
-**Consumers:** orchestrator (team, team-worktree)
+**Callers:** `team`, `team-fix`, `team-pr`
 
-**Context:** Worktree
-
-**Loads:**
+**Calls:**
 
 - `team-worktree`
 
@@ -737,209 +608,157 @@ Defines Team worktree creation, validation, and teardown.
 
 Defines machine-local teardown.
 
-**Consumers:** `pr-cleanup`, `worktree-isolation` (both inline)
-
-**Context:** Standalone: teardown after a merged PR, a closed PR, or a completed review
+**Callers:** None
 
 ### [pr-watch-mechanics](https://github.com/bostonaholic/team/blob/main/skills/pr-watch-mechanics/SKILL.md)
 
 Bounded watch-loop mechanics for the pr-watch skills: cycle timing, soft cap, handoff.
 
-**Consumers:** `pr-watch-as-author`, `pr-watch-as-reviewer` (both through the bounded-cycle-mechanics reference)
-
-**Context:** Standalone: bounded watch-loop mechanics
+**Callers:** `pr-watch-as-author`, `pr-watch-as-reviewer`
 
 ### [principle-blind-the-investigator](https://github.com/bostonaholic/team/blob/main/skills/principle-blind-the-investigator/SKILL.md)
 
 Keeps desired outcomes out of research prompts.
 
-**Consumers:** cited by `qrspi-workflow`, `nested-agents`, `decomposing-intent`, `researching-codebases`, `why`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-bounded-loops](https://github.com/bostonaholic/team/blob/main/skills/principle-bounded-loops/SKILL.md)
 
 Requires explicit retry and watch limits.
 
-**Consumers:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `principle-non-blocking-waits`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-deep-agents-narrow-seams](https://github.com/bostonaholic/team/blob/main/skills/principle-deep-agents-narrow-seams/SKILL.md)
 
 Keeps agent interfaces narrow and internal work deep.
 
-**Consumers:** cited by `nested-agents`, `team`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-evidence-over-assertion](https://github.com/bostonaholic/team/blob/main/skills/principle-evidence-over-assertion/SKILL.md)
 
 Requires evidence for claims and verdicts.
 
-**Consumers:** cited by `pr-verify`, `groom-backlog`, `pr-open-comments`, `researching-codebases`, `why`, `pr-screenshots`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-explicit-intent](https://github.com/bostonaholic/team/blob/main/skills/principle-explicit-intent/SKILL.md)
 
 Requires stated intent for irreversible actions.
 
-**Consumers:** cited by `shipit`, `pr-rebase`, `pr-cleanup`, `team-fix`, `reflect`, `groom-backlog`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-fail-closed](https://github.com/bostonaholic/team/blob/main/skills/principle-fail-closed/SKILL.md)
 
 Treats unknown guarantees as failures.
 
-**Consumers:** cited by `nested-agents`, `team`, `team-design`, `team-structure`, `principle-optimization-never-dependency`, `pr-screenshots`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-files-are-the-contract](https://github.com/bostonaholic/team/blob/main/skills/principle-files-are-the-contract/SKILL.md)
 
 Requires durable files for cross-step state.
 
-**Consumers:** cited by `qrspi-workflow`, `team`, `artifact-frontmatter`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-fix-root-causes](https://github.com/bostonaholic/team/blob/main/skills/principle-fix-root-causes/SKILL.md)
 
 Requires diagnosis and repair of root causes.
 
-**Consumers:** cited by `systematic-debugging`, `test-driven-bug-fix`, `implementing-slices`, `team-fix`, `no-comments`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** `implementing-slices`, `no-comments`
 
 ### [principle-generator-evaluator](https://github.com/bostonaholic/team/blob/main/skills/principle-generator-evaluator/SKILL.md)
 
 Separates producers from evaluators.
 
-**Consumers:** cited by `reviewing-code`, `eng-design-doc-review`, `nested-agents`, `pr-watch-as-reviewer`, `principle-blind-the-investigator`, `how`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-human-owns-the-ends](https://github.com/bostonaholic/team/blob/main/skills/principle-human-owns-the-ends/SKILL.md)
 
 Reserves goals and shipping decisions for the user.
 
-**Consumers:** cited by `review-severity-tiers`, `qrspi-workflow`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-idempotent-reruns](https://github.com/bostonaholic/team/blob/main/skills/principle-idempotent-reruns/SKILL.md)
 
 Requires reruns to converge without duplicate effects.
 
-**Consumers:** cited by `pr-cleanup`, `groom-backlog`, `team`, `pr-watch-as-author`, `team-design`, `principle-pre-image-first`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-least-privilege](https://github.com/bostonaholic/team/blob/main/skills/principle-least-privilege/SKILL.md)
 
 Limits tools, credentials, and environment to the task.
 
-**Consumers:** cited by `reviewing-code`, `reflect`, `eng-design-doc-review`, `cross-model-review`, `pr-verify`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-mechanical-gates](https://github.com/bostonaholic/team/blob/main/skills/principle-mechanical-gates/SKILL.md)
 
 Requires deterministic enforcement for reliable rules.
 
-**Consumers:** cited by `qrspi-workflow`, `test-first-development`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-never-interpolate](https://github.com/bostonaholic/team/blob/main/skills/principle-never-interpolate/SKILL.md)
 
 Keeps external text out of shell syntax.
 
-**Consumers:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `sweeping-local-state`, `decomposing-intent`, `cross-model-review`, `pr-screenshots`, `team-pr`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-non-blocking-waits](https://github.com/bostonaholic/team/blob/main/skills/principle-non-blocking-waits/SKILL.md)
 
 Requires resumable waits for external state.
 
-**Consumers:** cited by `pr-watch-as-author`, `pr-watch-as-reviewer`, `pr-watch-mechanics`, `shipit`, `cross-model-review`, `pr-rebase`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-optimization-never-dependency](https://github.com/bostonaholic/team/blob/main/skills/principle-optimization-never-dependency/SKILL.md)
 
 Keeps optional enhancements off the correctness path.
 
-**Consumers:** cited by `nested-agents`, `cross-model-review`, `team-pr`, `pr-verify`, `reflect`, `principle-fail-closed`, `why`, `how`, `pr-screenshots`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-plan-present-wait](https://github.com/bostonaholic/team/blob/main/skills/principle-plan-present-wait/SKILL.md)
 
 Requires a written plan and user approval before mutations.
 
-**Consumers:** cited by `groom-backlog`, `pr-open-comments`, `reflect`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-pre-image-first](https://github.com/bostonaholic/team/blob/main/skills/principle-pre-image-first/SKILL.md)
 
 Requires a recoverable baseline before destructive changes.
 
-**Consumers:** cited by `pr-rebase`, `groom-backlog`, `reflect`, `running-quality-checks`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-record-assumptions](https://github.com/bostonaholic/team/blob/main/skills/principle-record-assumptions/SKILL.md)
 
 Records autonomous resolutions as assumptions.
 
-**Consumers:** cited by `authoring-designs`, `decomposing-intent`, `nested-agents`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-scope-fence](https://github.com/bostonaholic/team/blob/main/skills/principle-scope-fence/SKILL.md)
 
 Restricts execution to approved scope.
 
-**Consumers:** cited by `implementing-slices`, `qrspi-workflow`, `test-first-development`, `principle-subtract-before-you-add`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-single-source-of-truth](https://github.com/bostonaholic/team/blob/main/skills/principle-single-source-of-truth/SKILL.md)
 
 Requires one authoritative definition per rule or schema.
 
-**Consumers:** cited by `qrspi-workflow`, `artifact-frontmatter`, `cross-model-review`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-skip-loudly](https://github.com/bostonaholic/team/blob/main/skills/principle-skip-loudly/SKILL.md)
 
 Requires skipped work to be reported explicitly.
 
-**Consumers:** cited by `reviewing-code`, `sweeping-local-state`, `groom-backlog`, `cross-model-review`, `principle-optimization-never-dependency`, `principle-scope-fence`, `pr-screenshots`, `why`, and the `code-reviewer` agent. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-subtract-before-you-add](https://github.com/bostonaholic/team/blob/main/skills/principle-subtract-before-you-add/SKILL.md)
 
 Requires removal before addition.
 
-**Consumers:** cited by `engineering-standards`, `implementing-slices`, `refactoring-to-patterns`, `authoring-designs`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ### [principle-untrusted-input-is-data](https://github.com/bostonaholic/team/blob/main/skills/principle-untrusted-input-is-data/SKILL.md)
 
 Treats external text as inert data.
 
-**Consumers:** cited by `pr-cleanup`, `pr-rebase`, `groom-backlog`, `cross-model-review`, `pr-watch-as-author`, `reflect`, `why`, `pr-screenshots`. Any agent (just-in-time)
-
-**Context:** Any (cross-cutting principle)
+**Callers:** None
 
 ## Name-collision pairs
 

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -8,31 +8,6 @@ import { loadsSkill } from "./helpers/skill-refs";
 
 const REPO_ROOT = process.cwd();
 
-function catalogConsumerField(page: string, name: string): string {
-  const heading = `### [${name}]`;
-  const start = page.indexOf(heading);
-  if (start === -1) return "";
-  const section = page.slice(start + heading.length);
-  const end = section.search(/\n#{2,3} /);
-  const entry = end === -1 ? section : section.slice(0, end);
-  const line = entry.split("\n").find((value) => value.startsWith("**Consumers:**"));
-  return line?.slice("**Consumers:**".length).trim() ?? "";
-}
-
-function mentions(text: string, name: string): boolean {
-  return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
-}
-
-function consumerContractOffenders(page: string, contracts: Record<string, string[]>): string[] {
-  return Object.entries(contracts).flatMap(([skill, consumers]) => {
-    const field = catalogConsumerField(page, skill);
-    if (field === "") return [`${skill}: consumer field missing or empty`];
-    return consumers
-      .filter((consumer) => !mentions(field, consumer))
-      .map((consumer) => `${skill}: consumer field omits ${consumer}`);
-  });
-}
-
 // Absence check: runs grep through execFileSync. A non-zero exit (grep found
 // nothing) is the PASS and returns true; a zero exit (a match was found)
 // returns false. grep's exit code 2 (a real error, e.g. unreadable path)
@@ -55,7 +30,6 @@ describe("skill architecture", () => {
   const TECHNICAL_WRITER = join(REPO_ROOT, "agents", "technical-writer.md");
   const VERIFIER = join(REPO_ROOT, "agents", "verifier.md");
   const IMPLEMENTER = join(REPO_ROOT, "agents", "implementer.md");
-  const SKILLS_MD = join(REPO_ROOT, "docs", "skills.md");
   const ARCHITECTURE_MD = join(REPO_ROOT, "docs", "architecture.md");
 
   test("code-reviewer references reviewing-code/SKILL.md", () => {
@@ -85,23 +59,6 @@ describe("skill architecture", () => {
     // methodology wherever it lives and must not dispatch a reviewer either.
     expect(read(VERIFIER)).not.toContain("code-review/SKILL.md");
     expect(read(VERIFIER)).not.toContain("reviewing-code/SKILL.md");
-  });
-
-  test("catalog consumer fields satisfy architecture and methodology contracts", () => {
-    expect(
-      consumerContractOffenders(read(SKILLS_MD), {
-        "reviewing-code": [
-          "code-reviewer",
-          "security-reviewer",
-          "ux-reviewer",
-          "technical-writer",
-          "reviewing-designs",
-        ],
-        "engineering-standards": ["planner", "implementer", "code-reviewer", "reviewing-designs"],
-        solid: ["implementer", "code-reviewer", "engineering-standards", "reviewing-code"],
-        "refactoring-to-patterns": ["implementer"],
-      }),
-    ).toEqual([]);
   });
 
   test("extraction threshold documented in docs/architecture.md", () => {

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -15,8 +15,8 @@ function catalogConsumerField(page: string, name: string): string {
   const section = page.slice(start + heading.length);
   const end = section.search(/\n#{2,3} /);
   const entry = end === -1 ? section : section.slice(0, end);
-  const line = entry.split("\n").find((value) => value.startsWith("**Invoked / loaded by:**"));
-  return line?.slice("**Invoked / loaded by:**".length).trim() ?? "";
+  const line = entry.split("\n").find((value) => value.startsWith("**Consumers:**"));
+  return line?.slice("**Consumers:**".length).trim() ?? "";
 }
 
 function mentions(text: string, name: string): boolean {

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -8,15 +8,29 @@ import { loadsSkill } from "./helpers/skill-refs";
 
 const REPO_ROOT = process.cwd();
 
-// Keep lines containing `key`, drop lines matching the `exclude` regex, take
-// the first 5, join. Isolates a single table row from a methodology doc.
-function filterRows(text: string, key: string, exclude: RegExp): string {
-  return text
-    .split("\n")
-    .filter((line) => line.includes(key))
-    .filter((line) => !exclude.test(line))
-    .slice(0, 5)
-    .join("\n");
+function catalogConsumerField(page: string, name: string): string {
+  const heading = `### [${name}]`;
+  const start = page.indexOf(heading);
+  if (start === -1) return "";
+  const section = page.slice(start + heading.length);
+  const end = section.search(/\n#{2,3} /);
+  const entry = end === -1 ? section : section.slice(0, end);
+  const line = entry.split("\n").find((value) => value.startsWith("**Invoked / loaded by:**"));
+  return line?.slice("**Invoked / loaded by:**".length).trim() ?? "";
+}
+
+function mentions(text: string, name: string): boolean {
+  return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
+}
+
+function consumerContractOffenders(page: string, contracts: Record<string, string[]>): string[] {
+  return Object.entries(contracts).flatMap(([skill, consumers]) => {
+    const field = catalogConsumerField(page, skill);
+    if (field === "") return [`${skill}: consumer field missing or empty`];
+    return consumers
+      .filter((consumer) => !mentions(field, consumer))
+      .map((consumer) => `${skill}: consumer field omits ${consumer}`);
+  });
 }
 
 // Absence check: runs grep through execFileSync. A non-zero exit (grep found
@@ -73,13 +87,21 @@ describe("skill architecture", () => {
     expect(read(VERIFIER)).not.toContain("reviewing-code/SKILL.md");
   });
 
-  test("reviewing-code row in docs/skills.md names all 4 consumer agents", () => {
-    // Key on the table-row delimiter so prose mentions of the skill name
-    // elsewhere in the doc cannot crowd the row out of the 5-line window.
-    const row = filterRows(read(SKILLS_MD), "| `reviewing-code` |", /^#|^>|SKILL\.md|\/\/|event/);
-    for (const agent of ["code-reviewer", "security-reviewer", "ux-reviewer", "technical-writer"]) {
-      expect(row).toContain(agent);
-    }
+  test("catalog consumer fields satisfy architecture and methodology contracts", () => {
+    expect(
+      consumerContractOffenders(read(SKILLS_MD), {
+        "reviewing-code": [
+          "code-reviewer",
+          "security-reviewer",
+          "ux-reviewer",
+          "technical-writer",
+          "reviewing-designs",
+        ],
+        "engineering-standards": ["planner", "implementer", "code-reviewer", "reviewing-designs"],
+        solid: ["implementer", "code-reviewer", "engineering-standards", "reviewing-code"],
+        "refactoring-to-patterns": ["implementer"],
+      }),
+    ).toEqual([]);
   });
 
   test("extraction threshold documented in docs/architecture.md", () => {

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -56,12 +56,6 @@ type Entry = {
 
 type EntryDraft = Pick<Entry, "name" | "section" | "body">;
 
-type RelationshipRow = {
-  name: string;
-  invokedBy: string;
-  phaseContext: string;
-};
-
 // ---------------------------------------------------------------------------
 // Parse and file walk. Scaffolding: no rule lives here.
 // ---------------------------------------------------------------------------
@@ -384,85 +378,6 @@ function mentions(text: string, name: string): boolean {
   return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
 }
 
-function migrationRelationshipOffenders(page: string, entries: Entry[]): string[] {
-  const start = page.indexOf("## Skill ↔ agent ↔ phase");
-  const end = page.indexOf("## Name-collision pairs", start);
-  if (start === -1 || end === -1) return ["migration relationship section is missing"];
-
-  const rows: RelationshipRow[] = [...page.slice(start, end).matchAll(
-    /^\| `([^`]+)` \| (.*?) \| (.*?) \|$/gm,
-  )].map((match) => ({
-    name: match[1] as string,
-    invokedBy: match[2] as string,
-    phaseContext: match[3] as string,
-  }));
-  const rowsByName = new Map(rows.map((row) => [row.name, row]));
-  const entriesByName = new Map(entries.map((entry) => [entry.name, entry]));
-  const invokedAdditions = new Map([
-    ["reviewing-code", ". `reviewing-designs` read-only Explore reviewer"],
-    ["engineering-standards", ". `reviewing-designs` read-only Explore reviewer"],
-    ["documenting-decisions", ". `reviewing-designs` read-only Explore reviewer"],
-    ["technical-design-doc", ". `reviewing-designs` read-only Explore reviewer"],
-    ["conventional-comments", ". `reviewing-designs` read-only Explore reviewer"],
-    ["writing-prose", ". `reviewing-designs` read-only Explore reviewer"],
-    [
-      "cross-model-review",
-      ". `reviewing-designs` read-only Explore reviewer (conditional, on `## External review input`)",
-    ],
-  ]);
-  const phaseAdditions = new Map([
-    ["reviewing-code", ", and Design (review gate)"],
-    ["engineering-standards", ", and Design (review gate)"],
-    ["documenting-decisions", ", and Design (review gate)"],
-    ["technical-design-doc", ", and Design (review gate)"],
-    ["conventional-comments", ", and Design (review gate): finding format"],
-    ["writing-prose", ". Design (review gate): prose bar"],
-  ]);
-  const offenders = [
-    ...(rows.length === 88 ? [] : [`migration parsed ${rows.length} relationship rows, expected 88`]),
-    ...(rows.length * 2 === 176 ? [] : [`migration parsed ${rows.length * 2} old cells, expected 176`]),
-    ...(rowsByName.size === rows.length ? [] : ["migration relationship rows contain duplicate names"]),
-    ...(entries.length === 90 ? [] : [`migration parsed ${entries.length} entries, expected 90`]),
-    ...(entriesByName.size === entries.length ? [] : ["migration catalog entries contain duplicate names"]),
-  ];
-
-  for (const row of rows) {
-    const entry = entriesByName.get(row.name);
-    if (!entry) {
-      offenders.push(`${row.name}: migration catalog entry missing`);
-      continue;
-    }
-    const expectedInvokedBy = row.invokedBy + (invokedAdditions.get(row.name) ?? "");
-    const expectedPhaseContext = row.phaseContext + (phaseAdditions.get(row.name) ?? "");
-    if (entry.invokedBy !== expectedInvokedBy) {
-      offenders.push(`${row.name}: migration consumer field differs from approved value`);
-    }
-    if (entry.phaseContext !== expectedPhaseContext) {
-      offenders.push(`${row.name}: migration context field differs from approved value`);
-    }
-  }
-
-  const tableless = new Map([
-    ["no-comments", [
-      "user (direct invocation; model invocation disabled)",
-      "Standalone: comment cleanup (not a QRSPI phase)",
-    ]],
-    ["reviewing-comments", [
-      "`no-comments` (direct load for read-only Explore review)",
-      "Standalone: source-comment review methodology",
-    ]],
-  ]);
-  for (const [name, [invokedBy, phaseContext]] of tableless) {
-    const entry = entriesByName.get(name);
-    if (!entry) offenders.push(`${name}: migration catalog entry missing`);
-    if (entry?.invokedBy !== invokedBy) offenders.push(`${name}: migration consumer field differs from source`);
-    if (entry?.phaseContext !== phaseContext) offenders.push(`${name}: migration context field differs from source`);
-    if (rowsByName.has(name)) offenders.push(`${name}: migration table unexpectedly contains a row`);
-  }
-
-  return offenders;
-}
-
 const REVIEWING_DESIGNS_LOADS = [...deriveLoads(
   SKILL_MD_TEXT.get("reviewing-designs") ?? "",
   "reviewing-designs",
@@ -498,11 +413,25 @@ function authoringContractOffenders(text: string): string[] {
   ];
 }
 
+function removedRelationshipPresentation(text: string): string[] {
+  return [
+    ...(/^## Skill ↔ agent ↔ phase$/m.test(text) ? ["relationship heading remains"] : []),
+    ...(text.includes("#skill--agent--phase") ? ["relationship anchor link remains"] : []),
+  ];
+}
+
 const CREATE_TEAM_SKILL_OFFENDERS = authoringContractOffenders(
   read(join(REPO_ROOT, ".claude", "skills", "create-team-skill", "SKILL.md")),
 );
 const CATALOG_TEXT = read(CATALOG);
-const MIGRATION_RELATIONSHIP_OFFENDERS = migrationRelationshipOffenders(CATALOG_TEXT, ENTRIES);
+const CATALOG_INTRODUCTION = CATALOG_TEXT.slice(
+  0,
+  CATALOG_TEXT.indexOf("\n## Entry-point skills"),
+);
+const REMOVED_RELATIONSHIP_OFFENDERS = removedRelationshipPresentation(CATALOG_TEXT);
+const MISSING_INTRODUCTION_LABELS = [INVOKED_HEADER, PHASE_HEADER].filter(
+  (label) => !CATALOG_INTRODUCTION.includes(label),
+);
 const LONG_RELATIONSHIP_BODY = [
   "Long relationship.",
   `${INVOKED_HEADER} ${"consumer ".repeat(40).trim()}`,
@@ -566,10 +495,11 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(CREATE_TEAM_SKILL_OFFENDERS).toEqual([]);
   });
 
-  test("migration checkpoint preserves every relationship before table deletion", () => {
-    expect(MIGRATION_RELATIONSHIP_OFFENDERS).toEqual([]);
+  test("catalog omits the relationship section and its anchor link", () => {
+    expect(CATALOG_TEXT.length).toBeGreaterThan(0);
+    expect(REMOVED_RELATIONSHIP_OFFENDERS).toEqual([]);
+    expect(MISSING_INTRODUCTION_LABELS).toEqual([]);
   });
-
 
   test("the page-side rules each see a planted positive", () => {
     // A well-formed body, used as the negative control for every rule below.
@@ -639,6 +569,12 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
       `${INVOKED_HEADER} user`,
       `${PHASE_HEADER} Any`,
     ]);
+
+    expect(
+      removedRelationshipPresentation(
+        "[old link](#skill--agent--phase)\n\n## Skill ↔ agent ↔ phase\n",
+      ),
+    ).toEqual(["relationship heading remains", "relationship anchor link remains"]);
 
     // Phantom name: a bullet naming no skill on disk.
     const derived = new Set(["pr-verify", "principle-fail-closed"]);

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -39,18 +39,16 @@ const REPO_ROOT = join(import.meta.dir, "..");
 const CATALOG = join(REPO_ROOT, "docs", "skills.md");
 const SKILLS_ROOT = join(REPO_ROOT, "skills");
 
-const LOADS_HEADER = "**Loads:**";
+const CALLS_HEADER = "**Calls:**";
 const LOAD_BULLET = /^- `([a-z0-9-]+)`$/;
-const INVOKED_HEADER = "**Consumers:**";
-const PHASE_HEADER = "**Context:**";
+const CALLERS_HEADER = "**Callers:**";
 
 type Entry = {
   name: string;
   section: string;
   body: string[];
   description: string[];
-  invokedBy: string;
-  phaseContext: string;
+  callers: string;
   loads: string[];
 };
 
@@ -102,28 +100,29 @@ function loadBullets(body: string[]): string[] {
   });
 }
 
-function entryFields(body: string[]): Pick<Entry, "description" | "invokedBy" | "phaseContext" | "loads"> {
-  const invokedLines = body.filter((line) => line.startsWith(INVOKED_HEADER));
-  const phaseLines = body.filter((line) => line.startsWith(PHASE_HEADER));
-  const invokedIndex = body.findIndex((line) => line.startsWith(INVOKED_HEADER));
+function callerNames(value: string): string[] | undefined {
+  if (value === "None") return [];
+  if (!/^`[a-z0-9-]+`(?:, `[a-z0-9-]+`)*$/.test(value)) return undefined;
+  return [...value.matchAll(/`([a-z0-9-]+)`/g)].map((match) => match[1] as string);
+}
+
+function entryFields(body: string[]): Pick<Entry, "description" | "callers" | "loads"> {
+  const callerLines = body.filter((line) => line.startsWith(CALLERS_HEADER));
+  const callerIndex = body.findIndex((line) => line.startsWith(CALLERS_HEADER));
 
   return {
-    description: invokedIndex === -1 ? [] : body.slice(0, invokedIndex),
-    invokedBy:
-      invokedLines.length === 1
-        ? (invokedLines[0] as string).slice(INVOKED_HEADER.length).trim()
-        : "",
-    phaseContext:
-      phaseLines.length === 1
-        ? (phaseLines[0] as string).slice(PHASE_HEADER.length).trim()
+    description: callerIndex === -1 ? [] : body.slice(0, callerIndex),
+    callers:
+      callerLines.length === 1
+        ? (callerLines[0] as string).slice(CALLERS_HEADER.length).trim()
         : "",
     loads: loadBullets(body),
   };
 }
 
-/** True when the body carries the loads header. */
-function hasLoadsHeader(body: string[]): boolean {
-  return body.some((line) => line.trim() === LOADS_HEADER);
+/** True when the body carries the calls header. */
+function hasCallsHeader(body: string[]): boolean {
+  return body.some((line) => line.trim() === CALLS_HEADER);
 }
 
 // ---------------------------------------------------------------------------
@@ -134,11 +133,11 @@ function hasLoadsHeader(body: string[]): boolean {
 
 /**
  * Shape offenders for one entry body, each naming the offending line. The body
- * must be one or more prose lines, then optionally the loads header followed
+ * must be one or more prose lines, then optionally the calls header followed
  * by one or more load bullets, and nothing after. Eight offenders: (1) zero
  * prose lines; (2) a line starting `- ` that is not exactly a load bullet
  * (a surviving `**Purpose:**` bullet, a trailing clause after a name); (3) a
- * prose line after the loads header; (4) a loads header with no bullet
+ * prose line after the calls header; (4) a calls header with no bullet
  * under it; (5) a load bullet with no header above it; (6) a second loads
  * header; (7) a duplicate name among the bullets; (8) any body line with
  * leading whitespace, first line included.
@@ -146,11 +145,8 @@ function hasLoadsHeader(body: string[]): boolean {
 function shape(body: string[]): string[] {
   const offenders: string[] = [];
   const seen = new Set<string>();
-  const invokedIndexes = body.flatMap((line, index) =>
-    line.startsWith(INVOKED_HEADER) ? [index] : [],
-  );
-  const phaseIndexes = body.flatMap((line, index) =>
-    line.startsWith(PHASE_HEADER) ? [index] : [],
+  const callerIndexes = body.flatMap((line, index) =>
+    line.startsWith(CALLERS_HEADER) ? [index] : [],
   );
   let headers = 0;
   let bullets = 0;
@@ -159,13 +155,13 @@ function shape(body: string[]): string[] {
     const trimmed = line.trim();
     if (line !== trimmed) offenders.push(`indented body line: ${JSON.stringify(line)}`);
 
-    if (trimmed.startsWith(INVOKED_HEADER) || trimmed.startsWith(PHASE_HEADER)) {
+    if (trimmed.startsWith(CALLERS_HEADER)) {
       continue;
     }
 
-    if (trimmed === LOADS_HEADER) {
+    if (trimmed === CALLS_HEADER) {
       headers++;
-      if (headers > 1) offenders.push("second loads header");
+      if (headers > 1) offenders.push("second calls header");
       continue;
     }
 
@@ -184,41 +180,32 @@ function shape(body: string[]): string[] {
       continue;
     }
 
-    if (headers > 0) offenders.push(`prose line after the loads header: ${JSON.stringify(trimmed)}`);
-    if ((phaseIndexes[0] ?? body.length) < index) {
-      offenders.push(`prose line after relationship fields: ${JSON.stringify(trimmed)}`);
+    if (headers > 0) offenders.push(`prose line after the calls header: ${JSON.stringify(trimmed)}`);
+    if ((callerIndexes[0] ?? body.length) < index) {
+      offenders.push(`prose line after the caller field: ${JSON.stringify(trimmed)}`);
     }
   }
 
-  if (invokedIndexes.length !== 1) {
-    offenders.push(`${invokedIndexes.length} consumer fields`);
+  if (callerIndexes.length !== 1) {
+    offenders.push(`${callerIndexes.length} caller fields`);
   }
-  if (phaseIndexes.length !== 1) offenders.push(`${phaseIndexes.length} context fields`);
-
-  if (invokedIndexes.length === 1 && phaseIndexes.length === 1) {
-    const invokedIndex = invokedIndexes[0] as number;
-    const phaseIndex = phaseIndexes[0] as number;
-    if (invokedIndex === 0) offenders.push("no description before relationship fields");
-    if (phaseIndex !== invokedIndex + 1) {
-      offenders.push("relationship fields are not adjacent and ordered");
-    }
-    if ((body[invokedIndex] as string).slice(INVOKED_HEADER.length).trim() === "") {
-      offenders.push("consumer field is empty");
-    }
-    if ((body[phaseIndex] as string).slice(PHASE_HEADER.length).trim() === "") {
-      offenders.push("context field is empty");
+  if (callerIndexes.length === 1) {
+    const callerIndex = callerIndexes[0] as number;
+    if (callerIndex === 0) offenders.push("no description before the caller field");
+    if ((body[callerIndex] as string).slice(CALLERS_HEADER.length).trim() === "") {
+      offenders.push("caller field is empty");
     }
 
-    const loadsIndex = body.findIndex((line) => line === LOADS_HEADER);
-    if (loadsIndex === -1 && phaseIndex !== body.length - 1) {
-      offenders.push("content follows relationship fields without a loads header");
+    const loadsIndex = body.findIndex((line) => line === CALLS_HEADER);
+    if (loadsIndex === -1 && callerIndex !== body.length - 1) {
+      offenders.push("content follows the caller field without a calls header");
     }
-    if (loadsIndex !== -1 && loadsIndex !== phaseIndex + 1) {
-      offenders.push("loads header does not immediately follow relationship fields");
+    if (loadsIndex !== -1 && loadsIndex !== callerIndex + 1) {
+      offenders.push("calls header does not immediately follow the caller field");
     }
   }
 
-  if (headers > 0 && bullets === 0) offenders.push("loads header with no bullet under it");
+  if (headers > 0 && bullets === 0) offenders.push("calls header with no bullet under it");
   return offenders;
 }
 
@@ -363,8 +350,8 @@ const NAMED_EDGES = new Set(
   ),
 );
 const SKILL_MD_EDGES = edgeSet(SKILL_MD_TEXT);
-const ENTRIES_WITH_LOADS = ENTRIES.filter((entry) => hasLoadsHeader(entry.body)).length;
-const ENTRIES_WITHOUT_LOADS = ENTRIES.filter((entry) => !hasLoadsHeader(entry.body)).length;
+const ENTRIES_WITH_CALLS = ENTRIES.filter((entry) => hasCallsHeader(entry.body)).length;
+const ENTRIES_WITHOUT_CALLS = ENTRIES.filter((entry) => !hasCallsHeader(entry.body)).length;
 const EMPTY_ENTRY_BODIES = ENTRIES.filter((entry) => entry.body.length === 0).map(
   (entry) => entry.name,
 );
@@ -373,42 +360,45 @@ const SKILL_MD_EDGES_OUTSIDE_FULL_SCAN = [...SKILL_MD_EDGES].filter(
   (edge) => !ALL_EDGES.has(edge),
 );
 
-function mentions(text: string, name: string): boolean {
-  return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
+function callReciprocityOffenders(entries: Entry[]): string[] {
+  const expected = new Map(entries.map((entry) => [entry.name, [] as string[]]));
+  const unknownLoads: string[] = [];
+
+  for (const entry of entries) {
+    for (const load of entry.loads) {
+      const callers = expected.get(load);
+      if (!callers) unknownLoads.push(`${entry.name}: loads unknown skill ${load}`);
+      else callers.push(entry.name);
+    }
+  }
+
+  return [
+    ...unknownLoads,
+    ...entries.flatMap((entry) => {
+      const actual = callerNames(entry.callers);
+      if (!actual) return [`${entry.name}: invalid caller list ${JSON.stringify(entry.callers)}`];
+      const names = (expected.get(entry.name) ?? []).sort();
+      return actual.length === names.length && actual.every((name, index) => name === names[index])
+        ? []
+        : [`${entry.name}: expected callers ${JSON.stringify(names)}, got ${JSON.stringify(actual)}`];
+    }),
+  ];
 }
 
-const REVIEWING_DESIGNS_LOADS = [...deriveLoads(
-  SKILL_MD_TEXT.get("reviewing-designs") ?? "",
-  "reviewing-designs",
-  NAMES,
-)].sort();
-
-const REVIEWING_DESIGNS_OFFENDERS = REVIEWING_DESIGNS_LOADS.flatMap((name) => {
-  const entry = ENTRY_BY_NAME.get(name);
-  if (!entry) return [`${name}: catalog entry missing`];
-  return [
-    ...(mentions(entry.invokedBy, "reviewing-designs")
-      ? []
-      : [`${name}: consumer field omits reviewing-designs`]),
-    ...(/\bDesign\b/.test(entry.phaseContext)
-      ? []
-      : [`${name}: context field omits Design`]),
-  ];
-});
-
 function authoringContractOffenders(text: string): string[] {
-  const invoked = text.indexOf(INVOKED_HEADER);
-  const phase = text.indexOf(PHASE_HEADER);
-  const loads = text.indexOf(LOADS_HEADER);
+  const callers = text.indexOf(CALLERS_HEADER);
+  const calls = text.indexOf(CALLS_HEADER);
   return [
-    ...(invoked === -1 ? [`create-team-skill omits ${INVOKED_HEADER}`] : []),
-    ...(phase === -1 ? [`create-team-skill omits ${PHASE_HEADER}`] : []),
-    ...(invoked !== -1 && phase !== -1 && phase < invoked
-      ? ["create-team-skill orders phase before consumer"]
+    ...(callers === -1 ? [`create-team-skill omits ${CALLERS_HEADER}`] : []),
+    ...(callers !== -1 && calls !== -1 && calls < callers
+      ? ["create-team-skill orders calls before the caller field"]
       : []),
-    ...(phase !== -1 && loads !== -1 && loads < phase
-      ? ["create-team-skill orders loads before relationship fields"]
-      : []),
+    ...(text.includes("Set `**Callers:**` to `None`")
+      ? []
+      : ["create-team-skill omits the zero-caller rule"]),
+    ...(text.includes("every skill whose `**Calls:**` list names it")
+      ? []
+      : ["create-team-skill omits the reciprocal caller rule"]),
   ];
 }
 
@@ -428,20 +418,22 @@ const CATALOG_INTRODUCTION = CATALOG_TEXT.slice(
   CATALOG_TEXT.indexOf("\n## Entry-point skills"),
 );
 const REMOVED_RELATIONSHIP_OFFENDERS = removedRelationshipPresentation(CATALOG_TEXT);
-const MISSING_INTRODUCTION_LABELS = [INVOKED_HEADER, PHASE_HEADER].filter(
+const MISSING_INTRODUCTION_LABELS = [CALLERS_HEADER].filter(
   (label) => !CATALOG_INTRODUCTION.includes(label),
 );
-const LONG_RELATIONSHIP_BODY = [
+const CONTEXT_FIELD_OFFENDERS = CATALOG_TEXT.includes("**Context:**")
+  ? ["context field remains"]
+  : [];
+const CALL_RECIPROCITY_OFFENDERS = callReciprocityOffenders(ENTRIES);
+const LONG_CALLER_BODY = [
   "Long relationship.",
-  `${INVOKED_HEADER} ${"consumer ".repeat(40).trim()}`,
-  `${PHASE_HEADER} Design`,
+  `${CALLERS_HEADER} ${Array.from({ length: 40 }, (_, index) => `\`caller-${index}\``).join(", ")}`,
 ];
 const FINAL_ENTRY_BODY = catalogEntries([
   "## Methodology skills",
   "### [final-skill](target)",
   "Final skill.",
-  `${INVOKED_HEADER} user`,
-  `${PHASE_HEADER} Any`,
+  `${CALLERS_HEADER} None`,
   "## Name-collision pairs",
   "not part of the entry",
 ].join("\n"))[0]?.body;
@@ -453,8 +445,8 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // (docs/testing.md, "Prove a negative check can find a positive").
     expect(SKILL_DIRECTORIES.length).toBeGreaterThan(60); // (1) skills/ tree parsed
     expect(ENTRIES.length).toBeGreaterThan(60); // (2) page parsed
-    expect(ENTRIES_WITH_LOADS).toBeGreaterThan(0); // (3)
-    expect(ENTRIES_WITHOUT_LOADS).toBeGreaterThan(0); // (4)
+    expect(ENTRIES_WITH_CALLS).toBeGreaterThan(0); // (3)
+    expect(ENTRIES_WITHOUT_CALLS).toBeGreaterThan(0); // (4)
     expect(EMPTY_ENTRY_BODIES).toEqual([]); // (5) every parsed body non-empty
 
     // (6) Discrimination axis: a load is STRICTLY narrower than a mention. Every
@@ -481,31 +473,30 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(LOAD_ORDER_OFFENDERS).toEqual([]);
   });
 
-  test("catalog relationship fields are ordered, non-empty, and complete for every skill", () => {
+  test("catalog Callers and Calls fields are exact reciprocals", () => {
     expect(SKILL_DIRECTORIES.length).toBe(90);
     expect(ENTRIES.length).toBe(90);
     expect(SHAPE_OFFENDERS).toEqual([]);
+    expect(CALL_RECIPROCITY_OFFENDERS).toEqual([]);
   });
 
-  test("reviewing-designs dependencies and create-team-skill instructions preserve the metadata contract", () => {
-    expect(REVIEWING_DESIGNS_LOADS.length).toBe(7);
-    expect(REVIEWING_DESIGNS_OFFENDERS).toEqual([]);
+  test("create-team-skill instructions preserve the reciprocal call graph contract", () => {
     expect(CREATE_TEAM_SKILL_OFFENDERS).toEqual([]);
   });
 
-  test("catalog omits the relationship section and its anchor link", () => {
+  test("catalog omits the relationship section, its anchor link, and context fields", () => {
     expect(CATALOG_TEXT.length).toBeGreaterThan(0);
     expect(REMOVED_RELATIONSHIP_OFFENDERS).toEqual([]);
     expect(MISSING_INTRODUCTION_LABELS).toEqual([]);
+    expect(CONTEXT_FIELD_OFFENDERS).toEqual([]);
   });
 
   test("the page-side rules each see a planted positive", () => {
     // A well-formed body, used as the negative control for every rule below.
     const clean = [
       "Lands a reviewed PR.",
-      `${INVOKED_HEADER} user`,
-      `${PHASE_HEADER} Standalone`,
-      LOADS_HEADER,
+      `${CALLERS_HEADER} None`,
+      CALLS_HEADER,
       "- `pr-verify`",
       "- `principle-fail-closed`",
     ];
@@ -515,29 +506,28 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(
       shape([
         "Lands a reviewed PR.",
-        `${INVOKED_HEADER} user`,
-        `${PHASE_HEADER} Standalone`,
+        `${CALLERS_HEADER} None`,
         "- **Purpose:** Lands a reviewed PR.",
       ]),
     ).not.toEqual([]);
 
-    // Second loads header.
-    expect(shape([...clean, LOADS_HEADER, "- `shipit`"])).not.toEqual([]);
+    // Second calls header.
+    expect(shape([...clean, CALLS_HEADER, "- `shipit`"])).not.toEqual([]);
 
     // Trailing clause after a name.
     expect(
-      shape(["Lands a reviewed PR.", LOADS_HEADER, "- `pr-verify` for the checks"]),
+      shape(["Lands a reviewed PR.", CALLS_HEADER, "- `pr-verify` for the checks"]),
     ).not.toEqual([]);
 
     // Duplicate name among the bullets.
     expect(
-      shape(["Lands a reviewed PR.", LOADS_HEADER, "- `pr-verify`", "- `pr-verify`"]),
+      shape(["Lands a reviewed PR.", CALLS_HEADER, "- `pr-verify`", "- `pr-verify`"]),
     ).not.toEqual([]);
 
     // Indented line, as the first line and as a later line.
     expect(shape(["  Lands a reviewed PR."])).not.toEqual([]);
     expect(
-      shape(["Lands a reviewed PR.", LOADS_HEADER, "- `pr-verify`", "  continued"]),
+      shape(["Lands a reviewed PR.", CALLS_HEADER, "- `pr-verify`", "  continued"]),
     ).not.toEqual([]);
 
     // Drifted sentence: the page no longer copies the description's first sentence.
@@ -545,26 +535,39 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(sentence(["Lands a reviewed PR."], description)).toEqual([]);
     expect(sentence(["Lands a merged PR."], description)).not.toEqual([]);
 
-    expect(shape(["Leaf skill.", `${INVOKED_HEADER} user`, `${PHASE_HEADER} Any`])).toEqual([]);
-    expect(shape(["Leaf skill.", `${PHASE_HEADER} Any`])).not.toEqual([]);
-    expect(shape(["Leaf skill.", INVOKED_HEADER, `${PHASE_HEADER} Any`])).not.toEqual([]);
+    expect(shape(["Leaf skill.", `${CALLERS_HEADER} None`])).toEqual([]);
+    expect(shape(["Leaf skill."])).not.toEqual([]);
+    expect(shape(["Leaf skill.", CALLERS_HEADER])).not.toEqual([]);
     expect(
       shape([
         "Leaf skill.",
-        `${INVOKED_HEADER} user`,
-        `${INVOKED_HEADER} agent`,
-        `${PHASE_HEADER} Any`,
+        `${CALLERS_HEADER} None`,
+        `${CALLERS_HEADER} \`agent\``,
       ]),
     ).not.toEqual([]);
-    expect(
-      shape(["Leaf skill.", `${PHASE_HEADER} Any`, `${INVOKED_HEADER} user`]),
-    ).not.toEqual([]);
-    expect(shape(LONG_RELATIONSHIP_BODY)).toEqual([]);
+    expect(shape(LONG_CALLER_BODY)).toEqual([]);
     expect(FINAL_ENTRY_BODY).toEqual([
       "Final skill.",
-      `${INVOKED_HEADER} user`,
-      `${PHASE_HEADER} Any`,
+      `${CALLERS_HEADER} None`,
     ]);
+
+    const reciprocal = catalogEntries([
+      "## Methodology skills",
+      "### [a](target)",
+      "A skill.",
+      `${CALLERS_HEADER} None`,
+      CALLS_HEADER,
+      "- `b`",
+      "### [b](target)",
+      "B skill.",
+      `${CALLERS_HEADER} \`a\``,
+    ].join("\n"));
+    expect(callReciprocityOffenders(reciprocal)).toEqual([]);
+    expect(
+      callReciprocityOffenders(
+        reciprocal.map((entry) => entry.name === "b" ? { ...entry, callers: "None" } : entry),
+      ),
+    ).not.toEqual([]);
 
     expect(
       removedRelationshipPresentation(

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -41,8 +41,26 @@ const SKILLS_ROOT = join(REPO_ROOT, "skills");
 
 const LOADS_HEADER = "**Loads:**";
 const LOAD_BULLET = /^- `([a-z0-9-]+)`$/;
+const INVOKED_HEADER = "**Invoked / loaded by:**";
+const PHASE_HEADER = "**Phase / context:**";
 
-type Entry = { name: string; section: string; body: string[] };
+type Entry = {
+  name: string;
+  section: string;
+  body: string[];
+  description: string[];
+  invokedBy: string;
+  phaseContext: string;
+  loads: string[];
+};
+
+type EntryDraft = Pick<Entry, "name" | "section" | "body">;
+
+type RelationshipRow = {
+  name: string;
+  invokedBy: string;
+  phaseContext: string;
+};
 
 // ---------------------------------------------------------------------------
 // Parse and file walk. Scaffolding: no rule lives here.
@@ -56,9 +74,9 @@ type Entry = { name: string; section: string; body: string[] };
  * as catalogEntries() in tests/methodology-not-user-invocable.test.ts.
  */
 function catalogEntries(page: string): Entry[] {
-  const out: Entry[] = [];
+  const out: EntryDraft[] = [];
   let section = "";
-  let current: Entry | undefined;
+  let current: EntryDraft | undefined;
   for (const line of page.split("\n")) {
     if (/^#{2,3} /.test(line)) current = undefined;
     if (line.startsWith("## ")) section = line.trim();
@@ -70,7 +88,7 @@ function catalogEntries(page: string): Entry[] {
     }
     if (current && line.trim() !== "") current.body.push(line);
   }
-  return out;
+  return out.map((entry) => ({ ...entry, ...entryFields(entry.body) }));
 }
 
 /** Every `.md` file under `dir`, at any depth: references/ and prompt templates included. */
@@ -90,15 +108,29 @@ function loadBullets(body: string[]): string[] {
   });
 }
 
+/** Structured fields from one entry body. Invalid bodies return empty fields. */
+function entryFields(body: string[]): Pick<Entry, "description" | "invokedBy" | "phaseContext" | "loads"> {
+  const invokedLines = body.filter((line) => line.startsWith(INVOKED_HEADER));
+  const phaseLines = body.filter((line) => line.startsWith(PHASE_HEADER));
+  const invokedIndex = body.findIndex((line) => line.startsWith(INVOKED_HEADER));
+
+  return {
+    description: invokedIndex === -1 ? [] : body.slice(0, invokedIndex),
+    invokedBy:
+      invokedLines.length === 1
+        ? (invokedLines[0] as string).slice(INVOKED_HEADER.length).trim()
+        : "",
+    phaseContext:
+      phaseLines.length === 1
+        ? (phaseLines[0] as string).slice(PHASE_HEADER.length).trim()
+        : "",
+    loads: loadBullets(body),
+  };
+}
+
 /** True when the body carries the loads header. */
 function hasLoadsHeader(body: string[]): boolean {
   return body.some((line) => line.trim() === LOADS_HEADER);
-}
-
-/** A body line that is neither the loads header nor a load bullet. */
-function isProse(line: string): boolean {
-  const trimmed = line.trim();
-  return trimmed !== LOADS_HEADER && !LOAD_BULLET.test(trimmed);
 }
 
 // ---------------------------------------------------------------------------
@@ -121,13 +153,22 @@ function isProse(line: string): boolean {
 function shape(body: string[]): string[] {
   const offenders: string[] = [];
   const seen = new Set<string>();
+  const invokedIndexes = body.flatMap((line, index) =>
+    line.startsWith(INVOKED_HEADER) ? [index] : [],
+  );
+  const phaseIndexes = body.flatMap((line, index) =>
+    line.startsWith(PHASE_HEADER) ? [index] : [],
+  );
   let headers = 0;
-  let prose = 0;
   let bullets = 0;
 
-  for (const line of body) {
+  for (const [index, line] of body.entries()) {
     const trimmed = line.trim();
     if (line !== trimmed) offenders.push(`indented body line: ${JSON.stringify(line)}`);
+
+    if (trimmed.startsWith(INVOKED_HEADER) || trimmed.startsWith(PHASE_HEADER)) {
+      continue;
+    }
 
     if (trimmed === LOADS_HEADER) {
       headers++;
@@ -150,11 +191,40 @@ function shape(body: string[]): string[] {
       continue;
     }
 
-    prose++;
     if (headers > 0) offenders.push(`prose line after the loads header: ${JSON.stringify(trimmed)}`);
+    if ((phaseIndexes[0] ?? body.length) < index) {
+      offenders.push(`prose line after relationship fields: ${JSON.stringify(trimmed)}`);
+    }
   }
 
-  if (prose === 0) offenders.push("no prose line");
+  if (invokedIndexes.length !== 1) {
+    offenders.push(`${invokedIndexes.length} invoked / loaded by fields`);
+  }
+  if (phaseIndexes.length !== 1) offenders.push(`${phaseIndexes.length} phase / context fields`);
+
+  if (invokedIndexes.length === 1 && phaseIndexes.length === 1) {
+    const invokedIndex = invokedIndexes[0] as number;
+    const phaseIndex = phaseIndexes[0] as number;
+    if (invokedIndex === 0) offenders.push("no description before relationship fields");
+    if (phaseIndex !== invokedIndex + 1) {
+      offenders.push("relationship fields are not adjacent and ordered");
+    }
+    if ((body[invokedIndex] as string).slice(INVOKED_HEADER.length).trim() === "") {
+      offenders.push("invoked / loaded by field is empty");
+    }
+    if ((body[phaseIndex] as string).slice(PHASE_HEADER.length).trim() === "") {
+      offenders.push("phase / context field is empty");
+    }
+
+    const loadsIndex = body.findIndex((line) => line === LOADS_HEADER);
+    if (loadsIndex === -1 && phaseIndex !== body.length - 1) {
+      offenders.push("content follows relationship fields without a loads header");
+    }
+    if (loadsIndex !== -1 && loadsIndex !== phaseIndex + 1) {
+      offenders.push("loads header does not immediately follow relationship fields");
+    }
+  }
+
   if (headers > 0 && bullets === 0) offenders.push("loads header with no bullet under it");
   return offenders;
 }
@@ -166,7 +236,7 @@ function shape(body: string[]): string[] {
  * A missing/empty description and a description with no sentence terminator are
  * each a named offender — no skip, no vacuous pass.
  */
-function sentence(body: string[], description: string): string[] {
+function sentence(descriptionLines: string[], description: string): string[] {
   const value = description.trim();
   if (value === "") return ["description is missing or empty"];
 
@@ -174,7 +244,7 @@ function sentence(body: string[], description: string): string[] {
   if (!cut) return [`description has no sentence terminator: ${JSON.stringify(value)}`];
 
   const expected = squash(cut[0]).trim();
-  const actual = squash(body.filter(isProse).join(" ")).trim();
+  const actual = squash(descriptionLines.join(" ")).trim();
 
   return actual === expected
     ? []
@@ -274,70 +344,239 @@ const shapeOffenders = (name: string): string[] =>
   shape(bodyOf(name)).map((offender) => `${name}: ${offender}`);
 
 const sentenceOffenders = (name: string): string[] =>
-  sentence(bodyOf(name), description(SKILL_MD_TEXT.get(name) ?? "")).map(
+  sentence(ENTRY_BY_NAME.get(name)?.description ?? [], description(SKILL_MD_TEXT.get(name) ?? "")).map(
     (offender) => `${name}: ${offender}`,
   );
 
 const loadSetOffenders = (name: string): string[] =>
   loadSet(
-    loadBullets(bodyOf(name)),
+    ENTRY_BY_NAME.get(name)?.loads ?? [],
     deriveLoads(ALL_MD_TEXT.get(name) ?? "", name, NAMES),
     NAMES,
   ).map((offender) => `${name}: ${offender}`);
 
 const loadOrderOffenders = (name: string): string[] =>
-  loadOrder(loadBullets(bodyOf(name))).map((offender) => `${name}: ${offender}`);
+  loadOrder(ENTRY_BY_NAME.get(name)?.loads ?? []).map((offender) => `${name}: ${offender}`);
+
+const MISSING_CATALOG_ENTRIES = SKILL_DIRECTORIES.filter((name) => !ENTRY_BY_NAME.has(name));
+const SENTENCE_OFFENDERS = SKILL_DIRECTORIES.flatMap(sentenceOffenders);
+const LOAD_SET_OFFENDERS = SKILL_DIRECTORIES.flatMap(loadSetOffenders);
+const LOAD_ORDER_OFFENDERS = SKILL_DIRECTORIES.flatMap(loadOrderOffenders);
+const SHAPE_OFFENDERS = SKILL_DIRECTORIES.flatMap(shapeOffenders);
+const ALL_EDGES = edgeSet(ALL_MD_TEXT);
+const NAMED_EDGES = new Set(
+  [...ALL_MD_TEXT].flatMap(([owner, text]) =>
+    [...namedSkills(text, owner, NAMES)].map((name) => `${owner} -> ${name}`),
+  ),
+);
+const SKILL_MD_EDGES = edgeSet(SKILL_MD_TEXT);
+const ENTRIES_WITH_LOADS = ENTRIES.filter((entry) => hasLoadsHeader(entry.body)).length;
+const ENTRIES_WITHOUT_LOADS = ENTRIES.filter((entry) => !hasLoadsHeader(entry.body)).length;
+const EMPTY_ENTRY_BODIES = ENTRIES.filter((entry) => entry.body.length === 0).map(
+  (entry) => entry.name,
+);
+const LOAD_EDGES_WITHOUT_MENTIONS = [...ALL_EDGES].filter((edge) => !NAMED_EDGES.has(edge));
+const SKILL_MD_EDGES_OUTSIDE_FULL_SCAN = [...SKILL_MD_EDGES].filter(
+  (edge) => !ALL_EDGES.has(edge),
+);
+
+function mentions(text: string, name: string): boolean {
+  return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
+}
+
+function migrationRelationshipOffenders(page: string, entries: Entry[]): string[] {
+  const start = page.indexOf("## Skill ↔ agent ↔ phase");
+  const end = page.indexOf("## Name-collision pairs", start);
+  if (start === -1 || end === -1) return ["migration relationship section is missing"];
+
+  const rows: RelationshipRow[] = [...page.slice(start, end).matchAll(
+    /^\| `([^`]+)` \| (.*?) \| (.*?) \|$/gm,
+  )].map((match) => ({
+    name: match[1] as string,
+    invokedBy: match[2] as string,
+    phaseContext: match[3] as string,
+  }));
+  const rowsByName = new Map(rows.map((row) => [row.name, row]));
+  const entriesByName = new Map(entries.map((entry) => [entry.name, entry]));
+  const invokedAdditions = new Map([
+    ["reviewing-code", ". `reviewing-designs` read-only Explore reviewer"],
+    ["engineering-standards", ". `reviewing-designs` read-only Explore reviewer"],
+    ["documenting-decisions", ". `reviewing-designs` read-only Explore reviewer"],
+    ["technical-design-doc", ". `reviewing-designs` read-only Explore reviewer"],
+    ["conventional-comments", ". `reviewing-designs` read-only Explore reviewer"],
+    ["writing-prose", ". `reviewing-designs` read-only Explore reviewer"],
+    [
+      "cross-model-review",
+      ". `reviewing-designs` read-only Explore reviewer (conditional, on `## External review input`)",
+    ],
+  ]);
+  const phaseAdditions = new Map([
+    ["reviewing-code", ", and Design (review gate)"],
+    ["engineering-standards", ", and Design (review gate)"],
+    ["documenting-decisions", ", and Design (review gate)"],
+    ["technical-design-doc", ", and Design (review gate)"],
+    ["conventional-comments", ", and Design (review gate): finding format"],
+    ["writing-prose", ". Design (review gate): prose bar"],
+  ]);
+  const offenders = [
+    ...(rows.length === 88 ? [] : [`migration parsed ${rows.length} relationship rows, expected 88`]),
+    ...(rows.length * 2 === 176 ? [] : [`migration parsed ${rows.length * 2} old cells, expected 176`]),
+    ...(rowsByName.size === rows.length ? [] : ["migration relationship rows contain duplicate names"]),
+    ...(entries.length === 90 ? [] : [`migration parsed ${entries.length} entries, expected 90`]),
+    ...(entriesByName.size === entries.length ? [] : ["migration catalog entries contain duplicate names"]),
+  ];
+
+  for (const row of rows) {
+    const entry = entriesByName.get(row.name);
+    if (!entry) {
+      offenders.push(`${row.name}: migration catalog entry missing`);
+      continue;
+    }
+    const expectedInvokedBy = row.invokedBy + (invokedAdditions.get(row.name) ?? "");
+    const expectedPhaseContext = row.phaseContext + (phaseAdditions.get(row.name) ?? "");
+    if (entry.invokedBy !== expectedInvokedBy) {
+      offenders.push(`${row.name}: migration consumer field differs from approved value`);
+    }
+    if (entry.phaseContext !== expectedPhaseContext) {
+      offenders.push(`${row.name}: migration context field differs from approved value`);
+    }
+  }
+
+  const tableless = new Map([
+    ["no-comments", [
+      "user (direct invocation; model invocation disabled)",
+      "Standalone: comment cleanup (not a QRSPI phase)",
+    ]],
+    ["reviewing-comments", [
+      "`no-comments` (direct load for read-only Explore review)",
+      "Standalone: source-comment review methodology",
+    ]],
+  ]);
+  for (const [name, [invokedBy, phaseContext]] of tableless) {
+    const entry = entriesByName.get(name);
+    if (!entry) offenders.push(`${name}: migration catalog entry missing`);
+    if (entry?.invokedBy !== invokedBy) offenders.push(`${name}: migration consumer field differs from source`);
+    if (entry?.phaseContext !== phaseContext) offenders.push(`${name}: migration context field differs from source`);
+    if (rowsByName.has(name)) offenders.push(`${name}: migration table unexpectedly contains a row`);
+  }
+
+  return offenders;
+}
+
+const REVIEWING_DESIGNS_LOADS = [...deriveLoads(
+  SKILL_MD_TEXT.get("reviewing-designs") ?? "",
+  "reviewing-designs",
+  NAMES,
+)].sort();
+
+const REVIEWING_DESIGNS_OFFENDERS = REVIEWING_DESIGNS_LOADS.flatMap((name) => {
+  const entry = ENTRY_BY_NAME.get(name);
+  if (!entry) return [`${name}: catalog entry missing`];
+  return [
+    ...(mentions(entry.invokedBy, "reviewing-designs")
+      ? []
+      : [`${name}: consumer field omits reviewing-designs`]),
+    ...(/\bDesign\b/.test(entry.phaseContext)
+      ? []
+      : [`${name}: context field omits Design`]),
+  ];
+});
+
+function authoringContractOffenders(text: string): string[] {
+  const invoked = text.indexOf(INVOKED_HEADER);
+  const phase = text.indexOf(PHASE_HEADER);
+  const loads = text.indexOf(LOADS_HEADER);
+  return [
+    ...(invoked === -1 ? [`create-team-skill omits ${INVOKED_HEADER}`] : []),
+    ...(phase === -1 ? [`create-team-skill omits ${PHASE_HEADER}`] : []),
+    ...(invoked !== -1 && phase !== -1 && phase < invoked
+      ? ["create-team-skill orders phase before consumer"]
+      : []),
+    ...(phase !== -1 && loads !== -1 && loads < phase
+      ? ["create-team-skill orders loads before relationship fields"]
+      : []),
+  ];
+}
+
+const CREATE_TEAM_SKILL_OFFENDERS = authoringContractOffenders(
+  read(join(REPO_ROOT, ".claude", "skills", "create-team-skill", "SKILL.md")),
+);
+const CATALOG_TEXT = read(CATALOG);
+const MIGRATION_RELATIONSHIP_OFFENDERS = migrationRelationshipOffenders(CATALOG_TEXT, ENTRIES);
+const LONG_RELATIONSHIP_BODY = [
+  "Long relationship.",
+  `${INVOKED_HEADER} ${"consumer ".repeat(40).trim()}`,
+  `${PHASE_HEADER} Design`,
+];
+const FINAL_ENTRY_BODY = catalogEntries([
+  "## Methodology skills",
+  "### [final-skill](target)",
+  "Final skill.",
+  `${INVOKED_HEADER} user`,
+  `${PHASE_HEADER} Any`,
+  "## Name-collision pairs",
+  "not part of the entry",
+].join("\n"))[0]?.body;
 
 describe("docs/skills.md catalog matches the skills on disk", () => {
-  test("every entry's shape, sentence, load set, and load order match disk", () => {
+  test("catalog entries preserve sourced descriptions and direct loads", () => {
     // Seven vacuity guards. Each names the property that vanished, because a
     // mis-scoped haystack makes every sweep below pass for the wrong reason
     // (docs/testing.md, "Prove a negative check can find a positive").
     expect(SKILL_DIRECTORIES.length).toBeGreaterThan(60); // (1) skills/ tree parsed
     expect(ENTRIES.length).toBeGreaterThan(60); // (2) page parsed
-    expect(ENTRIES.filter((entry) => hasLoadsHeader(entry.body)).length).toBeGreaterThan(0); // (3)
-    expect(ENTRIES.filter((entry) => !hasLoadsHeader(entry.body)).length).toBeGreaterThan(0); // (4)
-    expect(ENTRIES.filter((entry) => entry.body.length === 0).map((entry) => entry.name)).toEqual(
-      [],
-    ); // (5) every parsed body non-empty
+    expect(ENTRIES_WITH_LOADS).toBeGreaterThan(0); // (3)
+    expect(ENTRIES_WITHOUT_LOADS).toBeGreaterThan(0); // (4)
+    expect(EMPTY_ENTRY_BODIES).toEqual([]); // (5) every parsed body non-empty
 
     // (6) Discrimination axis: a load is STRICTLY narrower than a mention. Every
     // load edge is also a mention edge, and dozens of mention edges are not load
     // edges — a `principle-*` citation, a "see also", a name in prose. An equal
     // pair means the extractor collapsed back into a name grep, which is exactly
     // the wrong relation: it would draw `b -> a` from `b` merely naming `a`.
-    const allEdges = edgeSet(ALL_MD_TEXT);
-    const namedEdges = new Set(
-      [...ALL_MD_TEXT].flatMap(([owner, text]) =>
-        [...namedSkills(text, owner, NAMES)].map((name) => `${owner} -> ${name}`),
-      ),
-    );
-    expect([...allEdges].filter((edge) => !namedEdges.has(edge))).toEqual([]);
-    expect(allEdges.size).toBeLessThan(namedEdges.size);
+    expect(LOAD_EDGES_WITHOUT_MENTIONS).toEqual([]);
+    expect(ALL_EDGES.size).toBeLessThan(NAMED_EDGES.size);
 
     // (7) Depth axis: the edge set over the SKILL.md files alone is a STRICT
     // subset of the set over every `.md` file. Dozens of edges live only in
     // references/ and the two prompt templates, so the margin is wide; an equal
     // pair means the walk shrank — a shallow glob or a missed references/
     // directory.
-    const skillMdEdges = edgeSet(SKILL_MD_TEXT);
-    expect([...skillMdEdges].filter((edge) => !allEdges.has(edge))).toEqual([]);
-    expect(skillMdEdges.size).toBeLessThan(allEdges.size);
+    expect(SKILL_MD_EDGES_OUTSIDE_FULL_SCAN).toEqual([]);
+    expect(SKILL_MD_EDGES.size).toBeLessThan(ALL_EDGES.size);
 
     // Every skill on disk has an entry. Fails loud rather than skipping.
-    expect(SKILL_DIRECTORIES.filter((name) => !ENTRY_BY_NAME.has(name))).toEqual([]);
+    expect(MISSING_CATALOG_ENTRIES).toEqual([]);
 
-    // The four sweeps, over every entry.
-    expect(SKILL_DIRECTORIES.flatMap(shapeOffenders)).toEqual([]);
-    expect(SKILL_DIRECTORIES.flatMap(sentenceOffenders)).toEqual([]);
-    expect(SKILL_DIRECTORIES.flatMap(loadSetOffenders)).toEqual([]);
-    expect(SKILL_DIRECTORIES.flatMap(loadOrderOffenders)).toEqual([]);
+    // The three source-preservation sweeps, over every entry.
+    expect(SENTENCE_OFFENDERS).toEqual([]);
+    expect(LOAD_SET_OFFENDERS).toEqual([]);
+    expect(LOAD_ORDER_OFFENDERS).toEqual([]);
   });
+
+  test("catalog relationship fields are ordered, non-empty, and complete for every skill", () => {
+    expect(SKILL_DIRECTORIES.length).toBe(90);
+    expect(ENTRIES.length).toBe(90);
+    expect(SHAPE_OFFENDERS).toEqual([]);
+  });
+
+  test("reviewing-designs dependencies and create-team-skill instructions preserve the metadata contract", () => {
+    expect(REVIEWING_DESIGNS_LOADS.length).toBe(7);
+    expect(REVIEWING_DESIGNS_OFFENDERS).toEqual([]);
+    expect(CREATE_TEAM_SKILL_OFFENDERS).toEqual([]);
+  });
+
+  test("migration checkpoint preserves every relationship before table deletion", () => {
+    expect(MIGRATION_RELATIONSHIP_OFFENDERS).toEqual([]);
+  });
+
 
   test("the page-side rules each see a planted positive", () => {
     // A well-formed body, used as the negative control for every rule below.
     const clean = [
       "Lands a reviewed PR.",
+      `${INVOKED_HEADER} user`,
+      `${PHASE_HEADER} Standalone`,
       LOADS_HEADER,
       "- `pr-verify`",
       "- `principle-fail-closed`",
@@ -345,7 +584,14 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(shape(clean)).toEqual([]);
 
     // Leftover bullet: a `**Purpose:**` line that survived the rewrite.
-    expect(shape(["Lands a reviewed PR.", "- **Purpose:** Lands a reviewed PR."])).not.toEqual([]);
+    expect(
+      shape([
+        "Lands a reviewed PR.",
+        `${INVOKED_HEADER} user`,
+        `${PHASE_HEADER} Standalone`,
+        "- **Purpose:** Lands a reviewed PR.",
+      ]),
+    ).not.toEqual([]);
 
     // Second loads header.
     expect(shape([...clean, LOADS_HEADER, "- `shipit`"])).not.toEqual([]);
@@ -370,6 +616,29 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     const description = "Lands a reviewed PR. Use on stated ship intent.";
     expect(sentence(["Lands a reviewed PR."], description)).toEqual([]);
     expect(sentence(["Lands a merged PR."], description)).not.toEqual([]);
+
+    // Relationship-field shape, including leaf, one-value, long-value, and
+    // final-entry boundaries from the design's edge-case inventory.
+    expect(shape(["Leaf skill.", `${INVOKED_HEADER} user`, `${PHASE_HEADER} Any`])).toEqual([]);
+    expect(shape(["Leaf skill.", `${PHASE_HEADER} Any`])).not.toEqual([]);
+    expect(shape(["Leaf skill.", INVOKED_HEADER, `${PHASE_HEADER} Any`])).not.toEqual([]);
+    expect(
+      shape([
+        "Leaf skill.",
+        `${INVOKED_HEADER} user`,
+        `${INVOKED_HEADER} agent`,
+        `${PHASE_HEADER} Any`,
+      ]),
+    ).not.toEqual([]);
+    expect(
+      shape(["Leaf skill.", `${PHASE_HEADER} Any`, `${INVOKED_HEADER} user`]),
+    ).not.toEqual([]);
+    expect(shape(LONG_RELATIONSHIP_BODY)).toEqual([]);
+    expect(FINAL_ENTRY_BODY).toEqual([
+      "Final skill.",
+      `${INVOKED_HEADER} user`,
+      `${PHASE_HEADER} Any`,
+    ]);
 
     // Phantom name: a bullet naming no skill on disk.
     const derived = new Set(["pr-verify", "principle-fail-closed"]);

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -39,15 +39,15 @@ const REPO_ROOT = join(import.meta.dir, "..");
 const CATALOG = join(REPO_ROOT, "docs", "skills.md");
 const SKILLS_ROOT = join(REPO_ROOT, "skills");
 
-const CALLS_HEADER = "**Calls:**";
-const CALLERS_HEADER = "**Callers:**";
+const USES_HEADER = "**Uses:**";
+const USED_BY_HEADER = "**Used by:**";
 
 type Entry = {
   name: string;
   section: string;
   body: string[];
   description: string[];
-  callers: string;
+  usedBy: string;
   loads: string[];
 };
 
@@ -98,21 +98,21 @@ function relationshipNames(value: string): string[] | undefined {
   return [...value.matchAll(/`([a-z0-9-]+)`/g)].map((match) => match[1] as string);
 }
 
-function entryFields(body: string[]): Pick<Entry, "description" | "callers" | "loads"> {
-  const callerLines = body.filter((line) => line.startsWith(CALLERS_HEADER));
-  const callLines = body.filter((line) => line.startsWith(CALLS_HEADER));
-  const callerIndex = body.findIndex((line) => line.startsWith(CALLERS_HEADER));
-  const calls = callLines.length === 1
-    ? (callLines[0] as string).slice(CALLS_HEADER.length).trim()
+function entryFields(body: string[]): Pick<Entry, "description" | "usedBy" | "loads"> {
+  const usedByLines = body.filter((line) => line.startsWith(USED_BY_HEADER));
+  const usesLines = body.filter((line) => line.startsWith(USES_HEADER));
+  const usedByIndex = body.findIndex((line) => line.startsWith(USED_BY_HEADER));
+  const uses = usesLines.length === 1
+    ? (usesLines[0] as string).slice(USES_HEADER.length).trim()
     : "";
 
   return {
-    description: callerIndex === -1 ? [] : body.slice(0, callerIndex),
-    callers:
-      callerLines.length === 1
-        ? (callerLines[0] as string).slice(CALLERS_HEADER.length).trim()
+    description: usedByIndex === -1 ? [] : body.slice(0, usedByIndex),
+    usedBy:
+      usedByLines.length === 1
+        ? (usedByLines[0] as string).slice(USED_BY_HEADER.length).trim()
         : "",
-    loads: relationshipNames(calls) ?? [],
+    loads: relationshipNames(uses) ?? [],
   };
 }
 
@@ -124,24 +124,24 @@ function entryFields(body: string[]): Pick<Entry, "description" | "callers" | "l
 
 /**
  * Shape offenders for one entry body, each naming the offending line. The body
- * must be one or more prose lines, then one Callers line and one Calls line.
+ * must be one or more prose lines, then one Used by line and one Uses line.
  * Both relationship fields use comma-separated skill names or `None`.
  */
 function shape(body: string[]): string[] {
   const offenders: string[] = [];
-  const callerIndexes = body.flatMap((line, index) =>
-    line.startsWith(CALLERS_HEADER) ? [index] : [],
+  const usedByIndexes = body.flatMap((line, index) =>
+    line.startsWith(USED_BY_HEADER) ? [index] : [],
   );
-  const callIndexes = body.flatMap((line, index) =>
-    line.startsWith(CALLS_HEADER) ? [index] : [],
+  const usesIndexes = body.flatMap((line, index) =>
+    line.startsWith(USES_HEADER) ? [index] : [],
   );
 
   for (const [index, line] of body.entries()) {
     const trimmed = line.trim();
     if (line !== trimmed) offenders.push(`indented body line: ${JSON.stringify(line)}`);
 
-    if (trimmed.startsWith(CALLERS_HEADER) || trimmed.startsWith(CALLS_HEADER)) {
-      const header = trimmed.startsWith(CALLERS_HEADER) ? CALLERS_HEADER : CALLS_HEADER;
+    if (trimmed.startsWith(USED_BY_HEADER) || trimmed.startsWith(USES_HEADER)) {
+      const header = trimmed.startsWith(USED_BY_HEADER) ? USED_BY_HEADER : USES_HEADER;
       const value = trimmed.slice(header.length).trim();
       const names = relationshipNames(value);
       if (names === undefined) offenders.push(`invalid ${header} list: ${JSON.stringify(value)}`);
@@ -151,25 +151,25 @@ function shape(body: string[]): string[] {
       continue;
     }
 
-    if ((callerIndexes[0] ?? body.length) < index) {
-      offenders.push(`prose line after the caller field: ${JSON.stringify(trimmed)}`);
+    if ((usedByIndexes[0] ?? body.length) < index) {
+      offenders.push(`prose line after the Used by field: ${JSON.stringify(trimmed)}`);
     }
   }
 
-  if (callerIndexes.length !== 1) {
-    offenders.push(`${callerIndexes.length} caller fields`);
+  if (usedByIndexes.length !== 1) {
+    offenders.push(`${usedByIndexes.length} Used by fields`);
   }
-  if (callIndexes.length !== 1) {
-    offenders.push(`${callIndexes.length} call fields`);
+  if (usesIndexes.length !== 1) {
+    offenders.push(`${usesIndexes.length} Uses fields`);
   }
-  if (callerIndexes.length === 1 && callIndexes.length === 1) {
-    const callerIndex = callerIndexes[0] as number;
-    const callIndex = callIndexes[0] as number;
-    if (callerIndex === 0) offenders.push("no description before the caller field");
-    if (callIndex !== callerIndex + 1) {
-      offenders.push("calls header does not immediately follow the caller field");
+  if (usedByIndexes.length === 1 && usesIndexes.length === 1) {
+    const usedByIndex = usedByIndexes[0] as number;
+    const usesIndex = usesIndexes[0] as number;
+    if (usedByIndex === 0) offenders.push("no description before the Used by field");
+    if (usesIndex !== usedByIndex + 1) {
+      offenders.push("Uses does not immediately follow Used by");
     }
-    if (callIndex !== body.length - 1) offenders.push("content follows the calls field");
+    if (usesIndex !== body.length - 1) offenders.push("content follows the Uses field");
   }
   return offenders;
 }
@@ -315,8 +315,8 @@ const NAMED_EDGES = new Set(
   ),
 );
 const SKILL_MD_EDGES = edgeSet(SKILL_MD_TEXT);
-const ENTRIES_WITH_CALLS = ENTRIES.filter((entry) => entry.loads.length > 0).length;
-const ENTRIES_WITHOUT_CALLS = ENTRIES.filter((entry) => entry.loads.length === 0).length;
+const ENTRIES_WITH_USES = ENTRIES.filter((entry) => entry.loads.length > 0).length;
+const ENTRIES_WITHOUT_USES = ENTRIES.filter((entry) => entry.loads.length === 0).length;
 const EMPTY_ENTRY_BODIES = ENTRIES.filter((entry) => entry.body.length === 0).map(
   (entry) => entry.name,
 );
@@ -325,39 +325,39 @@ const SKILL_MD_EDGES_OUTSIDE_FULL_SCAN = [...SKILL_MD_EDGES].filter(
   (edge) => !ALL_EDGES.has(edge),
 );
 
-function callReciprocityOffenders(entries: Entry[]): string[] {
+function usageReciprocityOffenders(entries: Entry[]): string[] {
   const expected = new Map(entries.map((entry) => [entry.name, [] as string[]]));
   const unknownLoads: string[] = [];
 
   for (const entry of entries) {
     for (const load of entry.loads) {
-      const callers = expected.get(load);
-      if (!callers) unknownLoads.push(`${entry.name}: loads unknown skill ${load}`);
-      else callers.push(entry.name);
+      const usedBy = expected.get(load);
+      if (!usedBy) unknownLoads.push(`${entry.name}: loads unknown skill ${load}`);
+      else usedBy.push(entry.name);
     }
   }
 
   return [
     ...unknownLoads,
     ...entries.flatMap((entry) => {
-      const actual = relationshipNames(entry.callers);
-      if (!actual) return [`${entry.name}: invalid caller list ${JSON.stringify(entry.callers)}`];
+      const actual = relationshipNames(entry.usedBy);
+      if (!actual) return [`${entry.name}: invalid Used by list ${JSON.stringify(entry.usedBy)}`];
       const names = (expected.get(entry.name) ?? []).sort();
       return actual.length === names.length && actual.every((name, index) => name === names[index])
         ? []
-        : [`${entry.name}: expected callers ${JSON.stringify(names)}, got ${JSON.stringify(actual)}`];
+        : [`${entry.name}: expected Used by ${JSON.stringify(names)}, got ${JSON.stringify(actual)}`];
     }),
   ];
 }
 
 function authoringContractOffenders(text: string): string[] {
-  const callers = text.indexOf(CALLERS_HEADER);
-  const calls = text.indexOf(CALLS_HEADER);
+  const usedBy = text.indexOf(USED_BY_HEADER);
+  const uses = text.indexOf(USES_HEADER);
   return [
-    ...(callers === -1 ? [`create-team-skill omits ${CALLERS_HEADER}`] : []),
-    ...(calls === -1 ? [`create-team-skill omits ${CALLS_HEADER}`] : []),
-    ...(callers !== -1 && calls !== -1 && calls < callers
-      ? ["create-team-skill orders calls before the caller field"]
+    ...(usedBy === -1 ? [`create-team-skill omits ${USED_BY_HEADER}`] : []),
+    ...(uses === -1 ? [`create-team-skill omits ${USES_HEADER}`] : []),
+    ...(usedBy !== -1 && uses !== -1 && uses < usedBy
+      ? ["create-team-skill orders Uses before Used by"]
       : []),
   ];
 }
@@ -378,24 +378,24 @@ const CATALOG_INTRODUCTION = CATALOG_TEXT.slice(
   CATALOG_TEXT.indexOf("\n## Entry-point skills"),
 );
 const REMOVED_RELATIONSHIP_OFFENDERS = removedRelationshipPresentation(CATALOG_TEXT);
-const MISSING_INTRODUCTION_LABELS = [CALLERS_HEADER, CALLS_HEADER].filter(
+const MISSING_INTRODUCTION_LABELS = [USED_BY_HEADER, USES_HEADER].filter(
   (label) => !CATALOG_INTRODUCTION.includes(label),
 );
 const CONTEXT_FIELD_OFFENDERS = CATALOG_TEXT.includes("**Context:**")
   ? ["context field remains"]
   : [];
-const CALL_RECIPROCITY_OFFENDERS = callReciprocityOffenders(ENTRIES);
-const LONG_CALLER_BODY = [
+const USAGE_RECIPROCITY_OFFENDERS = usageReciprocityOffenders(ENTRIES);
+const LONG_USED_BY_BODY = [
   "Long relationship.",
-  `${CALLERS_HEADER} ${Array.from({ length: 40 }, (_, index) => `\`caller-${index}\``).join(", ")}`,
-  `${CALLS_HEADER} None`,
+  `${USED_BY_HEADER} ${Array.from({ length: 40 }, (_, index) => `\`skill-${index}\``).join(", ")}`,
+  `${USES_HEADER} None`,
 ];
 const FINAL_ENTRY_BODY = catalogEntries([
   "## Methodology skills",
   "### [final-skill](target)",
   "Final skill.",
-  `${CALLERS_HEADER} None`,
-  `${CALLS_HEADER} None`,
+  `${USED_BY_HEADER} None`,
+  `${USES_HEADER} None`,
   "## Name-collision pairs",
   "not part of the entry",
 ].join("\n"))[0]?.body;
@@ -407,8 +407,8 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // (docs/testing.md, "Prove a negative check can find a positive").
     expect(SKILL_DIRECTORIES.length).toBeGreaterThan(60); // (1) skills/ tree parsed
     expect(ENTRIES.length).toBeGreaterThan(60); // (2) page parsed
-    expect(ENTRIES_WITH_CALLS).toBeGreaterThan(0); // (3)
-    expect(ENTRIES_WITHOUT_CALLS).toBeGreaterThan(0); // (4)
+    expect(ENTRIES_WITH_USES).toBeGreaterThan(0); // (3)
+    expect(ENTRIES_WITHOUT_USES).toBeGreaterThan(0); // (4)
     expect(EMPTY_ENTRY_BODIES).toEqual([]); // (5) every parsed body non-empty
 
     // (6) Discrimination axis: a load is STRICTLY narrower than a mention. Every
@@ -435,11 +435,11 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(LOAD_ORDER_OFFENDERS).toEqual([]);
   });
 
-  test("catalog Callers and Calls fields are exact reciprocals", () => {
+  test("catalog Used by and Uses fields are exact reciprocals", () => {
     expect(SKILL_DIRECTORIES.length).toBe(90);
     expect(ENTRIES.length).toBe(90);
     expect(SHAPE_OFFENDERS).toEqual([]);
-    expect(CALL_RECIPROCITY_OFFENDERS).toEqual([]);
+    expect(USAGE_RECIPROCITY_OFFENDERS).toEqual([]);
   });
 
   test("create-team-skill instructions preserve the reciprocal call graph contract", () => {
@@ -457,8 +457,8 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // A well-formed body, used as the negative control for every rule below.
     const clean = [
       "Lands a reviewed PR.",
-      `${CALLERS_HEADER} None`,
-      `${CALLS_HEADER} \`pr-verify\`, \`principle-fail-closed\``,
+      `${USED_BY_HEADER} None`,
+      `${USES_HEADER} \`pr-verify\`, \`principle-fail-closed\``,
     ];
     expect(shape(clean)).toEqual([]);
 
@@ -466,28 +466,28 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(
       shape([
         "Lands a reviewed PR.",
-        `${CALLERS_HEADER} None`,
+        `${USED_BY_HEADER} None`,
         "- **Purpose:** Lands a reviewed PR.",
       ]),
     ).not.toEqual([]);
 
-    // Second calls field.
-    expect(shape([...clean, `${CALLS_HEADER} \`shipit\``])).not.toEqual([]);
+    // Second Uses field.
+    expect(shape([...clean, `${USES_HEADER} \`shipit\``])).not.toEqual([]);
 
     // Trailing clause after a name.
     expect(
-      shape(["Lands a reviewed PR.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} \`pr-verify\` for the checks`]),
+      shape(["Lands a reviewed PR.", `${USED_BY_HEADER} None`, `${USES_HEADER} \`pr-verify\` for the checks`]),
     ).not.toEqual([]);
 
     // Duplicate name in the comma list.
     expect(
-      shape(["Lands a reviewed PR.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} \`pr-verify\`, \`pr-verify\``]),
+      shape(["Lands a reviewed PR.", `${USED_BY_HEADER} None`, `${USES_HEADER} \`pr-verify\`, \`pr-verify\``]),
     ).not.toEqual([]);
 
     // Indented line, as the first line and as a later line.
     expect(shape(["  Lands a reviewed PR."])).not.toEqual([]);
     expect(
-      shape(["Lands a reviewed PR.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} None`, "  continued"]),
+      shape(["Lands a reviewed PR.", `${USED_BY_HEADER} None`, `${USES_HEADER} None`, "  continued"]),
     ).not.toEqual([]);
 
     // Drifted sentence: the page no longer copies the description's first sentence.
@@ -495,39 +495,39 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(sentence(["Lands a reviewed PR."], description)).toEqual([]);
     expect(sentence(["Lands a merged PR."], description)).not.toEqual([]);
 
-    expect(shape(["Leaf skill.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} None`])).toEqual([]);
+    expect(shape(["Leaf skill.", `${USED_BY_HEADER} None`, `${USES_HEADER} None`])).toEqual([]);
     expect(shape(["Leaf skill."])).not.toEqual([]);
-    expect(shape(["Leaf skill.", CALLERS_HEADER])).not.toEqual([]);
+    expect(shape(["Leaf skill.", USED_BY_HEADER])).not.toEqual([]);
     expect(
       shape([
         "Leaf skill.",
-        `${CALLERS_HEADER} None`,
-        `${CALLERS_HEADER} \`agent\``,
-        `${CALLS_HEADER} None`,
+        `${USED_BY_HEADER} None`,
+        `${USED_BY_HEADER} \`agent\``,
+        `${USES_HEADER} None`,
       ]),
     ).not.toEqual([]);
-    expect(shape(LONG_CALLER_BODY)).toEqual([]);
+    expect(shape(LONG_USED_BY_BODY)).toEqual([]);
     expect(FINAL_ENTRY_BODY).toEqual([
       "Final skill.",
-      `${CALLERS_HEADER} None`,
-      `${CALLS_HEADER} None`,
+      `${USED_BY_HEADER} None`,
+      `${USES_HEADER} None`,
     ]);
 
     const reciprocal = catalogEntries([
       "## Methodology skills",
       "### [a](target)",
       "A skill.",
-      `${CALLERS_HEADER} None`,
-      `${CALLS_HEADER} \`b\``,
+      `${USED_BY_HEADER} None`,
+      `${USES_HEADER} \`b\``,
       "### [b](target)",
       "B skill.",
-      `${CALLERS_HEADER} \`a\``,
-      `${CALLS_HEADER} None`,
+      `${USED_BY_HEADER} \`a\``,
+      `${USES_HEADER} None`,
     ].join("\n"));
-    expect(callReciprocityOffenders(reciprocal)).toEqual([]);
+    expect(usageReciprocityOffenders(reciprocal)).toEqual([]);
     expect(
-      callReciprocityOffenders(
-        reciprocal.map((entry) => entry.name === "b" ? { ...entry, callers: "None" } : entry),
+      usageReciprocityOffenders(
+        reciprocal.map((entry) => entry.name === "b" ? { ...entry, usedBy: "None" } : entry),
       ),
     ).not.toEqual([]);
 

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -40,7 +40,6 @@ const CATALOG = join(REPO_ROOT, "docs", "skills.md");
 const SKILLS_ROOT = join(REPO_ROOT, "skills");
 
 const CALLS_HEADER = "**Calls:**";
-const LOAD_BULLET = /^- `([a-z0-9-]+)`$/;
 const CALLERS_HEADER = "**Callers:**";
 
 type Entry = {
@@ -92,15 +91,8 @@ function markdownFiles(dir: string): string[] {
   });
 }
 
-/** The names on the entry's load bullets, in authored order. */
-function loadBullets(body: string[]): string[] {
-  return body.flatMap((line) => {
-    const bullet = LOAD_BULLET.exec(line.trim());
-    return bullet ? [bullet[1] as string] : [];
-  });
-}
-
-function callerNames(value: string): string[] | undefined {
+/** The names in a relationship field, in authored order. */
+function relationshipNames(value: string): string[] | undefined {
   if (value === "None") return [];
   if (!/^`[a-z0-9-]+`(?:, `[a-z0-9-]+`)*$/.test(value)) return undefined;
   return [...value.matchAll(/`([a-z0-9-]+)`/g)].map((match) => match[1] as string);
@@ -108,7 +100,11 @@ function callerNames(value: string): string[] | undefined {
 
 function entryFields(body: string[]): Pick<Entry, "description" | "callers" | "loads"> {
   const callerLines = body.filter((line) => line.startsWith(CALLERS_HEADER));
+  const callLines = body.filter((line) => line.startsWith(CALLS_HEADER));
   const callerIndex = body.findIndex((line) => line.startsWith(CALLERS_HEADER));
+  const calls = callLines.length === 1
+    ? (callLines[0] as string).slice(CALLS_HEADER.length).trim()
+    : "";
 
   return {
     description: callerIndex === -1 ? [] : body.slice(0, callerIndex),
@@ -116,13 +112,8 @@ function entryFields(body: string[]): Pick<Entry, "description" | "callers" | "l
       callerLines.length === 1
         ? (callerLines[0] as string).slice(CALLERS_HEADER.length).trim()
         : "",
-    loads: loadBullets(body),
+    loads: relationshipNames(calls) ?? [],
   };
-}
-
-/** True when the body carries the calls header. */
-function hasCallsHeader(body: string[]): boolean {
-  return body.some((line) => line.trim() === CALLS_HEADER);
 }
 
 // ---------------------------------------------------------------------------
@@ -133,54 +124,33 @@ function hasCallsHeader(body: string[]): boolean {
 
 /**
  * Shape offenders for one entry body, each naming the offending line. The body
- * must be one or more prose lines, then optionally the calls header followed
- * by one or more load bullets, and nothing after. Eight offenders: (1) zero
- * prose lines; (2) a line starting `- ` that is not exactly a load bullet
- * (a surviving `**Purpose:**` bullet, a trailing clause after a name); (3) a
- * prose line after the calls header; (4) a calls header with no bullet
- * under it; (5) a load bullet with no header above it; (6) a second loads
- * header; (7) a duplicate name among the bullets; (8) any body line with
- * leading whitespace, first line included.
+ * must be one or more prose lines, then one Callers line and one Calls line.
+ * Both relationship fields use comma-separated skill names or `None`.
  */
 function shape(body: string[]): string[] {
   const offenders: string[] = [];
-  const seen = new Set<string>();
   const callerIndexes = body.flatMap((line, index) =>
     line.startsWith(CALLERS_HEADER) ? [index] : [],
   );
-  let headers = 0;
-  let bullets = 0;
+  const callIndexes = body.flatMap((line, index) =>
+    line.startsWith(CALLS_HEADER) ? [index] : [],
+  );
 
   for (const [index, line] of body.entries()) {
     const trimmed = line.trim();
     if (line !== trimmed) offenders.push(`indented body line: ${JSON.stringify(line)}`);
 
-    if (trimmed.startsWith(CALLERS_HEADER)) {
+    if (trimmed.startsWith(CALLERS_HEADER) || trimmed.startsWith(CALLS_HEADER)) {
+      const header = trimmed.startsWith(CALLERS_HEADER) ? CALLERS_HEADER : CALLS_HEADER;
+      const value = trimmed.slice(header.length).trim();
+      const names = relationshipNames(value);
+      if (names === undefined) offenders.push(`invalid ${header} list: ${JSON.stringify(value)}`);
+      if (names && new Set(names).size !== names.length) {
+        offenders.push(`duplicate name in ${header} list`);
+      }
       continue;
     }
 
-    if (trimmed === CALLS_HEADER) {
-      headers++;
-      if (headers > 1) offenders.push("second calls header");
-      continue;
-    }
-
-    const bullet = LOAD_BULLET.exec(trimmed);
-    if (bullet) {
-      const name = bullet[1] as string;
-      bullets++;
-      if (headers === 0) offenders.push(`load bullet with no header above it: ${name}`);
-      if (seen.has(name)) offenders.push(`duplicate load: ${name}`);
-      seen.add(name);
-      continue;
-    }
-
-    if (trimmed.startsWith("- ")) {
-      offenders.push(`bullet that is not a bare load: ${JSON.stringify(trimmed)}`);
-      continue;
-    }
-
-    if (headers > 0) offenders.push(`prose line after the calls header: ${JSON.stringify(trimmed)}`);
     if ((callerIndexes[0] ?? body.length) < index) {
       offenders.push(`prose line after the caller field: ${JSON.stringify(trimmed)}`);
     }
@@ -189,23 +159,18 @@ function shape(body: string[]): string[] {
   if (callerIndexes.length !== 1) {
     offenders.push(`${callerIndexes.length} caller fields`);
   }
-  if (callerIndexes.length === 1) {
+  if (callIndexes.length !== 1) {
+    offenders.push(`${callIndexes.length} call fields`);
+  }
+  if (callerIndexes.length === 1 && callIndexes.length === 1) {
     const callerIndex = callerIndexes[0] as number;
+    const callIndex = callIndexes[0] as number;
     if (callerIndex === 0) offenders.push("no description before the caller field");
-    if ((body[callerIndex] as string).slice(CALLERS_HEADER.length).trim() === "") {
-      offenders.push("caller field is empty");
-    }
-
-    const loadsIndex = body.findIndex((line) => line === CALLS_HEADER);
-    if (loadsIndex === -1 && callerIndex !== body.length - 1) {
-      offenders.push("content follows the caller field without a calls header");
-    }
-    if (loadsIndex !== -1 && loadsIndex !== callerIndex + 1) {
+    if (callIndex !== callerIndex + 1) {
       offenders.push("calls header does not immediately follow the caller field");
     }
+    if (callIndex !== body.length - 1) offenders.push("content follows the calls field");
   }
-
-  if (headers > 0 && bullets === 0) offenders.push("calls header with no bullet under it");
   return offenders;
 }
 
@@ -233,29 +198,29 @@ function sentence(descriptionLines: string[], description: string): string[] {
 
 /**
  * Load-set offenders, each naming the offending name: a derived name missing
- * from the bullets, a listed name absent from the derived set, and a listed name
+ * from the field, a listed name absent from the derived set, and a listed name
  * that is not a real skill at all. The second one is the direction check — a
  * skill that only *names* another skill has no edge to it, so listing it here
  * would draw an arrow the source never authorized.
  */
-function loadSet(bullets: string[], derived: Set<string>, names: Set<string>): string[] {
-  const listed = new Set(bullets);
+function loadSet(values: string[], derived: Set<string>, names: Set<string>): string[] {
+  const listed = new Set(values);
   return [
     ...[...derived].filter((name) => !listed.has(name)).map((name) => `loads omit ${name}`),
-    ...bullets.filter((name) => !derived.has(name)).map((name) => `loads list ${name}, which its files never load`),
-    ...bullets.filter((name) => !names.has(name)).map((name) => `loads list ${name}, which is not a skill`),
+    ...values.filter((name) => !derived.has(name)).map((name) => `loads list ${name}, which its files never load`),
+    ...values.filter((name) => !names.has(name)).map((name) => `loads list ${name}, which is not a skill`),
   ];
 }
 
 /**
- * Order offenders: the authored bullet names compared to that same array under
+ * Order offenders: the authored names compared to that same array under
  * `[...names].sort()` — codepoint order, so `pr-verify` precedes
  * `principle-fail-closed`. Names the first name out of place.
  */
-function loadOrder(bullets: string[]): string[] {
-  const sorted = [...bullets].sort();
-  const at = bullets.findIndex((name, index) => name !== sorted[index]);
-  return at === -1 ? [] : [`loads out of order at ${bullets[at]}, expected ${sorted[at]}`];
+function loadOrder(values: string[]): string[] {
+  const sorted = [...values].sort();
+  const at = values.findIndex((name, index) => name !== sorted[index]);
+  return at === -1 ? [] : [`loads out of order at ${values[at]}, expected ${sorted[at]}`];
 }
 
 /**
@@ -350,8 +315,8 @@ const NAMED_EDGES = new Set(
   ),
 );
 const SKILL_MD_EDGES = edgeSet(SKILL_MD_TEXT);
-const ENTRIES_WITH_CALLS = ENTRIES.filter((entry) => hasCallsHeader(entry.body)).length;
-const ENTRIES_WITHOUT_CALLS = ENTRIES.filter((entry) => !hasCallsHeader(entry.body)).length;
+const ENTRIES_WITH_CALLS = ENTRIES.filter((entry) => entry.loads.length > 0).length;
+const ENTRIES_WITHOUT_CALLS = ENTRIES.filter((entry) => entry.loads.length === 0).length;
 const EMPTY_ENTRY_BODIES = ENTRIES.filter((entry) => entry.body.length === 0).map(
   (entry) => entry.name,
 );
@@ -375,7 +340,7 @@ function callReciprocityOffenders(entries: Entry[]): string[] {
   return [
     ...unknownLoads,
     ...entries.flatMap((entry) => {
-      const actual = callerNames(entry.callers);
+      const actual = relationshipNames(entry.callers);
       if (!actual) return [`${entry.name}: invalid caller list ${JSON.stringify(entry.callers)}`];
       const names = (expected.get(entry.name) ?? []).sort();
       return actual.length === names.length && actual.every((name, index) => name === names[index])
@@ -390,15 +355,10 @@ function authoringContractOffenders(text: string): string[] {
   const calls = text.indexOf(CALLS_HEADER);
   return [
     ...(callers === -1 ? [`create-team-skill omits ${CALLERS_HEADER}`] : []),
+    ...(calls === -1 ? [`create-team-skill omits ${CALLS_HEADER}`] : []),
     ...(callers !== -1 && calls !== -1 && calls < callers
       ? ["create-team-skill orders calls before the caller field"]
       : []),
-    ...(text.includes("Set `**Callers:**` to `None`")
-      ? []
-      : ["create-team-skill omits the zero-caller rule"]),
-    ...(text.includes("every skill whose `**Calls:**` list names it")
-      ? []
-      : ["create-team-skill omits the reciprocal caller rule"]),
   ];
 }
 
@@ -418,7 +378,7 @@ const CATALOG_INTRODUCTION = CATALOG_TEXT.slice(
   CATALOG_TEXT.indexOf("\n## Entry-point skills"),
 );
 const REMOVED_RELATIONSHIP_OFFENDERS = removedRelationshipPresentation(CATALOG_TEXT);
-const MISSING_INTRODUCTION_LABELS = [CALLERS_HEADER].filter(
+const MISSING_INTRODUCTION_LABELS = [CALLERS_HEADER, CALLS_HEADER].filter(
   (label) => !CATALOG_INTRODUCTION.includes(label),
 );
 const CONTEXT_FIELD_OFFENDERS = CATALOG_TEXT.includes("**Context:**")
@@ -428,12 +388,14 @@ const CALL_RECIPROCITY_OFFENDERS = callReciprocityOffenders(ENTRIES);
 const LONG_CALLER_BODY = [
   "Long relationship.",
   `${CALLERS_HEADER} ${Array.from({ length: 40 }, (_, index) => `\`caller-${index}\``).join(", ")}`,
+  `${CALLS_HEADER} None`,
 ];
 const FINAL_ENTRY_BODY = catalogEntries([
   "## Methodology skills",
   "### [final-skill](target)",
   "Final skill.",
   `${CALLERS_HEADER} None`,
+  `${CALLS_HEADER} None`,
   "## Name-collision pairs",
   "not part of the entry",
 ].join("\n"))[0]?.body;
@@ -496,9 +458,7 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     const clean = [
       "Lands a reviewed PR.",
       `${CALLERS_HEADER} None`,
-      CALLS_HEADER,
-      "- `pr-verify`",
-      "- `principle-fail-closed`",
+      `${CALLS_HEADER} \`pr-verify\`, \`principle-fail-closed\``,
     ];
     expect(shape(clean)).toEqual([]);
 
@@ -511,23 +471,23 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
       ]),
     ).not.toEqual([]);
 
-    // Second calls header.
-    expect(shape([...clean, CALLS_HEADER, "- `shipit`"])).not.toEqual([]);
+    // Second calls field.
+    expect(shape([...clean, `${CALLS_HEADER} \`shipit\``])).not.toEqual([]);
 
     // Trailing clause after a name.
     expect(
-      shape(["Lands a reviewed PR.", CALLS_HEADER, "- `pr-verify` for the checks"]),
+      shape(["Lands a reviewed PR.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} \`pr-verify\` for the checks`]),
     ).not.toEqual([]);
 
-    // Duplicate name among the bullets.
+    // Duplicate name in the comma list.
     expect(
-      shape(["Lands a reviewed PR.", CALLS_HEADER, "- `pr-verify`", "- `pr-verify`"]),
+      shape(["Lands a reviewed PR.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} \`pr-verify\`, \`pr-verify\``]),
     ).not.toEqual([]);
 
     // Indented line, as the first line and as a later line.
     expect(shape(["  Lands a reviewed PR."])).not.toEqual([]);
     expect(
-      shape(["Lands a reviewed PR.", CALLS_HEADER, "- `pr-verify`", "  continued"]),
+      shape(["Lands a reviewed PR.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} None`, "  continued"]),
     ).not.toEqual([]);
 
     // Drifted sentence: the page no longer copies the description's first sentence.
@@ -535,7 +495,7 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(sentence(["Lands a reviewed PR."], description)).toEqual([]);
     expect(sentence(["Lands a merged PR."], description)).not.toEqual([]);
 
-    expect(shape(["Leaf skill.", `${CALLERS_HEADER} None`])).toEqual([]);
+    expect(shape(["Leaf skill.", `${CALLERS_HEADER} None`, `${CALLS_HEADER} None`])).toEqual([]);
     expect(shape(["Leaf skill."])).not.toEqual([]);
     expect(shape(["Leaf skill.", CALLERS_HEADER])).not.toEqual([]);
     expect(
@@ -543,12 +503,14 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
         "Leaf skill.",
         `${CALLERS_HEADER} None`,
         `${CALLERS_HEADER} \`agent\``,
+        `${CALLS_HEADER} None`,
       ]),
     ).not.toEqual([]);
     expect(shape(LONG_CALLER_BODY)).toEqual([]);
     expect(FINAL_ENTRY_BODY).toEqual([
       "Final skill.",
       `${CALLERS_HEADER} None`,
+      `${CALLS_HEADER} None`,
     ]);
 
     const reciprocal = catalogEntries([
@@ -556,11 +518,11 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
       "### [a](target)",
       "A skill.",
       `${CALLERS_HEADER} None`,
-      CALLS_HEADER,
-      "- `b`",
+      `${CALLS_HEADER} \`b\``,
       "### [b](target)",
       "B skill.",
       `${CALLERS_HEADER} \`a\``,
+      `${CALLS_HEADER} None`,
     ].join("\n"));
     expect(callReciprocityOffenders(reciprocal)).toEqual([]);
     expect(
@@ -575,7 +537,7 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
       ),
     ).toEqual(["relationship heading remains", "relationship anchor link remains"]);
 
-    // Phantom name: a bullet naming no skill on disk.
+    // Phantom name: a field naming no skill on disk.
     const derived = new Set(["pr-verify", "principle-fail-closed"]);
     expect(loadSet(["pr-verify", "principle-fail-closed"], derived, NAMES)).toEqual([]);
     expect(

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -102,7 +102,6 @@ function loadBullets(body: string[]): string[] {
   });
 }
 
-/** Structured fields from one entry body. Invalid bodies return empty fields. */
 function entryFields(body: string[]): Pick<Entry, "description" | "invokedBy" | "phaseContext" | "loads"> {
   const invokedLines = body.filter((line) => line.startsWith(INVOKED_HEADER));
   const phaseLines = body.filter((line) => line.startsWith(PHASE_HEADER));
@@ -477,7 +476,6 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     // Every skill on disk has an entry. Fails loud rather than skipping.
     expect(MISSING_CATALOG_ENTRIES).toEqual([]);
 
-    // The three source-preservation sweeps, over every entry.
     expect(SENTENCE_OFFENDERS).toEqual([]);
     expect(LOAD_SET_OFFENDERS).toEqual([]);
     expect(LOAD_ORDER_OFFENDERS).toEqual([]);
@@ -547,8 +545,6 @@ describe("docs/skills.md catalog matches the skills on disk", () => {
     expect(sentence(["Lands a reviewed PR."], description)).toEqual([]);
     expect(sentence(["Lands a merged PR."], description)).not.toEqual([]);
 
-    // Relationship-field shape, including leaf, one-value, long-value, and
-    // final-entry boundaries from the design's edge-case inventory.
     expect(shape(["Leaf skill.", `${INVOKED_HEADER} user`, `${PHASE_HEADER} Any`])).toEqual([]);
     expect(shape(["Leaf skill.", `${PHASE_HEADER} Any`])).not.toEqual([]);
     expect(shape(["Leaf skill.", INVOKED_HEADER, `${PHASE_HEADER} Any`])).not.toEqual([]);

--- a/tests/docs-skills-catalog.test.ts
+++ b/tests/docs-skills-catalog.test.ts
@@ -41,8 +41,8 @@ const SKILLS_ROOT = join(REPO_ROOT, "skills");
 
 const LOADS_HEADER = "**Loads:**";
 const LOAD_BULLET = /^- `([a-z0-9-]+)`$/;
-const INVOKED_HEADER = "**Invoked / loaded by:**";
-const PHASE_HEADER = "**Phase / context:**";
+const INVOKED_HEADER = "**Consumers:**";
+const PHASE_HEADER = "**Context:**";
 
 type Entry = {
   name: string;
@@ -191,9 +191,9 @@ function shape(body: string[]): string[] {
   }
 
   if (invokedIndexes.length !== 1) {
-    offenders.push(`${invokedIndexes.length} invoked / loaded by fields`);
+    offenders.push(`${invokedIndexes.length} consumer fields`);
   }
-  if (phaseIndexes.length !== 1) offenders.push(`${phaseIndexes.length} phase / context fields`);
+  if (phaseIndexes.length !== 1) offenders.push(`${phaseIndexes.length} context fields`);
 
   if (invokedIndexes.length === 1 && phaseIndexes.length === 1) {
     const invokedIndex = invokedIndexes[0] as number;
@@ -203,10 +203,10 @@ function shape(body: string[]): string[] {
       offenders.push("relationship fields are not adjacent and ordered");
     }
     if ((body[invokedIndex] as string).slice(INVOKED_HEADER.length).trim() === "") {
-      offenders.push("invoked / loaded by field is empty");
+      offenders.push("consumer field is empty");
     }
     if ((body[phaseIndex] as string).slice(PHASE_HEADER.length).trim() === "") {
-      offenders.push("phase / context field is empty");
+      offenders.push("context field is empty");
     }
 
     const loadsIndex = body.findIndex((line) => line === LOADS_HEADER);

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -1846,11 +1846,6 @@ describe("principle-untrusted-input-is-data (L2 content tripwire)", () => {
   });
 });
 
-// Consumer metadata drifted: new bare principle-name citations landed and the
-// catalog entry did not follow. This gate makes that drift class
-// deterministic: for every principle-* skill, every file under agents/ or
-// skills/ that cites its backticked name must appear in that skill entry's
-// consumer field. All parsing is precomputed once at module level.
 describe("docs/skills.md principle consumer fields match on-disk citations (L2 tripwire)", () => {
   const SKILLS_DIR = join(REPO_ROOT, "skills");
   const AGENTS_DIR = join(REPO_ROOT, "agents");

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -29,15 +29,15 @@ function body(text: string): string {
   return out.join("\n");
 }
 
-// Keep lines containing `key`, drop lines matching the `exclude` regex, take
-// the first 5, join. Isolates a single table row from a methodology doc.
-function filterRows(text: string, key: string, exclude: RegExp): string {
-  return text
-    .split("\n")
-    .filter((line) => line.includes(key))
-    .filter((line) => !exclude.test(line))
-    .slice(0, 5)
-    .join("\n");
+function catalogConsumerField(page: string, name: string): string {
+  const heading = `### [${name}]`;
+  const start = page.indexOf(heading);
+  if (start === -1) return "";
+  const section = page.slice(start + heading.length);
+  const end = section.search(/\n#{2,3} /);
+  const entry = end === -1 ? section : section.slice(0, end);
+  const line = entry.split("\n").find((value) => value.startsWith("**Invoked / loaded by:**"));
+  return line?.slice("**Invoked / loaded by:**".length).trim() ?? "";
 }
 
 // Text between two markers; "" when either marker is missing. Callers guard
@@ -79,7 +79,6 @@ function grepA4(text: string, pattern: RegExp): string {
 
 describe("engineering-standards methodology", () => {
   const SKILL_FILE = join(REPO_ROOT, "skills", "engineering-standards", "SKILL.md");
-  const SKILLS_MD = join(REPO_ROOT, "docs", "skills.md");
   const PLANNER = join(REPO_ROOT, "agents", "planner.md");
   const IMPLEMENTER = join(REPO_ROOT, "agents", "implementer.md");
   const CODE_REVIEWER = join(REPO_ROOT, "agents", "code-reviewer.md");
@@ -140,23 +139,6 @@ describe("engineering-standards methodology", () => {
     expect(loadsSkill(read(CODE_REVIEWER), "engineering-standards")).toBe(true);
   });
 
-  test("skills.md methodology table includes engineering-standards row with all 3 consumers", () => {
-    const row = filterRows(read(SKILLS_MD), "| `engineering-standards` |", /^#|^>|\/\/|event/);
-    expect(row.length).toBeGreaterThan(0);
-    for (const agent of ["planner", "implementer", "code-reviewer"]) {
-      expect(row).toContain(agent);
-    }
-  });
-
-  test("skills.md reviewing-code row unchanged", () => {
-    // Key on the table-row delimiter so prose mentions of the skill name
-    // elsewhere in the doc cannot crowd the row out of the 5-line window.
-    const row = filterRows(read(SKILLS_MD), "| `reviewing-code` |", /^#|^>|SKILL\.md|\/\/|event/);
-    for (const agent of ["code-reviewer", "security-reviewer", "ux-reviewer", "technical-writer"]) {
-      expect(row).toContain(agent);
-    }
-  });
-
   test("skill defers to solid for LSP/SRP", () => {
     expect(read(SKILL_FILE)).toContain("solid/SKILL.md");
   });
@@ -189,15 +171,6 @@ describe("engineering-standards methodology", () => {
   // The working-tree `git diff` cleanliness check is a CI-hygiene concern, not
   // a property of the code under test, so it is intentionally not covered here.
 
-  test("skills.md methodology table includes solid row", () => {
-    const row = filterRows(read(SKILLS_MD), "| `solid` |", /^#|^>|\/\/|event/);
-    expect(row.length).toBeGreaterThan(0);
-  });
-
-  test("skills.md methodology table includes refactoring-to-patterns row", () => {
-    const row = filterRows(read(SKILLS_MD), "| `refactoring-to-patterns` |", /^#|^>|\/\/|event/);
-    expect(row.length).toBeGreaterThan(0);
-  });
 });
 
 describe("product-thinking methodology", () => {
@@ -1873,16 +1846,12 @@ describe("principle-untrusted-input-is-data (L2 content tripwire)", () => {
   });
 });
 
-// The "Skill ↔ agent ↔ phase" table drifted: new bare principle-name citations
-// landed and the row did not follow. This gate makes that drift class
+// Consumer metadata drifted: new bare principle-name citations landed and the
+// catalog entry did not follow. This gate makes that drift class
 // deterministic: for every principle-* skill, every file under agents/ or
-// skills/ that cites its backticked name must appear in that skill's table
-// row. This is where inbound *agent* citers are covered, since the per-entry
-// Mentions: sweep in tests/docs-skills-catalog.test.ts reads nothing under
-// agents/. All parsing is precomputed once at module level: each file is read
-// once, and each test body is a declarative assertion whose failure value
-// names the skill and the missing consumer.
-describe("docs/skills.md principle table rows match on-disk citations (L2 tripwire)", () => {
+// skills/ that cites its backticked name must appear in that skill entry's
+// consumer field. All parsing is precomputed once at module level.
+describe("docs/skills.md principle consumer fields match on-disk citations (L2 tripwire)", () => {
   const SKILLS_DIR = join(REPO_ROOT, "skills");
   const AGENTS_DIR = join(REPO_ROOT, "agents");
   const SKILLS_MD = read(join(REPO_ROOT, "docs", "skills.md"));
@@ -1926,13 +1895,8 @@ describe("docs/skills.md principle table rows match on-disk citations (L2 tripwi
     }),
   );
 
-  // The `| \`<name>\` | ... |` row of the "Skill ↔ agent ↔ phase" table.
-  // "" when the row is missing, so the assertion fails loud, never vacuously.
-  const tableRows = new Map(
-    principleSkills.map((name) => {
-      const match = SKILLS_MD.match(new RegExp(`^\\| \`${name}\` \\|.*$`, "m"));
-      return [name, match ? match[0] : ""] as const;
-    }),
+  const consumerFields = new Map(
+    principleSkills.map((name) => [name, catalogConsumerField(SKILLS_MD, name)] as const),
   );
 
   // `name` bounded by non-name characters, so `code-review` never matches
@@ -1941,20 +1905,18 @@ describe("docs/skills.md principle table rows match on-disk citations (L2 tripwi
     return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
   }
 
-  test("the principle tier exists on disk (the loops below cannot go vacuous)", () => {
-    expect(principleSkills.length).toBeGreaterThan(20);
+  const missingConsumers = extractedPrinciples.flatMap((principle) => {
+    const field = consumerFields.get(principle) ?? "";
+    if (field === "") return [`${principle}: consumer field missing or empty`];
+    return (citersByPrinciple.get(principle) ?? [])
+      .filter((citer) => !mentions(field, citer))
+      .map((citer) => `${principle}: consumer field omits ${citer}`);
   });
 
-  for (const principle of extractedPrinciples) {
-    test(`table row for ${principle} omits no file that cites it by name`, () => {
-      const row = tableRows.get(principle) ?? "";
-      expect(row.length).toBeGreaterThan(0);
-      const missing = (citersByPrinciple.get(principle) ?? [])
-        .filter((citer) => !mentions(row, citer))
-        .map((citer) => `${principle}: table row omits consumer ${citer}`);
-      expect(missing).toEqual([]);
-    });
-  }
+  test("principle consumer fields include every source-derived citer", () => {
+    expect(principleSkills.length).toBeGreaterThan(20);
+    expect(missingConsumers).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -36,8 +36,8 @@ function catalogConsumerField(page: string, name: string): string {
   const section = page.slice(start + heading.length);
   const end = section.search(/\n#{2,3} /);
   const entry = end === -1 ? section : section.slice(0, end);
-  const line = entry.split("\n").find((value) => value.startsWith("**Invoked / loaded by:**"));
-  return line?.slice("**Invoked / loaded by:**".length).trim() ?? "";
+  const line = entry.split("\n").find((value) => value.startsWith("**Consumers:**"));
+  return line?.slice("**Consumers:**".length).trim() ?? "";
 }
 
 // Text between two markers; "" when either marker is missing. Callers guard

--- a/tests/methodology.test.ts
+++ b/tests/methodology.test.ts
@@ -29,17 +29,6 @@ function body(text: string): string {
   return out.join("\n");
 }
 
-function catalogConsumerField(page: string, name: string): string {
-  const heading = `### [${name}]`;
-  const start = page.indexOf(heading);
-  if (start === -1) return "";
-  const section = page.slice(start + heading.length);
-  const end = section.search(/\n#{2,3} /);
-  const entry = end === -1 ? section : section.slice(0, end);
-  const line = entry.split("\n").find((value) => value.startsWith("**Consumers:**"));
-  return line?.slice("**Consumers:**".length).trim() ?? "";
-}
-
 // Text between two markers; "" when either marker is missing. Callers guard
 // the slice as non-empty so a missing section fails loud, never vacuously
 // (pattern: tests/protocol.test.ts softSection guard).
@@ -1843,74 +1832,6 @@ describe("principle-untrusted-input-is-data (L2 content tripwire)", () => {
 
   test("citation site: pr-cleanup cites the principle by name", () => {
     expect(read(join(REPO_ROOT, "skills", "pr-cleanup", "SKILL.md"))).toContain("principle-untrusted-input-is-data");
-  });
-});
-
-describe("docs/skills.md principle consumer fields match on-disk citations (L2 tripwire)", () => {
-  const SKILLS_DIR = join(REPO_ROOT, "skills");
-  const AGENTS_DIR = join(REPO_ROOT, "agents");
-  const SKILLS_MD = read(join(REPO_ROOT, "docs", "skills.md"));
-
-  const skillNames = readdirSync(SKILLS_DIR).filter((name) =>
-    existsSync(join(SKILLS_DIR, name, "SKILL.md")),
-  );
-  const agentNames = readdirSync(AGENTS_DIR)
-    .filter((name) => name.endsWith(".md"))
-    .map((name) => name.replace(/\.md$/, ""));
-  const principleSkills = skillNames.filter((name) => name.startsWith("principle-")).sort();
-
-  // Every principle-prefixed skill is a single-invariant skill with a
-  // citer list; the multi-rule methodology sets carry no prefix.
-  const extractedPrinciples = principleSkills;
-
-  // Each skill and agent file is read exactly once.
-  const skillContents = new Map(
-    skillNames.map((skill) => [skill, read(join(SKILLS_DIR, skill, "SKILL.md"))]),
-  );
-  const agentContents = new Map(
-    agentNames.map((agent) => [agent, read(join(AGENTS_DIR, `${agent}.md`))]),
-  );
-
-  // Every agents/ and skills/ file (other than the skill's own) whose
-  // skill content cites the bare, backticked principle name; agent content
-  // retains the full path contract.
-  const citersByPrinciple = new Map(
-    principleSkills.map((principle) => {
-      const skillNeedle = `\`${principle}\``;
-      const agentNeedle = `skills/${principle}/SKILL.md`;
-      return [
-        principle,
-        [
-          ...skillNames.filter(
-            (skill) => skill !== principle && (skillContents.get(skill) ?? "").includes(skillNeedle),
-          ),
-          ...agentNames.filter((agent) => (agentContents.get(agent) ?? "").includes(agentNeedle)),
-        ],
-      ] as const;
-    }),
-  );
-
-  const consumerFields = new Map(
-    principleSkills.map((name) => [name, catalogConsumerField(SKILLS_MD, name)] as const),
-  );
-
-  // `name` bounded by non-name characters, so `code-review` never matches
-  // inside `code-reviewer` and `planner` never inside `structure-planner`.
-  function mentions(text: string, name: string): boolean {
-    return new RegExp(`(?:^|[^\\w-])${name}(?:$|[^\\w-])`).test(text);
-  }
-
-  const missingConsumers = extractedPrinciples.flatMap((principle) => {
-    const field = consumerFields.get(principle) ?? "";
-    if (field === "") return [`${principle}: consumer field missing or empty`];
-    return (citersByPrinciple.get(principle) ?? [])
-      .filter((citer) => !mentions(field, citer))
-      .map((citer) => `${principle}: consumer field omits ${citer}`);
-  });
-
-  test("principle consumer fields include every source-derived citer", () => {
-    expect(principleSkills.length).toBeGreaterThan(20);
-    expect(missingConsumers).toEqual([]);
   });
 });
 

--- a/tests/thin-agents.test.ts
+++ b/tests/thin-agents.test.ts
@@ -411,7 +411,7 @@ describe("thin agents: skills catalog stays complete", () => {
 
   for (const { skill } of NEW_SKILLS) {
     test(`docs/skills.md documents ${skill}`, () => {
-      expect(read(SKILLS_MD)).toContain(`\`${skill}\``);
+      expect(read(SKILLS_MD)).toContain(`### [${skill}](`);
     });
   }
 });


### PR DESCRIPTION
## Summary

- Each skills catalog entry now shows its incoming and outgoing skill-load relationships.
- `Used by` and `Uses` use matching comma-list fields for the same directed edges.
- Contract tests keep all 90 entries and their source-derived descriptions and load graph consistent.

## Design Decisions

- `Uses` lists skills the current skill loads; `Used by` lists skills that load it.
- Use `None` when either field has no skill names.
- Exclude users, agents, phases, and citations from the skill-load graph.

## Changes

- Added reciprocal `Used by` and `Uses` fields to every entry in `docs/skills.md`.
- Removed the `Skill ↔ agent ↔ phase` section and its anchor.
- Updated catalog-authoring guidance and entry-scoped contract tests.

## Screenshots

Screenshot capture skipped: Playwright is not installed. Live route and rendered-HTML checks passed.

## How to Verify

- `bun test`
- `bun run typecheck`
- `cd docs && RBENV_VERSION=3.3.6 /opt/homebrew/bin/rbenv exec bundle _2.7.1_ exec jekyll build`
- Serve the docs and confirm `/skills/` renders 90 entries with `Used by` and `Uses` fields.

## Review notes

- `[ux-reviewer]` Could improve: Playwright was unavailable, so screenshot capture was skipped. Live HTTP and rendered-HTML checks passed.

### cross-model-notes

> **Design round 1**
> ### Cross-model disposition
>
> #### codex
>
> Both claims were verified and adopted as blocking findings. The second finding also applies to `documenting-decisions`.
>
> Confidence: high — repository lines directly support both claims.
>
> #### agy
>
> Skipped because the vendor reported exhausted account quota. No claim was available to assess.
>
> Confidence: high — the supplied result contains only the skip reason.

> **Design round 2**
> ### Cross-model disposition
>
> - `codex`: Verified and adopted as blocking. Confidence: high — repository tests confirm the coverage gap.
> - `agy`: Skipped because its account quota was exhausted. Confidence: high — the supplied result states this reason.

> **Design round 3**
> ### Cross-model disposition
>
> - `codex`: Verified and adopted as Blocking.
> - `agy`: Skipped because its vendor quota was exhausted.

> **Design round 4**
> ### Cross-model disposition
>
> - `codex`: Skipped because its configured executable was missing.
> - `agy`: Skipped because its quota was exhausted.
> - No external claims required verification.

> **Design round 5**
> ### Cross-model disposition
>
> - **codex — Verified and adopted as non-blocking.** Both reported load edges exist. The first citation is one line early.
> - **agy — Skipped.** Its quota was exhausted.
>
> Confidence: high — repository files support the codex claim, and the prompt records the agy skip.

## References

- Design: `docs/plans/2026-09-08-embed-skill-agent-phase/6-design.md`
- Plan: `docs/plans/2026-09-08-embed-skill-agent-phase/8-plan.md`
