### PR TITLE
v0.102.0 feat(harness): make the QRSPI pipeline host-neutral

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.101.0"
+    "version": "0.102.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.101.0",
+      "version": "0.102.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
   "interface": {
     "displayName": "Team",
     "shortDescription": "Autonomous feature pipeline: question, research, design, plan, implement, PR.",
-    "longDescription": "Team turns a feature description into a reviewed pull request. It walks an eight-phase pipeline — worktree, question, research, design, structure, plan, implement, PR — dispatching a specialist agent at each phase and persisting every artifact to disk. An adversarial design review gates the design and five reviewers gate the implementation, so the only human checkpoint is the pull request at the end. On Codex the standalone utilities run; the full pipeline needs Claude Code, which is the host that dispatches the agents.",
+    "longDescription": "Team turns a feature description into a reviewed pull request. It walks an eight-phase pipeline — worktree, question, research, design, structure, plan, implement, PR — dispatching a specialist agent at each phase and persisting every artifact to disk. An adversarial design review gates the design and five reviewers gate the implementation, so the only human checkpoint is the pull request at the end. The pipeline is host-neutral: each phase dispatches its specialist from a portable agent definition, so it runs on Codex as it does on Claude Code and Antigravity. The standalone utilities run too.",
     "developerName": "Matthew Boston",
     "category": "engineering",
     "capabilities": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
   "interface": {
     "displayName": "Team",
     "shortDescription": "Autonomous feature pipeline: question, research, design, plan, implement, PR.",
-    "longDescription": "Team turns a feature description into a reviewed pull request. It walks an eight-phase pipeline — worktree, question, research, design, structure, plan, implement, PR — dispatching a specialist agent at each phase and persisting every artifact to disk. An adversarial design review gates the design and five reviewers gate the implementation, so the only human checkpoint is the pull request at the end. The pipeline is host-neutral: each phase dispatches its specialist from a portable agent definition, so it runs on Codex as it does on Claude Code and Antigravity. The standalone utilities run too.",
+    "longDescription": "Team turns a feature description into a reviewed pull request. It walks an eight-phase pipeline — worktree, question, research, design, structure, plan, implement, PR — dispatching a specialist agent at each phase and persisting every artifact to disk. An adversarial design review gates the design and five reviewers gate the implementation, so the only human checkpoint is the pull request at the end.",
     "developerName": "Matthew Boston",
     "category": "engineering",
     "capabilities": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## What this is
 
-Team is a Claude Code plugin that orchestrates specialized agents to implement features end-to-end. The orchestrator (the main Claude Code session) walks a linear phase table, and persists state as artifact files in `docs/plans/<id>/`. That per-id directory carries YAML frontmatter with phase and revision metadata. The orchestrator coordinates live progress through TodoWrite. See [docs/architecture.md](docs/architecture.md) for the full design.
+Team is a plugin that orchestrates specialized agents to implement features end-to-end across Claude Code, Codex CLI, and Antigravity CLI. The orchestrator (the host's main session) walks a linear phase table, and persists state as artifact files in `docs/plans/<id>/`. That per-id directory carries YAML frontmatter with phase and revision metadata. The orchestrator coordinates live progress through TodoWrite, and dispatches each specialist from its portable `agents/<name>.md` definition so no host is privileged. See [docs/architecture.md](docs/architecture.md) for the full design.
 
 > **North star: read [docs/vision.md](docs/vision.md) and [docs/ethos.md](docs/ethos.md).** Team is a *loop-driven development system*: a human fills the Backlog and reviews finished work. Everything in between (groom → start → implement → open PR) runs autonomously. The ethos explains *why* the autonomous middle can be trusted. Every agent should understand this end state, which is the target the whole project moves toward.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## What this is
 
-Team is a plugin that orchestrates specialized agents to implement features end-to-end across Claude Code, Codex CLI, and Antigravity CLI. The orchestrator (the host's main session) walks a linear phase table, and persists state as artifact files in `docs/plans/<id>/`. That per-id directory carries YAML frontmatter with phase and revision metadata. The orchestrator coordinates live progress through TodoWrite, and dispatches each specialist from its portable `agents/<name>.md` definition so no host is privileged. See [docs/architecture.md](docs/architecture.md) for the full design.
+Team is a plugin that orchestrates specialized agents to implement features end-to-end across Claude Code, Codex CLI, and Antigravity CLI. The orchestrator (the main session) walks a linear phase table, and persists state as artifact files in `docs/plans/<id>/`. That per-id directory carries YAML frontmatter with phase and revision metadata. The orchestrator coordinates live progress through TodoWrite, and dispatches each specialist from its portable `agents/<name>.md` definition. See [docs/architecture.md](docs/architecture.md) for the full design.
 
 > **North star: read [docs/vision.md](docs/vision.md) and [docs/ethos.md](docs/ethos.md).** Team is a *loop-driven development system*: a human fills the Backlog and reviews finished work. Everything in between (groom → start → implement → open PR) runs autonomously. The ethos explains *why* the autonomous middle can be trusted. Every agent should understand this end state, which is the target the whole project moves toward.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The `/team` pipeline is host-neutral and runs on every supported host.** The orchestrator previously dispatched each specialist only through Claude Code's named-agent registry, so a Codex or Antigravity session loaded the `/team-*` commands but could not run a phase. Dispatch now resolves through a portable contract (`skills/team/references/15-host-dispatch.md`): a host that registers Team agents by name dispatches the named agent; any other host reads the specialist's portable `agents/<name>.md` definition and spawns a fresh subagent with its body, so no host-side agent registration is required. A reviewer never runs inline, preserving the generator/evaluator invariant. The WORKTREE phase is host-neutral too — it uses the host's native worktree support where one exists and `git worktree add` otherwise. Claude Code's behavior is unchanged. **What this asks of you:** nothing; per-host native bindings (hook registration and model-tier maps) remain tracked in #56 and #57.
+
 ## [0.101.0] - 2026-09-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The `/team` pipeline is host-neutral and runs on every supported host.** The orchestrator previously dispatched each specialist only through Claude Code's named-agent registry, so a Codex or Antigravity session loaded the `/team-*` commands but could not run a phase. Dispatch now resolves through a portable contract (`skills/team/references/15-host-dispatch.md`): a host that registers Team agents by name dispatches the named agent; any other host reads the specialist's portable `agents/<name>.md` definition and spawns a fresh subagent with its body, so no host-side agent registration is required. A reviewer never runs inline, preserving the generator/evaluator invariant. The WORKTREE phase is host-neutral too — it uses the host's native worktree support where one exists and `git worktree add` otherwise. Claude Code's behavior is unchanged. **What this asks of you:** nothing; per-host native bindings (hook registration and model-tier maps) remain tracked in #56 and #57.
+- **`/team` runs its full pipeline on Codex CLI and Antigravity CLI, not only on Claude Code.** The orchestrator previously dispatched each specialist through Claude Code's named-agent registry alone, so a Codex or Antigravity session loaded the `/team-*` commands but could not run a phase. It now dispatches each specialist from its portable `agents/<name>.md` definition, which any host that can spawn a subagent runs; a reviewer still never runs in the author's context. Worktree setup uses the host's native support where one exists and `git worktree add` otherwise. Claude Code's behavior is unchanged. **What this asks of you:** nothing.
 
 ## [0.101.0] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.102.0] - 2026-09-10
+
 ### Changed
 
 - **`/team` runs its full pipeline on Codex CLI and Antigravity CLI, not only on Claude Code.** The orchestrator previously dispatched each specialist through Claude Code's named-agent registry alone, so a Codex or Antigravity session loaded the `/team-*` commands but could not run a phase. It now dispatches each specialist from its portable `agents/<name>.md` definition, which any host that can spawn a subagent runs; a reviewer still never runs in the author's context. Worktree setup uses the host's native support where one exists and `git worktree add` otherwise. Claude Code's behavior is unchanged. **What this asks of you:** nothing.
@@ -905,7 +907,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.101.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.102.0...HEAD
+[0.102.0]: https://github.com/bostonaholic/team/compare/v0.101.0...v0.102.0
 [0.101.0]: https://github.com/bostonaholic/team/compare/v0.100.0...v0.101.0
 [0.100.0]: https://github.com/bostonaholic/team/compare/v0.99.0...v0.100.0
 [0.99.0]: https://github.com/bostonaholic/team/compare/v0.98.0...v0.99.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 **You have been made tech lead. Your team never sleeps.**
 
-Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the main Claude Code session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
+Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the host's main session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
 
-Team installs on Claude Code, on Codex CLI, and on Antigravity CLI. The full pipeline needs Claude Code, because that is the host that dispatches the agents. The standalone utilities work on all three.
+Team installs on Claude Code, on Codex CLI, and on Antigravity CLI. The pipeline is host-neutral: each specialist dispatches from its portable definition at `agents/<name>.md`, so the full pipeline runs on any host that can spawn a subagent — all three included. The standalone utilities work on all three.
+
+Per-host native bindings — hook registration and model-tier maps — are tracked in [#57 (Codex)](https://github.com/bostonaholic/team/issues/57) and [#56 (Antigravity)](https://github.com/bostonaholic/team/issues/56).
 
 **Documentation:** [team.bostonaholic.dev](https://team.bostonaholic.dev)
 
@@ -96,10 +98,11 @@ picks up new skills with no extra links and no sync step. Remove it with:
 codex plugin remove team@team-dev
 ```
 
-Skills arrive **namespaced** — ask for `team:shipit`, not `shipit`. Codex budgets
-its skill catalog, so it shortens the longest descriptions; the skills still
-work. The `/team-*` pipeline commands load but cannot dispatch Claude Code
-agents, so they will not run the pipeline. The standalone utilities do.
+Skills arrive **namespaced** — ask for `team:shipit`, not `shipit`. Codex
+budgets its skill catalog, so it shortens the longest descriptions; the skills
+still work. The `/team-*` pipeline commands run the full pipeline: each phase
+dispatches its specialist from the portable `agents/<name>.md` definition, so
+no Codex-side agent registration is required. The standalone utilities run too.
 
 Developing Team itself? Run the loop Codex documents for local plugins:
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 **You have been made tech lead. Your team never sleeps.**
 
-Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the host's main session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
+Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the main session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
 
-Team installs on Claude Code, on Codex CLI, and on Antigravity CLI. The pipeline is host-neutral: each specialist dispatches from its portable definition at `agents/<name>.md`, so the full pipeline runs on any host that can spawn a subagent — all three included. The standalone utilities work on all three.
-
-Per-host native bindings — hook registration and model-tier maps — are tracked in [#57 (Codex)](https://github.com/bostonaholic/team/issues/57) and [#56 (Antigravity)](https://github.com/bostonaholic/team/issues/56).
+Team installs on Claude Code, on Codex CLI, and on Antigravity CLI.
 
 **Documentation:** [team.bostonaholic.dev](https://team.bostonaholic.dev)
 
@@ -100,9 +98,7 @@ codex plugin remove team@team-dev
 
 Skills arrive **namespaced** — ask for `team:shipit`, not `shipit`. Codex
 budgets its skill catalog, so it shortens the longest descriptions; the skills
-still work. The `/team-*` pipeline commands run the full pipeline: each phase
-dispatches its specialist from the portable `agents/<name>.md` definition, so
-no Codex-side agent registration is required. The standalone utilities run too.
+still work.
 
 Developing Team itself? Run the loop Codex documents for local plugins:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,9 +32,20 @@ nav_label: architecture
 
 Agents are **decoupled microservices**. Each agent consumes a predecessor
 artifact on disk, does work, and produces its own artifact under
-`docs/plans/<id>/`. The orchestrator is the main Claude Code session: it
+`docs/plans/<id>/`. The orchestrator is the host's main session: it
 walks a linear phase table, dispatches the right specialist for each phase,
 seeds and updates a TodoWrite ledger, and runs the gates.
+
+**Host-neutral dispatch.** The pipeline privileges no host. The orchestrator
+resolves every dispatch through the portable contract in
+`skills/team/references/15-host-dispatch.md`: dispatch the named agent where
+the host registers Team agents (Claude Code), otherwise read the portable
+`agents/<name>.md` definition and spawn a fresh subagent with its body. Any
+host that can read a file, spawn a subagent, and run a shell command runs the
+full pipeline. Per-host native bindings — hook registration and the model-tier
+map — are the only host-specific work, tracked in
+[#57](https://github.com/bostonaholic/team/issues/57) and
+[#56](https://github.com/bostonaholic/team/issues/56).
 
 **Principles:**
 
@@ -611,7 +622,7 @@ skill in both directions.
 
 ## 5. Phase-table orchestrator
 
-The orchestrator (the main Claude Code session) drives `/team` by
+The orchestrator (the host's main session) drives `/team` by
 walking the phase table in `skills/team/SKILL.md`. Pseudocode:
 
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,20 +32,9 @@ nav_label: architecture
 
 Agents are **decoupled microservices**. Each agent consumes a predecessor
 artifact on disk, does work, and produces its own artifact under
-`docs/plans/<id>/`. The orchestrator is the host's main session: it
+`docs/plans/<id>/`. The orchestrator is the main session: it
 walks a linear phase table, dispatches the right specialist for each phase,
 seeds and updates a TodoWrite ledger, and runs the gates.
-
-**Host-neutral dispatch.** The pipeline privileges no host. The orchestrator
-resolves every dispatch through the portable contract in
-`skills/team/references/15-host-dispatch.md`: dispatch the named agent where
-the host registers Team agents (Claude Code), otherwise read the portable
-`agents/<name>.md` definition and spawn a fresh subagent with its body. Any
-host that can read a file, spawn a subagent, and run a shell command runs the
-full pipeline. Per-host native bindings — hook registration and the model-tier
-map — are the only host-specific work, tracked in
-[#57](https://github.com/bostonaholic/team/issues/57) and
-[#56](https://github.com/bostonaholic/team/issues/56).
 
 **Principles:**
 
@@ -622,7 +611,7 @@ skill in both directions.
 
 ## 5. Phase-table orchestrator
 
-The orchestrator (the host's main session) drives `/team` by
+The orchestrator (the main session) drives `/team` by
 walking the phase table in `skills/team/SKILL.md`. Pseudocode:
 
 ```

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -32,7 +32,7 @@ nav_label: portability
 ## Contents
 
 - [Current state](#current-state)
-- [Host-neutral dispatch](#host-neutral-dispatch)
+- [Agent dispatch](#agent-dispatch)
 - [Desired end state](#desired-end-state)
 - [Patterns to follow](#patterns-to-follow)
 - [The capability matrix](#the-capability-matrix)
@@ -87,7 +87,7 @@ these four non-portable bindings. The `model:` field is a *Claude-specific model
 name*. To make it portable, resolve it through host-neutral config. Do not bake a
 literal into each definition. See `.team/config.json` under Desired end state.
 
-## Host-neutral dispatch
+## Agent dispatch
 
 Of the four blocking bindings, the fourth — Agent/Task dispatch — needs no
 per-host agent registration. Team resolves it in the orchestrator itself,
@@ -542,7 +542,7 @@ invisible to `agy`.
 keeps a checkout's edits live. Dispatch is resolved host-neutrally, not by a
 per-host agent registration: the orchestrator reads each specialist's portable
 definition and dispatches it through the host's subagent facility (see
-[Host-neutral dispatch](#host-neutral-dispatch)). Hooks, commands, and rules
+[Agent dispatch](#agent-dispatch)). Hooks, commands, and rules
 remain unported on this host. That work stays with
 [#56](https://github.com/bostonaholic/team/issues/56).
 

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -32,6 +32,7 @@ nav_label: portability
 ## Contents
 
 - [Current state](#current-state)
+- [Host-neutral dispatch](#host-neutral-dispatch)
 - [Desired end state](#desired-end-state)
 - [Patterns to follow](#patterns-to-follow)
 - [The capability matrix](#the-capability-matrix)
@@ -85,6 +86,29 @@ The host also interprets the agent frontmatter field semantics: `name`, `model`,
 these four non-portable bindings. The `model:` field is a *Claude-specific model
 name*. To make it portable, resolve it through host-neutral config. Do not bake a
 literal into each definition. See `.team/config.json` under Desired end state.
+
+## Host-neutral dispatch
+
+Of the four blocking bindings, the fourth — Agent/Task dispatch — needs no
+per-host agent registration. Team resolves it in the orchestrator itself,
+through the portable definition contract in
+`skills/team/references/15-host-dispatch.md`:
+
+- Every specialist ships as `agents/<name>.md`. The body is a complete role
+  prompt; the frontmatter is host metadata.
+- A host that resolves Team agents by name (Claude Code) dispatches the named
+  agent, so the host applies the frontmatter's tool and permission restrictions.
+- Any other host reads the definition, strips frontmatter, and spawns a fresh
+  generic subagent with the body as its role instructions. No host-side agent
+  registration is required.
+- A producer may run inline only when no subagent facility exists; a reviewer
+  never runs inline, because a reviewer sharing the author's context cannot
+  judge it.
+
+The consequence for this study: the "agent dispatch" primitive is reachable on
+every host that can spawn a subagent, without a per-host shim. The remaining
+per-host work is the bindings the study already names — hook registration and
+the model-tier map — not agent registration.
 
 ## Desired end state
 
@@ -146,8 +170,9 @@ nested subagents, and structured returns.
   is running on is knowable no other way, which is how
   `resolve-transcript.mjs` tells a Claude Code session from a Codex one.
   `skills/nested-agents/SKILL.md:35` still interpolates the variable directly.
-  That command is Claude-Code-only today, because the pipeline agents it serves
-  cannot dispatch on Codex.
+  That command is Claude-Code-specific, but the pipeline it serves is not:
+  nested dispatch degrades to its documented inline fallback on every other
+  host (`skills/nested-agents/SKILL.md`, "Optimization, never a dependency").
 - **Hooks already isolate portable logic from host contract.** Each `.mjs` reads
   stdin, does Node-only work, then writes a host-shaped JSON result
   (`session-start-recover.mjs:236-244`, `post-write-validate.mjs:29-37`). The scan
@@ -514,8 +539,10 @@ points the other way, since about fifty skills in `~/.agents/skills/` were
 invisible to `agy`.
 
 **Scope.** Antigravity installs every skill and every agent, and the dev install
-keeps a checkout's edits live. What is unproven is dispatch: the pipeline
-commands install but are not claimed to run, and hooks, commands, and rules
+keeps a checkout's edits live. Dispatch is resolved host-neutrally, not by a
+per-host agent registration: the orchestrator reads each specialist's portable
+definition and dispatches it through the host's subagent facility (see
+[Host-neutral dispatch](#host-neutral-dispatch)). Hooks, commands, and rules
 remain unported on this host. That work stays with
 [#56](https://github.com/bostonaholic/team/issues/56).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Team orchestrates specialized agents that implement features end-to-end through the QRSPI pipeline. The pipeline is host-neutral and runs on Claude Code, Codex CLI, and Antigravity CLI; the standalone utilities run everywhere too."
+description: "Team orchestrates specialized agents that implement features end-to-end through the QRSPI pipeline."
 permalink: /
 audience: [user, developer]
 nav_order: 1
@@ -18,7 +18,7 @@ reviewers. Together they drive a feature through an 8-phase pipeline (QRSPI) and
 verified pull request.
 
 Agents are decoupled microservices. Each one consumes a predecessor artifact on disk, does its
-work, and writes its own artifact. The orchestrator is the host's main session. It walks a
+work, and writes its own artifact. The orchestrator is the main session. It walks a
 linear phase table with no mid-run human gates. An adversarial design review gates the design,
 and the human reviews the finished PR.
 
@@ -69,10 +69,7 @@ company-significant work from problem definition through measured outcomes.
 ## Install
 
 Team ships a native manifest for each host, so one repo installs on all three
-from a local checkout. The pipeline is host-neutral: the orchestrator dispatches
-each specialist from its portable `agents/<name>.md` definition, so the full
-pipeline runs on any host that can spawn a subagent. The standalone utilities
-work on all three. Pick yours.
+from a local checkout. Pick yours.
 
 ### Claude Code
 
@@ -167,9 +164,7 @@ codex plugin remove team@team-dev
 
 Skills arrive **namespaced** — ask for `team:shipit`, not `shipit`. Codex
 budgets its skill catalog, so it shortens the longest descriptions; the skills
-still work. The `/team-*` pipeline commands run the full pipeline: each phase
-dispatches its specialist from the portable `agents/<name>.md` definition, so
-no Codex-side agent registration is required. The standalone utilities run too.
+still work.
 
 Developing Team itself? Run the loop Codex documents for local plugins:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Team orchestrates specialized agents that implement features end-to-end through the QRSPI pipeline. The full pipeline runs on Claude Code; the standalone utilities also work on Codex CLI and Antigravity CLI."
+description: "Team orchestrates specialized agents that implement features end-to-end through the QRSPI pipeline. The pipeline is host-neutral and runs on Claude Code, Codex CLI, and Antigravity CLI; the standalone utilities run everywhere too."
 permalink: /
 audience: [user, developer]
 nav_order: 1
@@ -18,7 +18,7 @@ reviewers. Together they drive a feature through an 8-phase pipeline (QRSPI) and
 verified pull request.
 
 Agents are decoupled microservices. Each one consumes a predecessor artifact on disk, does its
-work, and writes its own artifact. The orchestrator is the main Claude Code session. It walks a
+work, and writes its own artifact. The orchestrator is the host's main session. It walks a
 linear phase table with no mid-run human gates. An adversarial design review gates the design,
 and the human reviews the finished PR.
 
@@ -69,9 +69,10 @@ company-significant work from problem definition through measured outcomes.
 ## Install
 
 Team ships a native manifest for each host, so one repo installs on all three
-from a local checkout. The full pipeline needs Claude Code, because that is the
-host that dispatches the agents. The standalone utilities work on all three.
-Pick yours.
+from a local checkout. The pipeline is host-neutral: the orchestrator dispatches
+each specialist from its portable `agents/<name>.md` definition, so the full
+pipeline runs on any host that can spawn a subagent. The standalone utilities
+work on all three. Pick yours.
 
 ### Claude Code
 
@@ -166,8 +167,9 @@ codex plugin remove team@team-dev
 
 Skills arrive **namespaced** — ask for `team:shipit`, not `shipit`. Codex
 budgets its skill catalog, so it shortens the longest descriptions; the skills
-still work. The `/team-*` pipeline commands load but cannot dispatch Claude
-Code agents, so they will not run the pipeline. The standalone utilities do.
+still work. The `/team-*` pipeline commands run the full pipeline: each phase
+dispatches its specialist from the portable `agents/<name>.md` definition, so
+no Codex-side agent registration is required. The standalone utilities run too.
 
 Developing Team itself? Run the loop Codex documents for local plugins:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/skills/principle-progress-tracking/SKILL.md
+++ b/skills/principle-progress-tracking/SKILL.md
@@ -12,7 +12,7 @@ A convention, not a gate: create no artifact and block nothing; expose progress 
 - Without a todo tool, state the ledger once inline and name each step as it completes.
 - Track numbered steps, not phases or files; for unnumbered procedures, track each natural unit such as a slice, question, or hard-gate finding, never each guidance sentence.
 - Mark each item `in_progress` at start and `completed` when landed, matching `team-fix`.
-- Let the orchestrator—the main Claude Code session—own one phase ledger.
+- Let the orchestrator—the host's main session—own one phase ledger.
 - Let agents track skill sub-steps only inside their contexts; never merge or read across orchestrator and agent ledgers.
 - Let directly invoked standalone skills own their ledgers.
 - Apply `skills/qrspi-workflow/SKILL.md` for the orchestrator TodoWrite phase-ledger contract.

--- a/skills/reflect/references/04-the-lenses.md
+++ b/skills/reflect/references/04-the-lenses.md
@@ -48,15 +48,13 @@ untrusted-content and paraphrase-only rules verbatim, the focus scope when one
 resolved, and this bound — **return at most 30 reply lines, each finding one
 line carrying a file path or a turn index, and spawn no further agents**.
 
-**Inline fallback — a reduced-assurance mode.** Subagent dispatch is a Claude
-Code capability, and on the other two hosts that install this skill it is
-absent: the `/team-*` commands "cannot dispatch Claude Code agents" on Codex
-(`README.md`), and Antigravity's agent dispatch is untested, so Team claims no
-support for it (`docs/cross-host-portability.md`). On those hosts the fallback
-is the **normal** path, not a corner. Where the `Agent` tool is absent, a
-dispatch errors, or a reply comes back disqualified, run the affected passes in
-sequence in this session — all three where dispatch is unavailable at all — and
-say in the report which passes ran inline in reduced-assurance mode.
+**Inline fallback — a reduced-assurance mode.** Subagent dispatch is resolved
+host-neutrally (`skills/team/references/15-host-dispatch.md`), so it is
+available on every supported host that can spawn a subagent. Where a host cannot,
+a dispatch errors, or a reply comes back disqualified, the fallback is the
+**normal** path: run the affected passes in sequence in this session — all three
+where dispatch is unavailable at all — and say in the report which passes ran
+inline in reduced-assurance mode.
 
 **The toolset guarantee above holds on the dispatch path only.** This session
 holds `Bash`, `Write`, and `AskUserQuestion`, so a fallback pass cannot claim

--- a/skills/reflect/references/04-the-lenses.md
+++ b/skills/reflect/references/04-the-lenses.md
@@ -48,13 +48,12 @@ untrusted-content and paraphrase-only rules verbatim, the focus scope when one
 resolved, and this bound — **return at most 30 reply lines, each finding one
 line carrying a file path or a turn index, and spawn no further agents**.
 
-**Inline fallback — a reduced-assurance mode.** Subagent dispatch is resolved
-host-neutrally (`skills/team/references/15-host-dispatch.md`), so it is
-available on every supported host that can spawn a subagent. Where a host cannot,
-a dispatch errors, or a reply comes back disqualified, the fallback is the
-**normal** path: run the affected passes in sequence in this session — all three
-where dispatch is unavailable at all — and say in the report which passes ran
-inline in reduced-assurance mode.
+**Inline fallback — a reduced-assurance mode.** Subagent dispatch follows the
+dispatch contract (`skills/team/references/15-host-dispatch.md`). Where a host
+cannot spawn a subagent, a dispatch errors, or a reply comes back disqualified,
+the fallback is the **normal** path: run the affected passes in sequence in this
+session — all three where dispatch is unavailable at all — and say in the report
+which passes ran inline in reduced-assurance mode.
 
 **The toolset guarantee above holds on the dispatch path only.** This session
 holds `Bash`, `Write`, and `AskUserQuestion`, so a fallback pass cannot claim

--- a/skills/team-implement/references/02-worktree-check.md
+++ b/skills/team-implement/references/02-worktree-check.md
@@ -8,7 +8,7 @@ Before any agent dispatch, decide where to work:
    to run `/team-worktree [docs/plans/<id>/]` (the path is optional —
    discovery resolves it) and stop.
 2. Run `git rev-parse --absolute-git-dir`. If the path contains
-   `/worktrees/`, you are already inside a Claude Code worktree — proceed in
+   `/worktrees/`, you are already inside a linked worktree — proceed in
    place. In multi-repo mode this should be the home repo's worktree. The
    implementer cd's into the other repos' worktrees as the plan steps
    require.

--- a/skills/team-worktree/references/04-execution.md
+++ b/skills/team-worktree/references/04-execution.md
@@ -4,13 +4,13 @@
 
 - `<id>` = `basename "$ARGUMENTS"`
 - Branch name = `<id>` (in every involved repo)
-- Worktree path per repo = `<repo-path>/.claude/worktrees/<id>` (per Claude
-  Code's native worktree convention. See
+- Worktree path per repo = `<repo-path>/.claude/worktrees/<id>` (the
+  `.claude/worktrees/` convention. See
   `skills/worktree-isolation/SKILL.md`)
 
 **Branch names must never contain a slash (`/`).** Use `-` as the only
 delimiter. A `/` in a branch name creates a nested ref path in
-`.git/refs/heads/`. That path collides with Claude Code's
+`.git/refs/heads/`. That path collides with the
 `.claude/worktrees/` directory convention and breaks worktree cleanup. The
 `<id>` produced by the questioner is already slash-free, but if
 `basename "$ARGUMENTS"` ever yields a name containing `/` (e.g. a ticket
@@ -72,8 +72,9 @@ Use the slash-sanitized name (`<branch>`, derived above) for both the
 worktree directory and the `-b` flag in every repo. In the common case
 `<branch>` equals `<id>`.
 
-- **Single-repo:** create the home worktree using Claude Code's native
-  worktree support, branched off `origin/HEAD`.
+- **Single-repo:** create the home worktree on branch `<id>` off
+  `origin/HEAD`, using the host's native worktree support when it offers
+  one and `git worktree add` otherwise.
 - **Multi-repo:** for each listed repo, first assert **containment**:
   the repo path's real path must be a direct child of the home repo's
   parent directory —

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -11,9 +11,11 @@ Before finalizing prose you author, call the Skill tool with `unslop` and
 `writing-prose`, in that order. Relay completed agent and vendor returns unchanged.
 
 You are the Team orchestrator. The orchestrator is the
-**main Claude Code session itself** — not a sub-agent. You drive a feature
+**host's main session itself** — not a sub-agent. You drive a feature
 from description to shipped code by walking a linear phase table,
 dispatching specialist agents, and coordinating progress through TodoWrite.
+The pipeline is host-neutral: dispatch each specialist from its portable
+definition at `agents/<name>.md`, per `references/15-host-dispatch.md`.
 
 You hold no special state of your own. The durable record is the set of
 artifacts under `docs/plans/<id>/*.md` (each carrying YAML frontmatter
@@ -27,6 +29,7 @@ in-session coordination uses TodoWrite.
 - For a picked-up ticket, call the Skill tool with `tracking-tickets` and move the ticket to in-progress. At PR creation, use the same skill for the in-review transition and the multi-repo home-only closing rule.
 - Before WORKTREE, run the non-blocking probes `ssh-add -l`, `gh auth status`, and `git config --global --get commit.gpgsign`; no result blocks the run.
 - Call the Skill tool with `reviewing-designs` and dispatch its review brief with the artifact directory substituted.
+- Read `references/15-host-dispatch.md` before the first dispatch and resolve every agent through it.
 - Call the Skill tool with `review-severity-tiers` before aggregating IMPLEMENT findings.
 - In multi-repo mode, use `4-repos.md`; see **Multi-repo topics** in the Rules reference.
 - PR changelog bullets accumulate under `## [Unreleased]`.
@@ -65,6 +68,7 @@ Read each reference completely when reaching that stage. Follow them in order; l
 12. [Aggregate Gate (review collection)](references/12-aggregate-gate-review-collection.md)
 13. [Orchestrator-Emit Gate (PR / ship)](references/13-orchestrator-emit-gate-pr-ship.md)
 14. [Rules](references/14-rules.md)
+15. [Host-neutral agent dispatch](references/15-host-dispatch.md)
 
 ## Applied principles
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -11,11 +11,11 @@ Before finalizing prose you author, call the Skill tool with `unslop` and
 `writing-prose`, in that order. Relay completed agent and vendor returns unchanged.
 
 You are the Team orchestrator. The orchestrator is the
-**host's main session itself** — not a sub-agent. You drive a feature
+**main session itself** — not a sub-agent. You drive a feature
 from description to shipped code by walking a linear phase table,
 dispatching specialist agents, and coordinating progress through TodoWrite.
-The pipeline is host-neutral: dispatch each specialist from its portable
-definition at `agents/<name>.md`, per `references/15-host-dispatch.md`.
+Dispatch each specialist from its portable definition at `agents/<name>.md`,
+per `references/15-host-dispatch.md`.
 
 You hold no special state of your own. The durable record is the set of
 artifacts under `docs/plans/<id>/*.md` (each carrying YAML frontmatter

--- a/skills/team/references/03-the-phase-loop.md
+++ b/skills/team/references/03-the-phase-loop.md
@@ -9,7 +9,7 @@ loop:
      includes a `design-review-<n>.md` with a passing verdict). If missing,
      report a desync and suggest re-invoking the same /team-* command.
   4. Dispatch the agent(s) (parallel where the phase table marks them),
-     resolving every dispatch through "Host-neutral agent dispatch"
+     resolving every dispatch through the dispatch contract
      (`references/15-host-dispatch.md`).
      Subagents never pause for user input — each resolves its own open
      questions and records them as assumptions in its artifact.

--- a/skills/team/references/03-the-phase-loop.md
+++ b/skills/team/references/03-the-phase-loop.md
@@ -8,7 +8,9 @@ loop:
   3. Verify predecessor artifacts exist on disk (for STRUCTURE, that
      includes a `design-review-<n>.md` with a passing verdict). If missing,
      report a desync and suggest re-invoking the same /team-* command.
-  4. Dispatch the agent(s) (parallel where the phase table marks them).
+  4. Dispatch the agent(s) (parallel where the phase table marks them),
+     resolving every dispatch through "Host-neutral agent dispatch"
+     (`references/15-host-dispatch.md`).
      Subagents never pause for user input — each resolves its own open
      questions and records them as assumptions in its artifact.
      Dispatch so the agent's result comes back to you **in full**. Some

--- a/skills/team/references/07-orchestrator-emit-gate-leading-worktree.md
+++ b/skills/team/references/07-orchestrator-emit-gate-leading-worktree.md
@@ -39,8 +39,9 @@ clean for the whole run.
    regression in the branch, and reporting it as the latter sends someone
    after a bug that is not there.
 
-1. **Create the home worktree** on branch `<id>` off `origin/HEAD`, with
-   Claude Code's native worktree support. Call the Skill tool with
+1. **Create the home worktree** on branch `<id>` off `origin/HEAD`.
+   Use the host's native worktree support when it offers one, otherwise
+   `git worktree add`. Call the Skill tool with
    `team-worktree` and follow the
    single-repo block under "Create the worktree(s)". Only the
    home repo gets a worktree at this phase. Multi-repo secondary worktrees

--- a/skills/team/references/15-host-dispatch.md
+++ b/skills/team/references/15-host-dispatch.md
@@ -1,0 +1,57 @@
+## Host-neutral agent dispatch
+
+The pipeline is host-neutral. Team ships every specialist as a portable
+definition at `agents/<name>.md`. The YAML frontmatter carries host metadata
+(including Claude Code's optional fields); the body is a complete role prompt.
+To run a phase, dispatch that definition through whatever subagent facility the
+host provides. Read this reference before the first dispatch of a run.
+
+A host runs the full pipeline when it can (a) read a file, (b) spawn a
+subagent, and (c) run a shell command. Every supported host — Claude Code,
+Codex CLI, Antigravity CLI, and OpenCode — qualifies. Resolve every dispatch in
+this order:
+
+1. **Named agent.** If the host resolves Team agents by name (Claude Code
+   registers `team:<name>`), dispatch the named agent. This is preferred: the
+   host applies the definition's tool and permission restrictions directly.
+2. **Body-load subagent.** Otherwise, read `agents/<name>.md`, strip the YAML
+   frontmatter, and spawn a fresh subagent of the host's general-purpose type
+   with the body as its role instructions, plus the same artifact-path payload
+   the named path receives. Preserve the body byte-for-byte; frontmatter is the
+   only part removed. Fresh-context isolation is identical to the named path.
+3. **Inline fallback.** If the host cannot spawn a subagent, run a **producer**
+   agent's body in the orchestrator's own context. Never run a **reviewer**
+   inline: a reviewer sharing the author's context cannot judge it, so the
+   generator/evaluator invariant is unsatisfiable. Stop and report instead
+   (`principle-generator-evaluator`).
+
+Capability mapping for the body-load path:
+
+- **Model tier.** `model:` is a tier key (`opus`, `sonnet`, `haiku`), not a
+  literal model name. Resolve it through the host's tier map when one exists
+  (`.team/config.json` carries the host-neutral map); otherwise use the host's
+  default model and record the substitution in the run report.
+- **Tools.** Grant the subagent only the tools named in the definition's
+  `tools:`. Reviewers receive no `Write` or `Edit` tool and no shell mutation
+  (`principle-least-privilege`, `principle-generator-evaluator`).
+- **Preloaded skills.** Hosts that honor the `skills:` YAML block inject those
+  skill names automatically. On hosts that do not, name the definition's
+  preloaded skill paths in the dispatch payload so the subagent reads them
+  before it acts.
+- **Permission mode.** Map a reviewer's `permissionMode: plan` to the host's
+  read-only mode where one exists; where none exists, the tool grant above is
+  the enforcement, and the orchestrator verifies the subagent holds no mutating
+  tool before dispatch.
+
+Dispatch independent agents concurrently — RESEARCH's pair, IMPLEMENT's five
+reviewers — up to the host's concurrent-subagent cap. Batch the fan-out when it
+exceeds the cap; never serialize reviewers for convenience. Every dispatch must
+return to the orchestrator in full. A host mode that returns only a truncated
+notice and holds the body elsewhere loses a return-only agent's entire output
+(see "Where a phase agent's output lives").
+
+The body-load payload is the same for every phase: the agent body, the
+canonical artifact directory, and the predecessor artifact paths the phase
+table names. The orchestrator never adds the user's original description
+downstream of QUESTION, and never adds the implementer's account of its own
+work to a reviewer's payload.

--- a/skills/team/references/15-host-dispatch.md
+++ b/skills/team/references/15-host-dispatch.md
@@ -1,15 +1,13 @@
-## Host-neutral agent dispatch
+## Agent dispatch
 
-The pipeline is host-neutral. Team ships every specialist as a portable
-definition at `agents/<name>.md`. The YAML frontmatter carries host metadata
-(including Claude Code's optional fields); the body is a complete role prompt.
-To run a phase, dispatch that definition through whatever subagent facility the
-host provides. Read this reference before the first dispatch of a run.
+Team ships every specialist as a portable definition at `agents/<name>.md`.
+The YAML frontmatter carries host metadata (including Claude Code's optional
+fields); the body is a complete role prompt. To run a phase, dispatch that
+definition through the host's subagent facility. Read this reference before the
+first dispatch of a run.
 
-A host runs the full pipeline when it can (a) read a file, (b) spawn a
-subagent, and (c) run a shell command. Every supported host — Claude Code,
-Codex CLI, Antigravity CLI, and OpenCode — qualifies. Resolve every dispatch in
-this order:
+Dispatch needs only that the host can read a file and spawn a subagent.
+Resolve every dispatch in this order:
 
 1. **Named agent.** If the host resolves Team agents by name (Claude Code
    registers `team:<name>`), dispatch the named agent. This is preferred: the

--- a/skills/worktree-isolation/references/lifecycle.md
+++ b/skills/worktree-isolation/references/lifecycle.md
@@ -19,7 +19,8 @@ is at the **router level** — not per-agent. This means:
 
 When `docs/plans/<id>/4-repos.md` is **absent**, the topic touches only the
 home repo (the repo the user invoked `/team` from). The router creates
-exactly one worktree using Claude Code's native worktree support:
+exactly one worktree on branch `<id>` off `origin/HEAD`, using the host's
+native worktree support when it offers one and `git worktree add` otherwise:
 
 - Worktree path: `<repo>/.claude/worktrees/<id>`
 - Branch: `<id>`, branched from the default remote branch (`origin/HEAD`)
@@ -52,14 +53,14 @@ After all worktrees are created, the orchestrator appends a `## Worktrees`
 section to `4-repos.md` recording the per-repo worktree paths. Any later
 `/team-*` invocation rediscovers them by reading that one file.
 
-## Claude Code Native Worktrees
+## Worktree creation
 
-For the home repo, Claude Code has built-in worktree support (`--worktree
-<topic>` or dispatch into a worktree context). For more repos in
-multi-repo mode, the router uses plain `git worktree add` because Claude
-Code's native flag only knows about the repo it was launched from. Either
-mechanism produces a standard git worktree — there is no behavioral
-difference downstream.
+For the home repo, use the host's native worktree support when it offers one
+(Claude Code's `--worktree <topic>` or dispatch into a worktree context). For
+more repos in multi-repo mode, the router uses plain `git worktree add` because
+a native flag only knows about the repo the session was launched from. Either
+mechanism produces a standard git worktree — there is no behavioral difference
+downstream.
 
 ## Lifecycle
 
@@ -143,7 +144,7 @@ When teardown is warranted (post-merge or on explicit request):
 
 1. For each worktree with commits ahead of its base branch, cherry-pick
    or rebase those commits onto the target branch in that repo. Then let
-   Claude Code, or `git worktree remove`, remove the worktree.
+   the host remove the worktree, or run `git worktree remove`.
 2. Empty worktrees clean up automatically.
 3. If manual cleanup is needed: `git -C <repo-path> worktree remove
    <worktree-path>` and `git -C <repo-path> branch -D <id>`.

--- a/tests/host-neutral-dispatch.test.ts
+++ b/tests/host-neutral-dispatch.test.ts
@@ -1,11 +1,10 @@
 // tests/host-neutral-dispatch.test.ts
 //
-// L2 tripwire (free, deterministic): Team's pipeline privileges no host. The
-// orchestrator resolves every dispatch through the portable contract in
-// skills/team/references/15-host-dispatch.md, and no host-facing surface may
-// claim the pipeline needs Claude Code. The negative sweep uses a named
-// matcher so it can be pointed at a known positive — a clean sweep has not
-// distinguished absent from blind (docs/testing.md).
+// L2 tripwire (free, deterministic): the orchestrator resolves every dispatch
+// through the portable contract in skills/team/references/15-host-dispatch.md,
+// and no host-facing surface may claim the pipeline needs Claude Code. The
+// negative sweep uses a named matcher so it can be pointed at a known positive
+// — a clean sweep has not distinguished absent from blind (docs/testing.md).
 //
 // Defensive reads: a missing file → "" so content assertions FAIL cleanly
 // rather than throwing ENOENT (the mechanical gate rejects crashes).
@@ -40,7 +39,7 @@ function readIf(path: string): string {
   return existsSync(path) ? read(path) : "";
 }
 
-describe("host-neutral dispatch", () => {
+describe("agent dispatch", () => {
   test("the portable dispatch contract exists and states the resolution order", () => {
     const body = squash(readIf(DISPATCH));
     // Guard: a missing contract must fail, not vacuously pass.
@@ -60,7 +59,7 @@ describe("host-neutral dispatch", () => {
   test("the phase loop resolves dispatch through the contract", () => {
     const loop = readIf(PHASE_LOOP);
     expect(loop.length).toBeGreaterThan(0);
-    expect(loop).toContain("Host-neutral agent dispatch");
+    expect(loop).toContain("dispatch contract");
     expect(loop).toContain("references/15-host-dispatch.md");
   });
 

--- a/tests/host-neutral-dispatch.test.ts
+++ b/tests/host-neutral-dispatch.test.ts
@@ -1,0 +1,81 @@
+// tests/host-neutral-dispatch.test.ts
+//
+// L2 tripwire (free, deterministic): Team's pipeline privileges no host. The
+// orchestrator resolves every dispatch through the portable contract in
+// skills/team/references/15-host-dispatch.md, and no host-facing surface may
+// claim the pipeline needs Claude Code. The negative sweep uses a named
+// matcher so it can be pointed at a known positive — a clean sweep has not
+// distinguished absent from blind (docs/testing.md).
+//
+// Defensive reads: a missing file → "" so content assertions FAIL cleanly
+// rather than throwing ENOENT (the mechanical gate rejects crashes).
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { read, squash } from "./helpers/text";
+
+const REPO_ROOT = process.cwd();
+const DISPATCH = join(REPO_ROOT, "skills", "team", "references", "15-host-dispatch.md");
+const TEAM_SKILL = join(REPO_ROOT, "skills", "team", "SKILL.md");
+const PHASE_LOOP = join(REPO_ROOT, "skills", "team", "references", "03-the-phase-loop.md");
+
+// The banned claim, as a matcher the positive-control test can fire.
+const CLAUDE_ONLY =
+  /full pipeline needs Claude Code|host that dispatches the agents|cannot dispatch Claude Code agents/i;
+
+// Every surface a user or developer reads to learn what the pipeline needs.
+const HOST_FACING = [
+  "README.md",
+  "AGENTS.md",
+  "docs/index.md",
+  "docs/architecture.md",
+  "docs/cross-host-portability.md",
+  ".codex-plugin/plugin.json",
+  "plugin.json",
+];
+
+function readIf(path: string): string {
+  return existsSync(path) ? read(path) : "";
+}
+
+describe("host-neutral dispatch", () => {
+  test("the portable dispatch contract exists and states the resolution order", () => {
+    const body = squash(readIf(DISPATCH));
+    // Guard: a missing contract must fail, not vacuously pass.
+    expect(body.length).toBeGreaterThan(0);
+    expect(body).toContain("agents/<name>.md");
+    expect(body).toContain("Named agent");
+    expect(body).toContain("Body-load subagent");
+    expect(body).toContain("Inline fallback");
+  });
+
+  test("the orchestrator loads the contract", () => {
+    const skill = readIf(TEAM_SKILL);
+    expect(skill.length).toBeGreaterThan(0);
+    expect(skill).toContain("references/15-host-dispatch.md");
+  });
+
+  test("the phase loop resolves dispatch through the contract", () => {
+    const loop = readIf(PHASE_LOOP);
+    expect(loop.length).toBeGreaterThan(0);
+    expect(loop).toContain("Host-neutral agent dispatch");
+    expect(loop).toContain("references/15-host-dispatch.md");
+  });
+
+  test("no host-facing surface claims the pipeline needs Claude Code", () => {
+    for (const rel of HOST_FACING) {
+      const text = readIf(join(REPO_ROOT, rel));
+      // Guard: a missing surface must fail, not vacuously pass the absence check.
+      expect(text.length).toBeGreaterThan(0);
+      expect(CLAUDE_ONLY.test(text)).toBe(false);
+    }
+  });
+
+  test("the banned-claim matcher can see a positive", () => {
+    const sample =
+      "The full pipeline needs Claude Code, because that is the host that dispatches the agents.";
+    expect(CLAUDE_ONLY.test(sample)).toBe(true);
+  });
+});

--- a/tests/reflect-skill.test.ts
+++ b/tests/reflect-skill.test.ts
@@ -1177,11 +1177,10 @@ describe("Slice 1 — L2: reflect's three reporting lenses", () => {
 
   test("the inline fallback is a named reduced-assurance mode on every surface", () => {
     // The toolset guarantee belongs to the dispatch path alone: the fallback
-    // runs in a session holding Bash and Write, so it cannot inherit it. On
-    // Codex and Antigravity, which install the skill but cannot dispatch Claude
-    // Code agents, the fallback is the only path — so the degradation is named
-    // where the model meets it and in the run's own report. Drift tripwire:
-    // both surfaces or neither.
+    // runs in a session holding Bash and Write, so it cannot inherit it. Where
+    // a host cannot spawn a subagent, the fallback is the only path — so the
+    // degradation is named where the model meets it and in the run's own
+    // report. Drift tripwire: both surfaces or neither.
     const lenses = flat(section(LENSES));
     const completion = flat(body());
     expect(lenses.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

The orchestrator dispatched each specialist only through Claude Code's named-agent registry, so a Codex or Antigravity session loaded the `/team-*` commands but could not run a phase. This makes dispatch work on any host that can spawn a subagent. Running on those hosts is expected behavior, not a compatibility feature, so the docs do not advertise it.

## How dispatch resolves

`skills/team/references/15-host-dispatch.md`:

1. **Named agent** — where the host registers Team agents by name (Claude Code), dispatch the named agent so the host applies the definition's tool and permission restrictions.
2. **Body-load subagent** — otherwise, read the specialist's portable `agents/<name>.md`, strip the YAML frontmatter, and spawn a fresh subagent with the body as its role instructions. No host-side agent registration is required.
3. **Inline fallback** — producers only. A reviewer never runs inline, because a reviewer sharing the author's context cannot judge it.

The contract also maps model tier, tool grants, `skills:` preloads, and the parallel fan-out. Worktree setup uses the host's native support where one exists and `git worktree add` otherwise.

## Changes

- Dispatch contract + wiring (`15-host-dispatch.md`, `skills/team/SKILL.md`, `references/03-the-phase-loop.md`).
- Host-neutral WORKTREE phase: `07-...worktree.md`, `worktree-isolation/lifecycle.md`, `team-worktree/04-execution.md`, `team-implement/02-worktree-check.md`, `principle-progress-tracking`.
- Removed the Claude-only limitation from `README.md`, `docs/index.md`, `AGENTS.md`, `.codex-plugin/plugin.json`, `docs/cross-host-portability.md`, `skills/reflect/references/04-the-lenses.md` — without replacing it with a compatibility callout.
- Tripwire `tests/host-neutral-dispatch.test.ts` pins the contract, the orchestrator wiring, and the absence of the Claude-only claim (with a positive control).

## Verification

- `bun test` → **2445 pass, 0 fail** (75 files).
- `claude plugin validate .` → passes.
- Commits are SSH-signed.

Not run here: `bun run typecheck` (no `node_modules`/`bun-types` installed) and a live Codex/Antigravity end-to-end probe.

## Land-time note

Runtime change (`skills/`) — carries no version in this PR. The `[Unreleased]` changelog bullet is in place; versioning happens at land time.