### PR TITLE
feat: export an Agent Plugins compatible package

### DIFF
--- a/.github/scripts/version-bump-required.sh
+++ b/.github/scripts/version-bump-required.sh
@@ -103,6 +103,9 @@ runtime_changed=false
 if grep -qE "^($(IFS='|'; echo "${RUNTIME_DIRS[*]}"))/" <<<"$changed_files"; then
   runtime_changed=true
 fi
+if grep -qxF "scripts/export-agent-plugin.ts" <<<"$changed_files"; then
+  runtime_changed=true
+fi
 # Host manifest dirs — runtime only if a non-version line changed (a bare
 # version edit is the bump, not content). Strip diff file headers (+++/---),
 # keep added/removed lines, drop any line that touches the `"version"` field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added validated Agent Plugins 1.0.0 package export. Native installations retain their agents, hooks, and invocation controls.
+
 ### Changed
 
 - **The skills catalog now shows which skills use each skill and which skills it uses.** The separate relationship table is gone, so each entry shows both directions of every skill load. **What this asks of you:** nothing.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ reports nothing to do.
 
 </details>
 
+For Agent Plugins 1.0.0 clients, first install checkout dependencies with
+`bun install --frozen-lockfile`, then generate a portable package with
+`bun run export:agent-plugin /absolute/existing-parent/team-portable`.
+See the [compatibility guide](docs/agent-plugins.md) for prerequisites and limits.
+
 <details>
 <summary><strong>Codex CLI</strong></summary>
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "team",
+      "dependencies": {
+        "entities": "^8.1.0",
+      },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.124.0",
         "bun-types": "^1.4.1",
@@ -61,6 +64,8 @@
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
+
+    "entities": ["entities@8.1.0", "", {}, "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA=="],
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 

