### PR TITLE
fix(script): name the broken marketplace when Codex cannot list plugins

### DIFF
--- a/script/dev-install-codex
+++ b/script/dev-install-codex
@@ -130,31 +130,65 @@ migrate_legacy_link() {
 }
 
 # --- Codex state readers -----------------------------------------------------
+# Codex lists nothing while any configured marketplace root has no manifest: it
+# exits 1 with the offending name and path on stderr and an empty stdout. A
+# deleted worktree that once held a checkout is the common way to get there. So
+# every reader goes through this, which checks the status before a parser sees
+# the output — piped straight into node, that empty stdout reports a JSON syntax
+# error and never says which marketplace is broken.
+read_codex_json() {
+  local stderr_file status output
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/team-codex-stderr.XXXXXX")"
+  output="$(codex "$@" 2>"$stderr_file")" && status=0 || status=$?
+
+  if [ "$status" -eq 0 ]; then
+    rm -f "$stderr_file"
+    printf '%s' "$output"
+    return 0
+  fi
+
+  echo "Error: \`codex $*\` failed (exit ${status}). Codex reported:" >&2
+  sed 's/^/  /' "$stderr_file" >&2
+  rm -f "$stderr_file"
+  echo "If a root above no longer exists, drop its registration and re-run." >&2
+  echo "For Team's own: codex plugin marketplace remove ${MARKETPLACE}" >&2
+  return 1
+}
+
+MARKETPLACE_ROOT=""
+INSTALLED_VERSION=""
+
+# Both readers set a global rather than printing, for the same reason
+# stamp_cachebuster does: a command substitution runs the function in a
+# subshell, and `set -e` does not carry an inner failure back out through one,
+# so a reader that printed its answer could not stop the run on a failed read.
 read_marketplace_root() {
+  local listing
+  listing="$(read_codex_json plugin marketplace list --json)" || exit 1
   # The JavaScript template literal is intentionally protected from the shell.
   # shellcheck disable=SC2016
-  codex plugin marketplace list --json |
-    MARKETPLACE="$MARKETPLACE" node -e '
-      const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
-      const list = Array.isArray(entries) ? entries : (entries.marketplaces ?? []);
-      const matches = list.filter((entry) => entry.name === process.env.MARKETPLACE);
-      if (matches.length > 1) throw new Error("multiple team-dev marketplaces found");
-      if (matches.length === 1) process.stdout.write(String(matches[0].root ?? ""));
-    '
+  MARKETPLACE_ROOT="$(MARKETPLACE="$MARKETPLACE" LISTING="$listing" node -e '
+    const entries = JSON.parse(process.env.LISTING);
+    const list = Array.isArray(entries) ? entries : (entries.marketplaces ?? []);
+    const matches = list.filter((entry) => entry.name === process.env.MARKETPLACE);
+    if (matches.length > 1) throw new Error("multiple team-dev marketplaces found");
+    if (matches.length === 1) process.stdout.write(String(matches[0].root ?? ""));
+  ')"
 }
 
 read_installed_version() {
+  local listing
+  listing="$(read_codex_json plugin list --json)" || exit 1
   # shellcheck disable=SC2016
-  codex plugin list --json |
-    PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" node -e '
-      const parsed = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
-      const list = Array.isArray(parsed) ? parsed : (parsed.installed ?? []);
-      const matches = list.filter(
-        (entry) => entry.pluginId === process.env.PLUGIN_ID && entry.installed,
-      );
-      if (matches.length > 1) throw new Error("multiple Team installs found");
-      if (matches.length === 1) process.stdout.write(String(matches[0].version ?? ""));
-    '
+  INSTALLED_VERSION="$(PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" LISTING="$listing" node -e '
+    const parsed = JSON.parse(process.env.LISTING);
+    const list = Array.isArray(parsed) ? parsed : (parsed.installed ?? []);
+    const matches = list.filter(
+      (entry) => entry.pluginId === process.env.PLUGIN_ID && entry.installed,
+    );
+    if (matches.length > 1) throw new Error("multiple Team installs found");
+    if (matches.length === 1) process.stdout.write(String(matches[0].version ?? ""));
+  ')"
 }
 
 # --- Prune every cached copy but the one just installed ------------------------
@@ -181,7 +215,7 @@ echo
 
 migrate_legacy_link
 
