### PR TITLE
v0.103.0 feat(opencode): Add native installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-    "version": "0.102.0"
+    "version": "0.103.0"
   },
   "plugins": [
     {
       "name": "team",
       "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
-      "version": "0.102.0",
+      "version": "0.103.0",
       "source": "./",
       "author": {
         "name": "Matthew Boston",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/.github/scripts/version-bump-required.sh
+++ b/.github/scripts/version-bump-required.sh
@@ -26,7 +26,7 @@
 # PR lands, at which point the pre-merge guard denies the merge (PR #208).
 #
 # "Runtime" is the Runtime-vs-Development split in CLAUDE.md: the distributed
-# plugin is agents/, skills/, hooks/, and .claude-plugin/ *content*. A change
+# plugin is agents/, skills/, hooks/, opencode/, and host manifest content. A change
 # under .claude-plugin/ counts as runtime only when a non-version line changed —
 # the bump itself edits the `"version"` field in plugin.json + marketplace.json,
 # and that edit must not be mistaken for a content change (else every bump would
@@ -53,7 +53,7 @@ SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
 PLUGIN_JSON='.claude-plugin/plugin.json'
 
 # Distributed-plugin directories whose ANY change is a runtime change.
-RUNTIME_DIRS=(agents skills hooks)
+RUNTIME_DIRS=(agents skills hooks opencode)
 
 # Host manifest directories. Each host reads its own: Claude Code takes
 # .claude-plugin/, Codex prefers .codex-plugin/ and .agents/plugins/ over it.
@@ -99,7 +99,7 @@ changed_files=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA") \
   || die "could not diff merge-base..head"
 
 runtime_changed=false
-# agents/, skills/, hooks/ — any touched file is a runtime change.
+# agents/, skills/, hooks/, opencode/ — any touched file is a runtime change.
 if grep -qE "^($(IFS='|'; echo "${RUNTIME_DIRS[*]}"))/" <<<"$changed_files"; then
   runtime_changed=true
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,13 @@ Team is a plugin that orchestrates specialized agents to implement features end-
 
 This project produces a **distributed plugin**. Two contexts exist:
 
-**Runtime** (`agents/`, `skills/`, `hooks/`, and the host manifests `.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, and the root `plugin.json`) ships to end users. Fires when someone installs the Team plugin and runs `/team`. Changes here affect all users.
+**Runtime** (`agents/`, `skills/`, `hooks/`, `opencode/`, and the host manifests `.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/`, and the root `plugin.json`) ships to end users. Fires when someone installs the Team plugin and runs `/team`. Changes here affect all users.
 
 **Development** (`.claude/`) is our workspace tooling. Fires only when developing the plugin itself. Never distributed.
 
 | Concern | Where it lives | Who runs it |
 |---------|---------------|-------------|
-| Pipeline agents, skills, hooks | `agents/`, `skills/`, `hooks/` | End users |
+| Pipeline agents, skills, hooks, OpenCode adapter | `agents/`, `skills/`, `hooks/`, `opencode/` | End users |
 | Plugin manifests | `.claude-plugin/` (Claude Code), `.codex-plugin/` + `.agents/plugins/` (Codex), root `plugin.json` (Antigravity) | End users |
 | Registry sync validation | `.claude/hooks/check-registry-sync.mjs` | Plugin developers |
 | Pre-merge version gate | `.claude/hooks/pre-merge-guard.mjs` | Plugin developers |
@@ -29,7 +29,7 @@ This project produces a **distributed plugin**. Two contexts exist:
 | Work tracking | [GitHub Project board](https://github.com/users/bostonaholic/projects/5/views/1) | Plugin developers |
 | Behavioral regression harness | `tests/`, `evals/` | Plugin developers |
 | Versioning & release automation | [docs/versioning.md](docs/versioning.md), `.claude/skills/version-bump/`, `.claude/scripts/next-version.sh`, `.github/workflows/` | Plugin developers |
-| Dev install, per harness | `script/dev-install`/`dev-uninstall` (dispatch), `dev-install-<harness>` | Plugin developers |
+| Dev install, per harness | `script/dev-install`/`dev-uninstall` (Claude, Codex, Antigravity, OpenCode); [OpenCode lifecycle](docs/cross-host-portability.md#opencode) | Plugin developers |
 
 **Rule of thumb:** If it validates that the plugin is *built correctly*, it is a dev concern (`.claude/`). If it runs *as part of the plugin's functionality*, it is runtime (`hooks/`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.103.0] - 2026-09-10
+
 ### Added
 
 - **Native OpenCode installation from a live Team checkout.** `script/dev-install opencode` registers canonical skills and file-reading commands; `script/dev-uninstall opencode` removes only that checkout's link. Aggregate lifecycle commands include OpenCode. Registration preserves native configuration and credentials. Full pipeline execution, reviewer isolation, and hooks remain unverified; OpenCode session `/reflect` is unsupported.
@@ -911,7 +913,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced the earlier 6-phase RPI workflow with the 8-phase QRSPI pipeline.
 
-[Unreleased]: https://github.com/bostonaholic/team/compare/v0.102.0...HEAD
+[Unreleased]: https://github.com/bostonaholic/team/compare/v0.103.0...HEAD
+[0.103.0]: https://github.com/bostonaholic/team/compare/v0.102.0...v0.103.0
 [0.102.0]: https://github.com/bostonaholic/team/compare/v0.101.0...v0.102.0
 [0.101.0]: https://github.com/bostonaholic/team/compare/v0.100.0...v0.101.0
 [0.100.0]: https://github.com/bostonaholic/team/compare/v0.99.0...v0.100.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Native OpenCode installation from a live Team checkout.** `script/dev-install opencode` registers canonical skills and file-reading commands; `script/dev-uninstall opencode` removes only that checkout's link. Aggregate lifecycle commands include OpenCode. Registration preserves native configuration and credentials. Full pipeline execution, reviewer isolation, and hooks remain unverified; OpenCode session `/reflect` is unsupported.
+
 ## [0.102.0] - 2026-09-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 Team is a plugin that orchestrates specialized agents to autonomously implement entire features end-to-end, driven by the **QRSPI** workflow. The orchestrator is the main session. It persists pipeline state as artifacts in `docs/plans/` and tracks live progress with TodoWrite.
 
-Team installs on Claude Code, on Codex CLI, and on Antigravity CLI.
+Team installs on Claude Code, Codex CLI, Antigravity CLI, and OpenCode. The full pipeline runs on Claude Code, Codex CLI, and Antigravity CLI. OpenCode support covers skill/command discovery and installation. Execution limits are listed beside setup.
 
 **Documentation:** [team.bostonaholic.dev](https://team.bostonaholic.dev)
 
 ## Install
 
-Team ships a native manifest for each host, so one repo installs on all three
-from a local checkout. Pick yours.
+Team installs from one local checkout using each host's native plugin mechanism. Pick yours.
 
 <details>
 <summary><strong>Claude Code</strong></summary>
@@ -140,6 +139,56 @@ Developing Team itself? The install copies, so link your checkout instead:
 script/dev-install antigravity
 script/dev-uninstall antigravity
 ```
+
+</details>
+
+<details>
+<summary><strong>OpenCode</strong></summary>
+
+Requires **Node.js** for registration/removal and **OpenCode** for use. From a
+local Team checkout or linked Git worktree:
+
+```bash
+script/dev-install opencode
+script/dev-uninstall opencode
+```
+
+Or use `dev install opencode` / `dev uninstall opencode`. With no host argument,
+`script/dev-install` and `script/dev-uninstall` attempt every supported host;
+`dev install` and `dev uninstall` dispatch the same way.
+
+Registration links `plugins/team.js` to that checkout's `opencode/team.js`.
+The config directory is nonempty `OPENCODE_CONFIG_DIR`, otherwise
+`${XDG_CONFIG_HOME:-$HOME/.config}/opencode`. Relative overrides resolve against
+where you run the command. Spaces and Unicode work. Team rejects canonical
+checkout and skill paths containing `$`, backticks, or `@` because OpenCode
+interprets those characters in command templates. Relocate such a checkout before installing.
+
+Restart OpenCode after installation, removal, or checkout edits. New processes
+read current canonical skills without reinstalling or copying them. Keep the
+checkout available. Install success means **registered**, not that your native
+configuration parsed or the plugin loaded. Registration neither reads nor rewrites
+OpenCode JSON/JSONC, credentials, or other plugins. Native configuration errors
+surface when OpenCode starts.
+
+Reinstalling from the same checkout succeeds. Another checkout's link, a regular
+file, or a directory at the target causes refusal. Uninstall from the owning
+checkout before switching. Uninstall removes only the matching link, even if its
+runtime target is now missing. It retains config/plugin parent directories. Run
+removal before deleting the entire checkout, because removal needs its lifecycle
+scripts.
+
+A busy or stale `plugins/team.js.lock` stops either operation. Confirm no
+install/uninstall process remains, then manually remove that empty lock directory
+with `rmdir` and rerun. Team never breaks locks automatically.
+
+**Supported:** native registration, skill discovery, canonical file-reading
+commands, and this lifecycle. Full QRSPI execution, specialist/nested dispatch,
+reviewer isolation, and hook behavior on OpenCode remain unverified. `/reflect`
+appears in the command menu but OpenCode session reflection is unsupported.
+Methodology skills marked `user-invocable: false` also appear as commands.
+See [OpenCode support](docs/cross-host-portability.md#opencode) for command permissions, native argument preprocessing,
+external skill sources, and discovery diagnostics.
 
 </details>
 

--- a/dev.yml
+++ b/dev.yml
@@ -23,6 +23,7 @@ commands:
       claude: "script/dev-install claude"
       codex: "script/dev-install codex"
       antigravity: "script/dev-install antigravity"
+      opencode: "script/dev-install opencode"
   uninstall:
     run: "script/dev-uninstall"
     desc: "Uninstall this checkout from every supported harness"
@@ -30,6 +31,7 @@ commands:
       claude: "script/dev-uninstall claude"
       codex: "script/dev-uninstall codex"
       antigravity: "script/dev-uninstall antigravity"
+      opencode: "script/dev-uninstall opencode"
   docs:
     desc: "Build and serve the docs site locally at http://localhost:4000"
     run: "cd docs && bundle config set --local path 'vendor/bundle' && bundle install && bundle exec jekyll serve --livereload"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,7 @@ nav_label: architecture
 - [4. Agent roster](#4-agent-roster)
 - [5. Phase-table orchestrator](#5-phase-table-orchestrator)
 - [6. Skills](#6-skills)
+- [OpenCode adapter](#opencode-adapter)
 - [7. Hooks](#7-hooks)
 - [8. Behavioral evals](#8-behavioral-evals)
 - [9. State management](#9-state-management)
@@ -934,6 +935,51 @@ directions.
 `short_description` has no mechanical derivation. The creation guide requires
 updating `agents/openai.yaml` whenever `description:` changes; the manifest gate
 checks its shape and length.
+
+## OpenCode adapter
+
+Distributed `opencode/team.js` exports only the native plugin function. It resolves
+its real checkout and imports `opencode/catalog.mjs`, the same catalog validator
+used by `script/dev-opencode.mjs`. The Bash lifecycle entry scripts require Node.
+`script/dev-install`/`dev-uninstall` and `dev.yml` route the OpenCode target to them.
+`opencode/` counts as distributed runtime for land-time versioning.
+
+The catalog enumerates immediate real skill directories in stable order, reads
+each header once, and walks each tree once without following links. It rejects
+nested skill files, symlinks, invalid/ambiguous consumed frontmatter, duplicate
+names, empty catalogs, and canonical template-marker paths. References and
+scripts remain canonical files. Install validates before registration; plugin
+initialization validates before returning config contributions. Existing command
+collisions and invalid consumed config types fail before any config mutation.
+
+All skills receive native configured commands containing canonical file/base
+pointers and `$ARGUMENTS`, without embedded bodies, model overrides, or agent
+overrides. This includes methodology skills marked `user-invocable: false`.
+Frontmatter `disable-model-invocation: true` excludes only Team's added native
+skill paths. Those skills still have explicit commands. Existing external skill
+sources may expose their own guarded copies or resolve duplicate names to other
+files. Team commands retain canonical pointers, but later plugins/MCP can collide.
+
+Command-file reads use native `read` and `external_directory` permission. Unguarded
+cached skill loading uses `skill` permission. `read: deny` does not block that
+route. Supplied arguments retain native preprocessing, including shell syntax
+such as `` !`printf example` `` that can run before a model call, outside
+model-tool rules including `bash: deny`. File pointers preserve body text. They
+do not make arguments inert. See [OpenCode support](cross-host-portability.md#opencode)
+for usage and resolved-skill versus command-template diagnostics.
+
+Lifecycle operations canonicalize the existing plugin parent, acquire its atomic
+`team.js.lock` directory, then inspect/change only the exact-owned symlink. They
+release only their acquired empty lock, refuse busy/stale locks, preserve config
+and credentials without reading them, and never invoke OpenCode. Install success
+means registered. Native config loading remains separate. New host processes read
+live checkout edits. Concurrent checkout edits or external replacement without
+the lifecycle lock are unsupported.
+
+This adapter establishes discovery and lifecycle support. Full QRSPI execution,
+specialist/nested dispatch, reviewer isolation, and hooks on OpenCode remain
+unverified. `/reflect` stays guarded and discoverable but cannot process OpenCode
+sessions because its mandatory transcript resolver supports Claude Code/Codex.
 
 ## 7. Hooks
 

--- a/docs/cross-host-portability.md
+++ b/docs/cross-host-portability.md
@@ -1,6 +1,6 @@
 ---
 title: Cross-host portability
-description: "A capability matrix mapping Team's Claude Code plugin primitives onto the other hosts it runs on — Codex CLI and Antigravity CLI — and the portability strategy chosen for them."
+description: "A capability matrix mapping Team's Claude Code plugin primitives onto the other hosts it runs on — Codex CLI, Antigravity CLI, and OpenCode — and their supported capabilities."
 audience: [developer]
 nav_order: 9
 nav_label: portability
@@ -40,6 +40,7 @@ nav_label: portability
 - [Decisions made](#decisions-made)
 - [What #57 builds against](#what-57-builds-against)
 - [Antigravity CLI](#antigravity-cli)
+- [OpenCode](#opencode)
 - [Out of scope](#out-of-scope)
 - [Edge cases](#edge-cases)
 - [Open questions (deferred to the port epic)](#open-questions-deferred-to-the-port-epic)
@@ -546,6 +547,90 @@ definition and dispatches it through the host's subagent facility (see
 remain unported on this host. That work stays with
 [#56](https://github.com/bostonaholic/team/issues/56).
 
+## OpenCode
+
+OpenCode loads the native `opencode/team.js` plugin through one symlink in its
+configuration directory. `script/dev-install opencode` and
+`script/dev-uninstall opencode` manage that exact-owned registration; see
+[installation](index.md#opencode) for prerequisites, overrides, restart, worktrees,
+conflicts, dangling targets, and lock recovery. Installation validates the
+checkout without reading user JSON/JSONC or invoking OpenCode. Its success says
+registered. Malformed native configuration can still prevent loading afterward.
+
+`opencode/catalog.mjs` owns catalog validation for both installation and plugin
+initialization. The entry resolves its real file before importing the helper, so
+checkout aliases and linked worktrees resolve to canonical file/base paths.
+Each immediate real skill directory contributes one regular `SKILL.md`. The
+validator walks its tree once without following symlinks. It rejects linked
+entries, nested `SKILL.md`, duplicate names, ambiguous consumed frontmatter, and
+empty catalogs. Ordinary references and scripts stay available. Headers are read
+once. Bodies stay on disk. Canonical paths containing `$`, backticks, or `@` are
+rejected before registration or config contribution. Spaces and Unicode are
+supported. Existing command collisions or wrong consumed config types reject the
+whole contribution before paths or commands change.
+
+Every skill gets a native configured command with its description and a quoted
+absolute file/base pointer. The template declares explicit invocation, requests
+a filesystem read, resolves relative references against the canonical base, and
+supplies `$ARGUMENTS`. It embeds no skill body and sets no model or agent override.
+This preserves literal shell examples and argument references inside canonical
+skill content. Even `user-invocable: false` methodology skills appear in the
+command menu. Commands include `/reflect`, whose description states that OpenCode
+session reflection is unsupported: its transcript resolver supports Claude Code
+and Codex only.
+
+`disable-model-invocation: true` excludes a directory from **Team's added
+`skills.paths` only**. Other paths retain their order and exact duplicates are
+removed. Team does not rewrite user-owned skill sources. An external source can
+expose its own guarded copies or win resolution of a duplicate skill name.
+Inspect the resolved skill's location separately from the command template:
+Team's configured commands retain canonical pointers despite duplicate skill
+sources. Later plugins or MCP commands can still collide; the initialization
+collision check cannot guarantee ownership after other contributors run.
+
+### Command permissions and preprocessing
+
+A Team command requests a filesystem read subject to native `read` and
+`external_directory` rules. An unguarded skill-tool call instead uses `skill`
+permission and returns content cached by native discovery. `read: deny` does
+**not** deny that cached route. Guarded skills remain available as explicit
+command-file read requests. Team leaves existing `read`, `external_directory`,
+`skill`, and `bash` rules unchanged and adds no permission overrides.
+
+OpenCode preprocesses supplied command arguments. For example, the native syntax
+below can run `printf` before any model call:
+
+```text
+/team-question !`printf example`
+```
+
+This shell substitution runs outside model-tool permission checks, including
+`bash: deny`. Native file references and placeholders also retain their native
+argument behavior. Canonical file pointers protect skill **body text**, not
+untrusted arguments. Team adds no argument escaping or expansion adapter.
+
+### Lifecycle and support limits
+
+The shared Node lifecycle helper creates the plugin parent only for installation,
+canonicalizes it, then atomically acquires `plugins/team.js.lock` before inspecting
+or changing the target. Config aliases therefore share a lock. Matching absolute
+symlinks converge on reinstall/removal, including a missing runtime target on
+uninstall. Foreign links and non-link targets fail unchanged. Cleanup removes only
+the acquired empty lock. A busy/stale lock requires manual recovery after checking
+no lifecycle process remains. Config, credentials, other plugins, and existing
+parents remain untouched.
+
+Concurrent checkout edits during catalog loading and external programs replacing
+files without the lifecycle lock are unsupported. A new OpenCode process reads
+current checkout content. No generated catalog, cache copy, provider call, or
+persistent Team process is introduced.
+
+Native discovery was observed on OpenCode 1.18.20. Support covers registration,
+skill/command discovery, and the developer lifecycle. Full QRSPI execution,
+specialist/nested-agent dispatch, translated reviewer permissions, and runtime
+hooks remain unverified. No provider, credentials, model-tier translation, or
+model-quality guarantee is installed. `/reflect` cannot process OpenCode sessions.
+
 ## Out of scope
 
 - **Writing any of the port code.** #56 and #57 own the implementation. This is
@@ -556,10 +641,9 @@ remain unported on this host. That work stays with
   `.github/`), which is never distributed and never ported.
 - **Adopting MCP as a transport.** Documented as fallback only (decision 4).
 - **Reduced-MVP parity.** Explicitly rejected: full parity is the target.
-- **A fourth host.** Claude Code, Codex CLI, and Antigravity CLI are the three
-  this study covers. Only the first two are scored in the matrix; Antigravity
-  has its own section instead, because what is known about it covers one version
-  rather than every primitive.
+- **Full OpenCode parity.** Its native installation/discovery adapter is covered
+  separately above; the pipeline portability matrix does not certify OpenCode
+  execution, agent permissions, or hooks.
 - **Guaranteeing host API stability.** The young-API recency risk is surfaced and
   assigned to the shim layer plus version pinning, not eliminated.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,8 +68,10 @@ company-significant work from problem definition through measured outcomes.
 
 ## Install
 
-Team ships a native manifest for each host, so one repo installs on all three
-from a local checkout. Pick yours.
+Team installs from one local checkout using each host's native plugin mechanism.
+The full pipeline runs on Claude Code, Codex CLI, and Antigravity CLI. OpenCode
+support covers native skill/command discovery and installation. Execution limits
+are listed beside setup. Pick yours.
 
 ### Claude Code
 
@@ -203,6 +205,53 @@ Developing Team itself? The install copies, so link your checkout instead:
 script/dev-install antigravity
 script/dev-uninstall antigravity
 ```
+
+### OpenCode
+
+Requires **Node.js** for registration/removal and **OpenCode** for use. From a
+local Team checkout or linked Git worktree:
+
+```bash
+script/dev-install opencode
+script/dev-uninstall opencode
+```
+
+Or use `dev install opencode` / `dev uninstall opencode`. With no host argument,
+`script/dev-install` and `script/dev-uninstall` attempt every supported host;
+`dev install` and `dev uninstall` dispatch the same way.
+
+Registration links `plugins/team.js` to that checkout's `opencode/team.js`.
+The config directory is nonempty `OPENCODE_CONFIG_DIR`, otherwise
+`${XDG_CONFIG_HOME:-$HOME/.config}/opencode`. Relative overrides resolve against
+where you run the command. Spaces and Unicode work. Team rejects canonical
+checkout and skill paths containing `$`, backticks, or `@` because OpenCode
+interprets those characters in command templates. Relocate such a checkout before installing.
+
+Restart OpenCode after installation, removal, or checkout edits. New processes
+read current canonical skills without reinstalling or copying them. Keep the
+checkout available. Install success means **registered**, not that your native
+configuration parsed or the plugin loaded. Registration neither reads nor rewrites
+OpenCode JSON/JSONC, credentials, or other plugins. Native configuration errors
+surface when OpenCode starts.
+
+Reinstalling from the same checkout succeeds. Another checkout's link, a regular
+file, or a directory at the target causes refusal. Uninstall from the owning
+checkout before switching. Uninstall removes only the matching link, even if its
+runtime target is now missing. It retains config/plugin parent directories. Run
+removal before deleting the entire checkout, because removal needs its lifecycle
+scripts.
+
+A busy or stale `plugins/team.js.lock` stops either operation. Confirm no
+install/uninstall process remains, then manually remove that empty lock directory
+with `rmdir` and rerun. Team never breaks locks automatically.
+
+**Supported:** native registration, skill discovery, canonical file-reading
+commands, and this lifecycle. Full QRSPI execution, specialist/nested dispatch,
+reviewer isolation, and hook behavior on OpenCode remain unverified. `/reflect`
+appears in the command menu but OpenCode session reflection is unsupported.
+Methodology skills marked `user-invocable: false` also appear as commands.
+See [OpenCode support](cross-host-portability.md#opencode) for command permissions, native argument preprocessing,
+external skill sources, and discovery diagnostics.
 
 ## Read next
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -65,8 +65,8 @@ someone recomputes it. This is what happened on PR #208, which opened as
 
 The version, changelog, and release exist for **plugin end users**, so a bump is
 warranted **only when a PR changes the distributed plugin**: `agents/`,
-`skills/`, `hooks/`, or host manifest *content* — `.claude-plugin/`,
-`.codex-plugin/`, `.agents/plugins/` — (the
+`skills/`, `hooks/`, `opencode/`, or host manifest *content* — `.claude-plugin/`,
+`.codex-plugin/`, `.agents/plugins/`, root `plugin.json` — (the
 [Runtime vs. development](../AGENTS.md) split). Contributor-facing and
 plugin-developer infrastructure (`.github/`, `.claude/`, `docs/`, `tests/`,
 `evals/`, and build tooling) **never bumps**, whatever its conventional-commit

--- a/opencode/catalog.mjs
+++ b/opencode/catalog.mjs
@@ -1,0 +1,112 @@
+import { lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+
+function safePath(path) {
+  const marker = path.match(/[$`@]/)?.[0];
+  if (marker) {
+    throw new Error(`Unsupported character ${JSON.stringify(marker)} in ${path}. Relocate the checkout to a path without $, backticks, or @.`);
+  }
+}
+
+function requireType(path, type) {
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !(type === "directory" ? stat.isDirectory() : stat.isFile())) {
+    throw new Error(`Expected a real ${type}, not a link or other file type: ${path}`);
+  }
+}
+
+function stringScalar(value, fail) {
+  let decoded;
+  if (value.startsWith("'")) {
+    if (!/^'(?:[^']|'')*'$/.test(value)) fail("invalid single-quoted string");
+    decoded = value.slice(1, -1).replaceAll("''", "'");
+  } else if (value.startsWith('"')) {
+    try { decoded = JSON.parse(value); }
+    catch { fail("invalid double-quoted string"); }
+  } else {
+    if (!value || /^[\[\]{}|>&*!?#%@`]/.test(value) || /^-(?:\s|$)|:(?:\s|$)|\s#/.test(value) ||
+        /^(?:null|true|false|yes|no|on|off|~|[-+]?\d.*|[-+]?\.(?:\d.*|inf|nan))$/i.test(value)) {
+      fail("expected a plain or quoted string; unsupported scalar form");
+    }
+    decoded = value;
+  }
+  if (typeof decoded !== "string" || !decoded.trim()) fail("expected a nonempty string");
+  return decoded;
+}
+
+function header(source, file) {
+  const lines = source.split(/\r?\n/);
+  const fail = (message) => { throw new Error(`Invalid frontmatter in ${file}: ${message}`); };
+  if (lines[0] !== "---") fail("missing opening ---");
+  const end = lines.indexOf("---", 1);
+  if (end < 0) fail("missing closing ---");
+  const values = new Map();
+  const consumed = /^(name|description|disable-model-invocation):\s*(.*)$/;
+  let previousConsumed = false;
+  for (const line of lines.slice(1, end)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    if (previousConsumed && /^\s/.test(line)) fail("multiline consumed fields are unsupported");
+    const match = line.match(consumed);
+    previousConsumed = Boolean(match);
+    if (!match) {
+      if (/^\s*(?:['"]?(?:name|description|disable-model-invocation)['"]?\s*:|<<\s*:)/.test(line) ||
+          !/^\s*[\w-]+\s*:|^\s+\S/.test(line)) {
+        fail(`unsupported or ambiguous field: ${line}`);
+      }
+      continue;
+    }
+    const [, key, raw] = match;
+    if (values.has(key)) fail(`duplicate ${key}`);
+    const value = raw.trim();
+    if (key === "disable-model-invocation") {
+      if (value !== "true" && value !== "false") fail(`${key} must be an unquoted boolean`);
+      values.set(key, value === "true");
+    } else {
+      values.set(key, stringScalar(value, (message) => fail(`${key}: ${message}`)));
+    }
+  }
+  for (const key of ["name", "description"]) {
+    if (!values.has(key)) fail(`missing ${key}`);
+  }
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(values.get("name"))) fail("invalid skill name");
+  return { name: values.get("name"), description: values.get("description"), guarded: values.get("disable-model-invocation") === true };
+}
+
+function inspectTree(directory, base) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isSymbolicLink()) throw new Error(`Symlinks are unsupported in skill trees: ${path}`);
+    if (entry.name === "SKILL.md" && directory !== base) {
+      throw new Error(`Nested SKILL.md would expose an unintended native skill: ${path}`);
+    }
+    if (entry.isDirectory()) inspectTree(path, base);
+  }
+}
+
+export function loadCatalog(root) {
+  const checkout = realpathSync(root);
+  safePath(checkout);
+  for (const file of ["team.js", "catalog.mjs"]) requireType(join(checkout, "opencode", file), "file");
+  const skills = join(checkout, "skills");
+  requireType(skills, "directory");
+  const catalog = [];
+  const names = new Map();
+  for (const entry of readdirSync(skills, { withFileTypes: true }).sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0)) {
+    const base = join(skills, entry.name);
+    if (entry.isSymbolicLink()) throw new Error(`Symlinks are unsupported in the skills root: ${base}`);
+    if (!entry.isDirectory()) continue;
+    safePath(base);
+    requireType(base, "directory");
+    const file = join(base, "SKILL.md");
+    requireType(file, "file");
+    inspectTree(base, base);
+    const metadata = header(readFileSync(file, "utf8"), file);
+    if (names.has(metadata.name)) {
+      throw new Error(`Duplicate skill name ${metadata.name}: ${names.get(metadata.name)} and ${file}`);
+    }
+    names.set(metadata.name, file);
+    catalog.push({ ...metadata, base, file });
+  }
+  if (!catalog.length) throw new Error(`No skills found in ${skills}; restore the checkout's SKILL.md files.`);
+  return catalog;
+}

--- a/opencode/team.js
+++ b/opencode/team.js
@@ -1,0 +1,49 @@
+import { realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+function objectField(value, field) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Team OpenCode config: ${field} must be an object.`);
+  }
+}
+
+function command(skill) {
+  return {
+    description: skill.description + (skill.name === "reflect" ? " OpenCode session reflection is unsupported." : ""),
+    template: [
+      `The user explicitly invoked /${skill.name}.`,
+      `Read the canonical skill file ${JSON.stringify(skill.file)} using the filesystem read tool, then follow its instructions.`,
+      `Resolve relative references and scripts against the skill base directory ${JSON.stringify(skill.base)}.`,
+      "Use the following user arguments for the skill's argument references:",
+      "$ARGUMENTS",
+    ].join("\n"),
+  };
+}
+
+export default async function TeamPlugin() {
+  const entry = realpathSync(fileURLToPath(import.meta.url));
+  const root = dirname(dirname(entry));
+  const { loadCatalog } = await import(pathToFileURL(join(root, "opencode/catalog.mjs")).href);
+  const catalog = loadCatalog(root);
+  return {
+    async config(config) {
+      objectField(config, "config");
+      if (config.skills !== undefined) objectField(config.skills, "skills");
+      const paths = config.skills?.paths;
+      if (paths !== undefined && (!Array.isArray(paths) || paths.some((path) => typeof path !== "string"))) {
+        throw new Error("Team OpenCode config: skills.paths must be an array of strings.");
+      }
+      if (config.command !== undefined) objectField(config.command, "command");
+      for (const skill of catalog) {
+        if (Object.hasOwn(config.command ?? {}, skill.name)) {
+          throw new Error(`Team OpenCode command collision: ${skill.name}. Rename or remove the existing command before loading Team.`);
+        }
+      }
+      const commands = Object.fromEntries(catalog.map((skill) => [skill.name, command(skill)]));
+      const mergedPaths = [...new Set([...(paths ?? []), ...catalog.filter((skill) => !skill.guarded).map((skill) => skill.base)])];
+      config.skills = { ...config.skills, paths: mergedPaths };
+      config.command = { ...config.command, ...commands };
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "license": "MIT",
   "type": "module",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "Orchestrates specialized agents to autonomously implement entire features end-to-end",
   "author": {
     "name": "Matthew Boston",

--- a/script/dev-install
+++ b/script/dev-install
@@ -18,7 +18,7 @@ set -euo pipefail
 # re-run by hand. That asymmetry is an implementation detail — keep it out of
 # the output the user reads.
 
-HARNESSES=(claude codex antigravity)
+HARNESSES=(claude codex antigravity opencode)
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(dirname "$HERE")"
 HOOK_MARKER="# Managed by Team dev install."

--- a/script/dev-install-opencode
+++ b/script/dev-install-opencode
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: Node.js is required. Install Node.js and rerun script/dev-install opencode." >&2
+  exit 1
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+exec node "${HERE}/dev-opencode.mjs" install

--- a/script/dev-opencode.mjs
+++ b/script/dev-opencode.mjs
@@ -1,0 +1,61 @@
+import { lstatSync, mkdirSync, readlinkSync, realpathSync, rmdirSync, statSync, symlinkSync, unlinkSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+function optionalStat(path, stat) {
+  try { return stat(path); }
+  catch (error) {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function changeRegistration(operation, target, source) {
+  const existing = optionalStat(target, lstatSync);
+  if (existing && (!existing.isSymbolicLink() || readlinkSync(target) !== source)) {
+    throw new Error(`Refusing to change ${target}: it is not owned by this checkout (${source}). Uninstall from the owning checkout or relocate the conflicting target yourself.`);
+  }
+  if (operation === "install") {
+    if (!existing) symlinkSync(source, target);
+    console.log(`Registered Team: ${target} → ${source}\nRestart OpenCode to read the live checkout. Registration does not validate native configuration or prove plugin loading.`);
+  } else {
+    if (existing) unlinkSync(target);
+    console.log(`${existing ? "Removed" : "Already absent"}: ${target}\nRestart OpenCode to refresh its plugins.`);
+  }
+}
+
+async function main() {
+  const operation = process.argv[2];
+  if (operation !== "install" && operation !== "uninstall") throw new Error("Usage: dev-opencode.mjs install|uninstall");
+  const checkout = dirname(dirname(realpathSync(fileURLToPath(import.meta.url))));
+  const source = join(checkout, "opencode/team.js");
+  if (operation === "install") {
+    const { loadCatalog } = await import(pathToFileURL(join(checkout, "opencode/catalog.mjs")).href);
+    loadCatalog(checkout);
+  }
+  const config = process.env.OPENCODE_CONFIG_DIR || join(process.env.XDG_CONFIG_HOME || join(process.env.HOME, ".config"), "opencode");
+  const parent = resolve(config, "plugins");
+  if (operation === "install") mkdirSync(parent, { recursive: true });
+  const parentStat = optionalStat(parent, statSync);
+  if (!parentStat) {
+    console.log(`Already absent: ${join(parent, "team.js")}`);
+    return;
+  }
+  if (!parentStat.isDirectory()) throw new Error(`Expected a plugin directory: ${parent}`);
+  const target = join(realpathSync(parent), "team.js");
+  const lock = `${target}.lock`;
+  try { mkdirSync(lock); }
+  catch (error) {
+    if (error.code === "EEXIST") {
+      throw new Error(`Team lifecycle busy: ${lock}. After confirming no install/uninstall process remains, remove this stale lock directory manually and rerun.`);
+    }
+    throw error;
+  }
+  try { changeRegistration(operation, target, source); }
+  finally { rmdirSync(lock); }
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error.message}${error.code === "ERR_MODULE_NOT_FOUND" ? ". Restore the required checkout runtime files and rerun." : ""}`);
+  process.exitCode = 1;
+});

--- a/script/dev-uninstall
+++ b/script/dev-uninstall
@@ -7,7 +7,7 @@ set -euo pipefail
 #   script/dev-uninstall          every harness
 #   script/dev-uninstall codex    just that one
 
-HARNESSES=(claude codex antigravity)
+HARNESSES=(claude codex antigravity opencode)
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(dirname "$HERE")"
 HOOK_MARKER="# Managed by Team dev install."

--- a/script/dev-uninstall-opencode
+++ b/script/dev-uninstall-opencode
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: Node.js is required. Install Node.js and rerun script/dev-uninstall opencode." >&2
+  exit 1
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+exec node "${HERE}/dev-opencode.mjs" uninstall

--- a/tests/dev-install-antigravity.test.ts
+++ b/tests/dev-install-antigravity.test.ts
@@ -110,6 +110,7 @@ const HARNESS_DISPLAY_NAMES: Record<string, string> = {
   claude: "Claude Code",
   codex: "Codex CLI",
   antigravity: "Antigravity CLI",
+  opencode: "OpenCode",
 };
 
 const tempDirs: string[] = [];
@@ -325,6 +326,7 @@ describe("dev install: antigravity harness", () => {
       expect(blocks.length).toBeGreaterThan(0);
 
       expect(fromInstall).toContain("antigravity");
+      expect(fromInstall).toContain("opencode");
       expect(fromUninstall).toEqual(fromInstall);
       for (const block of blocks) expect(block).toEqual(fromInstall);
     });

--- a/tests/dev-install-opencode.test.ts
+++ b/tests/dev-install-opencode.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { chmodSync, closeSync, constants, cpSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, rmSync, symlinkSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { expectStatus, fixture, load, REPO, run, skill, state, write, type Fixture, type Result } from "./helpers/opencode";
+
+setDefaultTimeout(20_000);
+
+const fixtures: Fixture[] = [];
+function make(name = "checkout") { const f = fixture(name); fixtures.push(f); return f; }
+afterEach(() => { for (const f of fixtures.splice(0)) f.dispose(); });
+function targetAt(root: string) { return join(root, "plugins/team.js"); }
+function owned(f: Fixture, path = f.target) { expect(state(path)).toEqual({ kind: "link", value: join(f.checkout, "opencode/team.js") }); }
+function failed(result: Result, diagnostic: RegExp) { expect(result.status, result.output).not.toBe(0); expect(result.output).toMatch(diagnostic); }
+function seedTarget(f: Fixture, kind: string) {
+  mkdirSync(dirname(f.target), { recursive: true });
+  if (kind === "foreign link") symlinkSync(join(f.root, "foreign/opencode/team.js"), f.target);
+  else if (kind === "regular file") write(f.target, "User-owned plugin\n");
+  else mkdirSync(f.target);
+}
+function preload(f: Fixture, contents: string) { const path = join(f.root, "instrument.cjs"); write(path, contents); return { NODE_OPTIONS: `--require=${path}` }; }
+function denyWrites(f: Fixture) {
+  return preload(f, `const fs = require('node:fs');
+const { syncBuiltinESMExports } = require('node:module');
+const denied = () => Object.assign(new Error('EACCES: fixture write refusal'), { code: 'EACCES' });
+fs.symlinkSync = () => { throw denied(); };
+fs.symlink = (...args) => args.at(-1)(denied());
+fs.promises.symlink = async () => { throw denied(); };
+syncBuiltinESMExports();\n`);
+}
+function protectConfigReads(f: Fixture, paths: string[]) {
+  const env = preload(f, `const fs = require('node:fs');
+const { syncBuiltinESMExports } = require('node:module');
+const paths = new Set(${JSON.stringify(paths)});
+const deny = value => { if (paths.has(String(value))) { fs.writeFileSync(${JSON.stringify(join(f.root, 'config-read-attempt'))}, String(value)); throw new Error('Forbidden native config read: ' + value); } };
+for (const name of ['readFileSync', 'openSync']) { const original = fs[name]; fs[name] = function(path, ...args) { deny(path); return original.call(this, path, ...args); }; }
+for (const name of ['readFile', 'open']) { const original = fs[name]; fs[name] = function(path, ...args) { deny(path); return original.call(this, path, ...args); }; }
+for (const name of ['readFile', 'open']) { const original = fs.promises[name]; fs.promises[name] = async function(path, ...args) { deny(path); return original.call(this, path, ...args); }; }
+syncBuiltinESMExports();\n`);
+  const read = spawnSync(join(f.root, "bin/node"), ["-e", "require('node:fs').readFileSync(process.argv[1])", paths[0]!], { env: { ...f.env, ...env }, encoding: "utf8" });
+  expect(read.status).not.toBe(0);
+  expect(read.stderr).toContain("Forbidden native config read");
+  expect(state(join(f.root, "config-read-attempt"))).toEqual({ kind: "file", value: paths[0] });
+  rmSync(join(f.root, "config-read-attempt"));
+  const host = spawnSync(join(f.root, "bin/opencode"), [], { env: f.env, encoding: "utf8" });
+  expect(host.status).toBe(99);
+  expect(state(join(f.home, "host-invoked"))).toEqual({ kind: "file", value: "invoked" });
+  rmSync(join(f.home, "host-invoked"));
+  return env;
+}
+function killProcessGroup(child: ChildProcess) {
+  if (!child.pid) return;
+  try { process.kill(-child.pid, "SIGKILL"); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error; }
+}
+function releaseBarrier(fifo: string) {
+  const fd = openSync(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
+  try { writeSync(fd, "x"); } finally { closeSync(fd); }
+}
+async function concurrent(f: Fixture, operation: "install" | "uninstall", env: Record<string, string> = {}): Promise<Result> {
+  const child = spawn("/bin/bash", [join(f.checkout, "script", `dev-${operation}-opencode`)], { cwd: f.root, env: { ...f.env, ...env }, stdio: ["ignore", "pipe", "pipe"], detached: true });
+  const deadline = setTimeout(() => killProcessGroup(child), 10_000);
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += chunk; }); child.stderr.on("data", (chunk) => { output += chunk; });
+  try {
+    return await new Promise((resolve, reject) => { child.once("error", reject); child.once("close", (status) => resolve({ status: status ?? -1, output })); });
+  } finally { clearTimeout(deadline); killProcessGroup(child); }
+}
+async function lockedUninstall(f: Fixture, competitorEnv: Record<string, string> = {}) {
+  const fifo = join(f.root, "release-unlink");
+  expect(spawnSync("/usr/bin/mkfifo", [fifo]).status).toBe(0);
+  const env = preload(f, `const fs = require('node:fs');
+const { syncBuiltinESMExports } = require('node:module');
+const target = ${JSON.stringify(f.target)};
+const pause = path => { if (String(path) !== target) return; const fd = fs.openSync(${JSON.stringify(fifo)}, 'r+'); fs.writeSync(1, 'TEST_UNLINK_READY\\n'); fs.readSync(fd, Buffer.alloc(1), 0, 1, null); fs.closeSync(fd); };
+const unlinkSync = fs.unlinkSync; fs.unlinkSync = function(path) { pause(path); return unlinkSync(path); };
+const unlink = fs.unlink; fs.unlink = function(path, callback) { pause(path); return unlink(path, callback); };
+const asyncUnlink = fs.promises.unlink; fs.promises.unlink = async function(path) { pause(path); return asyncUnlink.call(this, path); };
+syncBuiltinESMExports();\n`);
+  const child = spawn("/bin/bash", [join(f.checkout, "script/dev-uninstall-opencode")], { cwd: f.root, env: { ...f.env, ...env }, stdio: ["ignore", "pipe", "pipe"], detached: true });
+  const deadline = setTimeout(() => killProcessGroup(child), 10_000);
+  let output = "";
+  const completed = new Promise<Result>((resolve, reject) => { child.once("error", reject); child.once("close", (status) => resolve({ status: status ?? -1, output })); });
+  const ready = new Promise<boolean>((resolve) => {
+    child.stdout.on("data", (chunk) => { output += chunk; if (output.includes("TEST_UNLINK_READY\n")) resolve(true); });
+    child.stderr.on("data", (chunk) => { output += chunk; });
+    child.once("close", () => resolve(false));
+  });
+  try {
+    expect(await ready, `Uninstall must reach unlink barrier: ${output}`).toBe(true);
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "directory" });
+    owned(f);
+    const competitor = run(f, "install", competitorEnv);
+    failed(competitor, /lock|busy/i);
+    expect(competitor.output).toContain(`${f.target}.lock`);
+    owned(f);
+    releaseBarrier(fifo);
+    expectStatus(await completed, 0);
+    expect(state(f.target)).toEqual({ kind: "absent" });
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+  } finally { clearTimeout(deadline); killProcessGroup(child); await completed; }
+}
+function dispatcher(f: Fixture, operation: "install" | "uninstall", args: string[], fail = "") {
+  const calls = join(f.root, "calls");
+  for (const host of ["claude", "codex", "antigravity", "opencode"]) {
+    const path = join(f.checkout, "script", `dev-${operation}-${host}`);
+    write(path, `#!/bin/sh\nprintf '%s\\n' '${host}' >> '${calls}'\nexit ${host === fail ? 7 : 0}\n`);
+    chmodSync(path, 0o755);
+  }
+  const hook = join(f.checkout, "script/dev-install-claude-pull-hook");
+  write(hook, `#!/bin/sh\nprintf 'hook\\n' >> '${calls}'\n`); chmodSync(hook, 0o755);
+  const result = spawnSync("/bin/bash", [join(f.checkout, "script", `dev-${operation}`), ...args], { cwd: f.checkout, env: f.env, encoding: "utf8" });
+  return { status: result.status ?? -1, output: `${result.stdout}${result.stderr}`, calls: existsSync(calls) ? readFileSync(calls, "utf8").trim().split("\n") : [] };
+}
+
+describe("Owned lifecycle converges without changing unrelated configuration.", () => {
+  test.each(["install", "uninstall"] as const)("%s entry script is executable strict Bash", (operation) => {
+    const f = make();
+    const script = join(f.checkout, "script", `dev-${operation}-opencode`);
+    const source = readFileSync(script, "utf8");
+    expect(lstatSync(script).mode & 0o111).toBeGreaterThan(0);
+    expect(source.startsWith("#!/usr/bin/env bash\n")).toBe(true);
+    expect(source).toContain("set -euo pipefail");
+  });
+
+  test.each(["default", "empty explicit", "XDG", "explicit", "relative explicit", "relative XDG"])("uses the %s configuration root", (choice) => {
+    const f = make();
+    const selections: Record<string, { env: Record<string, string>; root: string }> = {
+      default: { env: {}, root: f.config }, "empty explicit": { env: { OPENCODE_CONFIG_DIR: "" }, root: f.config },
+      XDG: { env: { XDG_CONFIG_HOME: join(f.root, "xdg") }, root: join(f.root, "xdg/opencode") },
+      explicit: { env: { XDG_CONFIG_HOME: join(f.root, "unused"), OPENCODE_CONFIG_DIR: join(f.root, "explicit") }, root: join(f.root, "explicit") },
+      "relative explicit": { env: { OPENCODE_CONFIG_DIR: "relative config" }, root: join(f.root, "relative config") },
+      "relative XDG": { env: { XDG_CONFIG_HOME: "relative xdg" }, root: join(f.root, "relative xdg/opencode") },
+    };
+    const selection = selections[choice]!;
+    expectStatus(run(f, "install", selection.env), 0);
+    owned(f, targetAt(selection.root));
+    expectStatus(run(f, "uninstall", selection.env), 0);
+    expect(state(targetAt(selection.root))).toEqual({ kind: "absent" });
+    expect(state(join(selection.root, "plugins"))).toEqual({ kind: "directory" });
+  });
+
+  test.each(["checkout with spaces", "équipe 日本語"])("installs and removes %s", (name) => {
+    const f = make(name);
+    expectStatus(run(f, "install"), 0);
+    owned(f);
+    expectStatus(run(f, "uninstall"), 0);
+    expect(state(f.target)).toEqual({ kind: "absent" });
+  });
+
+  test("canonical checkout and config aliases converge to the same registration", () => {
+    const f = make();
+    mkdirSync(f.config, { recursive: true });
+    const configAlias = join(f.root, "config-alias");
+    symlinkSync(f.config, configAlias);
+    const checkoutAlias = join(f.root, "checkout-alias");
+    symlinkSync(f.checkout, checkoutAlias);
+    expectStatus(run({ ...f, checkout: checkoutAlias }, "install", { OPENCODE_CONFIG_DIR: configAlias }), 0);
+    owned(f);
+    expectStatus(run(f, "install"), 0);
+    expectStatus(run({ ...f, checkout: checkoutAlias }, "uninstall", { OPENCODE_CONFIG_DIR: configAlias }), 0);
+    expect(state(f.target)).toEqual({ kind: "absent" });
+  });
+
+  test("a real linked worktree registers its own runtime path", () => {
+    const f = make();
+    const origin = join(f.root, "origin");
+    mkdirSync(origin);
+    expect(spawnSync("git", ["init", "-q", origin], { env: { ...f.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" } }).status).toBe(0);
+    const result = spawnSync("git", ["-C", origin, "worktree", "add", "--orphan", "-b", "fixture", join(f.root, "linked-worktree")], { env: { ...f.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" }, encoding: "utf8" });
+    expect({ status: result.status, output: result.stderr }).toMatchObject({ status: 0 });
+    cpSync(f.checkout, join(f.root, "linked-worktree"), { recursive: true });
+    const worktree = { ...f, checkout: join(f.root, "linked-worktree") };
+    expectStatus(run(worktree, "install"), 0);
+    owned(worktree);
+    expectStatus(run(worktree, "uninstall"), 0);
+  });
+
+  test("repeated install and removal converge and preserve plugin parents", () => {
+    const f = make();
+    expectStatus(run(f, "install"), 0);
+    expectStatus(run(f, "install"), 0);
+    owned(f);
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+    expectStatus(run(f, "uninstall"), 0);
+    expectStatus(run(f, "uninstall"), 0);
+    expect(state(f.target)).toEqual({ kind: "absent" });
+    expect(state(dirname(f.target))).toEqual({ kind: "directory" });
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+  });
+
+  test("a new initialization reads live edits through the installed link", async () => {
+    const f = make();
+    expectStatus(run(f, "install"), 0);
+    const before = await load(f, {}, f.target);
+    skill(f, "sample", "name: sample\ndescription: Updated description", "# Updated canonical body\n");
+    skill(f, "new-skill");
+    const after = await load(f, {}, f.target);
+    expect(before.command?.sample?.description).toBe("A fixture skill");
+    expect(after.command?.sample?.description).toBe("Updated description");
+    expect(after.command?.["new-skill"]?.template).toContain(join(f.checkout, "skills/new-skill/SKILL.md"));
+    expect(readFileSync(join(f.checkout, "skills/sample/SKILL.md"), "utf8")).toContain("# Updated canonical body");
+    owned(f);
+  });
+
+  test("uninstall removes its dangling link after the entire runtime directory disappears", () => {
+    const f = make();
+    expectStatus(run(f, "install"), 0);
+    rmSync(join(f.checkout, "opencode"), { recursive: true });
+    owned(f);
+    expectStatus(run(f, "uninstall"), 0);
+    expect(state(f.target)).toEqual({ kind: "absent" });
+  });
+
+  test.each(["opencode/team.js", "opencode/catalog.mjs", "skills", "skills/sample/SKILL.md"])("missing checkout path %s prevents registration", (path) => {
+    const f = make();
+    rmSync(join(f.checkout, path), { recursive: true });
+    failed(run(f, "install"), /missing|not found|ENOENT|invalid|require/i);
+    expect(state(f.config)).toEqual({ kind: "absent" });
+  });
+
+  test.each(["install", "uninstall"] as const)("%s without Node reports the prerequisite", (operation) => {
+    const f = make();
+    const bin = join(f.root, "without-node");
+    mkdirSync(bin);
+    symlinkSync("/bin/bash", join(bin, "bash"));
+    symlinkSync("/usr/bin/dirname", join(bin, "dirname"));
+    failed(run(f, operation, { PATH: bin }), /node/i);
+    expect(state(f.config)).toEqual({ kind: "absent" });
+  });
+
+  test.each(["foreign link", "regular file", "directory"])("install refuses a %s unchanged and releases its lock", (kind) => {
+    const f = make();
+    seedTarget(f, kind);
+    const before = state(f.target);
+    const result = run(f, "install");
+    failed(result, /exist|own|conflict|refus|another|foreign/i);
+    expect(result.output).toContain(f.target);
+    expect(state(f.target)).toEqual(before);
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+  });
+
+  test.each(["foreign link", "regular file", "directory"])("uninstall refuses a %s unchanged and releases its lock", (kind) => {
+    const f = make();
+    seedTarget(f, kind);
+    const before = state(f.target);
+    const result = run(f, "uninstall");
+    failed(result, /exist|own|conflict|refus|another|foreign/i);
+    expect(result.output).toContain(f.target);
+    expect(state(f.target)).toEqual(before);
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+  });
+
+  test("write refusal fails registration, releases its lock, and permits recovery", () => {
+    const f = make();
+    failed(run(f, "install", denyWrites(f)), /EACCES|permission|write/i);
+    expect(state(f.target)).toEqual({ kind: "absent" });
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+    expectStatus(run(f, "install"), 0);
+    owned(f);
+  });
+
+  test("absent-parent uninstall succeeds without creating directories", () => {
+    const f = make();
+    expectStatus(run(f, "uninstall"), 0);
+    expect(readdirSync(f.home)).toEqual([]);
+  });
+
+  test.each(["install", "uninstall"] as const)("%s diagnoses a non-directory parent", (operation) => {
+    const f = make();
+    write(dirname(f.target), "User-owned file\n");
+    const before = state(dirname(f.target));
+    failed(run(f, operation), /directory|ENOTDIR|EEXIST/i);
+    expect(state(dirname(f.target))).toEqual(before);
+  });
+
+  test.each(["opencode.json", "opencode.jsonc", "malformed opencode.json"])("preserves %s and unrelated data without reading config or invoking the host", (kind) => {
+    const f = make();
+    const configFile = join(f.config, kind.includes("jsonc") ? "opencode.jsonc" : "opencode.json");
+    const contents: string = kind.startsWith("malformed") ? "{ invalid json" : kind.endsWith("jsonc") ? '// retained comment\n{"model":"user/model",}\n' : '{"model":"user/model"}\n';
+    const credentials = join(f.home, ".local/share/opencode/auth.json");
+    const unrelated = join(f.config, "plugins/unrelated.js");
+    write(configFile, contents);
+    write(credentials, '{"synthetic":"fixture-only"}\n');
+    write(unrelated, "export default async () => ({});\n");
+    const env = protectConfigReads(f, [configFile, credentials]);
+    const installed = run(f, "install", env);
+    expectStatus(installed, 0);
+    expect(installed.output).toMatch(/register/i);
+    expect(installed.output).toMatch(/restart/i);
+    expect(installed.output).not.toMatch(/(?:loaded|validated) successfully|configuration (?:is )?valid/i);
+    expectStatus(run(f, "install", env), 0);
+    expectStatus(run(f, "uninstall", env), 0);
+    expect(readFileSync(configFile, "utf8")).toBe(contents);
+    expect(readFileSync(credentials, "utf8")).toBe('{"synthetic":"fixture-only"}\n');
+    expect(readFileSync(unrelated, "utf8")).toBe("export default async () => ({});\n");
+    expect(state(f.config)).toEqual({ kind: "directory" });
+    expect(state(join(f.home, "host-invoked"))).toEqual({ kind: "absent" });
+    expect(state(join(f.root, "config-read-attempt"))).toEqual({ kind: "absent" });
+  });
+
+  test("concurrent creation never replaces another checkout's registration", async () => {
+    const f = make();
+    const second = { ...f, checkout: join(f.root, "second-checkout") };
+    cpSync(f.checkout, second.checkout, { recursive: true });
+    const results = await Promise.all([concurrent(f, "install"), concurrent(second, "install")]);
+    expect(results.map((r) => r.status).filter((status) => status === 0)).toHaveLength(1);
+    expect([join(f.checkout, "opencode/team.js"), join(second.checkout, "opencode/team.js")]).toContain(state(f.target).value ?? "");
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+  });
+
+  test.each(["canonical", "alias"])("uninstall holds its lock against a competing %s install", async (kind) => {
+    const f = make();
+    expectStatus(run(f, "install"), 0);
+    const alias = join(f.root, "config-alias");
+    symlinkSync(f.config, alias);
+    await lockedUninstall(f, kind === "alias" ? { OPENCODE_CONFIG_DIR: alias } : {});
+  });
+
+  test.each(["install", "uninstall"] as const)("%s refuses a stale lock until deliberate recovery", (operation) => {
+    const f = make();
+    mkdirSync(`${f.target}.lock`, { recursive: true });
+    const result = run(f, operation);
+    failed(result, /lock|busy/i);
+    expect(result.output).toContain(`${f.target}.lock`);
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "directory" });
+    expect(state(f.target)).toEqual({ kind: "absent" });
+    rmSync(`${f.target}.lock`, { recursive: true });
+    expectStatus(run(f, operation), 0);
+    expect(state(`${f.target}.lock`)).toEqual({ kind: "absent" });
+  });
+
+  test.each(["install", "uninstall"] as const)("targeted %s dispatch selects only OpenCode", (operation) => {
+    const f = make();
+    const result = dispatcher(f, operation, ["opencode"]);
+    expectStatus(result, 0);
+    expect(result.calls).toEqual(["opencode"]);
+  });
+
+  test.each(["install", "uninstall"] as const)("aggregate %s attempts all hosts despite sibling failure", (operation) => {
+    const f = make();
+    const result = dispatcher(f, operation, [], "codex");
+    expect(result.status).not.toBe(0);
+    expect(result.calls.filter((name) => name !== "hook").sort()).toEqual(["antigravity", "claude", "codex", "opencode"]);
+    expect(result.calls.filter((name) => name === "hook")).toEqual([]);
+  });
+
+  test.each(["install", "uninstall"] as const)("developer command routes OpenCode %s through its dispatcher", (operation) => {
+    const f = make();
+    const dev = readFileSync(join(REPO, "dev.yml"), "utf8");
+    expect(dev).toContain(`script/dev-${operation} opencode`);
+    const dispatcherSource = readFileSync(join(f.checkout, "script", `dev-${operation}`), "utf8");
+    expect(dispatcherSource.match(/^HARNESSES=\(([^)]*)\)/m)?.[1]?.split(/\s+/)).toContain("opencode");
+  });
+});

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -2,7 +2,7 @@
 //
 // L2 tripwire (free, deterministic): README.md and docs/index.md are the two
 // self-contained install surfaces (GitHub and team.bostonaholic.dev). Each
-// must carry all thirteen install/uninstall command strings verbatim, so a reader
+// must carry all fifteen install/uninstall command strings verbatim, so a reader
 // on either surface can install and uninstall on every host without leaving
 // the page.
 //
@@ -23,8 +23,8 @@ function readIf(path: string): string {
   return existsSync(path) ? read(path) : "";
 }
 
-describe("docs-install-parity: README.md and docs/index.md each carry all thirteen install/uninstall command strings verbatim", () => {
-  test("README.md carries all thirteen install/uninstall command strings verbatim", () => {
+describe("docs-install-parity: README.md and docs/index.md each carry all fifteen install/uninstall command strings verbatim", () => {
+  test("README.md carries all fifteen install/uninstall command strings verbatim", () => {
     const readme = readIf(README_MD);
     // Guard: a missing README must fail cleanly, not vacuously pass.
     expect(readme.length).toBeGreaterThan(0);
@@ -42,9 +42,11 @@ describe("docs-install-parity: README.md and docs/index.md each carry all thirte
     expect(readme).toContain("agy plugin uninstall team");
     expect(readme).toContain("script/dev-install antigravity");
     expect(readme).toContain("script/dev-uninstall antigravity");
+    expect(readme).toContain("script/dev-install opencode");
+    expect(readme).toContain("script/dev-uninstall opencode");
   });
 
-  test("docs/index.md carries all thirteen install/uninstall command strings verbatim", () => {
+  test("docs/index.md carries all fifteen install/uninstall command strings verbatim", () => {
     const docsIndex = readIf(DOCS_INDEX_MD);
     // Guard: a missing docs page must fail cleanly, not vacuously pass.
     expect(docsIndex.length).toBeGreaterThan(0);
@@ -62,5 +64,7 @@ describe("docs-install-parity: README.md and docs/index.md each carry all thirte
     expect(docsIndex).toContain("agy plugin uninstall team");
     expect(docsIndex).toContain("script/dev-install antigravity");
     expect(docsIndex).toContain("script/dev-uninstall antigravity");
+    expect(docsIndex).toContain("script/dev-install opencode");
+    expect(docsIndex).toContain("script/dev-uninstall opencode");
   });
 });

--- a/tests/helpers/opencode.ts
+++ b/tests/helpers/opencode.ts
@@ -1,0 +1,67 @@
+import { expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const REPO = realpathSync(join(import.meta.dir, "../.."));
+export const REQUIRED = ["opencode/team.js", "opencode/catalog.mjs", "script/dev-install-opencode", "script/dev-uninstall-opencode", "script/dev-opencode.mjs"];
+export type Fixture = { root: string; checkout: string; home: string; config: string; target: string; env: Record<string, string>; dispose: () => void };
+export type Config = { skills?: { paths?: string[]; [key: string]: unknown }; command?: Record<string, { template: string; description?: string; [key: string]: unknown }>; [key: string]: unknown };
+export type Result = { status: number; output: string };
+
+export function write(path: string, content: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+export function skill(f: Fixture, name: string, header = `name: ${name}\ndescription: A fixture skill`, body = "# Canonical fixture body\n") {
+  const path = join(f.checkout, "skills", name, "SKILL.md");
+  write(path, `---\n${header}\n---\n${body}`);
+  return path;
+}
+export function fixture(checkoutName = "checkout", catalog: "one" | "empty" | "full" = "one"): Fixture {
+  expect(REQUIRED.filter((p) => !existsSync(join(REPO, p))), "required OpenCode implementation files").toEqual([]);
+  const root = realpathSync(mkdtempSync(join(tmpdir(), `team-opencode-${process.pid}-`)));
+  const checkout = join(root, checkoutName);
+  const home = join(root, "home");
+  const config = join(home, ".config/opencode");
+  const target = join(config, "plugins/team.js");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(join(checkout, "skills"), { recursive: true });
+  for (const dir of ["opencode", "script"]) cpSync(join(REPO, dir), join(checkout, dir), { recursive: true });
+  write(join(checkout, "package.json"), '{"type":"module"}\n');
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  const node = spawnSync("node", ["-p", "process.execPath"], { encoding: "utf8" });
+  expect(node.status, "Node is required by the offline lifecycle harness").toBe(0);
+  symlinkSync(node.stdout.trim(), join(bin, "node"));
+  write(join(bin, "opencode"), '#!/bin/sh\nprintf invoked > "$HOME/host-invoked"\nprintf "unexpected host invocation\\n" >&2\nexit 99\n');
+  chmodSync(join(bin, "opencode"), 0o755);
+  const f = { root, checkout, home, config, target, env: { HOME: home, PATH: `${bin}:/usr/bin:/bin`, LANG: "C", TZ: "UTC", TMPDIR: root }, dispose: () => rmSync(root, { force: true, recursive: true }) };
+  if (catalog === "one") skill(f, "sample");
+  if (catalog === "full") cpSync(join(REPO, "skills"), join(checkout, "skills"), { recursive: true });
+  return f;
+}
+export function run(f: Fixture, operation: "install" | "uninstall", env: Record<string, string> = {}, cwd = f.root): Result {
+  const result = spawnSync("/bin/bash", [join(f.checkout, "script", `dev-${operation}-opencode`)], { cwd, env: { ...f.env, ...env }, encoding: "utf8", timeout: 10_000 });
+  return { status: result.status ?? -1, output: `${result.stdout ?? ""}${result.stderr ?? ""}${result.error?.message ?? ""}` };
+}
+export function expectStatus(result: Result, status: number) { expect(result).toMatchObject({ status }); }
+export function state(path: string) {
+  try { const st = lstatSync(path); return st.isSymbolicLink() ? { kind: "link", value: readlinkSync(path) } : st.isDirectory() ? { kind: "directory" } : { kind: "file", value: readFileSync(path, "utf8") }; }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "absent" }; throw error; }
+}
+export async function load(f: Fixture, config: Config = {}, entry = join(f.checkout, "opencode/team.js")) {
+  const module = await import(pathToFileURL(entry).href);
+  const plugins = Object.values(module).filter((value): value is (input: object) => Promise<{ config: (config: Config) => Promise<void> }> => typeof value === "function");
+  expect(plugins.length, "native entry point must export exactly one plugin function").toBe(1);
+  expect(Object.keys(module).length, "native entry point exports no catalog helpers").toBe(1);
+  const hooks = await plugins[0]!({ directory: f.root, worktree: f.root });
+  expect(Object.keys(hooks)).toEqual(["config"]);
+  await hooks.config(config);
+  return config;
+}
+export async function rejection(f: Fixture, config: Config = {}) {
+  try { await load(f, config); return ""; } catch (error) { return String(error); }
+}

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cpSync, mkdirSync, readFileSync, readdirSync, renameSync, symlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { REPO, expectStatus, fixture, load, rejection, run, skill, state, write, type Config, type Fixture } from "./helpers/opencode";
+
+const fixtures: Fixture[] = [];
+function make(name = "checkout", catalog: "one" | "empty" | "full" = "one") { const f = fixture(name, catalog); fixtures.push(f); return f; }
+afterEach(() => { for (const f of fixtures.splice(0)) f.dispose(); });
+
+const badHeaders = [
+  ["missing header", "# no frontmatter\n"],
+  ["unclosed header", "---\nname: sample\ndescription: missing close\n"],
+  ["missing name", "---\ndescription: Missing name\n---\n"],
+  ["missing description", "---\nname: sample\n---\n"],
+  ["duplicate name key", "---\nname: sample\nname: second\ndescription: Duplicate\n---\n"],
+  ["duplicate description key", "---\nname: sample\ndescription: First\ndescription: Second\n---\n"],
+  ["duplicate guard key", "---\nname: sample\ndescription: Guard\ndisable-model-invocation: true\ndisable-model-invocation: false\n---\n"],
+  ["quoted name key", "---\n'name': sample\ndescription: Quoted key\n---\n"],
+  ["quoted description key", "---\nname: sample\n\"description\": Quoted key\n---\n"],
+  ["quoted guard key", "---\nname: sample\ndescription: Quoted guard\n\"disable-model-invocation\": true\n---\n"],
+  ["merged anchored guard", "---\ndefaults: &guard\n  disable-model-invocation: true\n<<: *guard\nname: sample\ndescription: Merged guard\n---\n"],
+  ["numeric name", "---\nname: 42\ndescription: Numeric\n---\n"],
+  ["list description", "---\nname: sample\ndescription: [a, b]\n---\n"],
+  ["mapping description", "---\nname: sample\ndescription: {a: b}\n---\n"],
+  ["boolean description", "---\nname: sample\ndescription: false\n---\n"],
+  ["empty description", "---\nname: sample\ndescription: ''\n---\n"],
+  ["quoted boolean guard", "---\nname: sample\ndescription: Guard\ndisable-model-invocation: 'true'\n---\n"],
+  ["invalid guard", "---\nname: sample\ndescription: Guard\ndisable-model-invocation: sometimes\n---\n"],
+  ["leading sequence indicator description scalar", "---\nname: sample\ndescription: - text\n---\nBody\n"],
+  ["bare sequence indicator description scalar", "---\nname: sample\ndescription: -\n---\nBody\n"],
+  ["terminal colon description scalar", "---\nname: sample\ndescription: Example:\n---\nBody\n"],
+  ["continued description scalar", "---\nname: sample\ndescription: First\n  second\n---\n"],
+  ["NaN description scalar", "---\nname: sample\ndescription: .nan\n---\n"],
+  ["infinite description scalar", "---\nname: sample\ndescription: .inf\n---\n"],
+  ["multiline consumed scalar", "---\nname: sample\ndescription: |\n  ambiguous block\n---\n"],
+  ["unclosed quote", "---\nname: sample\ndescription: 'broken\n---\n"],
+  ["alias consumed scalar", "---\nname: sample\ndescription: *description\n---\n"],
+  ["anchored consumed scalar", "---\nname: sample\ndescription: &description text\n---\n"],
+] as const;
+
+function invalidTree(f: Fixture, kind: string) {
+  const base = join(f.checkout, "skills/sample");
+  const external = join(f.root, "external");
+  mkdirSync(external);
+  if (kind === "root link") { renameSync(join(f.checkout, "skills"), join(external, "skills")); symlinkSync(join(external, "skills"), join(f.checkout, "skills")); }
+  else if (kind === "immediate directory link") { renameSync(base, join(external, "sample")); symlinkSync(join(external, "sample"), base); }
+  else if (kind === "skill file link") { renameSync(join(base, "SKILL.md"), join(external, "SKILL.md")); symlinkSync(join(external, "SKILL.md"), join(base, "SKILL.md")); }
+  else if (kind === "nested directory link") symlinkSync(external, join(base, "references"));
+  else if (kind === "nested file link") { write(join(external, "reference.md"), "Reference\n"); symlinkSync(join(external, "reference.md"), join(base, "reference.md")); }
+  else write(join(base, kind, "SKILL.md"), "---\nname: nested\ndescription: Hidden\n---\n");
+}
+async function expectCatalogRejected(f: Fixture, diagnostic?: string) {
+  const config: Config = { skills: { paths: ["existing"] }, command: { custom: { template: "unchanged" } } };
+  const before = structuredClone(config);
+  const error = await rejection(f, config);
+  expect(error.length, "direct initialization must reject invalid checkout").toBeGreaterThan(0);
+  if (diagnostic) expect(error).toContain(diagnostic);
+  expect(config).toEqual(before);
+  const installed = run(f, "install");
+  expect(installed.status, installed.output).not.toBe(0);
+  expect(installed.output.length).toBeGreaterThan(0);
+  if (diagnostic) expect(installed.output).toContain(diagnostic);
+  expect(state(f.config)).toEqual({ kind: "absent" });
+}
+// Offline model of native placeholder substitution and marker recognition only;
+// marker contents are collected as strings, never executed or read.
+function nativeExpansion(template: string, args: string) {
+  const words = args.match(/(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi)?.map((arg) => arg.replace(/^["']|["']$/g, "")) ?? [];
+  const placeholders = [...template.matchAll(/\$(\d+)/g)].map((match) => Number(match[1]));
+  const last = Math.max(0, ...placeholders);
+  const positional = template.replace(/\$(\d+)/g, (_, n: string) => Number(n) === last ? words.slice(Number(n) - 1).join(" ") : words[Number(n) - 1] ?? "");
+  const expanded = positional.replaceAll("$ARGUMENTS", args);
+  return { expanded, shell: [...expanded.matchAll(/!`([^`]+)`/g)].map((m) => m[1]), files: [...expanded.matchAll(/(?<![\w`])@(\.?[^\s`,.]*(?:\.[^\s`,.]+)*)/g)].map((m) => m[1]) };
+}
+function catalogNames(f: Fixture) { return readdirSync(join(f.checkout, "skills"), { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort(); }
+function assertCompleteCatalog(f: Fixture, config: Config) {
+  const names = catalogNames(f);
+  expect(Object.keys(config.command ?? {}).sort()).toEqual(names);
+  names.forEach((name) => assertCanonicalCommand(f, config, name));
+  const expected = names.filter((name) => !/^disable-model-invocation: true$/m.test(readFileSync(join(f.checkout, "skills", name, "SKILL.md"), "utf8").split("---")[1] ?? "")).map((name) => join(f.checkout, "skills", name));
+  expect(config.skills?.paths).toEqual(expected);
+}
+function assertCanonicalCommand(f: Fixture, config: Config, name: string) {
+  const command = config.command?.[name];
+  const file = join(f.checkout, "skills", name, "SKILL.md");
+  const body = readFileSync(file, "utf8").split(/^---\s*$/m).slice(2).join("---");
+  expect(command, name).toBeDefined();
+  expect(command!.template, name).toContain(file);
+  expect(command!.template, name).toContain(dirname(file));
+  expect(command!.template, name).toContain("$ARGUMENTS");
+  expect(command!.template, name).not.toContain(body.trim());
+  expect(command!.template, name).not.toContain("!`");
+  expect(command!.model, name).toBeUndefined();
+  expect(command!.agent, name).toBeUndefined();
+}
+
+describe("Canonical discovery preserves host configuration and rejects invalid catalogs.", () => {
+  test("zero skills rejects initialization and registration", async () => { await expectCatalogRejected(make("empty", "empty")); });
+
+  test("one skill registers its canonical directory and command", async () => {
+    const f = make();
+    const config = await load(f);
+    expect(config.skills?.paths).toEqual([join(f.checkout, "skills/sample")]);
+    expect(Object.keys(config.command ?? {})).toEqual(["sample"]);
+    assertCanonicalCommand(f, config, "sample");
+    expectStatus(run(f, "install"), 0);
+  });
+
+  test("the full real catalog registers every command and only unguarded paths", async () => {
+    const f = make("complete", "full");
+    const config = await load(f);
+    assertCompleteCatalog(f, config);
+    expect(config.command?.reflect?.description?.toLowerCase()).toContain("opencode");
+    expect(config.command?.reflect?.description?.toLowerCase()).toMatch(/unsupported|not support|unavailable/);
+    expectStatus(run(f, "install"), 0);
+  });
+
+  test("preserves existing settings and path order while deduplicating exact entries", async () => {
+    const f = make();
+    skill(f, "alpha");
+    const existing: Config = { model: "local/model", provider: { local: { options: { baseURL: "http://invalid.local" } } }, agent: { review: { model: "local/reviewer" } }, plugin: ["user-plugin"], permission: { read: { "*": "deny", allowed: "allow" }, external_directory: "deny", skill: { "*": "ask" }, bash: "deny" }, custom: { untouched: true }, skills: { urls: ["https://invalid.local"], paths: ["z-existing", join(f.checkout, "skills/sample"), "a-existing", "z-existing"] }, command: { custom: { template: "User command", model: "local/custom" } } };
+    const before = structuredClone(existing);
+    await load(f, existing);
+    expect(existing).toMatchObject({ model: before.model, provider: before.provider, agent: before.agent, plugin: before.plugin, permission: before.permission, custom: before.custom });
+    expect(existing.command?.custom).toEqual(before.command?.custom);
+    expect(existing.skills?.urls).toEqual(before.skills?.urls);
+    expect(existing.skills?.paths).toEqual(["z-existing", join(f.checkout, "skills/sample"), "a-existing", join(f.checkout, "skills/alpha")]);
+  });
+
+  test("frontmatter guards determine discovery regardless of command name or user visibility", async () => {
+    const f = make();
+    skill(f, "sample", "name: sample\ndescription: Guarded sample\ndisable-model-invocation: true");
+    skill(f, "reflect", "name: reflect\ndescription: Reflect fixture\ndisable-model-invocation: false");
+    skill(f, "method", "name: method\ndescription: Internal methodology\nuser-invocable: false");
+    const config = await load(f, { skills: { paths: [join(f.checkout, "skills/sample")] } });
+    expect(Object.keys(config.command ?? {}).sort()).toEqual(["method", "reflect", "sample"]);
+    expect(config.skills?.paths).toEqual([join(f.checkout, "skills/sample"), join(f.checkout, "skills/method"), join(f.checkout, "skills/reflect")]);
+  });
+
+  test.each([['single quotes', "'It''s a quoted: description'", "It's a quoted: description"], ['double quotes', '"A quoted: description"', "A quoted: description"]])("accepts %s and decodes the description", async (_, value, expected) => {
+    const f = make();
+    skill(f, "sample", `name: sample\ndescription: ${value}`);
+    expect((await load(f)).command?.sample?.description).toBe(expected);
+  });
+
+  test.each(badHeaders)("rejects %s through both callers", async (_, content) => {
+    const f = make();
+    write(join(f.checkout, "skills/sample/SKILL.md"), content);
+    await expectCatalogRejected(f, "SKILL.md");
+  });
+
+  test("a missing immediate skill file rejects both callers", async () => {
+    const f = make();
+    renameSync(join(f.checkout, "skills/sample/SKILL.md"), join(f.checkout, "skills/sample/README.md"));
+    await expectCatalogRejected(f, "SKILL.md");
+  });
+
+  test("duplicate names diagnose both canonical files without partial contribution", async () => {
+    const f = make();
+    const duplicate = skill(f, "second", "name: sample\ndescription: Duplicate name");
+    await expectCatalogRejected(f, "sample");
+    const error = await rejection(f);
+    expect(error).toContain(join(f.checkout, "skills/sample/SKILL.md"));
+    expect(error).toContain(duplicate);
+    expect(run(f, "install").output).toContain(duplicate);
+  });
+
+  test.each(["root link", "immediate directory link", "skill file link", "nested directory link", "nested file link", "references", "scripts/deep"])("rejects %s through both callers", async (kind) => {
+    const f = make();
+    invalidTree(f, kind);
+    await expectCatalogRejected(f);
+  });
+
+  test("ordinary reference and script trees remain accessible", async () => {
+    const f = make();
+    write(join(f.checkout, "skills/sample/references/deep/reference.md"), "Literal reference\n");
+    write(join(f.checkout, "skills/sample/scripts/example.sh"), "#!/bin/sh\nexit 0\n");
+    const config = await load(f);
+    expect(config.skills?.paths).toContain(join(f.checkout, "skills/sample"));
+    expectStatus(run(f, "install"), 0);
+    expect(readFileSync(join(f.checkout, "skills/sample/references/deep/reference.md"), "utf8")).toBe("Literal reference\n");
+  });
+
+  test.each(["$1", "$ARGUMENTS", "!`literal-command`", "@file"])("rejects checkout marker %s including a canonical alias", async (marker) => {
+    const f = make(`unsafe-${marker}`);
+    const alias = join(f.root, "safe-alias");
+    symlinkSync(f.checkout, alias);
+    await expectCatalogRejected(f, f.checkout);
+    const config: Config = {};
+    await expect(load(f, config, join(alias, "opencode/team.js"))).rejects.toThrow();
+    expect(config).toEqual({});
+  });
+
+  test.each(["$1", "$ARGUMENTS", "!`literal-command`", "@file"])("rejects emitted skill path marker %s through both callers", async (marker) => {
+    const f = make();
+    renameSync(join(f.checkout, "skills/sample"), join(f.checkout, "skills", `sample-${marker}`));
+    await expectCatalogRejected(f, marker);
+  });
+
+  test.each(["checkout with spaces", "équipe 日本語"])("preserves canonical paths in %s through native placeholder expansion", async (name) => {
+    const f = make(name);
+    const config = await load(f);
+    const expanded = nativeExpansion(config.command!.sample!.template, "argument value");
+    expect(expanded.expanded).toContain(join(f.checkout, "skills/sample/SKILL.md"));
+    expect(expanded.shell).toEqual([]);
+    expect(expanded.files).toEqual([]);
+    expectStatus(run(f, "install"), 0);
+  });
+
+  test.each([
+    ["skills", { skills: null }], ["skills", { skills: [] }], ["skills", { skills: "invalid" }],
+    ["paths", { skills: { paths: "invalid" } }], ["paths", { skills: { paths: ["valid", 42] } }],
+    ["paths", { skills: { paths: null } }], ["command", { command: null }], ["command", { command: [] }], ["command", { command: "invalid" }],
+  ])("rejects wrong consumed %s type before mutation: %j", async (field, value) => {
+    const f = make();
+    const config = value as Config;
+    const before = structuredClone(config);
+    expect(await rejection(f, config)).toContain(field as string);
+    expect(config).toEqual(before);
+  });
+
+  test.each(["alpha", "sample", "z-last"])("a collision at %s rejects the entire contribution", async (name) => {
+    const f = make();
+    skill(f, "alpha");
+    skill(f, "z-last");
+    const config: Config = { skills: { paths: ["keep"] }, command: { [name]: { template: "Existing command" } } };
+    const before = structuredClone(config);
+    expect(await rejection(f, config)).toContain(name);
+    expect(config).toEqual(before);
+  });
+
+  test.each([["git-commit", ""], ["git-commit", "literal arguments"], ["team-design", ""], ["team-design", "literal arguments"]])("canonical %s body stays byte-for-byte unchanged with arguments %j", async (name, args) => {
+    const f = make("real bodies", "empty");
+    cpSync(join(REPO, "skills", name!), join(f.checkout, "skills", name!), { recursive: true });
+    const file = join(f.checkout, "skills", name!, "SKILL.md");
+    const before = readFileSync(file, "utf8");
+    const config = await load(f);
+    const expanded = nativeExpansion(config.command![name!]!.template, args!);
+    expect(expanded.expanded).toContain(file);
+    expect(expanded.shell).toEqual([]);
+    expect(expanded.files).toEqual([]);
+    expect(readFileSync(file, "utf8")).toBe(before);
+    expect(config.command![name!]!.template).not.toContain(before);
+    expect(before).toContain(name === "git-commit" ? "!`" : "$ARGUMENTS");
+  });
+
+  test("native argument markers remain detectable without processing canonical content", async () => {
+    const f = make();
+    const config = await load(f);
+    const positive = nativeExpansion("$ARGUMENTS", "!`printf literal` @fixture $1");
+    const actual = nativeExpansion(config.command!.sample!.template, "!`printf literal` @fixture $1");
+    expect(positive.shell).toEqual(["printf literal"]);
+    expect(positive.files).toEqual(["fixture"]);
+    expect(actual.shell).toEqual(positive.shell);
+    expect(actual.files).toEqual(positive.files);
+    expect(actual.expanded).toContain("$1");
+    expect(actual.expanded).toContain(join(f.checkout, "skills/sample/SKILL.md"));
+  });
+});

--- a/tests/pre-merge-guard.test.ts
+++ b/tests/pre-merge-guard.test.ts
@@ -141,15 +141,15 @@ function scriptedStubs(opts: {
   } else if (headScript === "extendedRuntime") {
     const original = readFileSync(REAL_SCRIPT, "utf-8");
     const patched = original.replace(
-      "RUNTIME_DIRS=(agents skills hooks)",
-      "RUNTIME_DIRS=(agents skills hooks docs)",
+      "RUNTIME_DIRS=(agents skills hooks opencode)",
+      "RUNTIME_DIRS=(agents skills hooks opencode docs)",
     );
     // Anti-vacuity (docs/testing.md): a renamed array would leave the fixture
     // identical to the committed script, and the test would then pass by
     // measuring nothing.
     if (patched === original) {
       throw new Error(
-        "fixture is inert: RUNTIME_DIRS=(agents skills hooks) not found in " +
+        "fixture is inert: RUNTIME_DIRS=(agents skills hooks opencode) not found in " +
           REAL_SCRIPT,
       );
     }
@@ -489,6 +489,19 @@ describe.if(HAS_JQ)("verdict mapping through the real script", () => {
     );
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("must land with no bump");
+  });
+
+  test("denies an OpenCode adapter-only change without a version bump", () => {
+    const r = runHook(
+      "gh pr merge 5 --squash",
+      scriptedStubs({
+        headVersion: "0.33.2",
+        baseVersion: "0.33.2",
+        changedFiles: "opencode/team.js",
+      }),
+    );
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("cannot merge until version-bump runs at land time");
   });
 
   test("denies on the missing-bump verdict", () => {

--- a/tests/regression-314-foreign-hooks-path.test.ts
+++ b/tests/regression-314-foreign-hooks-path.test.ts
@@ -21,7 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const REPO_ROOT = join(import.meta.dir, "..");
-const HARNESSES = ["claude", "codex", "antigravity"] as const;
+const HARNESSES = ["claude", "codex", "antigravity", "opencode"] as const;
 const COPIED_SCRIPTS = [
   "dev-install",
   "dev-install-claude-pull-hook",

--- a/tests/version-bump-required.test.ts
+++ b/tests/version-bump-required.test.ts
@@ -145,6 +145,14 @@ describe.if(HAS_JQ)("version-bump-required.sh: the runtime-vs-dev bump invariant
     expect(run(dir, { HEAD_SHA: headSha, BASE_SHA: baseSha }).status).not.toBe(0);
   });
 
+  test("OpenCode adapter-only change WITHOUT a bump → violation (non-zero)", () => {
+    const { dir, headSha, baseSha } = scenario({
+      forkVersion: "0.13.1",
+      branchEdits: (d) => writeFile(d, "opencode/team.js", "export default async () => ({});\n"),
+    });
+    expect(run(dir, { HEAD_SHA: headSha, BASE_SHA: baseSha }).status).not.toBe(0);
+  });
+
   // The happy path: runtime change + forward bump.
   test("runtime change WITH a forward bump → ok (exit 0)", () => {
     const { dir, headSha, baseSha } = scenario({


### PR DESCRIPTION
## Summary

Install Team into OpenCode with `script/dev-install opencode` or `dev install opencode`.
The native plugin exposes current checkout skills and explicit commands while preserving the user's model, provider, and permission settings.

## Design Decisions

- Register one owned plugin symlink. Installation does not read native configuration or call OpenCode.
- Use one catalog validator for installation and native loading. Reject ambiguous metadata, unsafe paths, and command collisions before contributing settings.
- Point commands at canonical skill files. Keep guarded utilities out of Team's added model skill paths.
- Protect cooperating install/remove operations with an atomic lock. Refuse foreign files and links.

## Changes

- Add the native OpenCode adapter and install/remove scripts.
- Add OpenCode to aggregate dispatch and `dev.yml` commands.
- Document configuration paths, refresh behavior, recovery, native preprocessing, and support limits.
- Classify `opencode/` as distributed runtime. Keep version assignment at merge time.

## How to Verify

- `bun test`: 2,558 passed, four existing conditional skips, zero failures after rebasing onto current main.
- Focused catalog/lifecycle checks: 117 passed.
- Typecheck, ShellCheck, Claude plugin validation, and the Ruby 3.3.6 Jekyll build passed.
- OpenCode 1.18.20 in disposable profiles: 87 unguarded skills and 91 canonical commands. Native checks covered refresh, collisions, malformed configuration, preserved model/provider/permissions, and removal.
- Native verification used isolated configuration and no model calls. Paid behavioral evaluations were not run locally.

## Review notes

Full pipeline execution, specialist dispatch, reviewer isolation, and hooks remain unverified on OpenCode. `/reflect` does not support OpenCode sessions.

[design-review-9] The design's actual `git-commit` expansion claim is source-backed inference. The saved executable probe used a synthetic template.

[ux-reviewer] Add concrete commands for inspecting resolved skill locations and command templates to `docs/cross-host-portability.md:559`.

Before the rebase, code review returned APPROVE. Security, verification, native UX, and documentation reviews passed. The rebase changed only changelog context in the feature patch. The full suite, static checks, and native checks passed again after the rebase.

Claude's weekly quota prevented native Claude reviews. Fresh Codex reviewers used a sandbox that blocked source writes. External Antigravity returned no output in both code rounds.

[cross-model-notes]

> **Design round 1**
> ### Cross-model disposition
> 
> #### codex
> 
> - **Verified, blocking:** Configuration mutation and incomplete command-collision coverage, as above.
> - **Refuted for 1.18.20:** Malformed global JSON returned exit 1 (`.context/native-api-findings.md:21`). Dev-source fallback remains a compatibility caveat. **Confidence: high — recorded native evidence outranks the snapshot.**
> 
> #### agy
> 
> - **Verified omission, non-blocking:** Missing base-directory instructions. **Unverifiable:** claimed inevitable runtime failure without them.
> - **Refuted as a blocker:** Whole-contribution rejection is intentional. The design requires validation before mutation and detects ignored plugin failures (`6-design.md:120–129`, `182`). **Confidence: high — explicit failure policy.**
> - **Verified scan structure; refuted necessity of replacement:** Individual paths trigger separate scans (`skill-index.ts:211–220`). No performance measurement establishes a problem. Permission rewriting contradicts the chosen preservation constraint (`6-design.md:106–111`). **Confidence: high — source and decision agree.**
> - **Verified, accepted risk:** Native validation can involve unrelated plugins (`6-design.md:203`). The cited dependency failure logs a warning (`config.ts:463–469`), so inevitable rollback is unproven. **Confidence: moderate — dev-source evidence only.**
> - **Refuted as a design blocker:** Parent creation is routine implementation detail covered by the cited installer pattern (`script/dev-install-antigravity:58`). **Confidence: high — pattern explicitly creates parents.**
> - **Refuted:** Omitting the bumper’s descriptive directory list does not bypass versioning. Its authoritative decision uses the classifier (`.claude/skills/version-bump/SKILL.md:110–112`), which the design updates at line 134. **Confidence: high — explicit control flow.**
> - **Verified, already addressed:** Methodology commands remain visible (`command-index.ts:136`, `6-design.md:143`, `193`). **Confidence: high for captured source.**
> 


> **Design round 2**
> ### Cross-model disposition
> 
> **codex**
> 
> - **Duplicate skills:** Verified, adopted as non-blocking above. The design already accepts host precedence limits, so universal collision prevention is unnecessary.
> - **Uninstall race:** Verified, adopted as blocking above.
> - **Smoke isolation:** Verified, adopted as blocking above.
> 
> **agy**
> 
> - **Runtime fixture:** Verified, adopted as non-blocking above. Existing coverage updates and `bun test` are already required.
> - **Harness display map:** Verified, adopted as non-blocking above.
> - **Node dependency:** Refuted as a compatibility defect. `package.json:8` does not prohibit Node, and `script/dev-install-codex:82` already uses it. **Confidence: high**—Bun-only lifecycle support is not an existing contract.
> - **Guarded-command indirection:** Refuted as blocking. `6-design.md:117` explicitly preserves user restrictions, and native probes establish command discovery. Embedding bodies is an alternative. **Confidence: moderate**—model execution remains untested.
> - **Plugin exports:** Loader restriction verified at `plugin-loader.ts:103`, but the design requires no invalid exports. Refuted as an existing design defect. **Confidence: high**—the claimed failure depends on an unspecified implementation choice.
> - **Methodology menu exposure:** Verified and already addressed at `6-design.md:152`. **Confidence: high**—captured `command-index.ts:136` registers all discovered skills.
> 


> **Design round 3**
> ### Cross-model disposition
> 
> **codex**
> 
> - Recursive discovery: verified, blocking.
> - Duplicate catalog names: verified, non-blocking.
> 
> **agy**
> 
> - Missing dispatcher fixture: verified, blocking.
> - Missing lock parent: verified, blocking. Creating directories during uninstall is a possible workaround, not prescribed behavior.
> - Broad collision rejection: verified behavior, refuted as an accidental or silent defect. Design lines 114–117 deliberately reject partial registration, and line 143 requires diagnostics. **Confidence: high**—the policy is explicit.
> - Embedded command bodies: verified as a non-blocking improvement. Permission-free execution remains unverified.
> - Methodology menu exposure: verified, already documented at design line 162. **Confidence: high**—the native command loop has no visibility-flag check.
> 


> **Design round 4**
> ### Cross-model disposition
> 
> #### codex
> Verified and adopted as blocking: the support statement must disclose `/reflect` incompatibility. Evidence cited above.
> 
> #### agy
> Skipped: supplied review contained no output.
> 


> **Design round 5**
> ### Cross-model disposition
> 
> **codex**
> 
> - **Verified, Blocking:** Template expansion finding adopted above. Release-specific behavior remains unverified.
> 
> **agy**
> 
> - **Collision rejection — refuted as blocking:** Deliberate whole-catalog policy at `6-design.md:127–130`; logged-and-ignored plugin failure explicitly addressed at `:157` and `:241`. **Confidence: high**, design and loader agree.
> - **Stale locks — refuted as missing recovery:** Manual recovery explicitly required at `6-design.md:87` and tested at `:211`. Replacement alone does not preserve the stated ownership guarantee. **Confidence: high**, recovery is specified.
> - **External reads — refuted as inevitable failure:** Native default is `ask`, not `deny` (`agent.ts:122–124`). Permission-gated reads are intentional at `6-design.md:134`. **Confidence: high**, source contradicts automatic failure.
> - **Node prerequisite — refuted as regression:** Existing installers already invoke Node (`script/dev-install-claude:78`, `script/dev-install-codex:82`). **Confidence: high**, direct source evidence.
> - **Documentation parity — refuted:** Assertions check inclusion, not exact command count (`tests/docs-install-parity.test.ts:32`). Design explicitly requires parity additions at `:184`. **Confidence: high**, additional commands do not invalidate existing assertions.
> - **Methodology menu exposure — verified, non-blocking:** Native indexing ignores this flag (`command-index.ts:134`); design documents the limitation at `:181`. **Confidence: high**, source and design agree.
> 


> **Design round 6**
> ### Cross-model disposition
> 
> #### codex
> 
> - **Verified, adopted as blocking:** Skill-body shell expansion bypasses the proposed path validation. Evidence appears above. Confidence: **high**—direct source confirmation.
> 
> #### agy
> 
> - **Verified with qualification, included in the blocker:** Native replacement also processes body placeholders (`prompt.ts:1383–1391`). Ordinary argument substitution can be intentional. However, empty arguments erase `$ARGUMENTS` references that `skills/team-design/SKILL.md:32` subsequently instructs the model to bind after discovery. Confidence: **high**—replacement and affected instructions are explicit.
> - **Refuted as a required change:** Whole-catalog collision rejection is deliberate, with partial registration explicitly rejected (`6-design.md:134–137`). Prefixing is an alternative preference. Confidence: **high**—the design records the policy and reason.
> - **Refuted:** The harness-parity test compares dynamically extracted sets, without a fixed three-host expectation (`tests/dev-install-antigravity.test.ts:316–330`). Coordinated dispatcher and `dev.yml` changes satisfy it. Confidence: **high**—assertions inspected.
> - **Refuted:** Documentation updates do not require removing guarded names. The existing test remains valid (`tests/guarded-skill-prose.test.ts:76`). Confidence: **high**—no proposed edit violates that contract.
> - **Refuted:** Existing-directory canonicalization can use shell builtins `cd -P` and `pwd -P`. Also, `6-design.md:162` exempts uninstall from OpenCode, not Node.js. Confidence: **high**—neither alleged constraint prevents implementation.
> - **Verified:** Methodology skills remain command-visible (`command-index.ts:134–154`), matching `6-design.md:190`. Confidence: **high**—the indexing loop ignores `user-invocable`.
> 


> **Design round 7**
> ### Cross-model disposition
> 
> **codex**
> 
> - **Argument execution: verified, blocking.** Evidence above confirms the contradiction. The probe establishes execution, though it does not configure an explicit shell-deny policy.
> - **Collision rejection: behavior verified, blocking classification refuted.** [6-design.md:136–138](/Users/matthew/conductor/workspaces/team/lisbon/docs/plans/2026-09-10-opencode-install/6-design.md:136) explicitly chooses complete registration or actionable refusal. Namespacing is an alternative, not a demonstrated correctness requirement. **Confidence: high** — the failure policy is explicit.
> 
> **agy**
> 
> Skipped: supplied result reports no output.
> 


> **Design round 8**
> ### Cross-model disposition
> 
> - **codex:** Verified and adopted as blocking: the documented permission guarantee excludes an enabled access path.
> - **agy:** Skipped because it produced no output.
> 


> **Design round 9**
> ### Cross-model disposition
> 
> - **codex:** No concrete findings supplied to adopt or refute. Its reported review activity remains unverifiable.
> - **agy:** Skipped because no output was supplied.
> 
> Confidence: high on these dispositions; they match the supplied external input.
>

> **Code round 1**
>
> ### Cross-model disposition
>
> - **codex:** supplied output identified no defects. Independent verification found the issue above.
> - **agy:** unavailable review evidence because it returned no output.
> - Runner not repeated. No external instructions followed.
>
> Confidence: **high** about supplied-output disposition, based on the user-provided records.

> **Code round 2**
>
> ### Cross-model disposition
>
> - **codex:** supplied output contained no findings. Nothing adopted, refuted, or left unverifiable.
> - **agy:** skipped because it returned no output.
> - Runner not repeated. External output did not determine this verdict.
>
> Confidence: **high** about the supplied output’s disposition; no independent claim about vendor review coverage.

## References

- Issue: https://github.com/bostonaholic/team/issues/364
- Local design artifact: `docs/plans/2026-09-10-opencode-install/6-design.md` (not committed).
- Local plan artifact: `docs/plans/2026-09-10-opencode-install/8-plan.md` (not committed).

Closes #364