--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -1,0 +1,182 @@
+---
+title: Agent Plugins compatibility
+description: "Generate a validated Agent Plugins 1.0.0 package while keeping Team's native installation and invocation controls."
+---
+
+# Agent Plugins compatibility
+
+Team can export a directory targeting Agent Plugins 1.0.0. This compatibility
+claim applies only to the generated directory. The native checkout retains
+host metadata, agent registrations, hooks, and invocation controls.
+
+Use the [native installation instructions](https://github.com/bostonaholic/team#install)
+for the full Claude Code pipeline. Choose one distribution per client because
+both distributions use the plugin name `team`.
+
+## Generate a package
+
+Use Bun 1.4.2, the verified exporter runtime, with its built-in YAML and Markdown APIs.
+The package's broader Bun engine range does not establish exporter support.
+Install the checkout dependencies before exporting:
+
+```bash
+bun install --frozen-lockfile
+```
+
+Exporter execution disables Bun auto-install and requires these installed dependencies.
+Export from a stable checkout into a trusted, existing parent directory.
+The command requires filesystem read/write permissions. It downloads nothing,
+executes no copied helper, and needs no login or credentials.
+
+From the Team checkout, replace the example with an absolute, fresh directory:
+
+```bash
+bun run export:agent-plugin /absolute/existing-parent/team-portable
+```
+
+The script also works from another working directory when invoked by absolute path:
+
+```bash
+bun run --no-install /absolute/team-checkout/scripts/export-agent-plugin.ts /absolute/existing-parent/team-portable
+```
+
+The command validates all selected inputs before creating output. It refuses
+relative destinations, paths inside the checkout, missing parents, and existing
+entries, including dangling symlinks. Concurrent exporters cannot own the same
+directory. A losing exporter leaves the winner's files alone.
+
+Invalid metadata, missing resources, unsupported links, symlinks, special files,
+MCP configuration, and unaudited extensions fail with a path and rule.
+Nonhidden dotted root directories require an extension audit, even without manifest registration.
+Only `agents/openai.yaml` may appear in each excluded skill registration directory.
+Unexpected registration files require another audit.
+
+Copy or final-validation failures remove only this invocation's output.
+Cleanup failures report both errors. A process interruption can leave incomplete
+output. Choose a fresh directory for another attempt. There is no overwrite or
+recovery mode. Success reports the destination and omitted discovery files.
+
+Generation does not install or publish anything. Supply the completed directory
+to a compatible client's own installation mechanism.
+
+## Contents and limits
+
+The output contains `plugin.json`, `LICENSE`, this document as `README.md`, and
+`skills/`. The manifest copies the source version. All eligible skill bodies,
+resource bytes, and file permissions remain unchanged. Projected frontmatter
+retains `name`, `description`, `license`, `compatibility`, `metadata`, and
+`allowed-tools` when present.
+
+The exporter validates and removes four native fields from generated metadata:
+`effort`, `argument-hint`, `user-invocable`, and `disable-model-invocation`.
+The native declarations remain authoritative and unchanged in the checkout.
+A boolean `disable-model-invocation: true` omits discovery for:
+
+- `no-comments`
+- `pr-rebase`
+- `pr-watch-as-reviewer`
+- `reflect`
+
+Their shared resources remain available. For example, `pr-screenshots` still
+uses `pr-watch-as-reviewer` references. Use native installation when these
+explicit-invocation utilities are needed. Ordinary `user-invocable: false`
+controls presentation in native hosts. Portable menu visibility is client-defined.
+
+Native agent/hook registrations and per-skill `agents/openai.yaml` are absent.
+The export supplies no native enforcement, dispatch adapter, or replacement
+invocation control. It does not promise that a generic client can run the Team
+pipeline. Instructions can require Skill, Agent, Bash, TodoWrite, and host
+messaging tools, plus Git, GitHub CLI, and repository-specific build tools.
+Host capabilities, authentication, helper dependencies, and execution permissions
+remain prerequisites for the instructions that use them.
+
+Existing resource directories, direct scripts, declarations, templates, and
+`team/registry.json` remain present. Cross-skill citations keep plugin-root paths.
+Clients must supply the working context those instructions expect. Script
+resources are retained, without a guarantee of execution on every client.
+The `shipit` versioning reference uses an absolute repository URL and therefore
+requires network access when read. The exporter itself performs no network I/O.
+
+## Sources and interpretation
+
+This audit uses [Agent Plugins 1.0.0](https://agent-plugins.org/specification),
+its [canonical manifest schema](https://agent-plugins.org/schemas/1.0.0/plugin.schema.json),
+and [Agent Skills](https://agentskills.io/specification), retrieved 2026-09-08.
+Agent Skills has no version identifier on that document. Reference validation
+uses [skills-ref at commit 69ef37e9424c0a7ea9dd2293b559e43ec8176379](https://github.com/agentskills/agentskills/tree/69ef37e9424c0a7ea9dd2293b559e43ec8176379/skills-ref).
+Normative text takes precedence over examples and schema interpretation.
+
+Two source-profile interpretations remain disputed: extra Agent Skills
+frontmatter fields, and legacy client files outside extension directories.
+The strict generated profile avoids relying on either interpretation. The native
+checkout does not claim this generated profile's compatibility.
+Contained symlinks are permitted by the specification, but this exporter rejects
+all symlink inputs. MCP and extensions are optional specification features
+that this audited exporter does not support.
+
+Confidence: high for the stated package checks and explicit requirements.
+Confidence: moderate for advisory-text interpretation and client usability beyond format discovery.
+
+## Requirement audit
+
+AP denotes Agent Plugins. AS denotes Agent Skills. Evidence identifiers refer
+to the observed verification results below. Client-only duties describe behavior
+that a package exporter cannot certify.
+
+| Requirement | Disposition | Evidence |
+| --- | --- | --- |
+| AP §§1–3: version and definitions | Generated package targets 1.0.0 only. | V1, V4 |
+| AP §4.1(1–3): root and containment | One output root, containing regular files/directories. Symlink inputs fail. | V2, V4 |
+| AP §4.1(4): configured relative paths | No portable path configuration is emitted. Markdown citations are not configuration fields. | V4 inventory |
+| AP §4.1(5): failure boundaries | Client-only loader and sandbox behavior. No certification claim. | Output scope above |
+| AP §4.2: example layout | Root manifest, skills, README, and license follow the example. | V2, V4 |
+| AP §§5.1–5.3: manifest shape and identity | Canonical schema, object root, required identifiers, types, and unknown-field refusal. | V1, V4 |
+| AP §5.4: metadata and author | All present fields validated, including closed author object. No additional URL/email restrictions. | V1, V4 |
+| AP §§5.4, 10.2: semver and SPDX recommendations | Source version `0.96.0` and license `MIT` comply. Export copies the authoritative version. | V3, V4 |
+| AP §5.5: plugin name | `team` complies. Tests cover length, character set, endpoints, and repeated separators. | V1 |
+| AP §5.6, §§8.1–8.2: extensions | Optional, absent. No invented namespace replaces native files. | V1, V2 |
+| AP §§5.1–5.3: loading/schema selection | Client-only compatibility mappings and rejection behavior remain outside scope. | Output scope above |
+| AP §§6–7.1: component placement | Immediate `skills/<name>/SKILL.md` files define discovery. Guarded resource directories provide no discovery file. | V2, V4 |
+| AP §§6–7.1: discovery/failure handling | Client-only behavior. Tests inspect package locations without certifying a client. | V2 scope |
+| AP §7.1: referenced skill format | Each discoverable skill uses published fields and passes reference validation. | V1, V4 |
+| AP §7: other component types | Native agents/hooks are outside v1 and absent from output. | V2 |
+| AP §7.2.1: MCP schema/transports/paths/headers | Conditional, not applicable. No MCP files, servers, executables, endpoints, or credentials are configured. | V1, V2 |
+| AP §7.2.2: MCP loading/failures | Client-only startup, handshake, authentication, retries, and transports are not implemented. | No MCP profile |
+| AP §8: client file placement | Native manifests and per-skill client registrations are absent. No legacy-layout allowance is assumed. | V2 |
+| AP §8: namespace ownership/stability | Client recommendation, not applicable without a namespace. | No extensions profile |
+| AP §§9.1–9.2: process variables/expansion | Conditional/client duties, not applicable without stdio MCP. Skill shell commands are not MCP configuration. | No MCP profile |
+| AP §10.1: schema agreement | Manifest schema pinned to 1.0.0. MCP agreement is inapplicable. Schema publishing belongs to specification maintainers. | V1, V4 |
+| AP §11 and appendices | No client certification. Appendix A and Design Decisions supply non-normative guidance. | Output scope above |
+| AS directory/document format | Delimited YAML precedes unchanged Markdown. Each name matches its immediate directory. | V1, V2, V4 |
+| AS name/description | Validate types, names of 1–64 characters, nonblank descriptions of 1–1024 Unicode code points, syntax, and directory agreement. ASCII names are this exporter profile. | V1, V4 |
+| AS optional fields | Strings, compatibility length 1–500 Unicode code points, string-to-string metadata, and experimental `allowed-tools` string. | V1, V4 |
+| AS extra frontmatter | Strict output contains only six published fields. Source native fields remain intact. | V1, V2, V3 |
+| AS body/scripts/references/assets | Allowed resources retain bytes and modes. Local Markdown targets resolve inside output. | V2, V4 |
+| AS descriptions/progressive disclosure | Source budgets remain below the recommended 500 lines. Descriptions and split references remain unchanged. | V3, V4 |
+| AS relative references/shallow access | Within-skill relative links remain. Cross-skill plugin-root citations preserve the established convention and shared resources. This is an advisory deviation. | V2 |
+| AS script self-containment/errors/dependencies | Helpers and dependency instructions remain. Hosts must supply their tools. No generic execution guarantee. | V2 copied-helper check |
+
+## Verification evidence
+
+Observed on 2026-09-08 with Bun 1.4.2:
+
+| ID | Check | Observed result |
+| --- | --- | --- |
+| V1 | Metadata and source contracts, `tests/agent-plugins.test.ts` | 125 passed, 0 failed. Malformed inputs and each audited field constraint reject with specific diagnostics. |
+| V2 | Export and runtime-classifier suites | 70 passed, 0 failed. Includes concurrent ownership, fault cleanup, deterministic output, body references, HTML entities, skill loads, and copied helper execution. |
+| V3 | Affected native and documentation suites | 184 passed, 0 failed. Jekyll build passed. Full `bun test`: 2535 passed, 4 baseline skips, 0 failed across 70 files. Typecheck passed. |
+| V3 | Native validation against edited checkout | Antigravity accepted 90 skills and 13 agents. Claude manifest validation passed with no errors or warnings. |
+| V4 | Cached official JSON Schema plus pinned `skills-ref` | Manifest passed. All 86 discovered skills passed. Four guarded discovery files omitted. |
+| V4 | Independent final-package comparison | 262 files verified. Bodies, resources, modes, README, license, manifest, and containment passed. |
+| V4 | Documented export command | Completed in 0.231 seconds. This observation has no benchmark threshold. |
+
+The independent tooling stays outside project dependencies and free suites.
+The exporter and free tests run without network requests or paid model calls.
+Native observations establish metadata acceptance, without generic client certification.
+
+## Related documentation
+
+- [Native installation](https://github.com/bostonaholic/team#install)
+- [Cross-host portability](https://github.com/bostonaholic/team/blob/main/docs/cross-host-portability.md)
+- [Land-time versioning](https://github.com/bostonaholic/team/blob/main/docs/versioning.md)
+- [Testing strategy](https://github.com/bostonaholic/team/blob/main/docs/testing.md)

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -8,6 +8,11 @@ nav_label: portability
 
 # Cross-host portability
 
+Team also generates an [Agent Plugins 1.0.0 package](agent-plugins.md).
+It exports validated skills and resources, omits four guarded discovery files,
+and supplies no native agent registrations, hooks, or invocation enforcement.
+Generic format compatibility does not establish full pipeline support.
+
 > **What this is.** A portability study. It shows how Team's Claude Code plugin
 > primitives map onto Codex CLI, and gives the strategy we chose to support
 > that host alongside Claude Code. Team also runs on

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -63,6 +63,11 @@ someone recomputes it. This is what happened on PR #208, which opened as
 
 ## Only runtime changes bump (the runtime-vs-dev gate)
 
+The classifier also treats exactly `scripts/export-agent-plugin.ts` as runtime
+because it determines the generated distribution. Other `scripts/` files do not
+inherit that classification. Export copies the authoritative root manifest
+version into output without assigning another version or changing land-time timing.
+
 The version, changelog, and release exist for **plugin end users**, so a bump is
 warranted **only when a PR changes the distributed plugin**: `agents/`,
 `skills/`, `hooks/`, or host manifest *content* — `.claude-plugin/`,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bun": ">=1.0.0"
   },
   "scripts": {
+    "export:agent-plugin": "bun run --no-install scripts/export-agent-plugin.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "test:evals": "EVALS=1 bun test --retry=2 --concurrent --max-concurrency 15 ./tests/*.evals.ts",
@@ -27,5 +28,8 @@
     "@anthropic-ai/sdk": "^0.124.0",
     "bun-types": "^1.4.1",
     "typescript": "^7.0.2"
+  },
+  "dependencies": {
+    "entities": "^8.1.0"
   }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "team",
   "version": "0.96.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",

--- a/scripts/export-agent-plugin.ts
+++ b/scripts/export-agent-plugin.ts
@@ -1,0 +1,257 @@
+import { chmodSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { decodeHTMLAttribute } from "entities";
+
+const SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const PORTABLE = ["name", "description", "license", "compatibility", "metadata", "allowed-tools"];
+const NATIVE: Record<string, string> = {
+  effort: "string", "argument-hint": "string", "user-invocable": "boolean", "disable-model-invocation": "boolean",
+};
+
+function fail(path: string, rule: string): never {
+  throw new Error(`${path}: ${rule}`);
+}
+
+function mapping(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(value: unknown, path: string, field: string): asserts value is string {
+  if (typeof value !== "string") fail(path, `${field} must be a string`);
+}
+
+export function validateManifest(text: string, path: string): Record<string, unknown> {
+  let manifest: unknown;
+  try { manifest = JSON.parse(text); }
+  catch (error) { throw new Error(`${path}: invalid JSON`, { cause: error }); }
+  if (!mapping(manifest)) fail(path, "manifest must be an object");
+  for (const [key, value] of Object.entries(manifest)) {
+    if (["extensions", "mcp", "mcpServers"].includes(key)) fail(path, `${key} requires an export profile audit`);
+    if (["$schema", "name", "version", "description", "homepage", "repository", "license"].includes(key)) {
+      stringField(value, path, key);
+    } else if (key === "keywords") {
+      if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) fail(path, "keywords must be an array of strings");
+    } else if (key === "author") {
+      if (!mapping(value)) fail(path, "author must be an object");
+      for (const [field, entry] of Object.entries(value)) {
+        if (!["name", "email", "url"].includes(field)) fail(path, `author.${field} is not permitted`);
+        stringField(entry, path, `author.${field}`);
+      }
+    } else fail(path, `${key} requires an export profile audit`);
+  }
+  if (manifest.$schema !== SCHEMA) fail(path, `$schema must equal ${SCHEMA}`);
+  const name = manifest.name;
+  stringField(name, path, "name");
+  if (name.length < 1 || name.length > 64 || !/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(name) || /--|\.\./.test(name)) {
+    fail(path, "name must be 1–64 lowercase ASCII letters/digits/dots/hyphens, with alphanumeric endpoints and no repeated separator");
+  }
+  return manifest;
+}
+
+export function projectSkill(text: string, directory: string, path: string) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/.exec(text);
+  if (!match) fail(path, "missing delimited YAML frontmatter");
+  let source: unknown;
+  try { source = Bun.YAML.parse(match[1]!); }
+  catch (error) { throw new Error(`${path}: invalid YAML frontmatter`, { cause: error }); }
+  if (!mapping(source)) fail(path, "frontmatter must be a mapping");
+  for (const [key, value] of Object.entries(source)) {
+    if (Object.hasOwn(NATIVE, key)) {
+      if (typeof value !== NATIVE[key]) fail(path, `${key} must be ${NATIVE[key]}; export profile audit required`);
+    } else if (!PORTABLE.includes(key)) fail(path, `${key} requires an export profile audit`);
+    else if (key === "metadata") {
+      if (!mapping(value) || Object.values(value).some((entry) => typeof entry !== "string")) fail(path, "metadata must be a string-to-string mapping");
+    } else stringField(value, path, key);
+  }
+  const { name, description, compatibility } = source;
+  stringField(name, path, "name");
+  if (name.length < 1 || name.length > 64 || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name) || name !== directory) {
+    fail(path, "name must match its directory and contain 1–64 lowercase ASCII letters/digits with single internal hyphens");
+  }
+  stringField(description, path, "description");
+  // The Python reference validator also treats four C0 separators as whitespace.
+  if (/^[\p{White_Space}\u001c-\u001f]*$/u.test(description)) fail(path, "description must not be blank");
+  if ([...description].length > 1024) fail(path, "description length must be 1–1024");
+  if (typeof compatibility === "string" && ([...compatibility].length < 1 || [...compatibility].length > 500)) fail(path, "compatibility length must be 1–500");
+  const metadata = Object.fromEntries(PORTABLE.filter((key) => Object.hasOwn(source, key)).map((key) => [key, source[key]]));
+  const body = text.slice(match[0].length);
+  return { metadata, body, content: `---\n${Bun.YAML.stringify(metadata, null, 2)}\n---${body}`, eligible: source["disable-model-invocation"] !== true };
+}
+
+type File = { path: string; bytes: Buffer; mode: number };
+type Package = { files: File[]; directories: string[]; omitted: string[]; skills: string[] };
+
+function inside(root: string, path: string): boolean {
+  const child = relative(root, path);
+  return !isAbsolute(child) && child !== ".." && !child.startsWith(`..${sep}`);
+}
+
+function inputStat(path: string) {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink()) fail(path, "symbolic link inputs are unsupported");
+  if (!stat.isFile() && !stat.isDirectory()) fail(path, "unsupported special file; require a regular file or directory");
+  return stat;
+}
+
+function readInput(path: string, output: string): File {
+  const stat = inputStat(path);
+  if (!stat.isFile()) fail(path, "require a regular file");
+  return { path: output, bytes: readFileSync(path), mode: stat.mode & 0o777 };
+}
+
+function markdownLinks(text: string): string[] {
+  const links: string[] = [];
+  new HTMLRewriter().on("a[href], img[src]", {
+    element(element) {
+      const attribute = element.getAttribute(element.tagName === "a" ? "href" : "src");
+      if (attribute !== null) links.push(decodeHTMLAttribute(attribute));
+    },
+  }).transform(Bun.markdown.html(text));
+  return links.filter((target) => !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(target));
+}
+
+function validateReferences(pkg: Package, root: string) {
+  const paths = new Set([...pkg.files.map((file) => file.path), ...pkg.directories]);
+  for (const file of pkg.files.filter((entry) => entry.path.endsWith(".md"))) {
+    const content = file.bytes.toString("utf8");
+    const skill = pkg.skills.find((name) => file.path === join("skills", name, "SKILL.md"));
+    const text = skill ? projectSkill(content, skill, join(root, file.path)).body : content;
+    for (const link of markdownLinks(text)) {
+      let decoded: string;
+      try { decoded = decodeURIComponent(link.split(/[?#]/)[0]!); }
+      catch (error) { throw new Error(`${file.path}: invalid link ${link}`, { cause: error }); }
+      const target = resolve(root, dirname(file.path), decoded);
+      if (!inside(root, target) || !paths.has(relative(root, target))) fail(file.path, `link ${link} must resolve inside the exported package`);
+    }
+    if (!file.path.startsWith(`skills${sep}`)) continue;
+    const flat = text.replace(/\s+/g, " ").trim();
+    for (const match of flat.matchAll(/call the Skill tool with\b/gi)) {
+      const clause = flat.slice(match.index + match[0].length).split(/(?<=[.:;!?])\s/)[0]!;
+      for (const name of clause.matchAll(/`([a-z0-9][a-z0-9-]*)`/g)) {
+        if (!pkg.skills.includes(name[1]!)) fail(file.path, `loaded skill ${name[1]} is absent from exported discovery`);
+      }
+    }
+  }
+}
+
+function preflight(source: string): Package {
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    const name = entry.name;
+    const namespaceDirectory = entry.isDirectory() && !name.startsWith(".") && name.includes(".");
+    if (["mcp.json", ".mcp.json", "extensions"].includes(name) || namespaceDirectory) fail(join(source, name), "requires an export profile audit");
+  }
+  const files = [readInput(join(source, "plugin.json"), "plugin.json"), readInput(join(source, "LICENSE"), "LICENSE")];
+  validateManifest(files[0]!.bytes.toString("utf8"), join(source, "plugin.json"));
+  if (!inputStat(join(source, "docs")).isDirectory()) fail(join(source, "docs"), "require a directory");
+  files.push(readInput(join(source, "docs/agent-plugins.md"), "README.md"));
+  const pkg: Package = { files, directories: ["skills"], omitted: [], skills: [] };
+  const skillsRoot = join(source, "skills");
+  if (!inputStat(skillsRoot).isDirectory()) fail(skillsRoot, "require a skills directory");
+  const entries = readdirSync(skillsRoot).sort();
+  if (!entries.length) fail(skillsRoot, "incomplete Team input: skills directory is empty");
+  for (const name of entries) {
+    const directory = join(skillsRoot, name);
+    if (inputStat(directory).isFile()) {
+      files.push(readInput(directory, join("skills", name)));
+      continue;
+    }
+    const discovery = readInput(join(directory, "SKILL.md"), join("skills", name, "SKILL.md"));
+    const projected = projectSkill(discovery.bytes.toString("utf8"), name, join(directory, "SKILL.md"));
+    if (projected.eligible) {
+      pkg.skills.push(name);
+      files.push({ ...discovery, bytes: Buffer.from(projected.content) });
+    } else pkg.omitted.push(name);
+    collectResources(source, join("skills", name), pkg);
+  }
+  if (!pkg.skills.length && !pkg.omitted.length) fail(skillsRoot, "incomplete Team input: no skill declarations");
+  validateReferences(pkg, source);
+  return pkg;
+}
+
+function collectResources(source: string, path: string, pkg: Package) {
+  pkg.directories.push(path);
+  for (const name of readdirSync(join(source, path)).sort()) {
+    const child = join(path, name);
+    const absolute = join(source, child);
+    const stat = inputStat(absolute);
+    const immediate = path.split(sep).length === 2;
+    if (immediate && name === "SKILL.md") continue;
+    if (immediate && name === "agents") {
+      if (!stat.isDirectory()) fail(absolute, "native agents registration must be a directory");
+      for (const registration of readdirSync(absolute).sort()) {
+        const registered = join(absolute, registration);
+        const registeredStat = inputStat(registered);
+        if (registration !== "openai.yaml" || !registeredStat.isFile()) fail(registered, "unexpected native registration requires an export profile audit");
+      }
+    } else if (stat.isDirectory()) collectResources(source, child, pkg);
+    else pkg.files.push(readInput(absolute, child));
+  }
+}
+
+function validateOutput(destination: string, expected: Package) {
+  const files: File[] = [];
+  const directories: string[] = [];
+  function visit(path: string) {
+    for (const name of readdirSync(join(destination, path)).sort()) {
+      const child = join(path, name);
+      if (inputStat(join(destination, child)).isDirectory()) {
+        directories.push(child);
+        visit(child);
+      } else files.push(readInput(join(destination, child), child));
+    }
+  }
+  visit("");
+  if (files.length !== expected.files.length || directories.slice().sort().join("\n") !== expected.directories.slice().sort().join("\n")) fail(destination, "final output inventory differs from the validated package");
+  for (const file of files) {
+    const original = expected.files.find((entry) => entry.path === file.path);
+    if (!original || !original.bytes.equals(file.bytes) || original.mode !== file.mode) fail(join(destination, file.path), "final output bytes or permissions differ from the validated package");
+    if (file.path === "plugin.json") validateManifest(file.bytes.toString("utf8"), join(destination, file.path));
+    if (file.path.split(sep).length === 3 && basename(file.path) === "SKILL.md") {
+      projectSkill(file.bytes.toString("utf8"), basename(dirname(file.path)), join(destination, file.path));
+    }
+  }
+  validateReferences({ ...expected, files, directories }, destination);
+}
+
+export async function exportPlugin(sourceRoot: string, destination: string): Promise<{ destination: string; omitted: string[] }> {
+  if (!isAbsolute(destination)) fail(destination, "destination must be absolute");
+  const source = realpathSync(sourceRoot);
+  const output = join(realpathSync(dirname(resolve(destination))), basename(resolve(destination)));
+  if (inside(source, output)) fail(destination, "destination must be outside the source checkout");
+  try {
+    lstatSync(output);
+    fail(destination, "destination exists; choose a fresh directory");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const pkg = preflight(source);
+  try { mkdirSync(output); }
+  catch (error) {
+    throw new Error(`${destination}: mkdir failed; choose a fresh directory: ${String(error)}`, { cause: error });
+  }
+  // Only the invocation that exclusively created output may remove it.
+  try {
+    for (const directory of pkg.directories) mkdirSync(join(output, directory));
+    for (const file of pkg.files) {
+      writeFileSync(join(output, file.path), file.bytes, { flag: "wx", mode: file.mode });
+      chmodSync(join(output, file.path), file.mode);
+    }
+    validateOutput(output, pkg);
+  } catch (error) {
+    try { rmSync(output, { recursive: true }); }
+    catch (cleanup) { throw new Error(`${destination}: export failed: ${String(error)}; cleanup removal failed: ${String(cleanup)}`, { cause: error }); }
+    throw new Error(`${destination}: export failed: ${String(error)}`, { cause: error });
+  }
+  return { destination, omitted: pkg.omitted };
+}
+
+if (import.meta.main) {
+  try {
+    if (process.argv.length !== 3) fail("export:agent-plugin", "usage: bun run export:agent-plugin /absolute/fresh-directory");
+    const result = await exportPlugin(resolve(import.meta.dir, ".."), process.argv[2]!);
+    console.log(`Exported ${result.destination}\nOmitted discovery: ${result.omitted.join(", ") || "none"}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/skills/shipit/SKILL.md
+++ b/skills/shipit/SKILL.md
@@ -15,7 +15,7 @@ the title, that version shows up in `git log`. It
 does no versioning, changelog editing, or release work. If a project assigns a
 version at land time, that happens in a separate project-specific step *before*
 `/shipit` (in this repo, the dev `version-bump` skill — see
-[docs/versioning.md](../../docs/versioning.md)). `shipit` only cares that the
+[docs/versioning.md](https://github.com/bostonaholic/team/blob/main/docs/versioning.md)). `shipit` only cares that the
 branch is ready to land.
 
 `gh pr merge` is irreversible, so two things guard it — neither of them a

--- a/tests/agent-plugins.test.ts
+++ b/tests/agent-plugins.test.ts
@@ -1,0 +1,267 @@
+// L1 metadata rules and L2 native contracts for the portable export. No schemas,
+// network, host installs, or model calls are needed by these acceptance tests.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { skillNames } from "./helpers/skill-refs";
+
+const ROOT = join(import.meta.dir, "..");
+const MODULE = join(ROOT, "scripts/export-agent-plugin.ts");
+const SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const MANIFEST = { $schema: SCHEMA, name: "team" };
+const SOURCE_PATH = "skills/example/SKILL.md";
+const BODY = "\n\n# Example\n\nKeep `---` and café unchanged.\n\n```yaml\nkey: value\n```\n";
+const PORTABLE = {
+  name: "example",
+  description: "Example skill",
+  license: "MIT",
+  compatibility: "A host with a shell",
+  metadata: { author: "Team", revision: "1" },
+  "allowed-tools": "Read Bash",
+};
+type Projection = { metadata: Record<string, unknown>; body: string; content: string; eligible: boolean };
+type ExportModule = {
+  validateManifest: (text: string, path: string) => Record<string, unknown>;
+  projectSkill: (text: string, directory: string, path: string) => Projection;
+};
+const exporter: Partial<ExportModule> | null = existsSync(MODULE)
+  ? await import(pathToFileURL(MODULE).href)
+  : null;
+const temporary: string[] = [];
+afterAll(() => {
+  for (const path of temporary) rmSync(path, { recursive: true, force: true });
+});
+
+// An absent implementation fails an explicit assertion; it never aborts imports
+// or supplies a fake result that could accidentally satisfy a rejection case.
+function manifest(text: string): Record<string, unknown> {
+  expect(typeof exporter?.validateManifest, "exporter must expose validateManifest").toBe("function");
+  return exporter!.validateManifest!(text, "plugin.json");
+}
+function project(text: string, directory = "example"): Projection {
+  expect(typeof exporter?.projectSkill, "exporter must expose projectSkill").toBe("function");
+  return exporter!.projectSkill!(text, directory, SOURCE_PATH);
+}
+function skill(metadata: Record<string, unknown>, body = BODY): string {
+  return `---\n${Bun.YAML.stringify(metadata, null, 2)}\n---${body}`;
+}
+function withoutField(value: Record<string, unknown>, key: string): Record<string, unknown> {
+  const result = { ...value };
+  delete result[key];
+  return result;
+}
+function yamlDescription(description: string): string {
+  return `---\nname: example\ndescription: ${description}\n---\n`;
+}
+function caught(operation: () => unknown): string {
+  try {
+    operation();
+    return "";
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+function rejectManifest(value: unknown, rule: string) {
+  expect(typeof exporter?.validateManifest, "exporter must expose validateManifest").toBe("function");
+  const message = caught(() => manifest(JSON.stringify(value)));
+  expect(message).toContain("plugin.json");
+  expect(message.toLowerCase()).toContain(rule.toLowerCase());
+}
+function rejectSkill(text: string, rule: string, directory = "example") {
+  expect(typeof exporter?.projectSkill, "exporter must expose projectSkill").toBe("function");
+  const message = caught(() => project(text, directory));
+  expect(message).toContain(SOURCE_PATH);
+  expect(message.toLowerCase()).toContain(rule.toLowerCase());
+}
+function frontmatter(text: string): Record<string, unknown> {
+  return Bun.YAML.parse(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(text)?.[1] ?? "") as Record<string, unknown>;
+}
+function guardedSource(): string[] {
+  return [...skillNames(ROOT)].filter((name) => frontmatter(readFileSync(join(ROOT, "skills", name, "SKILL.md"), "utf8"))["disable-model-invocation"] === true).sort();
+}
+
+const INVALID_MANIFEST_FIELDS: [string, unknown][] = [
+  ["$schema", 1], ["name", 1], ["version", 1], ["description", []],
+  ["homepage", {}], ["repository", false], ["license", null], ["keywords", "team"],
+  ["keywords", ["team", 1]], ["author", "Team"], ["author", []], ["author", null],
+  ["author.name", { name: 1 }], ["author.email", { email: false }],
+  ["author.url", { url: [] }], ["author.extra", { extra: "unaudited" }],
+  ["extensions", null], ["extensions", []], ["extensions", { "dev.example": true }],
+];
+const INVALID_SKILL_FIELDS: [string, unknown][] = [
+  ["name", 1], ["description", 1], ["description", null], ["license", []],
+  ["compatibility", false], ["allowed-tools", ["Read"]], ["metadata", "author"],
+  ["metadata", []], ["metadata", null], ["metadata", { revision: 1 }],
+  ["metadata", { nested: { author: "Team" } }],
+  ["effort", 1], ["argument-hint", []], ["user-invocable", "false"],
+  ["disable-model-invocation", "true"], ["disable-model-invocation", "false"],
+  ["disable-model-invocation", 0], ["disable-model-invocation", null],
+];
+
+describe("Validated portable metadata rejects audited violations", () => {
+  test("accepts the required manifest identifiers without optional fields", () => {
+    expect(manifest(JSON.stringify(MANIFEST))).toEqual(MANIFEST);
+  });
+
+  test("preserves every permitted manifest field without adding URL, email, semver, or SPDX rules", () => {
+    const input = {
+      ...MANIFEST, version: "release label", description: "", homepage: "local documentation",
+      repository: "repository label", license: "custom license", keywords: ["", "team"],
+      author: { name: "", email: "not an email", url: "not a URL" },
+    };
+    expect(manifest(JSON.stringify(input))).toEqual(input);
+  });
+
+  test("accepts an empty author object and empty keyword list", () => {
+    expect(manifest(JSON.stringify({ ...MANIFEST, author: {}, keywords: [] }))).toMatchObject({ author: {}, keywords: [] });
+  });
+
+  test("malformed JSON names the source path and JSON rule", () => {
+    expect(typeof exporter?.validateManifest).toBe("function");
+    const message = caught(() => manifest('{"name":'));
+    expect(message).toContain("plugin.json");
+    expect(message).toMatch(/json/i);
+  });
+
+  test.each([[null], [[]], ["team"], [7], [true]])("rejects a non-object manifest root: %j", (value) => {
+    rejectManifest(value, "object");
+  });
+  test.each(["$schema", "name"])("requires manifest identifier %s", (key) => {
+    rejectManifest(withoutField(MANIFEST, key), key);
+  });
+  test.each(INVALID_MANIFEST_FIELDS)("rejects wrong manifest type or closed author field %s: %j", (field, value) => {
+    const key = field.split(".")[0]!;
+    rejectManifest({ ...MANIFEST, [key]: value }, field.split(".").at(-1)!);
+  });
+  test("rejects an unknown manifest field", () => {
+    rejectManifest({ ...MANIFEST, extra: "unaudited" }, "extra");
+  });
+  test.each(["", "https://agent-plugins.org/schemas/2.0.0/plugin.schema.json"])("rejects noncanonical schema %s", (schema) => {
+    rejectManifest({ ...MANIFEST, $schema: schema }, "$schema");
+  });
+  test.each(["a", "0", "a".repeat(64), "my.plugin-2", "a.-b"])("accepts plugin name %s", (name) => {
+    expect(manifest(JSON.stringify({ ...MANIFEST, name })).name).toBe(name);
+  });
+  test.each(["", "a".repeat(65), "-a", "a-", ".a", "a.", "A", "a_b", "a b", "a--b", "a..b", "é"])("rejects plugin name %s", (name) => {
+    rejectManifest({ ...MANIFEST, name }, "name");
+  });
+  test.each([{}, { "dev.example": {} }])("refuses unaudited extensions profile %j", (extensions) => {
+    rejectManifest({ ...MANIFEST, extensions }, "audit");
+  });
+  test.each(["mcp", "mcpServers"])("refuses unaudited %s configuration", (field) => {
+    rejectManifest({ ...MANIFEST, [field]: {} }, field);
+  });
+
+  test.each([
+    ['"quoted: value"', "quoted: value"],
+    [">\n  folded\n  description", "folded description\n"],
+    ["|\n  literal\n  description", "literal\ndescription\n"],
+  ])("parses semantic YAML description %s", (yaml, description) => {
+    expect(project(yamlDescription(yaml)).metadata.description).toBe(description);
+  });
+  test.each([
+    ["# No frontmatter\n", "frontmatter"], ["---\nname: example\n", "frontmatter"],
+    ["---\nname: [\n---\n", "yaml"], ["---\n- example\n---\n", "mapping"],
+    ["---\nexample\n---\n", "mapping"], ["---\nnull\n---\n", "mapping"],
+  ])("rejects malformed or non-mapping frontmatter %s", (text, rule) => {
+    rejectSkill(text, rule);
+  });
+  test.each(["name", "description"])("requires skill field %s", (key) => {
+    rejectSkill(skill(withoutField(PORTABLE, key)), key);
+  });
+  test("requires skill name to match its directory", () => {
+    rejectSkill(skill(PORTABLE), "name", "different");
+  });
+  test.each(["a", "a".repeat(64), "example-2"])("accepts skill name %s", (name) => {
+    expect(project(skill({ ...PORTABLE, name }), name).metadata.name).toBe(name);
+  });
+  test.each(["", "a".repeat(65), "-a", "a-", "a--b", "A", "a_b", "a.b", "a b"])("rejects skill name %s", (name) => {
+    rejectSkill(skill({ ...PORTABLE, name }), "name", name);
+  });
+  test.each([1, 1024])("accepts description length %i", (length) => {
+    const description = "x".repeat(length);
+    expect(project(skill({ ...PORTABLE, description })).metadata.description).toBe(description);
+  });
+  test.each([0, 1025])("rejects description length %i", (length) => {
+    rejectSkill(skill({ ...PORTABLE, description: "x".repeat(length) }), "description");
+  });
+  test("rejects whitespace-only skill descriptions", () => {
+    rejectSkill(skill({ ...PORTABLE, description: "   " }), "description");
+  });
+  test.each([
+    ["U+0085", "\u0085"],
+    ["U+001C", "\u001c"],
+    ["U+001D", "\u001d"],
+    ["U+001E", "\u001e"],
+    ["U+001F", "\u001f"],
+  ])("rejects Unicode-only whitespace description %s as empty", (_label, description) => {
+    rejectSkill(skill({ ...PORTABLE, description }), "description");
+  });
+  test("preserves a valid 513-emoji description unchanged", () => {
+    const description = "😀".repeat(513);
+    expect(caught(() => project(skill({ ...PORTABLE, description })))).toBe("");
+    expect(project(skill({ ...PORTABLE, description })).metadata.description).toBe(description);
+  });
+  test("preserves a valid 251-emoji compatibility unchanged", () => {
+    const compatibility = "😀".repeat(251);
+    expect(caught(() => project(skill({ ...PORTABLE, compatibility })))).toBe("");
+    expect(project(skill({ ...PORTABLE, compatibility })).metadata.compatibility).toBe(compatibility);
+  });
+  test.each([1, 500])("accepts compatibility length %i", (length) => {
+    const compatibility = "x".repeat(length);
+    expect(project(skill({ ...PORTABLE, compatibility })).metadata.compatibility).toBe(compatibility);
+  });
+  test.each([0, 501])("rejects compatibility length %i", (length) => {
+    rejectSkill(skill({ ...PORTABLE, compatibility: "x".repeat(length) }), "compatibility");
+  });
+  test.each(INVALID_SKILL_FIELDS)("rejects wrong source type for %s: %j", (field, value) => {
+    rejectSkill(skill({ ...PORTABLE, [field]: value }), field);
+  });
+  test("accepts optional strings and a string-to-string metadata mapping", () => {
+    const result = project(skill({ ...PORTABLE, license: "", "allowed-tools": "", metadata: { "": "", revision: "1" } }));
+    expect(result.metadata).toMatchObject({ license: "", "allowed-tools": "", metadata: { "": "", revision: "1" } });
+  });
+  test("accepts absent optional fields", () => {
+    expect(project(skill({ name: "example", description: "Example skill" })).metadata).toEqual({ name: "example", description: "Example skill" });
+  });
+  test("preserves the six published fields and removes only typed native fields", () => {
+    const result = project(skill({ ...PORTABLE, effort: "high", "argument-hint": "<task>", "user-invocable": false, "disable-model-invocation": false }));
+    expect(result.metadata).toEqual(PORTABLE);
+    expect(frontmatter(result.content)).toEqual(PORTABLE);
+  });
+  test("retains the exact Markdown suffix after projected frontmatter", () => {
+    const result = project(skill({ ...PORTABLE, effort: "high" }, BODY));
+    expect(result.body).toBe(BODY);
+    expect(result.content.slice(result.content.indexOf("---", 3) + 3)).toBe(BODY);
+  });
+  test("rejects an unaudited source key instead of silently stripping it", () => {
+    rejectSkill(skill({ ...PORTABLE, future: true }), "future");
+    rejectSkill(skill({ ...PORTABLE, future: true }), "audit");
+  });
+  test.each([true, false])("uses boolean invocation control %j for discovery eligibility", (guarded) => {
+    expect(project(skill({ ...PORTABLE, "disable-model-invocation": guarded })).eligible).toBe(!guarded);
+  });
+  test("absent invocation control leaves discovery eligible", () => {
+    expect(project(skill(PORTABLE)).eligible).toBe(true);
+  });
+  test.each([true, false])("user-invocable %j remains a presentation hint", (visible) => {
+    expect(project(skill({ ...PORTABLE, "user-invocable": visible })).eligible).toBe(true);
+  });
+  test("root manifest declares the canonical schema", () => {
+    expect(JSON.parse(readFileSync(join(ROOT, "plugin.json"), "utf8")).$schema).toBe(SCHEMA);
+  });
+  test("native guarded declarations retain their authoritative boolean controls", () => {
+    expect(guardedSource()).toEqual(["no-comments", "pr-rebase", "pr-watch-as-reviewer", "reflect"]);
+  });
+  test("importing the module with a destination argument creates no output", () => {
+    const directory = mkdtempSync(join(tmpdir(), "agent-plugin-import-"));
+    temporary.push(directory);
+    const result = spawnSync(process.execPath, ["--eval", "await import(process.argv[1]);", pathToFileURL(MODULE).href, join(directory, "output")], { cwd: directory, encoding: "utf8" });
+    expect({ status: result.status, stderr: result.stderr }).toMatchObject({ status: 0 });
+    expect(result.stdout).toBe("");
+    expect(readdirSync(directory)).toEqual([]);
+  });
+});

--- a/tests/export-agent-plugin.test.ts
+++ b/tests/export-agent-plugin.test.ts
@@ -1,0 +1,778 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { loadedSkills, skillNames } from "./helpers/skill-refs";
+
+const ROOT = realpathSync(join(import.meta.dir, ".."));
+const EXPORTER = join(ROOT, "scripts/export-agent-plugin.ts");
+const SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const SHIPIT_URL = "https://github.com/bostonaholic/team/blob/main/docs/versioning.md";
+const PORTABLE_FIELDS = ["allowed-tools", "compatibility", "description", "license", "metadata", "name"];
+const temporaryDirectories: string[] = [];
+
+afterAll(() => {
+  for (const directory of temporaryDirectories) rmSync(directory, { recursive: true, force: true });
+});
+
+type Exporter = {
+  exportPlugin(sourceRoot: string, destination: string): Promise<{ destination: string; omitted: string[] }>;
+  validateManifest(text: string, path: string): Record<string, unknown>;
+  projectSkill(text: string, directoryName: string, path: string): {
+    metadata: Record<string, unknown>; body: string; content: string; eligible: boolean;
+  };
+};
+
+const exporter: Exporter | null = existsSync(EXPORTER)
+  ? await import(pathToFileURL(EXPORTER).href) as Exporter
+  : null;
+
+function requireExporter(): Exporter {
+  expect(existsSync(EXPORTER), "export CLI exists").toBe(true);
+  expect(typeof exporter?.exportPlugin, "explicit export operation exists").toBe("function");
+  return exporter!;
+}
+
+function temporaryDirectory(): string {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), `agent-plugin-${process.pid}-`)));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function write(root: string, path: string, content: string | Buffer): void {
+  mkdirSync(dirname(join(root, path)), { recursive: true });
+  writeFileSync(join(root, path), content);
+}
+
+function fixture(): { parent: string; source: string; destination: string } {
+  const parent = temporaryDirectory();
+  const source = join(parent, "source");
+  write(source, "plugin.json", JSON.stringify({ $schema: SCHEMA, name: "team", version: "0.96.0" }));
+  write(source, "LICENSE", "MIT fixture license\n");
+  write(source, "docs/agent-plugins.md", "# Portable fixture\n\n[Documentation](https://example.com/docs)\n");
+  write(source, "skills/alpha/SKILL.md", "---\nname: alpha\ndescription: Fixture skill\nuser-invocable: false\n---\n\n# Alpha\n\n[Notes](references/notes.md?view=plain#usage)\n");
+  write(source, "skills/alpha/references/notes.md", "# Notes\n\nUse the fixture.\n");
+  write(source, "skills/alpha/agents/openai.yaml", "interface:\n  display_name: Alpha\n");
+  mkdirSync(join(source, "scripts"));
+  symlinkSync(join(ROOT, "node_modules"), join(source, "node_modules"));
+  if (existsSync(EXPORTER)) copyFileSync(EXPORTER, join(source, "scripts/export-agent-plugin.ts"));
+  return { parent, source, destination: join(parent, "export") };
+}
+
+function file(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+function paths(root: string, prefix = ""): string[] {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(prefix, entry.name);
+    return entry.isDirectory() ? [path, ...paths(join(root, entry.name), path)] : [path];
+  }).sort();
+}
+
+function snapshot(root: string) {
+  return paths(root).map((path) => {
+    const absolute = join(root, path);
+    const stat = lstatSync(absolute);
+    return {
+      path,
+      kind: stat.isDirectory() ? "directory" : stat.isSymbolicLink() ? "symlink" : "file",
+      executable: stat.mode & 0o111,
+      bytes: stat.isFile() ? readFileSync(absolute).toString("base64") : "",
+      target: stat.isSymbolicLink() ? readlinkSync(absolute) : "",
+    };
+  });
+}
+
+function splitSkill(text: string): { metadata: Record<string, unknown>; body: string } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/.exec(text);
+  expect(match, "skill has delimited YAML frontmatter").not.toBeNull();
+  return {
+    metadata: Bun.YAML.parse(match![1]!) as Record<string, unknown>,
+    body: text.slice(match![0].length),
+  };
+}
+
+function sourceInventory(source: string) {
+  const names = [...skillNames(source)].sort();
+  const omitted = names.filter((name) => splitSkill(file(join(source, "skills", name, "SKILL.md"))).metadata["disable-model-invocation"] === true);
+  return { names: names.filter((name) => !omitted.includes(name)), omitted };
+}
+
+function markdownDestinations(text: string): string[] {
+  const destinations: string[] = [];
+  new HTMLRewriter()
+    .on("a[href], img[src]", {
+      element(element) {
+        const target = element.getAttribute(element.tagName === "a" ? "href" : "src");
+        if (target !== null) destinations.push(target);
+      },
+    })
+    .transform(Bun.markdown.html(text));
+  return destinations.filter((target) => !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(target));
+}
+
+function linkProblems(root: string): string[] {
+  const problems: string[] = [];
+  for (const path of paths(join(root, "skills")).filter((path) => path.endsWith(".md"))) {
+    const containingFile = join(root, "skills", path);
+    for (const destination of markdownDestinations(markdownSource(root, path))) {
+      const target = resolve(dirname(containingFile), decodeURIComponent(destination.split(/[?#]/)[0]!));
+      const fromRoot = relative(root, target);
+      if (isAbsolute(fromRoot) || fromRoot === ".." || fromRoot.startsWith(`..${sep}`) || !existsSync(target)) {
+        problems.push(`${path}: ${destination}`);
+      }
+    }
+  }
+  return problems.sort();
+}
+
+function missingLoads(root: string): string[] {
+  const inventory = skillNames(root);
+  return paths(join(root, "skills")).filter((path) => path.endsWith(".md"))
+    .flatMap((path) => loadedSkills(markdownSource(root, path))
+      .filter((name) => !inventory.has(name)).map((name) => `${path}: ${name}`)).sort();
+}
+
+function markdownSource(root: string, path: string): string {
+  const text = file(join(root, "skills", path));
+  return path.split(sep).length === 2 && basename(path) === "SKILL.md" ? splitSkill(text).body : text;
+}
+
+async function cli(source: string, args: string[], cwd: string, preload?: string) {
+  requireExporter();
+  const command = [process.execPath, "--no-install", ...(preload ? ["--preload", preload] : []), join(source, "scripts/export-agent-plugin.ts"), ...args];
+  const child = Bun.spawn(command, { cwd, env: { ...process.env, TZ: "UTC", LANG: "C" }, stdout: "pipe", stderr: "pipe" });
+  const [status, stdout, stderr] = await Promise.all([
+    child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+  ]);
+  return { status, stdout, stderr, output: stdout + stderr };
+}
+
+function expectSuccess(result: { status: number; output: string }): void {
+  expect(result, "CLI reports successful completed export").toMatchObject({ status: 0 });
+}
+
+function expectRefusal(result: { status: number; output: string }, diagnostic: RegExp | string): void {
+  expect(result, "CLI refuses invalid export").not.toMatchObject({ status: 0 });
+  if (typeof diagnostic === "string") expect(result.output).toContain(diagnostic);
+  else expect(result.output).toMatch(diagnostic);
+}
+
+async function preflight(source: string, destination: string, parent: string) {
+  const preload = faultPreload(parent, destination, "observe-create");
+  const result = await cli(source, [destination], parent, preload);
+  return { ...result, destinationCreated: existsSync(join(parent, "fault-observed")) };
+}
+
+// Faults apply only to this child's disposable destination. Real filesystem
+// methods serve every other operation, including all source reads.
+function faultPreload(parent: string, destination: string, fault: string): string {
+  const preload = join(parent, `fault-${fault}.ts`);
+  writeFileSync(preload, `
+import { mock } from "bun:test";
+import fs from "node:fs";
+import promises from "node:fs/promises";
+import { join, resolve, relative, sep } from "node:path";
+const destination = ${JSON.stringify(destination)};
+const fault = ${JSON.stringify(fault)};
+const marker = ${JSON.stringify(join(parent, "fault-observed"))};
+const rawWrite = fs.writeFileSync.bind(fs);
+const rawExists = fs.existsSync.bind(fs);
+const writeTargets = new Set(["copyFile", "cp"]);
+function wrapped(name, original, asynchronous) {
+  return function (...args) {
+    const base = name.replace(/Sync$/, "");
+    const target = String(args[writeTargets.has(base) ? 1 : 0]);
+    const path = resolve(target);
+    const child = relative(destination, path);
+    const inside = path === destination || (child !== ".." && !child.startsWith(".." + sep) && !child.startsWith(sep));
+    let code = "";
+    if (fault === "observe-create" && base === "mkdir" && path === destination) rawWrite(marker, "created");
+    if (fault === "mkdir" && base === "mkdir" && path === destination) code = "EACCES";
+    if (inside && ["writeFile", "copyFile", "cp"].includes(base) && rawExists(destination)) {
+      if (["copy", "cleanup"].includes(fault)) code = "EIO";
+      if (fault === "disk-full") code = "ENOSPC";
+    }
+    if (fault === "cleanup" && ["rm", "rmdir", "unlink"].includes(base) && inside) code = "EACCES";
+    if (code) {
+      rawWrite(marker, code);
+      const error = Object.assign(new Error(code + ": " + base + " " + path), { code, syscall: base, path });
+      if (asynchronous) return Promise.reject(error);
+      throw error;
+    }
+    const result = original(...args);
+    if (fault === "corrupt" && inside && ["writeFile", "copyFile", "cp"].includes(base) && path.endsWith("SKILL.md")) {
+      const corrupt = () => { rawWrite(path, "---\\nname: []\\n---\\ncorrupt\\n"); rawWrite(marker, "corrupt"); };
+      if (asynchronous) return Promise.resolve(result).then(value => { corrupt(); return value; });
+      corrupt();
+    }
+    return result;
+  };
+}
+const sync = { ...fs };
+const async = { ...promises };
+for (const name of ["mkdir", "writeFile", "copyFile", "cp", "rm", "rmdir", "unlink"]) {
+  if (typeof fs[name + "Sync"] === "function") sync[name + "Sync"] = wrapped(name + "Sync", fs[name + "Sync"].bind(fs), false);
+  if (typeof promises[name] === "function") async[name] = wrapped(name, promises[name].bind(promises), true);
+}
+sync.promises = async;
+mock.module("node:fs", () => ({ ...sync, default: sync }));
+mock.module("node:fs/promises", () => ({ ...async, default: async }));
+`);
+  return preload;
+}
+
+describe("Fresh exports preserve package integrity and ownership", () => {
+  test("real checkout produces validated required files and reports destination and omissions", async () => {
+    const api = requireExporter();
+    const destination = join(temporaryDirectory(), "team");
+    const result = await api.exportPlugin(ROOT, destination);
+
+    expect(result.destination).toBe(destination);
+    expect(result.omitted.sort()).toEqual(sourceInventory(ROOT).omitted);
+    expect(readdirSync(destination).sort()).toEqual(["LICENSE", "README.md", "plugin.json", "skills"]);
+    expect(api.validateManifest(file(join(destination, "plugin.json")), join(destination, "plugin.json"))).toEqual(JSON.parse(file(join(ROOT, "plugin.json"))));
+    expect(file(join(destination, "LICENSE"))).toBe(file(join(ROOT, "LICENSE")));
+    expect(file(join(destination, "README.md"))).toBe(file(join(ROOT, "docs/agent-plugins.md")));
+    expect([...skillNames(destination)].sort()).toEqual(sourceInventory(ROOT).names);
+    expect(exportedMetadataProblems(api, destination)).toEqual([]);
+  });
+
+  test("one-skill source exports from another working directory and reports its destination", async () => {
+    const { source, parent, destination } = fixture();
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(result.output).toContain(destination);
+    expect([...skillNames(destination)]).toEqual(["alpha"]);
+    expect(linkProblems(destination)).toEqual([]);
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).metadata).toEqual({ name: "alpha", description: "Fixture skill" });
+  });
+
+  test.each(["missing", "empty"])("%s source skills tree fails before destination creation", async (state) => {
+    const { source, parent, destination } = fixture();
+    removeSkills(source, state);
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, /skills/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test.each([0, 2])("%i destination arguments report usage without output", async (count) => {
+    const { source, parent, destination } = fixture();
+    const result = await cli(source, Array(count).fill(destination), parent);
+
+    expectRefusal(result, /usage|exactly one|one.*destination/i);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("relative destination is refused", async () => {
+    const { source, parent } = fixture();
+    const result = await cli(source, ["relative-output"], parent);
+
+    expectRefusal(result, /absolute/i);
+    expect(existsSync(join(parent, "relative-output"))).toBe(false);
+  });
+
+  test("destination inside source is refused without source mutation", async () => {
+    const { source, parent } = fixture();
+    const before = snapshot(source);
+    const result = await cli(source, [join(source, "output")], parent);
+
+    expectRefusal(result, /outside|within|inside|contain/i);
+    expect(snapshot(source)).toEqual(before);
+  });
+
+  test("symlinked parent cannot disguise destination inside source", async () => {
+    const { source, parent } = fixture();
+    symlinkSync(source, join(parent, "alias"));
+    const result = await cli(source, [join(parent, "alias/output")], parent);
+
+    expectRefusal(result, /outside|within|inside|contain/i);
+    expect(existsSync(join(source, "output"))).toBe(false);
+  });
+
+  test("missing destination parent is refused without creating parents", async () => {
+    const { source, parent } = fixture();
+    const result = await cli(source, [join(parent, "missing/output")], parent);
+
+    expectRefusal(result, join(parent, "missing"));
+    expect(existsSync(join(parent, "missing"))).toBe(false);
+  });
+
+  test.each(["directory", "file", "live symlink", "dangling symlink"])("existing %s survives refusal byte-for-byte", async (kind) => {
+    const { source, parent, destination } = fixture();
+    existingDestination(parent, destination, kind);
+    const before = snapshot(parent);
+    const result = await cli(source, [destination], parent);
+
+    expectRefusal(result, /exist/i);
+    expect(result.output).toMatch(/fresh|new directory|different directory/i);
+    expect(snapshot(parent)).toEqual(before);
+  });
+
+  test("simultaneous exporters have one owner and the loser preserves completed output", async () => {
+    const { source, parent, destination } = fixture();
+    const results = await Promise.all([cli(source, [destination], parent), cli(source, [destination], parent)]);
+
+    expect(results.filter((result) => result.status === 0)).toHaveLength(1);
+    expect(results.filter((result) => result.status !== 0)).toHaveLength(1);
+    expect(file(join(destination, "LICENSE"))).toBe("MIT fixture license\n");
+    expect([...skillNames(destination)]).toEqual(["alpha"]);
+    expect(linkProblems(destination)).toEqual([]);
+  });
+
+  test("late invalid skill aborts before destination creation", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "skills/zz-invalid/SKILL.md", "---\nname: zz-invalid\ndescription: 42\n---\n\nInvalid.\n");
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "skills/zz-invalid/SKILL.md");
+    expect(result.output).toMatch(/description/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("source MCP configuration requires an audit before export", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "mcp.json", '{"mcpServers":{}}\n');
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "mcp.json");
+    expect(result.output).toMatch(/audit|profile|unsupported/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("directory-only client extension requires an audit before destination creation", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "com.example.client/hooks/hooks.json", '{"hooks":{}}\n');
+    expect(JSON.parse(file(join(source, "plugin.json"))).extensions).toBeUndefined();
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "com.example.client");
+    expect(result.output).toMatch(/audit/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("whitespace-only description aborts before destination creation", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "skills/alpha/SKILL.md", "---\nname: alpha\ndescription: '   '\n---\n\n# Alpha\n");
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "skills/alpha/SKILL.md");
+    expect(result.output).toMatch(/description/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test.each(["LICENSE", "docs/agent-plugins.md", "skills/alpha/references/notes.md"])("missing required resource %s aborts before creation", async (path) => {
+    const { source, parent, destination } = fixture();
+    rmSync(join(source, path));
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, basename(path));
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("unexpected native registration content is not silently omitted", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "skills/alpha/agents/other.yaml", "unexpected: true\n");
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "skills/alpha/agents/other.yaml");
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test.each(["skills/alpha/references/linked.md", "skills/alpha/agents/openai.yaml", "LICENSE"])("symlink input %s is refused without following it", async (path) => {
+    const { source, parent, destination } = fixture();
+    write(parent, "outside.txt", "outside remains unchanged\n");
+    rmSync(join(source, path), { force: true });
+    symlinkSync(join(parent, "outside.txt"), join(source, path));
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, path);
+    expect(result.output).toMatch(/symlink|symbolic/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+    expect(file(join(parent, "outside.txt"))).toBe("outside remains unchanged\n");
+  });
+
+  test("special-file input is refused before copying", async () => {
+    const { source, parent, destination } = fixture();
+    const created = spawnSync("mkfifo", [join(source, "skills/alpha/references/pipe")], { encoding: "utf8" });
+    expect({ status: created.status, stderr: created.stderr }).toMatchObject({ status: 0 });
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "skills/alpha/references/pipe");
+    expect(result.output).toMatch(/special|regular|unsupported/i);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("unwritable destination reports failed creation without output", async () => {
+    const { source, parent, destination } = fixture();
+    const preload = faultPreload(parent, destination, "mkdir");
+    const result = await cli(source, [destination], parent, preload);
+
+    expect(file(join(parent, "fault-observed"))).toBe("EACCES");
+    expectRefusal(result, /mkdir|creat/i);
+    expect(result.output).toContain(destination);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test.each(["copy", "disk-full"])("post-creation %s failure removes only owned incomplete output", async (fault) => {
+    const { source, parent, destination } = fixture();
+    write(parent, "unrelated/keep.txt", "keep\n");
+    const before = snapshot(source);
+    const preload = faultPreload(parent, destination, fault);
+    const result = await cli(source, [destination], parent, preload);
+
+    expect(file(join(parent, "fault-observed"))).toMatch(/EIO|ENOSPC/);
+    expectRefusal(result, /EIO|ENOSPC/);
+    expect(result.output).toMatch(/copy|write/i);
+    expect(existsSync(destination)).toBe(false);
+    expect(file(join(parent, "unrelated/keep.txt"))).toBe("keep\n");
+    expect(snapshot(source)).toEqual(before);
+  });
+
+  test("cleanup failure reports both write and removal errors without success", async () => {
+    const { source, parent, destination } = fixture();
+    const preload = faultPreload(parent, destination, "cleanup");
+    const result = await cli(source, [destination], parent, preload);
+
+    expect(file(join(parent, "fault-observed"))).toBe("EACCES");
+    expectRefusal(result, /EIO/);
+    expect(result.output).toMatch(/EACCES/);
+    expect(result.output).toMatch(/clean|remov|\brm\b/i);
+    expect(existsSync(destination)).toBe(true);
+  });
+
+  test("final output corruption fails validation and removes owned output", async () => {
+    const { source, parent, destination } = fixture();
+    const preload = faultPreload(parent, destination, "corrupt");
+    const result = await cli(source, [destination], parent, preload);
+
+    expect(file(join(parent, "fault-observed"))).toBe("corrupt");
+    expectRefusal(result, /SKILL\.md/);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("interrupted output and reruns are refused with fresh-directory advice", async () => {
+    const { source, parent, destination } = fixture();
+    write(destination, "skills/alpha/SKILL.md", "partial export\n");
+    const before = snapshot(destination);
+    const first = await cli(source, [destination], parent);
+    const second = await cli(source, [destination], parent);
+
+    expectRefusal(first, /fresh|new directory|different directory/i);
+    expectRefusal(second, /fresh|new directory|different directory/i);
+    expect(snapshot(destination)).toEqual(before);
+  });
+
+  test("two fresh stable exports preserve paths bytes executable bits and source", async () => {
+    const api = requireExporter();
+    const { source, parent, destination } = fixture();
+    write(source, "skills/alpha/scripts/helper.sh", "#!/bin/sh\nprintf 'fixture\\n'\n");
+    chmodSync(join(source, "skills/alpha/scripts/helper.sh"), 0o751);
+    const before = snapshot(source);
+    await api.exportPlugin(source, destination);
+    await api.exportPlugin(source, join(parent, "second"));
+
+    expect(snapshot(destination)).toEqual(snapshot(join(parent, "second")));
+    expect(snapshot(source)).toEqual(before);
+    expect(lstatSync(join(destination, "skills/alpha/scripts/helper.sh")).mode & 0o111).toBe(0o111);
+    expect(file(join(destination, "skills/alpha/scripts/helper.sh"))).toBe(file(join(source, "skills/alpha/scripts/helper.sh")));
+  });
+
+  test("guarded skill discovery is omitted while its resources and omission report remain", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "skills/guarded/SKILL.md", "---\nname: guarded\ndescription: Explicit invocation only\ndisable-model-invocation: true\n---\n\nGuarded instructions.\n");
+    write(source, "skills/guarded/references/shared.md", "# Shared resource\n");
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(result.output).toContain("guarded");
+    expect([...skillNames(destination)]).toEqual(["alpha"]);
+    expect(existsSync(join(destination, "skills/guarded/SKILL.md"))).toBe(false);
+    expect(file(join(destination, "skills/guarded/references/shared.md"))).toBe("# Shared resource\n");
+  });
+
+  test("real export preserves every body resource and mode while omitting native discovery and registration", async () => {
+    const api = requireExporter();
+    const destination = join(temporaryDirectory(), "team");
+    const before = snapshot(join(ROOT, "skills"));
+    await api.exportPlugin(ROOT, destination);
+
+    expect(packageDifferences(ROOT, destination)).toEqual([]);
+    expect(snapshot(join(ROOT, "skills"))).toEqual(before);
+    expect(paths(destination).filter((path) => /(?:^|\/)(?:agents|hooks|\.claude-plugin|\.codex-plugin|\.agents)(?:\/|$)/.test(path))).toEqual([]);
+    expect(file(join(destination, "skills/team/registry.json"))).toBe(file(join(ROOT, "skills/team/registry.json")));
+    expect(file(join(destination, "skills/pr-watch-as-reviewer/references/02-input.md"))).toBe(file(join(ROOT, "skills/pr-watch-as-reviewer/references/02-input.md")));
+    expect(file(join(destination, "skills/pr-screenshots/references/01-input-and-result.md"))).toContain("skills/pr-watch-as-reviewer/references/02-input.md");
+  });
+
+  test("real exported skill loads and Markdown file links resolve within the package", async () => {
+    const api = requireExporter();
+    const destination = join(temporaryDirectory(), "team");
+    await api.exportPlugin(ROOT, destination);
+
+    expect([...skillNames(destination)].length).toBeGreaterThan(0);
+    expect(missingLoads(destination)).toEqual([]);
+    expect(linkProblems(destination)).toEqual([]);
+    expect(file(join(ROOT, "skills/shipit/SKILL.md"))).toContain(SHIPIT_URL);
+    expect(file(join(destination, "skills/shipit/SKILL.md"))).toContain(SHIPIT_URL);
+  });
+
+  test.each([
+    ["original shipit", "../../docs/versioning.md"],
+    ["missing target", "references/missing.md#part"],
+    ["escaping target", "../../../outside.md?raw=1#part"],
+  ])("%s Markdown link is rejected before output creation", async (_label, target) => {
+    const { source, parent, destination } = fixture();
+    write(parent, "outside.md", "outside package\n");
+    writeBrokenLink(source, target);
+    const result = await preflight(source, destination, parent);
+
+    expect(linkProblems(source)).toHaveLength(1);
+    expectRefusal(result, /SKILL\.md/);
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("retained local links resolve while fenced examples and external URLs are ignored", async () => {
+    const { source, parent, destination } = fixture();
+    write(source, "skills/alpha/references/notes.md", "# Notes\n\n[Self](notes.md?plain=1#notes)\n\n[External](https://example.invalid/missing)\n\n```md\n[Example](missing.md)\n```\n\n~~~markdown\n[Another example](also-missing.md)\n~~~\n");
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(linkProblems(destination)).toEqual([]);
+    expect(file(join(destination, "skills/alpha/references/notes.md"))).toBe(file(join(source, "skills/alpha/references/notes.md")));
+  });
+
+  test("nested-label Markdown link with a missing target aborts before destination creation", async () => {
+    const { source, parent, destination } = fixture();
+    const text = "---\nname: alpha\ndescription: Fixture skill\n---\n\n[Guide [details]](references/missing.md)\n";
+    write(source, "skills/alpha/SKILL.md", text);
+    expect(Bun.markdown.html(text)).toContain('href="references/missing.md"');
+    expect(markdownDestinations(text)).toEqual(["references/missing.md"]);
+    const result = await preflight(source, destination, parent);
+
+    expect(linkProblems(source)).toHaveLength(1);
+    expectRefusal(result, "skills/alpha/SKILL.md");
+    expect(result.output).toContain("references/missing.md");
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("balanced-parentheses Markdown link exports its existing target", async () => {
+    const { source, parent, destination } = fixture();
+    const text = "---\nname: alpha\ndescription: Fixture skill\n---\n\n[Notes](references/notes(v2).md)\n";
+    write(source, "skills/alpha/SKILL.md", text);
+    write(source, "skills/alpha/references/notes(v2).md", "# Notes version 2\n");
+    expect(Bun.markdown.html(text)).toContain('href="references/notes(v2).md"');
+    expect(markdownDestinations(text)).toEqual(["references/notes(v2).md"]);
+    expect(linkProblems(source)).toEqual([]);
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(linkProblems(destination)).toEqual([]);
+    expect(file(join(destination, "skills/alpha/references/notes(v2).md"))).toBe("# Notes version 2\n");
+  });
+
+  test.each([
+    ["link-like", "Use [Format](shape) syntax"],
+    ["skill-load-like", "call the Skill tool with `absent`"],
+  ])("metadata-only %s description is preserved without body reference checks", async (_label, description) => {
+    const { source, parent, destination } = fixture();
+    const body = "\n\n# Plain body\n";
+    writeSkillBody(source, body, description);
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).metadata.description).toBe(description);
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).body).toBe(body);
+    expect(linkProblems(destination)).toEqual([]);
+    expect(missingLoads(destination)).toEqual([]);
+  });
+
+  test.each([
+    "references/notes&#46;md",
+    "references/notes&#x2e;md",
+    "references/notes&period;md",
+    "references/notes&#46md",
+    "references/notes&#x2emd",
+  ])("raw HTML href %s resolves to the existing literal notes.md target", async (href) => {
+    const { source, parent, destination } = fixture();
+    const body = rawLinkBody(href);
+    writeSkillBody(source, body);
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(file(join(destination, "skills/alpha/references/notes.md"))).toBe("# Notes\n\nUse the fixture.\n");
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).body).toBe(body);
+  });
+
+  test("raw HTML href is decoded once to a literal notes&period;md filename", async () => {
+    const { source, parent, destination } = fixture();
+    const body = '\n\n<a href="references/notes&amp;period;md">Notes</a>\n';
+    rmSync(join(source, "skills/alpha/references/notes.md"));
+    write(source, "skills/alpha/references/notes&period;md", "# Literal entity filename\n");
+    writeSkillBody(source, body);
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(file(join(destination, "skills/alpha/references/notes&period;md"))).toBe("# Literal entity filename\n");
+    expect(existsSync(join(destination, "skills/alpha/references/notes.md"))).toBe(false);
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).body).toBe(body);
+  });
+
+  test.each([
+    ["references/&copy.md", "references/©.md"],
+    ["references/&copy=notes.md", "references/&copy=notes.md"],
+  ])("raw HTML legacy href %s preserves attribute-context semantics", async (href, target) => {
+    const { source, parent, destination } = fixture();
+    const body = rawLinkBody(href);
+    rmSync(join(source, "skills/alpha/references/notes.md"));
+    write(join(source, "skills/alpha"), target, "# Legacy attribute target\n");
+    writeSkillBody(source, body);
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(file(join(destination, "skills/alpha", target))).toBe("# Legacy attribute target\n");
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).body).toBe(body);
+  });
+
+  test("raw HTML encoded image src resolves to its existing literal image.png target", async () => {
+    const { source, parent, destination } = fixture();
+    const body = '\n\n<img src="references/image&period;png" alt="Fixture">\n';
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    write(source, "skills/alpha/references/image.png", bytes);
+    writeSkillBody(source, body);
+    const result = await cli(source, [destination], parent);
+
+    expectSuccess(result);
+    expect(readFileSync(join(destination, "skills/alpha/references/image.png"))).toEqual(bytes);
+    expect(splitSkill(file(join(destination, "skills/alpha/SKILL.md"))).body).toBe(body);
+  });
+
+  test("raw HTML encoded missing href fails preflight with its decoded destination", async () => {
+    const { source, parent, destination } = fixture();
+    const body = '\n\n<a href="references/missing&period;md">Missing</a>\n';
+    writeSkillBody(source, body);
+    const result = await preflight(source, destination, parent);
+
+    expectRefusal(result, "references/missing.md");
+    expect(result.output).toContain("skills/alpha/SKILL.md");
+    expect(result.destinationCreated).toBe(false);
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  test("exported screenshot helper preserves an existing deterministic refusal fixture", async () => {
+    const api = requireExporter();
+    const destination = join(temporaryDirectory(), "team");
+    await api.exportPlugin(ROOT, destination);
+    const helper = await import(pathToFileURL(join(destination, "skills/pr-screenshots/scripts/splice.mjs")).href);
+    const result = helper.splice(REAL_SCREENSHOTS, DEGRADED_SCREENSHOTS);
+
+    expect(result.body).toBe(REAL_SCREENSHOTS);
+    expect(result.changed).toBe(false);
+    expect(result.reason.length).toBeGreaterThan(0);
+    expect(lstatSync(join(destination, "skills/pr-screenshots/scripts/splice.mjs")).mode & 0o111).toBe(lstatSync(join(ROOT, "skills/pr-screenshots/scripts/splice.mjs")).mode & 0o111);
+  });
+});
+
+function writeSkillBody(source: string, body: string, description = "Fixture skill"): void {
+  const metadata = Bun.YAML.stringify({ name: "alpha", description }, null, 2);
+  write(source, "skills/alpha/SKILL.md", `---\n${metadata}\n---${body}`);
+}
+
+function rawLinkBody(href: string): string {
+  return `\n\n<a href="${href}">Notes</a>\n`;
+}
+
+function removeSkills(source: string, state: string): void {
+  rmSync(join(source, "skills"), { recursive: true });
+  if (state === "empty") mkdirSync(join(source, "skills"));
+}
+
+function existingDestination(parent: string, destination: string, kind: string): void {
+  if (kind === "directory") write(destination, "keep.txt", "existing directory\n");
+  if (kind === "file") writeFileSync(destination, "existing file\n");
+  if (kind === "live symlink") {
+    write(parent, "target/keep.txt", "symlink target\n");
+    symlinkSync(join(parent, "target"), destination);
+  }
+  if (kind === "dangling symlink") symlinkSync(join(parent, "absent"), destination);
+}
+
+function writeBrokenLink(source: string, target: string): void {
+  write(source, "skills/alpha/SKILL.md", `---\nname: alpha\ndescription: Broken link fixture\n---\n\n[Resource](${target})\n`);
+}
+
+function exportedMetadataProblems(api: Exporter, destination: string): string[] {
+  const problems: string[] = [];
+  for (const name of [...skillNames(destination)].sort()) {
+    const path = join(destination, "skills", name, "SKILL.md");
+    const text = file(path);
+    const metadata = splitSkill(text).metadata;
+    for (const key of Object.keys(metadata)) if (!PORTABLE_FIELDS.includes(key)) problems.push(`${name}: unsupported ${key}`);
+    try {
+      const projected = api.projectSkill(text, name, path);
+      if (!projected.eligible) problems.push(`${name}: exported guarded skill`);
+    } catch (error) {
+      problems.push(`${name}: ${String(error)}`);
+    }
+  }
+  return problems;
+}
+
+function packageDifferences(source: string, destination: string): string[] {
+  const inventory = sourceInventory(source);
+  const problems: string[] = [];
+  const expectedFiles: string[] = [];
+  for (const path of paths(join(source, "skills"))) {
+    if (lstatSync(join(source, "skills", path)).isDirectory() || path.split(sep)[1] === "agents") continue;
+    const discovery = path.split(sep).length === 2 && basename(path) === "SKILL.md";
+    if (discovery && inventory.omitted.includes(path.split(sep)[0]!)) continue;
+    expectedFiles.push(path);
+    const output = join(destination, "skills", path);
+    if (!existsSync(output)) { problems.push(`${path}: missing`); continue; }
+    const input = join(source, "skills", path);
+    const sourceBytes = discovery ? Buffer.from(splitSkill(file(input)).body) : readFileSync(input);
+    const outputBytes = discovery ? Buffer.from(splitSkill(file(output)).body) : readFileSync(output);
+    if (!sourceBytes.equals(outputBytes)) problems.push(`${path}: bytes differ`);
+    if ((lstatSync(input).mode & 0o111) !== (lstatSync(output).mode & 0o111)) problems.push(`${path}: executable bits differ`);
+  }
+  const actualFiles = paths(join(destination, "skills")).filter((path) => !lstatSync(join(destination, "skills", path)).isDirectory());
+  for (const path of actualFiles) if (!expectedFiles.includes(path)) problems.push(`${path}: unexpected`);
+  return problems.sort();
+}
+
+// Existing inputs from tests/pr-screenshots-skill.test.ts, "splice will not
+// downgrade a section holding real screenshots".
+const REAL_SCREENSHOTS = "## Summary\n\nAdds a login page.\n\n## Screenshots\n\n**Login** (default)\n![screenshot-01](https://github.com/user-attachments/assets/abcd)\n\nCloses #12\n";
+const DEGRADED_SCREENSHOTS = "## Screenshots\n\n**Login** (default) — captured, not yet uploaded: login.png";

--- a/tests/version-bump-required.test.ts
+++ b/tests/version-bump-required.test.ts
@@ -273,3 +273,24 @@ describe.if(HAS_JQ)("version-bump-required.sh: input validation", () => {
     expect(r.err).toMatch(/semver/);
   });
 });
+
+describe.if(HAS_JQ)("Native compatibility and documented distribution boundaries remain verifiable", () => {
+  test("exporter-only runtime change without a bump is rejected", () => {
+    const { dir, headSha, baseSha } = scenario({
+      forkVersion: "0.13.1",
+      branchEdits: (d) => writeFile(d, "scripts/export-agent-plugin.ts", "export const profile = 1;\n"),
+    });
+    expect(run(dir, { HEAD_SHA: headSha, BASE_SHA: baseSha }).status).not.toBe(0);
+  });
+
+  test("exporter-only runtime change with a forward bump is accepted", () => {
+    const { dir, headSha, baseSha } = scenario({
+      forkVersion: "0.13.1",
+      branchEdits: (d) => {
+        writeFile(d, "scripts/export-agent-plugin.ts", "export const profile = 1;\n");
+        writePlugin(d, "0.14.0");
+      },
+    });
+    expect(run(dir, { HEAD_SHA: headSha, BASE_SHA: baseSha }).status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Generate a validated [Agent Plugins 1.0.0](https://agent-plugins.org/specification) package with `bun run export:agent-plugin /absolute/existing-parent/team-portable`.
The generated directory keeps skill bodies and resources unchanged and exports supported metadata fields. Native installations keep their existing invocation controls.

## Design Decisions

- Export into a fresh directory outside the checkout. Validate inputs before creation and completed output before success.
- Use `entities` for complete HTML attribute decoding. Install locked dependencies before export, then disable automatic downloads during execution.
- Omit discovery for four explicit-invocation skills while retaining their shared resources.
- Validation covers package format. Generic clients still need the tools and working context each skill expects.

## Changes

- Add the canonical manifest schema and export command, including metadata, reference, ownership, and failure checks.
- Document compatibility requirements, observed evidence, usage, omissions, and host limits in `docs/agent-plugins.md`.
- Classify the exporter as runtime code. Add an Unreleased entry and preserve current versions until land time.

## How to Verify

- `bun test`: **2,507 passed, four baseline skips, zero failed** across 70 files after rebasing onto `main` at `b6b88751`. Main removed obsolete catalog checks; the same baseline commands pass before and after the rebase.
- Focused metadata/export/version suites: **195 passed**.
- `bun install --frozen-lockfile`, `bun run typecheck`, and the production Jekyll build passed.
- Both documented export commands succeeded. Independent official-schema and pinned `skills-ref` checks accepted **86 skills and 262 files**.
- Fresh CLI review ran both export entry points with network access denied. Both passed without changing source files.
- Body, resource, permission, README, license, manifest, and containment comparisons passed. Four guarded discovery files were absent as intended.
- Claude manifest validation passed. Antigravity native validation accepted 90 skills and 13 agents.
- The four skips are existing hook-output schema cases. Paid behavioral evals were not run.

Confidence: high — direct checks and fresh independent reviews confirm these results.

## Review notes

- `[ux-reviewer, round 1]` Optional CLI improvements remain: `--help` reports a path error, and missing parents report raw `ENOENT`.
- `[documentation-reviewer, round 3]` The audit labels AP §4.1(5) as failure handling. Correcting that citation and identifying opaque configuration values remains advisory.

`cross-model-notes`:

> **Design round 1**
> ### Cross-model disposition
> 
> #### codex
> 
> - **Verified, adopted as Blocking:** the export omits the document referenced by `shipit`. Evidence: `skills/shipit/SKILL.md:18` and design lines 40–43.
> - **Refuted as a mandatory correction:** adding copied documentation to runtime classification does not follow from the existing release policy. `docs/versioning.md:64–74` explicitly exempts documentation changes. `tests/version-bump-required.test.ts:241–246` preserves that exemption. Changing this policy requires a separate justification beyond distributing a README.
> 
> Confidence: high on the file evidence, moderate on the policy interpretation because the generated distribution is new.
> 
> #### agy
> 
> Skipped: the supplied runner result reports exhausted account quota and exit code 1. No substantive claims were available.
> 
> Confidence: high — the provided result records that failure.

> **Design round 2**
> ### Cross-model disposition
> 
> **Round 2 — codex:** Refuted the claim that excluding `docs/agent-plugins.md` from runtime classification violates the version gate. Documentation remains exempt under `docs/versioning.md:71`; `tests/version-bump-required.test.ts:241` also preserves documentation-only acceptance. Decision 7 deliberately adds the exporter’s behavioral transformation to the classifier. No finding adopted. Confidence: high, from policy and classifier evidence.
> 
> **Round 2 — agy:** Skipped because the vendor process reported an exhausted individual quota. No review claims available. Confidence: high in the supplied skip record.

> **Code round 1**
> ### Cross-model disposition
>
> Round 1:
>
> - **codex:** Adopted the parenthesized-destination defect within finding 1, Blocking tier. Independently confirmed at `scripts/export-agent-plugin.ts:111`. No refuted or unverifiable claims.
> - **agy:** Skipped because its quota was exhausted.
> - Post-vendor checkout remained clean. Confidence: high, confirmed with `git status --short`.

> **Code round 2**
> ### Cross-model disposition
>
> Round 2, `codex`:
>
> - **Adopted, Blocking:** directory-only extensions bypass audit refusal, confirmed at `scripts/export-agent-plugin.ts:136`.
> - **Refuted as a policy defect:** README changes remaining version-exempt follow the explicit documentation exemption in `7-structure.md:106`. Checked classifier line 106 and README copying at exporter line 141.
> - **Unverifiable as a requirement violation:** `file:` URLs bypass reference checks at exporter line 109. Reproduced, but the design excludes external URLs without defining scheme-specific handling. No blocking finding adopted.
>
> Round 2, `agy`:
>
> - Skipped because the vendor reported exhausted quota.
>
> The orchestrator and this reviewer observed a clean tracked tree after the vendor pass.

> **Code round 3**
> ### Cross-model disposition
>
> Round 3:
>
> - **codex:** Adopted its entity-decoding claim as Blocking after independent confirmation at `scripts/export-agent-plugin.ts:107` and `:119`. No refuted or unverifiable claims.
> - **agy:** Review unavailable because its account quota was exhausted.
> - Root performed adapter calls under the stated collaborator adaptation. Post-adapter working-tree inspection was clean, independently confirmed.
>
> Confidence: high—raw vendor data inspected, adopted claim reproduced, tree checked.

> **Code round 4**
> ### Cross-model disposition
>
> **Codex:** Neither proposed defect adopted.
>
> - Version-classification concern refuted against approved scope. The exact exporter addition at `.github/scripts/version-bump-required.sh:106` preserves the explicit docs-only exemption in `8-plan.md:121`.
> - Fenced skill-load scanning confirmed at `scripts/export-agent-plugin.ts:127`, but refuted as a new contract violation. It matches `tests/helpers/skill-refs.ts:63`. The plan separately exempts fenced examples from Markdown-link checks at `8-plan.md:64`.
>
> **Agy:** Adapter completed without review content. Its pass was unavailable; no claims to assess.
>
> Tracked tree remained clean after both adapters. Confidence: high — final external records and tree status inspected.

## References

- Design (local artifact): `docs/plans/349-agent-plugins-compatibility/6-design.md`
- Plan (local artifact): `docs/plans/349-agent-plugins-compatibility/8-plan.md`
- Compatibility guide: `docs/agent-plugins.md`

Closes #349