-MARKETPLACE_ROOT=$(read_marketplace_root)
+read_marketplace_root
 if [ -z "$MARKETPLACE_ROOT" ]; then
   # Only the personal marketplace (~/.agents/plugins/marketplace.json) is
   # discovered implicitly. A repo marketplace has to be registered.
@@ -189,7 +223,15 @@ if [ -z "$MARKETPLACE_ROOT" ]; then
 elif [ "$MARKETPLACE_ROOT" != "$PLUGIN_ROOT" ]; then
   echo "Error: the ${MARKETPLACE} marketplace already points at a different checkout:" >&2
   echo "  ${MARKETPLACE_ROOT}" >&2
-  echo "Run script/dev-uninstall codex from that checkout first." >&2
+  if [ -f "${MARKETPLACE_ROOT}/.codex-plugin/plugin.json" ]; then
+    echo "Run script/dev-uninstall codex from that checkout first." >&2
+  else
+    # That path is no longer a Team checkout, so the uninstall script it would
+    # otherwise name is not there to run. Dropping the registration is the
+    # whole recovery.
+    echo "That path is not a Team checkout, so drop the registration instead:" >&2
+    echo "  codex plugin marketplace remove ${MARKETPLACE}" >&2
+  fi
   exit 1
 fi
 
@@ -198,7 +240,7 @@ echo "  Cachebuster: ${STAMPED_VERSION}"
 
 codex plugin add "${PLUGIN}@${MARKETPLACE}" 2>&1
 
-INSTALLED_VERSION=$(read_installed_version)
+read_installed_version
 if [ "$INSTALLED_VERSION" != "$STAMPED_VERSION" ]; then
   echo "Error: Codex reports Team at '${INSTALLED_VERSION}', not '${STAMPED_VERSION}'." >&2
   exit 1

--- a/script/dev-uninstall-codex
+++ b/script/dev-uninstall-codex
@@ -45,33 +45,66 @@ elif [ -e "$LEGACY_LINK" ]; then
 fi
 
 # --- The native plugin install -----------------------------------------------
+# Codex lists nothing while any configured marketplace root has no manifest: it
+# exits 1 with the offending name and path on stderr and an empty stdout. A
+# root that has been deleted is exactly the state someone reaches for an
+# uninstall in, so an unreadable listing reports what Codex said and the
+# teardown continues on what it can still do — `marketplace remove` and the
+# cache sweep both work while the listing does not.
+read_codex_json() {
+  local stderr_file status output
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/team-codex-stderr.XXXXXX")"
+  output="$(codex "$@" 2>"$stderr_file")" && status=0 || status=$?
+
+  if [ "$status" -eq 0 ]; then
+    rm -f "$stderr_file"
+    printf '%s' "$output"
+    return 0
+  fi
+
+  echo "  Note: \`codex $*\` failed (exit ${status}). Codex reported:" >&2
+  sed 's/^/    /' "$stderr_file" >&2
+  rm -f "$stderr_file"
+  return 1
+}
+
 if command -v codex >/dev/null 2>&1; then
-  # shellcheck disable=SC2016
-  INSTALLED=$(
-    codex plugin list --json |
-      PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" node -e '
-        const parsed = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+  CODEX_STATE_READABLE=true
+
+  if PLUGIN_LISTING=$(read_codex_json plugin list --json); then
+    # shellcheck disable=SC2016
+    INSTALLED=$(
+      PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" LISTING="$PLUGIN_LISTING" node -e '
+        const parsed = JSON.parse(process.env.LISTING);
         const list = Array.isArray(parsed) ? parsed : (parsed.installed ?? []);
         if (list.some((entry) => entry.pluginId === process.env.PLUGIN_ID && entry.installed)) {
           process.stdout.write("yes");
         }
       '
-  )
+    )
+  else
+    CODEX_STATE_READABLE=false
+    INSTALLED=""
+  fi
   if [ -n "$INSTALLED" ]; then
     codex plugin remove "${PLUGIN}@${MARKETPLACE}" 2>&1
     REMOVED_SOMETHING=true
   fi
 
