### PR TITLE
fix(claude): install through Claude Code's own commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`script/dev-install claude` no longer replaces Claude Code's copy of the plugin with a symlink to your checkout.** The cache path carries the version, so the directory name was fixed at install time while its contents followed the checkout: on a branch that bumped the version, `claude plugin list` named the old release while Claude ran the new code. The install now follows the loop Claude Code documents for local plugins: stamp a `+claude.<timestamp>` cachebuster onto `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` — the plugin cache is keyed on the version and `claude plugin update` copies nothing when it has not moved — refresh the marketplace, install, then restore the manifests and prune the copy the previous run left. `script/dev-uninstall claude` now sweeps the whole cache tree, including a symlink an install from before this change left behind. **What this asks of you:** the install is a copy now, so a skill you edit does not reach Claude Code until you re-run `script/dev-install claude`. The clone-local pull hooks already re-run it after a merge or rebase pull. Verified on 2026-09-10.
+
 ## [0.97.0] - 2026-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,16 +25,22 @@ The first command registers the checkout as a marketplace; the second installs
 from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
 hooks load with them.
 
-For a clone-backed install that updates when `git pull` changes the checkout:
+Developing Team itself? Run the loop Claude Code documents for local plugins:
 
 ```bash
 script/dev-install claude
 ```
 
