### PR TITLE
v0.99.0 feat(team): raise orchestration effort

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.98.0"
+    "version": "0.99.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.98.0",
+      "version": "0.99.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/team` now uses extra-high effort for full-pipeline coordination.** The design author and structure planner also use extra-high effort because their artifacts determine later implementation work; all other model and effort assignments remain at their existing cost-based tiers.
+
 ## [0.98.0] - 2026-09-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`/team` now uses extra-high effort for full-pipeline coordination.** The design author and structure planner also use extra-high effort because their artifacts determine later implementation work; all other model and effort assignments remain at their existing cost-based tiers.
+- **`/team` now uses high effort for full-pipeline coordination.** The design author and structure planner use extra-high effort because their artifacts determine later implementation work; all other model and effort assignments remain at their existing cost-based tiers.
 
 ## [0.98.0] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.99.0] - 2026-09-10
+
 ### Changed
 
 - **`/team` now uses high effort for full-pipeline coordination.** The design author and structure planner use extra-high effort because their artifacts determine later implementation work; all other model and effort assignments remain at their existing cost-based tiers.
@@ -883,7 +885,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.98.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.99.0...HEAD
+[0.99.0]: https://github.com/bostonaholic/team/compare/v0.98.0...v0.99.0
 [0.98.0]: https://github.com/bostonaholic/team/compare/v0.97.0...v0.98.0
 [0.97.0]: https://github.com/bostonaholic/team/compare/v0.96.0...v0.97.0
 [0.96.0]: https://github.com/bostonaholic/team/compare/v0.95.0...v0.96.0

--- a/agents/design-author.md
+++ b/agents/design-author.md
@@ -3,7 +3,7 @@ name: design-author
 description: Use after research is complete to draft the approach before any code is written. Drafts a ~200-line design document covering current state, desired end state, patterns to follow, and decisions made. Resolves its own open questions autonomously, recording each as an explicit, auditable assumption in the design.
 color: purple
 model: opus
-effort: high
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, TodoWrite
 permissionMode: acceptEdits
 skills:

--- a/agents/structure-planner.md
+++ b/agents/structure-planner.md
@@ -3,7 +3,7 @@ name: structure-planner
 description: Use after the design review passes to break the work into vertical slices with verification checkpoints. Each slice is end-to-end (touches every layer needed to deliver one piece of functionality), independently testable, and atomically committable. Produces a ~2-page document that the planner and implementer consume; it advances autonomously to PLAN with no approval gate.
 color: purple
 model: opus
-effort: high
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, TodoWrite
 permissionMode: acceptEdits
 skills:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -601,6 +601,14 @@ bounded single pass. `EXPECTED_EFFORTS` (`tests/architecture.test.ts`)
 pins all thirteen values in both directions. Methodology skills carry no
 `effort`. They inherit it from the loading agent.
 
+User-facing skills use the same ladder. The full `/team` orchestrator runs at
+`xhigh` because it maintains state and applies gates across all eight phases.
+Single-phase orchestrators stay at `medium`; their specialist agents perform
+the complex work. Mechanical worktree setup runs at `low`, while entry points
+that directly perform complex analysis or conflict resolution run at `high`.
+`EXPECTED_SKILL_EFFORTS` (`tests/architecture.test.ts`) pins every user-facing
+skill in both directions.
+
 ## 5. Phase-table orchestrator
 
 The orchestrator (the main Claude Code session) drives `/team` by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -602,7 +602,7 @@ pins all thirteen values in both directions. Methodology skills carry no
 `effort`. They inherit it from the loading agent.
 
 User-facing skills use the same ladder. The full `/team` orchestrator runs at
-`xhigh` because it maintains state and applies gates across all eight phases.
+`high` because it maintains state and applies gates across all eight phases.
 Single-phase orchestrators stay at `medium`; their specialist agents perform
 the complex work. Mechanical worktree setup runs at `low`, while entry points
 that directly perform complex analysis or conflict resolution run at `high`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: team
 description: 'Runs the 8-phase QRSPI feature pipeline. Trigger on "hey team", "build a feature", or "/team" only; never infer pipeline intent from a plain coding request.'