-  # shellcheck disable=SC2016
-  REGISTERED=$(
-    codex plugin marketplace list --json |
-      MARKETPLACE="$MARKETPLACE" node -e '
-        const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+  if MARKETPLACE_LISTING=$(read_codex_json plugin marketplace list --json); then
+    # shellcheck disable=SC2016
+    REGISTERED=$(
+      MARKETPLACE="$MARKETPLACE" LISTING="$MARKETPLACE_LISTING" node -e '
+        const entries = JSON.parse(process.env.LISTING);
         const list = Array.isArray(entries) ? entries : (entries.marketplaces ?? []);
         const match = list.find((entry) => entry.name === process.env.MARKETPLACE);
         if (match) process.stdout.write(String(match.root ?? ""));
       '
-  )
+    )
+  else
+    CODEX_STATE_READABLE=false
+    REGISTERED=""
+  fi
   if [ -n "$REGISTERED" ]; then
     if [ "$REGISTERED" != "$PLUGIN_ROOT" ]; then
       echo "  Note: the ${MARKETPLACE} marketplace points at another checkout:"
@@ -79,6 +112,13 @@ if command -v codex >/dev/null 2>&1; then
     fi
     codex plugin marketplace remove "$MARKETPLACE" 2>&1
     REMOVED_SOMETHING=true
+  elif [ "$CODEX_STATE_READABLE" = false ]; then
+    # Whether Team is registered is unknown, so ask Codex to remove it and read
+    # the answer from the attempt. It fails harmlessly when it was not there.
+    if codex plugin marketplace remove "$MARKETPLACE" >/dev/null 2>&1; then
+      echo "  Removed the ${MARKETPLACE} marketplace registration."
+      REMOVED_SOMETHING=true
+    fi
   fi
 else
   echo "  Note: the codex CLI is not on PATH. Removing Team's files only."

--- a/tests/helpers/fake-codex.mjs
+++ b/tests/helpers/fake-codex.mjs
@@ -14,6 +14,9 @@
 //   add.
 // - `plugin remove` deletes the cached version directory without following
 //   symlinks inside it.
+// - `plugin list` and `plugin marketplace list` both fail, exit 1, when any
+//   configured root has no manifest, while `plugin marketplace remove` still
+//   works — which is what makes removal the recovery from that state.
 //
 // State lives entirely under $HOME, so each test isolates with HOME=<tempdir>.
 // Invocations are appended to $HOME/.fake-codex-calls for assertions.
@@ -67,6 +70,27 @@ function manifestVersion(root) {
   return JSON.parse(readFileSync(manifest, "utf8")).version;
 }
 