-This adds clone-local hooks for merge and rebase pulls. Existing non-Team hooks
-and a `core.hooksPath` outside the clone are never overwritten: the install
-still completes, and reports that it skipped the hooks and how to wire them up
-yourself. Remove the install and Team-owned hooks with:
+Claude Code keys its plugin cache on the manifest version and reports "already
+at the latest version" when it has not moved, so the install stamps a
+`+claude.<timestamp>` cachebuster onto the manifests, refreshes the catalog,
+installs, restores the manifests, and prunes the copy the last run left. The
+install is a copy either way, so **re-run it after changing a skill.**
+
+It also adds clone-local hooks that re-run it after merge and rebase pulls.
+Existing non-Team hooks and a `core.hooksPath` outside the clone are never
+overwritten: the install still completes, and reports that it skipped the hooks
+and how to wire them up yourself. Remove the install and Team-owned hooks with:
 
 ```bash
 script/dev-uninstall claude

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -330,6 +330,24 @@ full parity. It starts from the matrix and works around the named gaps.
   suffix to force the re-copy rather than a version bump;
   `script/dev-install-codex` stamps one, reinstalls, restores the manifest, and
   prunes the previous copy.
+- **Claude Code installs the same way, and takes the same loop.** `claude
+  plugin install` copies the marketplace root to
+  `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, and `claude
+  plugin update` reports "already at the latest version" and copies nothing
+  when the version has not moved, so `script/dev-install-claude` stamps
+  `<base>+claude.<cachebuster>` onto `.claude-plugin/plugin.json` and both
+  version strings in `.claude-plugin/marketplace.json` — the catalog is a
+  snapshot taken when the marketplace is added or updated, so the stamp has to
+  land before the refresh. Two details differ from Codex: the cache directory
+  is named with `+` rewritten to `-` while the reported version keeps the `+`,
+  so the served path comes from what `claude plugin list` reports rather than
+  from the version string; and there is no legacy collection link to migrate.
+  Verified on 2026-09-10.
+- **Do not replace the cached copy with a symlink to the checkout.** It makes
+  edits take effect without a reinstall, and it decouples the served content
+  from the version Claude reports: the directory name is fixed at install time
+  while the contents follow the checkout, so a branch that bumps the version
+  runs the new code under the old number (#355).
 - **Codex's plugin validator rejects `disable-model-invocation`.**
   `plugin-creator`'s `validate_plugin.py` requires the key to be absent or
   `false`, and Team's four guarded skills set it `true` because Claude Code

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,16 +84,22 @@ The first command registers the checkout as a marketplace; the second installs
 from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
 hooks load with them.
 
-For a clone-backed install that updates when `git pull` changes the checkout:
+Developing Team itself? Run the loop Claude Code documents for local plugins:
 
 ```bash
 script/dev-install claude
 ```
 
-This adds clone-local hooks for merge and rebase pulls. Existing non-Team hooks
-and a `core.hooksPath` outside the clone are never overwritten: the install
-still completes, and reports that it skipped the hooks and how to wire them up
-yourself. Remove the install and Team-owned hooks with:
+Claude Code keys its plugin cache on the manifest version and reports "already
+at the latest version" when it has not moved, so the install stamps a
+`+claude.<timestamp>` cachebuster onto the manifests, refreshes the catalog,
+installs, restores the manifests, and prunes the copy the last run left. The
+install is a copy either way, so **re-run it after changing a skill.**
+
+It also adds clone-local hooks that re-run it after merge and rebase pulls.
+Existing non-Team hooks and a `core.hooksPath` outside the clone are never
+overwritten: the install still completes, and reports that it skipped the hooks
+and how to wire them up yourself. Remove the install and Team-owned hooks with:
 
 ```bash
 script/dev-uninstall claude

--- a/script/dev-install
+++ b/script/dev-install
@@ -9,15 +9,14 @@ set -euo pipefail
 # Each harness has its own script beside this one, because each host installs
 # a plugin its own way. Adding a harness means adding `dev-install-<name>` and
 # `dev-uninstall-<name>`, then listing it below.
-# The Claude target also installs clone-local hooks that refresh its versioned
-# cache after merge-based and rebase-based pulls. Only Claude needs them,
-# because only its link IS the versioned path: a pull that bumps plugin.json
-# renames the path Claude looks under and strands the link. Codex's cache path
-# is versioned too, but the link sits inside it, at <version>/skills, so a bump
-# leaves the skills resolving through to the checkout and only the version
-# Codex reports lags — until the next install prunes the old directory.
-# Antigravity links a fixed path and is unaffected either way. That asymmetry
-# is an implementation detail — keep it out of the output the user reads.
+# The Claude target also installs clone-local hooks that reinstall after
+# merge-based and rebase-based pulls. Claude Code and Codex both install by
+# copying, so a pull moves the checkout without moving what either host serves;
+# the hooks exist so that at least one host stays current without being asked.
+# They are Claude-only because Claude Code is the host that runs the pipeline,
+# so a stale copy there is the one that costs a run. Codex and Antigravity are
+# re-run by hand. That asymmetry is an implementation detail — keep it out of
+# the output the user reads.
 
 HARNESSES=(claude codex antigravity)
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/script/dev-install-claude
+++ b/script/dev-install-claude
@@ -1,36 +1,117 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Installs Team for Claude Code from a local checkout, using only Claude Code's
+# own plugin commands.
+#
+# `claude plugin install` copies the marketplace root into
+# ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>, and the version
+# string is the cache key: `claude plugin update` reports "already at the
+# latest version" and copies nothing when the version has not moved. So a
+# skill edited in the checkout does not reach Claude on its own. This script
+# moves the version for you — it stamps a `<base-version>+claude.<cachebuster>`
+# suffix onto the manifests, refreshes the catalog, and installs.
+#
+# An earlier version of this script deleted the copy and put a symlink to the
+# checkout in its place, so edits took effect immediately. That symlink is why
+# this one does not: the directory name is fixed at install time while its
+# contents follow the checkout, so Claude reports the version the directory is
+# named after rather than the one it is loading. On a branch that bumps the
+# version, `claude plugin list` names the old release while running the new
+# code (#355).
+#
+# The stamped version is not committed. These manifests carry three of Team's
+# six pinned version strings, so a cachebuster left in the working tree turns
+# `bun test` red. The stamp is restored on the way out, including on an
+# interrupted run, and the tree is byte-identical afterwards.
+
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PLUGIN_VERSION=$(node -p "require('${PLUGIN_ROOT}/.claude-plugin/plugin.json').version")
-CACHE_PATH="${HOME}/.claude/plugins/cache/team-dev/team/${PLUGIN_VERSION}"
+PLUGIN_MANIFEST="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+MARKETPLACE_MANIFEST="${PLUGIN_ROOT}/.claude-plugin/marketplace.json"
+MARKETPLACE="team-dev"
+PLUGIN="team"
+CACHE_ROOT="${HOME}/.claude/plugins/cache/${MARKETPLACE}/${PLUGIN}"
 
-if [ -z "$PLUGIN_VERSION" ]; then
-  echo "Error: could not read version from plugin.json" >&2
+for manifest in "$PLUGIN_MANIFEST" "$MARKETPLACE_MANIFEST"; do
+  if [ ! -f "$manifest" ]; then
+    echo "Error: no $(basename "$manifest") at ${PLUGIN_ROOT}/.claude-plugin" >&2
+    exit 1
+  fi
+done
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "Error: the claude CLI is not on PATH." >&2
+  echo "Install Claude Code first: https://code.claude.com/docs" >&2
   exit 1
 fi
 
-if [ -L "$CACHE_PATH" ] && [ "$(readlink "$CACHE_PATH")" != "$PLUGIN_ROOT" ]; then
-  echo "Error: ${CACHE_PATH} already links a different checkout:" >&2
-  echo "  $(readlink "$CACHE_PATH")" >&2
-  echo "Run script/dev-uninstall claude from that checkout first." >&2
-  exit 1
-fi
+# --- Manifest stamp, and its guaranteed undo -----------------------------------
+BACKUP_DIR=""
 
-if [ -e "$CACHE_PATH" ] && [ ! -d "$CACHE_PATH" ]; then
-  echo "Error: ${CACHE_PATH} exists and is not a directory or symlink." >&2
-  exit 1
-fi
+restore_manifests() {
+  # Runs on every exit path, so an interrupted install never leaves a
+  # cachebuster in a tracked file.
+  if [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR" ]; then
+    mv -f "${BACKUP_DIR}/plugin.json" "$PLUGIN_MANIFEST"
+    mv -f "${BACKUP_DIR}/marketplace.json" "$MARKETPLACE_MANIFEST"
+    rmdir "$BACKUP_DIR"
+    BACKUP_DIR=""
+  fi
+}
+trap restore_manifests EXIT INT TERM
 
-echo "Installing Team for Claude Code (dev)..."
-echo "  Source: ${PLUGIN_ROOT}"
-echo
+STAMPED_VERSION=""
 
-MARKETPLACE_PATH=$(
+stamp_cachebuster() {
+  # Sets the two globals rather than printing, because a command substitution
+  # would run this in a subshell and strand BACKUP_DIR there — leaving the trap
+  # with nothing to restore.
+  #
+  # All three Claude-side strings move together. The catalog is what
+  # `plugin install` and `plugin update` read, and the plugin manifest is what
+  # Claude reports for the installed copy; stamping only one of them leaves the
+  # two disagreeing about what is installed.
+  BACKUP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/team-claude-manifests.XXXXXX")"
+  cp "$PLUGIN_MANIFEST" "${BACKUP_DIR}/plugin.json"
+  cp "$MARKETPLACE_MANIFEST" "${BACKUP_DIR}/marketplace.json"
+  STAMPED_VERSION="$(
+    PLUGIN_MANIFEST="$PLUGIN_MANIFEST" MARKETPLACE_MANIFEST="$MARKETPLACE_MANIFEST" node -e '
+      const fs = require("node:fs");
+      const read = (path) => JSON.parse(fs.readFileSync(path, "utf8"));
+      const write = (path, value) =>
+        fs.writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+
+      const pluginPath = process.env.PLUGIN_MANIFEST;
+      const marketplacePath = process.env.MARKETPLACE_MANIFEST;
+      const plugin = read(pluginPath);
+      if (typeof plugin.version !== "string" || plugin.version.trim() === "") {
+        throw new Error(`${pluginPath} must contain a non-empty string "version"`);
+      }
+      const stamp = new Date().toISOString().replace(/\D/g, "").slice(0, 14);
+      // Replace any existing suffix rather than appending a second one.
+      const stamped = `${plugin.version.split("+", 1)[0]}+claude.${stamp}`;
+
+      plugin.version = stamped;
+      write(pluginPath, plugin);
+
+      const marketplace = read(marketplacePath);
+      marketplace.metadata.version = stamped;
+      for (const entry of marketplace.plugins) entry.version = stamped;
+      write(marketplacePath, marketplace);
+
+      process.stdout.write(stamped);
+    '
+  )"
+}
+
+# --- Claude state readers ------------------------------------------------------
+read_marketplace_path() {
+  # The JavaScript template literal is intentionally protected from the shell.
+  # shellcheck disable=SC2016
   claude plugin marketplace list --json |
-    node -e '
+    MARKETPLACE="$MARKETPLACE" node -e '
       const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
-      const matches = entries.filter((entry) => entry.name === "team-dev");
+      const matches = entries.filter((entry) => entry.name === process.env.MARKETPLACE);
       if (matches.length > 1) throw new Error("multiple team-dev marketplaces found");
       if (matches.length === 1) {
         const entry = matches[0];
@@ -40,27 +121,15 @@ MARKETPLACE_PATH=$(
         process.stdout.write(entry.path);
       }
     '
-)
-
-MARKETPLACE_ADDED=false
-if [ -z "$MARKETPLACE_PATH" ]; then
-  claude plugin marketplace add "$PLUGIN_ROOT" --scope user 2>&1
-  MARKETPLACE_ADDED=true
-elif [ "$MARKETPLACE_PATH" != "$PLUGIN_ROOT" ]; then
-  echo "Error: team-dev already points to a different checkout:" >&2
-  echo "  ${MARKETPLACE_PATH}" >&2
-  echo "Run script/dev-uninstall claude from that checkout first." >&2
-  exit 1
-fi
+}
 
 read_plugin_state() {
-  # The JavaScript template literal is intentionally protected from the shell.
   # shellcheck disable=SC2016
   claude plugin list --json |
-    node -e '
+    PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" node -e '
       const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
       const matches = entries.filter(
-        (entry) => entry.id === "team@team-dev" && entry.scope === "user",
+        (entry) => entry.id === process.env.PLUGIN_ID && entry.scope === "user",
       );
       if (matches.length > 1) throw new Error("multiple user-scope Team installs found");
       if (matches.length === 1) {
@@ -73,62 +142,20 @@ read_plugin_state() {
     '
 }
 
-PLUGIN_STATE=$(read_plugin_state)
-INSTALLED_VERSION=""
-INSTALLED_PATH=""
-if [ -n "$PLUGIN_STATE" ]; then
-  IFS=$'\t' read -r INSTALLED_VERSION INSTALLED_PATH <<< "$PLUGIN_STATE"
-fi
-
-if [ -z "$INSTALLED_VERSION" ]; then
-  if [ "$MARKETPLACE_ADDED" = false ]; then
-    claude plugin marketplace update team-dev 2>&1
-  fi
-  if [ -L "$CACHE_PATH" ]; then
-    rm "$CACHE_PATH"
-  fi
-  claude plugin install team@team-dev --scope user 2>&1
-  PLUGIN_STATE=$(read_plugin_state)
-elif [ "$INSTALLED_VERSION" != "$PLUGIN_VERSION" ] || [ "$INSTALLED_PATH" != "$CACHE_PATH" ]; then
-  if [ -L "$CACHE_PATH" ]; then
-    rm "$CACHE_PATH"
-  fi
-  claude plugin marketplace update team-dev 2>&1
-  claude plugin update team@team-dev --scope user 2>&1
-  PLUGIN_STATE=$(read_plugin_state)
-fi
-
-IFS=$'\t' read -r INSTALLED_VERSION INSTALLED_PATH <<< "$PLUGIN_STATE"
-if [ "$INSTALLED_VERSION" != "$PLUGIN_VERSION" ] || [ "$INSTALLED_PATH" != "$CACHE_PATH" ]; then
-  echo "Error: Claude Code did not install Team ${PLUGIN_VERSION} at ${CACHE_PATH}." >&2
-  exit 1
-fi
-
-# Replace the cached copy with a symlink to the source
-if [ -d "$CACHE_PATH" ] && [ ! -L "$CACHE_PATH" ]; then
-  rm -rf "$CACHE_PATH"
-  ln -s "$PLUGIN_ROOT" "$CACHE_PATH"
-  echo "  Linked: ${CACHE_PATH} → ${PLUGIN_ROOT}"
-elif [ -L "$CACHE_PATH" ]; then
-  echo "Team already installed for Claude Code (dev)."
-else
-  echo "Error: Claude Code reported Team at ${CACHE_PATH}, but that directory does not exist." >&2
-  exit 1
-fi
-
-# Every version ever installed from this checkout leaves a directory behind,
-# because the cache path carries the version. Left alone they accumulate one
-# copy of the whole plugin per release. Sweep the ones Claude no longer serves.
-CACHE_ROOT="$(dirname "$CACHE_PATH")"
-if [ -d "$CACHE_ROOT" ]; then
-  # An install Claude still reports — another scope, another version — stays.
+# --- Prune every cached copy but the one just installed ------------------------
+# Each reinstall mints a new cachebuster, so without this the cache grows by a
+# full copy of the plugin per run. An install Claude still reports — another
+# scope, another version — stays.
+prune_other_versions() {
+  local keep="$1" live entry
+  [ -d "$CACHE_ROOT" ] || return 0
   # shellcheck disable=SC2016
-  LIVE_PATHS=$(
+  live=$(
     claude plugin list --json |
-      node -e '
+      PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" node -e '
         const entries = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
         for (const entry of entries) {
-          if (entry.id === "team@team-dev" && typeof entry.installPath === "string") {
+          if (entry.id === process.env.PLUGIN_ID && typeof entry.installPath === "string") {
             process.stdout.write(`${entry.installPath}\n`);
           }
         }
@@ -136,8 +163,8 @@ if [ -d "$CACHE_ROOT" ]; then
   )
   for entry in "$CACHE_ROOT"/*; do
     [ -e "$entry" ] || [ -L "$entry" ] || continue
-    [ "$entry" != "$CACHE_PATH" ] || continue
-    if printf '%s\n' "$LIVE_PATHS" | grep -qxF "$entry"; then
+    [ "$entry" != "$keep" ] || continue
+    if printf '%s\n' "$live" | grep -qxF "$entry"; then
       continue
     fi
     # A stale entry can be a symlink an older dev install left pointing at the
@@ -145,7 +172,63 @@ if [ -d "$CACHE_ROOT" ]; then
     rm -rf "$entry"
     echo "  Pruned stale cache: $(basename "$entry")"
   done
+}
+
+# --- Install -------------------------------------------------------------------
+echo "Installing Team for Claude Code (dev)..."
+echo "  Source: ${PLUGIN_ROOT}"
+echo
+
+MARKETPLACE_PATH=$(read_marketplace_path)
+if [ -n "$MARKETPLACE_PATH" ] && [ "$MARKETPLACE_PATH" != "$PLUGIN_ROOT" ]; then
+  echo "Error: ${MARKETPLACE} already points to a different checkout:" >&2
+  echo "  ${MARKETPLACE_PATH}" >&2
+  echo "Run script/dev-uninstall claude from that checkout first." >&2
+  exit 1
 fi
 
+stamp_cachebuster
+echo "  Cachebuster: ${STAMPED_VERSION}"
+
+# The catalog is a snapshot taken when the marketplace is added or updated, so
+# it has to be refreshed after the stamp and before the install reads it.
+if [ -z "$MARKETPLACE_PATH" ]; then
+  claude plugin marketplace add "$PLUGIN_ROOT" --scope user 2>&1
+else
+  claude plugin marketplace update "$MARKETPLACE" 2>&1
+fi
+
+if [ -z "$(read_plugin_state)" ]; then
+  claude plugin install "${PLUGIN}@${MARKETPLACE}" --scope user 2>&1
+else
+  claude plugin update "${PLUGIN}@${MARKETPLACE}" --scope user 2>&1
+fi
+
+PLUGIN_STATE=$(read_plugin_state)
+INSTALLED_VERSION=""
+INSTALLED_PATH=""
+if [ -n "$PLUGIN_STATE" ]; then
+  IFS=$'\t' read -r INSTALLED_VERSION INSTALLED_PATH <<< "$PLUGIN_STATE"
+fi
+
+if [ "$INSTALLED_VERSION" != "$STAMPED_VERSION" ]; then
+  echo "Error: Claude Code reports Team at '${INSTALLED_VERSION}', not '${STAMPED_VERSION}'." >&2
+  exit 1
+fi
+# Claude rewrites `+` to `-` for the directory name, so the served path comes
+# from what Claude reports rather than from the version string.
+if [ -L "$INSTALLED_PATH" ] || [ ! -d "$INSTALLED_PATH" ]; then
+  echo "Error: ${INSTALLED_PATH} is not a directory Claude Code copied there." >&2
+  exit 1
+fi
+if [ ! -d "${INSTALLED_PATH}/skills" ]; then
+  echo "Error: no skills/ in ${INSTALLED_PATH}." >&2
+  exit 1
+fi
+
+prune_other_versions "$INSTALLED_PATH"
+restore_manifests
+
 echo
-echo "Done. Restart Claude Code to load the plugin."
+echo "Installed Team for Claude Code (dev). Restart Claude Code to load it."
+echo "The install is a copy — re-run this after changing a skill."

--- a/script/dev-uninstall-claude
+++ b/script/dev-uninstall-claude
@@ -1,21 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PLUGIN_VERSION=$(node -p "require('${PLUGIN_ROOT}/.claude-plugin/plugin.json').version")
-CACHE_PATH="${HOME}/.claude/plugins/cache/team-dev/team/${PLUGIN_VERSION}"
+# Removes the Claude Code dev install: the plugin, the marketplace entry, and
+# the cache tree.
+#
+# The cache is swept wholesale rather than by version. Each dev install mints a
+# `+claude.<cachebuster>` version of its own, an interrupted run can leave the
+# copy from the run before it, and an install from before #355 left a symlink
+# to the checkout at a version-named path. `rm -rf` on the tree unlinks any
+# such symlink; it never descends into the checkout it points at.
+
+MARKETPLACE="team-dev"
+PLUGIN="team"
+CACHE_ROOT="${HOME}/.claude/plugins/cache/${MARKETPLACE}"
 
 echo "Uninstalling Team for Claude Code (dev)..."
 echo
 
-claude plugin uninstall team@team-dev 2>&1 || true
-claude plugin marketplace remove team-dev 2>&1 || true
+REMOVED=false
 
-# Clean up the symlink left in the cache
-if [ -L "$CACHE_PATH" ]; then
-  rm "$CACHE_PATH"
-  rmdir "${HOME}/.claude/plugins/cache/team-dev/team" 2>/dev/null || true
-  rmdir "${HOME}/.claude/plugins/cache/team-dev" 2>/dev/null || true
+if command -v claude >/dev/null 2>&1; then
+  # shellcheck disable=SC2016
+  INSTALLED=$(
+    claude plugin list --json 2>/dev/null |
+      PLUGIN_ID="${PLUGIN}@${MARKETPLACE}" node -e '
+        let raw = "";
+        try {
+          raw = require("node:fs").readFileSync(0, "utf8");
+        } catch {
+          process.exit(0);
+        }
+        const entries = raw.trim() === "" ? [] : JSON.parse(raw);
+        if (entries.some((entry) => entry.id === process.env.PLUGIN_ID)) {
+          process.stdout.write("yes");
+        }
+      ' || true
+  )
+  if [ "$INSTALLED" = "yes" ]; then
+    claude plugin uninstall "${PLUGIN}@${MARKETPLACE}" 2>&1
+    REMOVED=true
+  fi
+  if claude plugin marketplace remove "$MARKETPLACE" 2>&1; then
+    REMOVED=true
+  fi
+fi
+
+if [ -e "$CACHE_ROOT" ] || [ -L "$CACHE_ROOT" ]; then
+  rm -rf "$CACHE_ROOT"
+  echo "  Removed the plugin cache: ${CACHE_ROOT}"
+  REMOVED=true
+fi
+
+if [ "$REMOVED" = false ]; then
+  echo "Nothing to do: Team is not installed for Claude Code."
+  exit 0
 fi
 
 echo

--- a/tests/dev-install-claude.test.ts
+++ b/tests/dev-install-claude.test.ts
@@ -1,17 +1,18 @@
 // tests/dev-install-claude.test.ts
 //
-// Acceptance tests for `script/dev-install-claude`'s cache hygiene.
+// Acceptance tests for `script/dev-install-claude`.
 //
-// Claude Code installs a plugin under a path that carries its version, so
-// every version ever installed from a checkout leaves a directory behind:
-// eighteen of them, several gigabytes' worth over a project's life, plus the
-// occasional stale symlink from an older dev install. The installer prunes
-// them, keeping only the version it just installed and any other install
-// Claude still reports.
+// Claude Code copies a plugin into a path that carries its version, and
+// `claude plugin update` no-ops when the version has not moved. A dev install
+// therefore has to move the version to make the copy happen, and has to sweep
+// the copies it leaves behind. This suite pins that loop: the cachebuster
+// stamp, the restore of the tracked manifests, and the prune.
 //
-// L3 subprocess-snapshot. HOME is a tempdir and the fake `claude` from
-// tests/helpers/fake-claude.ts is first on PATH. Idempotency and marketplace
-// refusal are covered by tests/regression-309-idempotent-install.test.ts.
+// L3 subprocess-snapshot. HOME is a tempdir, the fake `claude` from
+// tests/helpers/fake-claude.ts is first on PATH, and the script runs against a
+// disposable plugin root because it rewrites manifests. The version drift the
+// old symlink produced is pinned separately by
+// tests/regression-355-claude-install-version-drift.test.ts.
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
@@ -21,7 +22,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  readlinkSync,
+  readdirSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -29,13 +30,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  type ClaudePluginFixture,
+  fixtureBaseVersion,
+  makeClaudePluginFixture,
+} from "./helpers/claude-plugin-fixture";
 import { writeFakeClaude } from "./helpers/fake-claude";
-
-const REPO_ROOT = join(import.meta.dir, "..");
-const INSTALL = join(REPO_ROOT, "script", "dev-install-claude");
-const VERSION: string = JSON.parse(
-  readFileSync(join(REPO_ROOT, ".claude-plugin", "plugin.json"), "utf8"),
-).version;
 
 const tempDirs: string[] = [];
 
@@ -43,21 +43,27 @@ afterAll(() => {
   for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
 });
 
+function newFixture(): ClaudePluginFixture {
+  const fixture = makeClaudePluginFixture();
+  tempDirs.push(fixture.root);
+  return fixture;
+}
+
 function newHome(): string {
-  const home = mkdtempSync(join(tmpdir(), `claude-prune-${process.pid}-`));
+  const home = mkdtempSync(join(tmpdir(), `claude-install-${process.pid}-`));
   tempDirs.push(home);
   writeFakeClaude(home);
   return home;
 }
 
-function run(home: string) {
-  const result = spawnSync("bash", [INSTALL], {
+function run(install: string, home: string, failOn?: string) {
+  const result = spawnSync("bash", [install], {
     encoding: "utf8",
     env: {
       ...process.env,
       HOME: home,
       PATH: `${join(home, "bin")}:${process.env.PATH ?? ""}`,
-      PLUGIN_VERSION: VERSION,
+      ...(failOn ? { FAKE_CLAUDE_FAIL: failOn } : {}),
     },
   });
   return {
@@ -69,70 +75,197 @@ function run(home: string) {
 const cacheRoot = (home: string) =>
   join(home, ".claude", "plugins", "cache", "team-dev", "team");
 
-function plantStaleCopy(home: string, version: string) {
-  const dir = join(cacheRoot(home), version);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "marker"), `${version}\n`);
-  return dir;
-}
+const cachedVersions = (home: string) =>
+  existsSync(cacheRoot(home)) ? readdirSync(cacheRoot(home)).sort() : [];
 
-describe("dev install: claude cache hygiene", () => {
-  test("stale version directories are pruned", () => {
+const reportedVersion = (home: string) =>
+  readFileSync(join(home, "state", "installed-version"), "utf8");
+
+describe("dev install: claude", () => {
+  // Claude keys its plugin cache on the version string, so a source edit at an
+  // unchanged version never reaches the cache.
+  test("install stamps a cachebuster onto the base version", () => {
+    const fixture = newFixture();
+    const base = fixtureBaseVersion(fixture);
     const home = newHome();
-    plantStaleCopy(home, "0.62.0");
-    plantStaleCopy(home, "0.87.0");
 
-    const { status, output } = run(home);
+    const { status, output } = run(fixture.install, home);
 
     expect(status).toBe(0);
-    expect(existsSync(join(cacheRoot(home), "0.62.0"))).toBe(false);
-    expect(existsSync(join(cacheRoot(home), "0.87.0"))).toBe(false);
-    expect(output).toContain("0.62.0");
-    expect(output).toContain("0.87.0");
-    expect(readlinkSync(join(cacheRoot(home), VERSION))).toBe(REPO_ROOT);
+    const installed = reportedVersion(home);
+    expect(installed).toStartWith(`${base}+claude.`);
+    expect(installed).toMatch(/\+claude\.\d{14}$/);
+    expect(output).toContain(installed);
   });
 
-  // The stale entry left by an older dev install is a symlink into the
-  // checkout. Pruning must unlink it, never descend it.
+  // All three Claude-side version strings drive the install: the plugin
+  // manifest, and both copies in the marketplace catalog. Stamping only some
+  // of them leaves the catalog reporting the old version, and the update
+  // no-ops.
+  test("the stamp reaches every Claude-side version string", () => {
+    const fixture = newFixture();
+    const home = newHome();
+
+    expect(run(fixture.install, home).status).toBe(0);
+
+    const installed = reportedVersion(home);
+    const served = join(cacheRoot(home), installed.replace("+", "-"));
+    const plugin = JSON.parse(
+      readFileSync(join(served, ".claude-plugin", "plugin.json"), "utf8"),
+    );
+    const marketplace = JSON.parse(
+      readFileSync(join(served, ".claude-plugin", "marketplace.json"), "utf8"),
+    );
+    expect(plugin.version).toBe(installed);
+    expect(marketplace.metadata.version).toBe(installed);
+    expect(marketplace.plugins[0].version).toBe(installed);
+  });
+
+  test("install leaves the tracked manifests byte-identical", () => {
+    const fixture = newFixture();
+    const before = {
+      plugin: readFileSync(fixture.pluginManifest, "utf8"),
+      marketplace: readFileSync(fixture.marketplaceManifest, "utf8"),
+    };
+    const home = newHome();
+
+    expect(run(fixture.install, home).status).toBe(0);
+
+    expect(readFileSync(fixture.pluginManifest, "utf8")).toBe(before.plugin);
+    expect(readFileSync(fixture.marketplaceManifest, "utf8")).toBe(
+      before.marketplace,
+    );
+  });
+
+  // The stamp is a mutation of tracked files carrying pinned version strings.
+  // A run that dies partway must still put them back, or `bun test` goes red
+  // on a working tree nobody edited.
+  test("an install that dies after the stamp still restores the manifests", () => {
+    const fixture = newFixture();
+    const before = {
+      plugin: readFileSync(fixture.pluginManifest, "utf8"),
+      marketplace: readFileSync(fixture.marketplaceManifest, "utf8"),
+    };
+    const home = newHome();
+
+    // Fail the copy itself, which runs after the stamp — the case the plain
+    // refusals never reach, and the only one where the trap does any work.
+    const { status, output } = run(
+      fixture.install,
+      home,
+      "plugin install team@team-dev",
+    );
+
+    expect(status).not.toBe(0);
+    expect(output).toContain("Cachebuster:");
+    expect(readFileSync(fixture.pluginManifest, "utf8")).toBe(before.plugin);
+    expect(readFileSync(fixture.marketplaceManifest, "utf8")).toBe(
+      before.marketplace,
+    );
+    expect(readFileSync(fixture.marketplaceManifest, "utf8")).not.toContain(
+      "+claude.",
+    );
+  });
+
+  test("each install prunes the copies the earlier ones left", () => {
+    const fixture = newFixture();
+    const base = fixtureBaseVersion(fixture);
+    const home = newHome();
+    // Two shapes a previous run could have left: the plain base version, and
+    // an earlier cachebuster.
+    for (const stale of [base, `${base}-claude.20200101000000`]) {
+      const dir = join(cacheRoot(home), stale);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "marker"), `${stale}\n`);
+    }
+
+    const { status, output } = run(fixture.install, home);
+
+    expect(status).toBe(0);
+    expect(cachedVersions(home)).toHaveLength(1);
+    expect(output).toContain(base);
+    expect(output).toContain("20200101000000");
+  });
+
+  // The stale entry an older dev install left is a symlink into the checkout.
+  // Pruning must unlink it, never descend it.
   test("a stale symlink into the checkout is unlinked, not followed", () => {
+    const fixture = newFixture();
     const home = newHome();
     mkdirSync(cacheRoot(home), { recursive: true });
-    symlinkSync(REPO_ROOT, join(cacheRoot(home), "0.81.0"));
+    symlinkSync(fixture.root, join(cacheRoot(home), "0.81.0"));
 
-    expect(run(home).status).toBe(0);
+    expect(run(fixture.install, home).status).toBe(0);
 
-    expect(lstatSync(join(cacheRoot(home), "0.81.0"), { throwIfNoEntry: false })).toBeUndefined();
-    expect(existsSync(join(REPO_ROOT, "skills", "team", "SKILL.md"))).toBe(true);
-    expect(existsSync(join(REPO_ROOT, ".claude-plugin", "plugin.json"))).toBe(true);
+    expect(
+      lstatSync(join(cacheRoot(home), "0.81.0"), { throwIfNoEntry: false }),
+    ).toBeUndefined();
+    expect(existsSync(join(fixture.root, "skills", "team", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(fixture.pluginManifest)).toBe(true);
   });
 
-  test("the installed version is never pruned", () => {
+  test("repeated installs converge on exactly one served version", () => {
+    const fixture = newFixture();
     const home = newHome();
-    expect(run(home).status).toBe(0);
 
-    const second = run(home);
+    expect(run(fixture.install, home).status).toBe(0);
+    // A second within the same clock second would mint the same stamp, which
+    // is a no-op rather than a second copy. Sleep past it.
+    spawnSync("sleep", ["1.1"]);
+    expect(run(fixture.install, home).status).toBe(0);
 
-    expect(second.status).toBe(0);
-    expect(lstatSync(join(cacheRoot(home), VERSION)).isSymbolicLink()).toBe(true);
-    expect(readlinkSync(join(cacheRoot(home), VERSION))).toBe(REPO_ROOT);
+    const versions = cachedVersions(home);
+    expect(versions).toHaveLength(1);
+    const [served = ""] = versions;
+    expect(served).toBe(reportedVersion(home).replace("+", "-"));
   });
+});
 
-  test("a version Claude still reports installed is kept", () => {
+describe("dev uninstall: claude", () => {
+  test("uninstall leaves no cache, marketplace entry, or install", () => {
+    const fixture = newFixture();
     const home = newHome();
-    const kept = plantStaleCopy(home, "0.0.1");
-    // Claude reports 0.0.1 as installed, so the installer updates rather than
-    // installs — and must not delete the directory Claude is still serving
-    // from until the update has moved off it.
-    mkdirSync(join(home, "state"), { recursive: true });
-    writeFileSync(join(home, "state", "marketplace-path"), REPO_ROOT);
-    writeFileSync(join(home, "state", "installed-version"), "0.0.1");
+    expect(run(fixture.install, home).status).toBe(0);
+    expect(cachedVersions(home)).toHaveLength(1);
 
-    const { status } = run(home);
+    const { status } = run(fixture.uninstall, home);
 
     expect(status).toBe(0);
-    // The update moved the install to the current version, so 0.0.1 is stale
-    // by the time the prune runs.
-    expect(existsSync(kept)).toBe(false);
-    expect(readlinkSync(join(cacheRoot(home), VERSION))).toBe(REPO_ROOT);
+    expect(
+      existsSync(join(home, ".claude", "plugins", "cache", "team-dev")),
+    ).toBe(false);
+    expect(existsSync(join(home, "state", "marketplace-path"))).toBe(false);
+    expect(existsSync(join(home, "state", "installed-version"))).toBe(false);
+  });
+
+  // An install from before #355 left a symlink to the checkout at a
+  // version-named path. Removing the tree must unlink it, not follow it.
+  test("a legacy symlink into the checkout is unlinked, not followed", () => {
+    const fixture = newFixture();
+    const home = newHome();
+    mkdirSync(cacheRoot(home), { recursive: true });
+    symlinkSync(fixture.root, join(cacheRoot(home), "0.81.0"));
+
+    expect(run(fixture.uninstall, home).status).toBe(0);
+
+    expect(
+      existsSync(join(home, ".claude", "plugins", "cache", "team-dev")),
+    ).toBe(false);
+    expect(existsSync(join(fixture.root, "skills", "team", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(fixture.pluginManifest)).toBe(true);
+  });
+
+  test("uninstalling nothing reports nothing to do", () => {
+    const fixture = newFixture();
+    const home = newHome();
+
+    const { status, output } = run(fixture.uninstall, home);
+
+    expect(status).toBe(0);
+    expect(output).toContain("Nothing to do");
   });
 });

--- a/tests/helpers/claude-plugin-fixture.ts
+++ b/tests/helpers/claude-plugin-fixture.ts
@@ -1,0 +1,82 @@
+// tests/helpers/claude-plugin-fixture.ts
+//
+// A throwaway copy of the plugin root for the Claude Code dev-install tests.
+//
+// `script/dev-install-claude` stamps a cachebuster into
+// `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, then
+// restores both on the way out. Running it against the real checkout would
+// mutate tracked files carrying three of Team's six pinned version strings,
+// and a crashed test would leave them stamped. Every test therefore drives a
+// copy: same layout, same script, disposable manifests.
+//
+// `skills/` here is two stub skills rather than the real tree, because the fake
+// `claude` copies it on every install and the real one is a few megabytes. What
+// these tests assert about skills is that the served copy is a snapshot, which
+// two files show as well as ninety directories do.
+
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+export type ClaudePluginFixture = {
+  /** The plugin root the scripts resolve from. */
+  root: string;
+  install: string;
+  uninstall: string;
+  pluginManifest: string;
+  marketplaceManifest: string;
+  skills: string;
+};
+
+/** Build a disposable plugin root. The caller removes `root` when done. */
+export function makeClaudePluginFixture(): ClaudePluginFixture {
+  const root = mkdtempSync(join(tmpdir(), `team-claude-plugin-${process.pid}-`));
+
+  mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+  for (const name of ["plugin.json", "marketplace.json"]) {
+    copyFileSync(
+      join(REPO_ROOT, ".claude-plugin", name),
+      join(root, ".claude-plugin", name),
+    );
+  }
+
+  for (const name of ["team", "shipit"]) {
+    mkdirSync(join(root, "skills", name), { recursive: true });
+    writeFileSync(
+      join(root, "skills", name, "SKILL.md"),
+      `---\nname: ${name}\ndescription: fixture skill\n---\n\nfixture\n`,
+    );
+  }
+
+  mkdirSync(join(root, "script"), { recursive: true });
+  for (const name of ["dev-install-claude", "dev-uninstall-claude"]) {
+    const destination = join(root, "script", name);
+    copyFileSync(join(REPO_ROOT, "script", name), destination);
+    chmodSync(destination, 0o755);
+  }
+
+  return {
+    root,
+    install: join(root, "script", "dev-install-claude"),
+    uninstall: join(root, "script", "dev-uninstall-claude"),
+    pluginManifest: join(root, ".claude-plugin", "plugin.json"),
+    marketplaceManifest: join(root, ".claude-plugin", "marketplace.json"),
+    skills: join(root, "skills"),
+  };
+}
+
+/** The base version the fixture's manifest carries, before any cachebuster. */
+export function fixtureBaseVersion(fixture: ClaudePluginFixture): string {
+  const manifest = JSON.parse(readFileSync(fixture.pluginManifest, "utf8"));
+  const [base = ""] = String(manifest.version).split("+");
+  return base;
+}

--- a/tests/helpers/fake-claude.ts
+++ b/tests/helpers/fake-claude.ts
@@ -6,8 +6,19 @@
 // reads back. State lives under $HOME, so every test isolates with
 // HOME=<tempdir>, and each invocation is appended to $HOME/state/calls.
 //
-// Extracted from tests/regression-309-idempotent-install.test.ts unchanged when
-// tests/dev-install-claude.test.ts became a second consumer.
+// Three behaviors here were measured against the real CLI on 2026-09-10 and
+// are what make the cachebuster loop necessary. A fake that got any of them
+// wrong would let a broken installer pass:
+//
+//   1. The catalog is a SNAPSHOT. `plugin install` and `plugin update` read the
+//      version recorded when the marketplace was last added or updated, not
+//      whatever the source manifest says right now.
+//   2. `plugin update` NO-OPS when the catalog version equals the installed
+//      one. Editing a skill without moving the version leaves the cached copy
+//      untouched: "Plugin is already at the latest version."
+//   3. The install is a COPY into a directory named for the version, with `+`
+//      rewritten to `-`. The version Claude reports keeps its `+`, so the
+//      reported version and the directory name differ by that one character.
 
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -16,8 +27,38 @@ const STUB = `#!/usr/bin/env bash
 set -euo pipefail
 
 STATE="$HOME/state"
+CACHE="$HOME/.claude/plugins/cache/team-dev/team"
 mkdir -p "$STATE"
 printf '%s\\n' "$*" >> "$STATE/calls"
+
+# Test knob: fail one subcommand, so a caller can exercise a mid-run abort.
+# Set it to the first three words of the call, e.g. "plugin install team@team-dev".
+if [ -n "\${FAKE_CLAUDE_FAIL:-}" ] && [ "\${FAKE_CLAUDE_FAIL}" = "$1 $2 $3" ]; then
+  echo "fake claude: forced failure for '$1 $2 $3'" >&2
+  exit 1
+fi
+
+# The version the marketplace catalog carries. Claude snapshots it at
+# 'marketplace add' / 'marketplace update' time, so a later source edit is
+# invisible until one of those runs again.
+snapshot_catalog() {
+  local root="$1"
+  node -p "require('$root/.claude-plugin/marketplace.json').plugins[0].version" > "$STATE/catalog-version"
+}
+
+# Claude's cache directory is named for the version with '+' rewritten to '-'.
+sanitize() { printf '%s' "\${1//+/-}"; }
+
+copy_into_cache() {
+  local version="$1" root dir
+  root=$(<"$STATE/marketplace-path")
+  dir="$CACHE/$(sanitize "$version")"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  cp -R "$root/.claude-plugin" "$dir/.claude-plugin"
+  [ -d "$root/skills" ] && cp -R "$root/skills/" "$dir/skills"
+  printf '%s' "$version" > "$STATE/installed-version"
+}
 
 case "$1 $2 $3" in
   "plugin marketplace list")
@@ -34,25 +75,43 @@ case "$1 $2 $3" in
       exit 1
     fi
     printf '%s' "$4" > "$STATE/marketplace-path"
+    snapshot_catalog "$4"
     ;;
   "plugin marketplace update")
+    [ -f "$STATE/marketplace-path" ] || { echo "No such marketplace: team-dev" >&2; exit 1; }
+    snapshot_catalog "$(<"$STATE/marketplace-path")"
     ;;
   "plugin install team@team-dev")
     if [ -f "$STATE/installed-version" ]; then
       echo "Plugin 'team@team-dev' is already installed" >&2
       exit 1
     fi
-    printf '%s' "$PLUGIN_VERSION" > "$STATE/installed-version"
-    mkdir -p "$HOME/.claude/plugins/cache/team-dev/team/$PLUGIN_VERSION"
+    copy_into_cache "$(<"$STATE/catalog-version")"
     ;;
   "plugin update team@team-dev")
-    printf '%s' "$PLUGIN_VERSION" > "$STATE/installed-version"
-    mkdir -p "$HOME/.claude/plugins/cache/team-dev/team/$PLUGIN_VERSION"
+    catalog=$(<"$STATE/catalog-version")
+    installed=""
+    [ -f "$STATE/installed-version" ] && installed=$(<"$STATE/installed-version")
+    if [ "$catalog" = "$installed" ]; then
+      echo "team is already at the latest version ($catalog)."
+      exit 0
+    fi
+    copy_into_cache "$catalog"
+    ;;
+  "plugin uninstall team@team-dev")
+    [ -f "$STATE/installed-version" ] || { echo "Plugin 'team@team-dev' is not installed" >&2; exit 1; }
+    rm -rf "$CACHE/$(sanitize "$(<"$STATE/installed-version")")"
+    rm -f "$STATE/installed-version"
+    ;;
+  "plugin marketplace remove")
+    [ -f "$STATE/marketplace-path" ] || { echo "No such marketplace: team-dev" >&2; exit 1; }
+    rm -f "$STATE/marketplace-path" "$STATE/catalog-version"
     ;;
   "plugin list --json")
     if [ -f "$STATE/installed-version" ]; then
       version=$(<"$STATE/installed-version")
-      printf '[{"id":"team@team-dev","version":"%s","scope":"user","installPath":"%s/.claude/plugins/cache/team-dev/team/%s"}]\\n' "$version" "$HOME" "$version"
+      printf '[{"id":"team@team-dev","version":"%s","scope":"user","installPath":"%s/%s"}]\\n' \\
+        "$version" "$CACHE" "$(sanitize "$version")"
     else
       printf '[]\\n'
     fi

--- a/tests/regression-309-idempotent-install.test.ts
+++ b/tests/regression-309-idempotent-install.test.ts
@@ -1,27 +1,51 @@
+// Regression test for issue #309.
+//
+// `script/dev-install-claude` was not idempotent: a second run against an
+// already-installed checkout could leave the cache in a state Claude could not
+// serve from, and an older installed version was never moved off.
+//
+// The bug is pinned here; its expression moved. #309 was fixed while the
+// installer replaced Claude's copy with a symlink to the checkout, so these
+// tests used to assert that a re-run restored that symlink. #355 removed the
+// symlink — it made Claude report a version that did not describe what it
+// loaded — so convergence is now expressed as "exactly one served copy, and it
+// is the one Claude reports".
+//
+// L3 subprocess-snapshot: an isolated HOME, the fake `claude` from
+// tests/helpers/fake-claude.ts on PATH, and a disposable plugin root, because
+// the install stamps the manifests.
+
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
-  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  readlinkSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  type ClaudePluginFixture,
+  makeClaudePluginFixture,
+} from "./helpers/claude-plugin-fixture";
 import { writeFakeClaude } from "./helpers/fake-claude";
 
-const REPO_ROOT = join(import.meta.dir, "..");
-const INSTALL = join(REPO_ROOT, "script", "dev-install-claude");
-const VERSION = JSON.parse(
-  readFileSync(join(REPO_ROOT, ".claude-plugin", "plugin.json"), "utf8"),
-).version;
-
 const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
+function newFixture(): ClaudePluginFixture {
+  const fixture = makeClaudePluginFixture();
+  tempDirs.push(fixture.root);
+  return fixture;
+}
 
 function newHome(): string {
   const home = mkdtempSync(join(tmpdir(), `team-install-${process.pid}-`));
@@ -30,14 +54,13 @@ function newHome(): string {
   return home;
 }
 
-function run(home: string) {
-  const result = spawnSync("bash", [INSTALL], {
+function run(install: string, home: string) {
+  const result = spawnSync("bash", [install], {
     encoding: "utf8",
     env: {
       ...process.env,
       HOME: home,
       PATH: `${join(home, "bin")}:${process.env.PATH ?? ""}`,
-      PLUGIN_VERSION: VERSION,
     },
   });
   return {
@@ -46,57 +69,54 @@ function run(home: string) {
   };
 }
 
-const cachePath = (home: string) =>
-  join(home, ".claude", "plugins", "cache", "team-dev", "team", VERSION);
+const cacheRoot = (home: string) =>
+  join(home, ".claude", "plugins", "cache", "team-dev", "team");
 const statePath = (home: string, name: string) => join(home, "state", name);
-
-afterAll(() => {
-  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
-});
+const reportedVersion = (home: string) =>
+  readFileSync(statePath(home, "installed-version"), "utf8");
 
 describe("regression #309: Claude dev installation is idempotent", () => {
-  test("a repeated install restores a cache directory to the checkout symlink", () => {
+  test("a repeated install converges on one copy Claude can serve", () => {
+    const fixture = newFixture();
     const home = newHome();
-    expect(run(home).status).toBe(0);
+    expect(run(fixture.install, home).status).toBe(0);
 
-    rmSync(cachePath(home));
-    mkdirSync(cachePath(home));
-    writeFileSync(join(cachePath(home), "copied-cache"), "owned by Claude\n");
-    writeFileSync(statePath(home, "calls"), "");
+    // Corrupt what Claude serves: a directory with none of the plugin in it.
+    const served = join(cacheRoot(home), reportedVersion(home).replace("+", "-"));
+    rmSync(served, { force: true, recursive: true });
+    mkdirSync(served, { recursive: true });
+    writeFileSync(join(served, "not-the-plugin"), "junk\n");
+    // Each run stamps a 14-digit second-resolution timestamp, so two runs in
+    // the same second would mint the same version and copy nothing.
+    spawnSync("sleep", ["1.1"]);
 
-    const second = run(home);
+    const second = run(fixture.install, home);
 
     expect(second.status).toBe(0);
-    expect(lstatSync(cachePath(home)).isSymbolicLink()).toBe(true);
-    expect(readlinkSync(cachePath(home))).toBe(REPO_ROOT);
-    expect(existsSync(join(cachePath(home), "copied-cache"))).toBe(false);
-    expect(readFileSync(statePath(home, "calls"), "utf8")).not.toMatch(
-      /marketplace (add|update)|plugin (install|update)/,
-    );
-
-    const third = run(home);
-    expect(third.status).toBe(0);
-    expect(third.output).toContain("already installed");
-    expect(readlinkSync(cachePath(home))).toBe(REPO_ROOT);
+    const versions = readdirSync(cacheRoot(home));
+    expect(versions).toHaveLength(1);
+    const [current = ""] = versions;
+    expect(current).toBe(reportedVersion(home).replace("+", "-"));
+    expect(existsSync(join(cacheRoot(home), current, "skills", "team", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(cacheRoot(home), current, "not-the-plugin"))).toBe(false);
   });
 
-  test("a repeated install updates an older installed version", () => {
+  test("a repeated install moves an older installed version off", () => {
+    const fixture = newFixture();
     const home = newHome();
-    mkdirSync(join(home, "state"));
-    writeFileSync(statePath(home, "marketplace-path"), REPO_ROOT);
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeFileSync(statePath(home, "marketplace-path"), fixture.root);
+    writeFileSync(statePath(home, "catalog-version"), "0.0.1");
     writeFileSync(statePath(home, "installed-version"), "0.0.1");
-    mkdirSync(join(home, ".claude/plugins/cache/team-dev/team/0.0.1"), {
-      recursive: true,
-    });
+    mkdirSync(join(cacheRoot(home), "0.0.1"), { recursive: true });
 
-    const result = run(home);
+    const result = run(fixture.install, home);
 
     expect(result.status).toBe(0);
-    expect(readFileSync(statePath(home, "installed-version"), "utf8")).toBe(
-      VERSION,
-    );
-    expect(lstatSync(cachePath(home)).isSymbolicLink()).toBe(true);
-    expect(readlinkSync(cachePath(home))).toBe(REPO_ROOT);
+    expect(reportedVersion(home)).toMatch(/\+claude\.\d{14}$/);
+    expect(existsSync(join(cacheRoot(home), "0.0.1"))).toBe(false);
+    // The catalog is a snapshot, so refreshing it is what makes the update
+    // see a new version at all. Ordering is the whole fix.
     const calls = readFileSync(statePath(home, "calls"), "utf8");
     expect(calls.indexOf("plugin marketplace update team-dev")).toBeLessThan(
       calls.indexOf("plugin update team@team-dev"),
@@ -104,18 +124,19 @@ describe("regression #309: Claude dev installation is idempotent", () => {
   });
 
   test("an existing marketplace for another checkout is refused", () => {
+    const fixture = newFixture();
     const home = newHome();
     const foreign = join(home, "other-team-checkout");
-    mkdirSync(join(home, "state"));
+    mkdirSync(join(home, "state"), { recursive: true });
     writeFileSync(statePath(home, "marketplace-path"), foreign);
 
-    const result = run(home);
+    const result = run(fixture.install, home);
 
     expect(result.status).not.toBe(0);
     expect(result.output).toContain("different checkout");
-    expect(readFileSync(statePath(home, "marketplace-path"), "utf8")).toBe(
-      foreign,
-    );
-    expect(existsSync(cachePath(home))).toBe(false);
+    // Refused before the stamp, so there is nothing to undo.
+    expect(result.output).not.toContain("Cachebuster:");
+    expect(readFileSync(statePath(home, "marketplace-path"), "utf8")).toBe(foreign);
+    expect(existsSync(cacheRoot(home))).toBe(false);
   });
 });

--- a/tests/regression-355-claude-install-version-drift.test.ts
+++ b/tests/regression-355-claude-install-version-drift.test.ts
@@ -1,0 +1,117 @@
+// Regression test for issue #355.
+//
+// `script/dev-install-claude` used to install through Claude Code's own
+// commands and then delete the copied cache directory, replacing it with a
+// symlink to the checkout. The cache path carries the version, so the
+// directory name was fixed at install time while its contents followed the
+// checkout. Claude reported the version its directory was named after, not the
+// one the loaded manifest declared: on a branch that bumped the version, it ran
+// the new content under the old number.
+//
+// The two facts this pins:
+//   1. What Claude serves is a copy. Editing the checkout after an install does
+//      not change it, so the served tree and the version reported for it always
+//      describe each other.
+//   2. Nothing under the cache root points back into the checkout.
+//
+// L3 subprocess-snapshot: an isolated HOME, the fake `claude` from
+// tests/helpers/fake-claude.ts on PATH, and a disposable plugin root, because
+// the install stamps the manifests.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  type ClaudePluginFixture,
+  fixtureBaseVersion,
+  makeClaudePluginFixture,
+} from "./helpers/claude-plugin-fixture";
+import { writeFakeClaude } from "./helpers/fake-claude";
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+});
+
+const cacheRoot = (home: string) =>
+  join(home, ".claude", "plugins", "cache", "team-dev", "team");
+
+function install(): { fixture: ClaudePluginFixture; home: string } {
+  const fixture = makeClaudePluginFixture();
+  const home = mkdtempSync(join(tmpdir(), `claude-drift-${process.pid}-`));
+  tempDirs.push(fixture.root, home);
+  writeFakeClaude(home);
+
+  const result = spawnSync("bash", [fixture.install], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: `${join(home, "bin")}:${process.env.PATH ?? ""}`,
+    },
+  });
+  expect(result.status).toBe(0);
+  return { fixture, home };
+}
+
+const servedPath = (home: string) => {
+  const [entry = ""] = readdirSync(cacheRoot(home));
+  return join(cacheRoot(home), entry);
+};
+
+describe("regression #355: Claude serves a copy, not the checkout", () => {
+  test("the served tree does not follow the checkout after the install", () => {
+    const { fixture, home } = install();
+    const served = servedPath(home);
+
+    // Positive control: the skill the install copied is there to be found, so
+    // the absence assertion below cannot pass by looking in the wrong place.
+    expect(existsSync(join(served, "skills", "team", "SKILL.md"))).toBe(true);
+
+    writeFileSync(
+      join(fixture.skills, "team", "SKILL.md"),
+      "---\nname: team\ndescription: edited after install\n---\n\nEDITED\n",
+    );
+
+    expect(readFileSync(join(served, "skills", "team", "SKILL.md"), "utf8")).not.toContain(
+      "EDITED",
+    );
+  });
+
+  test("the version Claude reports describes the tree it serves", () => {
+    const { fixture, home } = install();
+    const served = servedPath(home);
+    const reported = readFileSync(
+      join(home, "state", "installed-version"),
+      "utf8",
+    );
+
+    const manifest = JSON.parse(
+      readFileSync(join(served, ".claude-plugin", "plugin.json"), "utf8"),
+    );
+    expect(manifest.version).toBe(reported);
+    expect(reported).toStartWith(`${fixtureBaseVersion(fixture)}+claude.`);
+  });
+
+  test("no cache entry links back into the checkout", () => {
+    const { home } = install();
+
+    for (const entry of readdirSync(cacheRoot(home))) {
+      expect(lstatSync(join(cacheRoot(home), entry)).isSymbolicLink()).toBe(
+        false,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Why

`script/dev-install claude` installed the plugin through Claude Code's own commands, then deleted the copy Claude made and put a symlink to the checkout in its place. The cache path carries the version, so the directory name was fixed at install time while its contents followed the checkout. Claude reported the version its directory was named after, not the one it was loading: on a branch that bumped the version, it ran the new code under the old release number.

The symlink was also not a mechanism Claude Code documents. The Codex installer moved to Codex's documented loop in #354; this brings the Claude installer to Claude Code's own install and update commands.

Closes #355.

## What changed

The install now runs the loop Claude Code documents for local plugins: stamp a `+claude.<timestamp>` cachebuster onto the plugin manifest and both version strings in the marketplace manifest, refresh the catalog, install, then restore the manifests and prune the copy the previous run left. Two measured facts shape it — the catalog is a snapshot taken when the marketplace is added or updated, so the stamp has to land before the refresh; and `claude plugin update` reports "already at the latest version" and copies nothing when the version has not moved, which is why there is a stamp at all.

The served path comes from what `claude plugin list` reports rather than from the version string, because Claude names the cache directory with `+` rewritten to `-` while reporting the `+`.

`script/dev-uninstall claude` now sweeps the whole cache tree, so an install from before this change leaves no symlink behind.

**This changes how you develop Team on Claude Code.** The install is a copy, so a skill you edit no longer takes effect until you re-run `script/dev-install claude`. That matches Codex, and the clone-local pull hooks already re-run it after a merge or rebase pull.

## Test plan

Tests run against a fake `claude` and a disposable plugin root, so none touches the tracked manifests or a real host.

- Full suite: 2347 pass, 0 fail. `bun run typecheck` clean.
- The new regression test was confirmed red against the old installer before the fix, and the manifest-restore test was confirmed red with the restore trap disabled.
- Verified live against the real CLI in an isolated `HOME`: `claude plugin install` copies into a version-named directory; `marketplace update` + `plugin update` at an unchanged version copies nothing; a build-metadata version bump forces the re-copy and Claude reports the stamped version while naming the directory with `-`.
- Verified live on this machine: install pruned a stale `0.96.0` symlink into the checkout plus the previous copy, leaving one real directory serving all 90 skills, with the reported version matching the checkout's manifest.
- Verified live: uninstall leaves no cache directory, no marketplace entry, and no install; the following fresh install comes back healthy; the checkout's three version strings are byte-identical afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