-effort: xhigh
+effort: high
 argument-hint: "<ticket id, issue URL, or feature description>"
 ---
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: team
 description: 'Runs the 8-phase QRSPI feature pipeline. Trigger on "hey team", "build a feature", or "/team" only; never infer pipeline intent from a plain coding request.'
-effort: medium
+effort: xhigh
 argument-hint: "<ticket id, issue URL, or feature description>"
 ---
 

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -271,14 +271,14 @@ describe("effort tiering", () => {
   // EXPECTED_MODELS in describe("model tiering") below.
   const EXPECTED_EFFORTS: Record<string, string> = {
     "code-reviewer": "high",
-    "design-author": "high",
+    "design-author": "xhigh",
     "file-finder": "low",
     implementer: "high",
     planner: "high",
     questioner: "high",
     researcher: "medium",
     "security-reviewer": "high",
-    "structure-planner": "high",
+    "structure-planner": "xhigh",
     "technical-writer": "low",
     "test-architect": "high",
     "ux-reviewer": "medium",
@@ -314,6 +314,49 @@ describe("effort tiering", () => {
     expect(effortMismatch("planted-agent", "xhigh", "model: opus\n")).toBe(
       "planted-agent: expected effort xhigh, got none",
     );
+  });
+
+  const EXPECTED_SKILL_EFFORTS: Record<string, string> = {
+    "code-review": "high",
+    "eng-design-doc-review": "high",
+    "groom-backlog": "high",
+    how: "medium",
+    "no-comments": "high",
+    "pr-cleanup": "medium",
+    "pr-open-comments": "high",
+    "pr-rebase": "high",
+    "pr-screenshots": "medium",
+    "pr-verify": "high",
+    "pr-watch-as-author": "medium",
+    "pr-watch-as-reviewer": "medium",
+    reflect: "high",
+    shipit: "medium",
+    team: "xhigh",
+    "team-design": "medium",
+    "team-fix": "high",
+    "team-implement": "medium",
+    "team-plan": "medium",
+    "team-pr": "medium",
+    "team-question": "medium",
+    "team-research": "medium",
+    "team-structure": "medium",
+    "team-worktree": "low",
+    why: "high",
+  };
+
+  test("EXPECTED_SKILL_EFFORTS pins every user-facing skill to its level", () => {
+    const files = skillFiles().filter((file) =>
+      /^argument-hint:/m.test(frontmatter(read(join(REPO_ROOT, file)))),
+    );
+    const names = files.map((file) => basename(join(REPO_ROOT, file, "..")));
+    expect(Object.keys(EXPECTED_SKILL_EFFORTS).sort()).toEqual(names);
+    const offenders: string[] = [];
+    for (const [skill, level] of Object.entries(EXPECTED_SKILL_EFFORTS)) {
+      const fm = frontmatter(read(join(REPO_ROOT, "skills", skill, "SKILL.md")));
+      const offender = effortMismatch(skill, level, fm);
+      if (offender) offenders.push(offender);
+    }
+    expect(offenders).toEqual([]);
   });
 
   test("each agent's frontmatter carries exactly one effort: key", () => {

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -331,7 +331,7 @@ describe("effort tiering", () => {
     "pr-watch-as-reviewer": "medium",
     reflect: "high",
     shipit: "medium",
-    team: "xhigh",
+    team: "high",
     "team-design": "medium",
     "team-fix": "high",
     "team-implement": "medium",


### PR DESCRIPTION
## Summary

- Runs the full `/team` orchestrator at high effort.
- Gives design and structure authors extra-high effort while retaining lower-cost tiers for bounded and mechanical work.

## Design Decisions

- Keep the existing Opus, Sonnet, and Haiku assignments; they already match complex, bounded-judgment, and mechanical roles.
- Reserve extra-high effort for the full pipeline and the two strategic artifacts consumed by every later implementation phase.

## Changes

- Raised `/team` to `high`, and raised `design-author` and `structure-planner` to `xhigh`.
- Added a complete effort-assignment pin for every user-facing skill.
- Documented the effort policy and updated the changelog.

## How to Verify

- `bun test` (2,359 passed, 4 skipped)
- `bun test tests/architecture.test.ts` (63 passed)

## Pre-merge

- [x] Confirm `bun run typecheck` passes in CI; local nodenv could not find `tsc`.

## References

- Architecture: `docs/architecture.md`