+/**
+ * Codex loads every configured marketplace before it lists anything, so one
+ * root without a manifest — a deleted checkout, most often — fails the whole
+ * command: exit 1, the offending name and path on stderr, nothing on stdout.
+ * The two commands word it differently, which is why the headline is a
+ * parameter.
+ */
+function assertRootsLoadable(entries, headline) {
+  const broken = entries.filter(
+    (entry) => !existsSync(join(entry.root, ".agents", "plugins", "marketplace.json")),
+  );
+  if (broken.length === 0) return;
+  const detail = broken
+    .map(
+      (entry) =>
+        `- \`${entry.name}\` at ${entry.root}: marketplace root does not contain a supported manifest`,
+    )
+    .join("\n");
+  fail(`Error: failed to load ${headline}:\n${detail}`);
+}
+
 function marketplaceName(root) {
   const manifest = join(root, ".agents", "plugins", "marketplace.json");
   if (!existsSync(manifest)) fail(`error: no .agents/plugins/marketplace.json in ${root}`);
@@ -83,6 +107,7 @@ if (command === "marketplace") {
   const entries = readRegistry();
 
   if (sub === "list") {
+    assertRootsLoadable(entries, "marketplace(s)");
     if (subArgs.includes("--json")) {
       process.stdout.write(
         JSON.stringify(
@@ -126,6 +151,7 @@ if (command === "marketplace") {
 
 if (command === "list") {
   const installed = [];
+  assertRootsLoadable(readRegistry(), "configured marketplace snapshot(s)");
   for (const entry of readRegistry()) {
     for (const plugin of entry.plugins) {
       installed.push({

--- a/tests/regression-356-codex-marketplace-root-gone.test.ts
+++ b/tests/regression-356-codex-marketplace-root-gone.test.ts
@@ -1,0 +1,177 @@
+// Regression test for issue #356.
+//
+// Codex loads every configured marketplace before it lists anything, so a
+// `team-dev` registration pointing at a deleted checkout fails both
+// `codex plugin marketplace list --json` and `codex plugin list --json`: exit
+// 1, the offending name and path on stderr, nothing on stdout. Both Codex dev
+// scripts used to pipe that empty stdout straight into `node -e`, so the
+// operator saw a JSON syntax error and a node stack and never learned which
+// marketplace was broken or how to drop it.
+//
+// The facts this pins: the install names the broken root and the recovery
+// command instead of a parse error, and the uninstall — the script someone
+// reaches for in that state — completes the teardown rather than crashing.
+//
+// L3 subprocess-snapshot, matching tests/dev-install-codex.test.ts: an
+// isolated HOME, the fake `codex` from tests/helpers/fake-codex.mjs on PATH,
+// and a disposable copy of the plugin root, because the install stamps the
+// manifest.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { makePluginFixture, type PluginFixture } from "./helpers/codex-plugin-fixture";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const FAKE_CODEX = join(REPO_ROOT, "tests", "helpers", "fake-codex.mjs");
+
+const disposable: string[] = [];
+
+afterAll(() => {
+  for (const dir of disposable) rmSync(dir, { force: true, recursive: true });
+});
+
+function newFixture(): PluginFixture {
+  const fixture = makePluginFixture();
+  disposable.push(fixture.root);
+  return fixture;
+}
+
+function newHome(): string {
+  const home = mkdtempSync(join(tmpdir(), `regression-356-${process.pid}-`));
+  disposable.push(home);
+  return home;
+}
+
+function stubCodex(home: string): string {
+  const binDir = join(home, "stub-bin");
+  mkdirSync(binDir, { recursive: true });
+  const stub = join(binDir, "codex");
+  writeFileSync(stub, `#!/usr/bin/env bash\nexec node "${FAKE_CODEX}" "$@"\n`);
+  chmodSync(stub, 0o755);
+  return binDir;
+}
+
+function run(script: string, home: string) {
+  const result = spawnSync("bash", [script], {
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, PATH: `${stubCodex(home)}:${process.env.PATH ?? ""}` },
+  });
+  return {
+    status: result.status ?? -1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}`,
+  };
+}
+
+const cacheRoot = (home: string) =>
+  join(home, ".codex", "plugins", "cache", "team-dev", "team");
+const cachedVersions = (home: string) =>
+  existsSync(cacheRoot(home)) ? readdirSync(cacheRoot(home)).sort() : [];
+
+/**
+ * Register `team-dev` from a throwaway checkout, then delete it — the state a
+ * merged-and-removed worktree leaves behind.
+ */
+function registerThenDeleteRoot(home: string): string {
+  const doomed = newFixture();
+  const binDir = stubCodex(home);
+  const added = spawnSync(
+    "bash",
+    ["-c", `"${binDir}/codex" plugin marketplace add "${doomed.root}"`],
+    { encoding: "utf8", env: { ...process.env, HOME: home } },
+  );
+  expect(added.status).toBe(0);
+  rmSync(doomed.root, { force: true, recursive: true });
+  return doomed.root;
+}
+
+describe("regression #356: a marketplace root that is gone reports itself", () => {
+  test("install names the broken root and the recovery command", () => {
+    const fixture = newFixture();
+    const home = newHome();
+    const goneRoot = registerThenDeleteRoot(home);
+
+    const { status, output } = run(fixture.install, home);
+
+    expect(status).not.toBe(0);
+    // What Codex said, verbatim enough to identify the marketplace at fault.
+    expect(output).toContain("team-dev");
+    expect(output).toContain(goneRoot);
+    expect(output).toContain("codex plugin marketplace remove team-dev");
+    // Not a parser complaining about the empty stdout behind that failure.
+    expect(output).not.toContain("Unexpected end of JSON input");
+    expect(output).not.toContain("SyntaxError");
+  });
+
+  test("a failed read leaves the tracked manifest and the cache untouched", () => {
+    const fixture = newFixture();
+    const before = readFileSync(fixture.manifest, "utf8");
+    const home = newHome();
+    registerThenDeleteRoot(home);
+
+    expect(run(fixture.install, home).status).not.toBe(0);
+
+    expect(readFileSync(fixture.manifest, "utf8")).toBe(before);
+    expect(cachedVersions(home)).toHaveLength(0);
+  });
+
+  test("uninstall drops the stale registration and the cache", () => {
+    const fixture = newFixture();
+    const home = newHome();
+    registerThenDeleteRoot(home);
+    // A cached copy from before the root went away.
+    mkdirSync(join(cacheRoot(home), "0.96.0+codex.20200101000000"), { recursive: true });
+
+    const { status, output } = run(fixture.uninstall, home);
+
+    expect(status).toBe(0);
+    expect(output).toContain("Uninstalled Team for Codex");
+    expect(existsSync(join(home, ".codex", "plugins", "cache", "team-dev"))).toBe(false);
+    expect(output).not.toContain("Unexpected end of JSON input");
+
+    // The registration is gone, so Codex can list again.
+    const listed = spawnSync(
+      "bash",
+      ["-c", `"${join(home, "stub-bin", "codex")}" plugin marketplace list --json`],
+      { encoding: "utf8", env: { ...process.env, HOME: home } },
+    );
+    expect(listed.status).toBe(0);
+    expect(listed.stdout).not.toContain("team-dev");
+  });
+
+  // The pre-existing advice — run script/dev-uninstall from the other checkout
+  // — is a dead end when that path holds no Team checkout to run it from.
+  test("install points at the registration when the other root is not Team's", () => {
+    const fixture = newFixture();
+    const home = newHome();
+    const foreign = join(newHome(), "not-a-team-checkout");
+    mkdirSync(join(foreign, ".agents", "plugins"), { recursive: true });
+    writeFileSync(
+      join(foreign, ".agents", "plugins", "marketplace.json"),
+      `${JSON.stringify({ name: "team-dev", plugins: [] }, null, 2)}\n`,
+    );
+    const binDir = stubCodex(home);
+    spawnSync("bash", ["-c", `"${binDir}/codex" plugin marketplace add "${foreign}"`], {
+      env: { ...process.env, HOME: home },
+    });
+
+    const { status, output } = run(fixture.install, home);
+
+    expect(status).not.toBe(0);
+    expect(output).toContain(foreign);
+    expect(output).toContain("codex plugin marketplace remove team-dev");
+    expect(output).not.toContain("dev-uninstall");
+  });
+});


### PR DESCRIPTION
Closes #356

## Why

`script/dev-install codex` crashed with a node stack instead of a diagnosis:

```
Error: failed to load marketplace(s):
- `team-dev` at /…/.claude/worktrees/2026-09-09-codex-native-plugin-install: marketplace root does not contain a supported manifest
undefined:1

SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
```

Codex loads every configured marketplace before it lists anything, so a `team-dev` registration pointing at a deleted checkout — a merged worktree, most often the one the install itself was developed in — fails both `codex plugin marketplace list --json` and `codex plugin list --json`: exit 1, the offending name and path on stderr, nothing on stdout. Both Codex dev scripts piped that empty stdout straight into `node -e`, so the operator learned neither which marketplace was broken nor how to drop it. `script/dev-uninstall codex`, the script you reach for in that state, crashed the same way, which left Team with no working recovery of its own.

## What changes

- The install checks the exit status before a parser sees the output, repeats what Codex said, and names the recovery command (`codex plugin marketplace remove team-dev`).
- The uninstall reports the same and then finishes the teardown on what still works. `marketplace remove` and the cache sweep both work while the listing does not, so an unreadable listing no longer stops a removal.
- When the marketplace resolves to a root that holds no Team checkout, the error points at the registration instead of telling you to run a script that is not there.
- The readers set globals instead of printing, for the reason `stamp_cachebuster` already documents: `set -e` does not carry an inner failure back out through a command substitution, so a reader that printed its answer could not stop the run on a failed read.

The fake `codex` test double now models the failure, including that `marketplace remove` keeps working through it — which is what makes removal the recovery.

Dev-only change (`script/`, `tests/`), so no version bump and no changelog entry.

## Test plan

- `tests/regression-356-codex-marketplace-root-gone.test.ts` pins the install message, the untouched manifest and cache, the completed uninstall, and the non-Team-root advice.
- Ran the new tests against the pre-fix scripts: 3 of the 4 fail, so none is vacuous.
- Full free suite green (2342 pass, 0 fail).
- Reproduced the original crash and the recovery by hand on this machine: the stale registration was removed, `script/dev-install codex` then installed `0.97.0+codex.<stamp>` and left the tracked manifest byte-identical.
- `shellcheck` on both scripts adds no new findings (one pre-existing SC2016 on `stamp_cachebuster` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)