### PR TITLE
docs(install): document three install methods per harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,34 @@ Team installs on Claude Code, Codex CLI, Antigravity CLI, and OpenCode. The full
 
 ## Install
 
-Team installs from one local checkout using each host's native plugin mechanism. Pick yours.
+Each host installs Team through its own plugin mechanism. Every section below
+covers the same three methods, so a method missing on a host says so instead of
+leaving you to find out. Pick yours.
 
 <details>
 <summary><strong>Claude Code</strong></summary>
+
+#### Native plugin installation
+
+```bash
+claude plugin marketplace add bostonaholic/team
+claude plugin install team@team-dev
+```
+
+The first command clones this repo as a marketplace; the second installs from
+it. Skills register as slash commands (`/team`, `/shipit`), and agents and hooks
+load with them.
+
+#### Local git checkout installation
 
 ```bash
 claude plugin marketplace add /path/to/team
 claude plugin install team@team-dev
 ```
 
-The first command registers the checkout as a marketplace; the second installs
-from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
-hooks load with them.
+Same two commands against a clone on disk. Both sources declare the marketplace
+name `team-dev`, so Claude Code holds one or the other, never both: remove the
+registered one before adding the other.
 
 Developing Team itself? Run the loop Claude Code documents for local plugins:
 
@@ -77,10 +92,34 @@ claude plugin update team@team-dev
 The order matters. `plugin update` reads the cached catalog, so on its own it
 reports nothing to do.
 
+#### Live development installation
+
+```bash
+claude --plugin-dir /path/to/team
+```
+
+That loads the directory as the plugin for that session only, with no
+marketplace registration, no cachebuster, and no copy, so the next session picks
+up whatever is on disk. It leaves your installed copy untouched, which also
+makes it the way to try a worktree or a branch you have not installed. Run
+`script/dev-install claude` when you want the change in every session.
+
 </details>
 
 <details>
 <summary><strong>Codex CLI</strong></summary>
+
+#### Native plugin installation
+
+```bash
+codex plugin marketplace add bostonaholic/team
+codex plugin add team@team-dev
+```
+
+The first command registers this repo as a Git marketplace; the second installs
+from it.
+
+#### Local git checkout installation
 
 ```bash
 codex plugin marketplace add /path/to/team
@@ -117,10 +156,25 @@ directory. Keeping that link alongside a plugin install registers every skill
 twice, which halves the description budget Codex renders each one with. Both
 `script/dev-install codex` and `script/dev-uninstall codex` remove it for you.
 
+#### Live development installation
+
+Not supported by Codex CLI. The CLI has no session-scoped plugin load, so
+`script/dev-install codex` and a new thread are the whole loop after an edit.
+[openai/codex#40457](https://github.com/openai/codex/issues/40457) tracks the
+request.
+
 </details>
 
 <details>
 <summary><strong>Antigravity CLI</strong></summary>
+
+#### Native plugin installation
+
+Not supported by Antigravity CLI. `agy plugin install` takes a directory, and a
+remote target fails with `install target must be a directory`. Clone the repo
+and use the method below.
+
+#### Local git checkout installation
 
 ```bash
 agy plugin install /path/to/team
@@ -133,17 +187,27 @@ so it installs as a native Antigravity plugin — all skills and all 13 agents.
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
 install copies the checkout, so upgrading means installing again.
 
-Developing Team itself? The install copies, so link your checkout instead:
+#### Live development installation
 
 ```bash
 script/dev-install antigravity
 script/dev-uninstall antigravity
 ```
 
+This links the checkout into Antigravity's plugin directory instead of copying
+it, so edits are live and the next session picks them up.
+
 </details>
 
 <details>
 <summary><strong>OpenCode</strong></summary>
+
+#### Native plugin installation
+
+Not supported by OpenCode. Team publishes no package for it; the plugin is
+`opencode/team.js` in this repo, registered from a checkout.
+
+#### Local git checkout installation
 
 Requires **Node.js** for registration/removal and **OpenCode** for use. From a
 local Team checkout or linked Git worktree:
@@ -181,6 +245,12 @@ scripts.
 A busy or stale `plugins/team.js.lock` stops either operation. Confirm no
 install/uninstall process remains, then manually remove that empty lock directory
 with `rmdir` and rerun. Team never breaks locks automatically.
+
+#### Live development installation
+
+The install above is already the live one: registration links the checkout
+rather than copying it, so restarting OpenCode is all an edit needs. There is no
+separate command and nothing to reinstall.
 
 **Supported:** native registration, skill discovery, canonical file-reading
 commands, and this lifecycle. Full QRSPI execution, specialist/nested dispatch,

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,21 +68,35 @@ company-significant work from problem definition through measured outcomes.
 
 ## Install
 
-Team installs from one local checkout using each host's native plugin mechanism.
-The full pipeline runs on Claude Code, Codex CLI, and Antigravity CLI. OpenCode
-support covers native skill/command discovery and installation. Execution limits
-are listed beside setup. Pick yours.
+Each host installs Team through its own plugin mechanism. Every section below
+covers the same three methods, so a method missing on a host says so instead of
+leaving you to find out. The full pipeline runs on Claude Code, Codex CLI, and
+Antigravity CLI. OpenCode support covers native skill/command discovery and
+installation. Execution limits are listed beside setup. Pick yours.
 
 ### Claude Code
+
+#### Native plugin installation
+
+```bash
+claude plugin marketplace add bostonaholic/team
+claude plugin install team@team-dev
+```
+
+The first command clones this repo as a marketplace; the second installs from
+it. Skills register as slash commands (`/team`, `/shipit`), and agents and hooks
+load with them.
+
+#### Local git checkout installation
 
 ```bash
 claude plugin marketplace add /path/to/team
 claude plugin install team@team-dev
 ```
 
-The first command registers the checkout as a marketplace; the second installs
-from it. Skills register as slash commands (`/team`, `/shipit`), and agents and
-hooks load with them.
+Same two commands against a clone on disk. Both sources declare the marketplace
+name `team-dev`, so Claude Code holds one or the other, never both: remove the
+registered one before adding the other.
 
 Developing Team itself? Run the loop Claude Code documents for local plugins:
 
@@ -137,6 +151,18 @@ claude plugin update team@team-dev
 The order matters. `plugin update` reads the cached catalog, so on its own it
 reports nothing to do.
 
+#### Live development installation
+
+```bash
+claude --plugin-dir /path/to/team
+```
+
+That loads the directory as the plugin for that session only, with no
+marketplace registration, no cachebuster, and no copy, so the next session picks
+up whatever is on disk. It leaves your installed copy untouched, which also
+makes it the way to try a worktree or a branch you have not installed. Run
+`script/dev-install claude` when you want the change in every session.
+
 Then run a phase end-to-end:
 
 ```bash
@@ -150,6 +176,18 @@ For a focused bug fix that skips the QRSPI ceremony:
 ```
 
 ### Codex CLI
+
+#### Native plugin installation
+
+```bash
+codex plugin marketplace add bostonaholic/team
+codex plugin add team@team-dev
+```
+
+The first command registers this repo as a Git marketplace; the second installs
+from it.
+
+#### Local git checkout installation
 
 ```bash
 codex plugin marketplace add /path/to/team
@@ -186,7 +224,22 @@ directory. Keeping that link alongside a plugin install registers every skill
 twice, which halves the description budget Codex renders each one with. Both
 `script/dev-install codex` and `script/dev-uninstall codex` remove it for you.
 
+#### Live development installation
+
+Not supported by Codex CLI. The CLI has no session-scoped plugin load, so
+`script/dev-install codex` and a new thread are the whole loop after an edit.
+[openai/codex#40457](https://github.com/openai/codex/issues/40457) tracks the
+request.
+
 ### Antigravity CLI
+
+#### Native plugin installation
+
+Not supported by Antigravity CLI. `agy plugin install` takes a directory, and a
+remote target fails with `install target must be a directory`. Clone the repo
+and use the method below.
+
+#### Local git checkout installation
 
 ```bash
 agy plugin install /path/to/team
@@ -199,14 +252,24 @@ installs with it. `agy plugin uninstall team` removes it.
 Skills arrive under **bare names** — ask for `shipit`, not `team:shipit`. The
 install copies the checkout, so upgrading means installing again.
 
-Developing Team itself? The install copies, so link your checkout instead:
+#### Live development installation
 
 ```bash
 script/dev-install antigravity
 script/dev-uninstall antigravity
 ```
 
+This links the checkout into Antigravity's plugin directory instead of copying
+it, so edits are live and the next session picks them up.
+
 ### OpenCode
+
+#### Native plugin installation
+
+Not supported by OpenCode. Team publishes no package for it; the plugin is
+`opencode/team.js` in this repo, registered from a checkout.
+
+#### Local git checkout installation
 
 Requires **Node.js** for registration/removal and **OpenCode** for use. From a
 local Team checkout or linked Git worktree:
@@ -244,6 +307,12 @@ scripts.
 A busy or stale `plugins/team.js.lock` stops either operation. Confirm no
 install/uninstall process remains, then manually remove that empty lock directory
 with `rmdir` and rerun. Team never breaks locks automatically.
+
+#### Live development installation
+
+The install above is already the live one: registration links the checkout
+rather than copying it, so restarting OpenCode is all an edit needs. There is no
+separate command and nothing to reinstall.
 
 **Supported:** native registration, skill discovery, canonical file-reading
 commands, and this lifecycle. Full QRSPI execution, specialist/nested dispatch,

--- a/tests/docs-install-parity.test.ts
+++ b/tests/docs-install-parity.test.ts
@@ -2,9 +2,14 @@
 //
 // L2 tripwire (free, deterministic): README.md and docs/index.md are the two
 // self-contained install surfaces (GitHub and team.bostonaholic.dev). Each
-// must carry all fifteen install/uninstall command strings verbatim, so a reader
+// must carry all eighteen install/uninstall command strings verbatim, so a reader
 // on either surface can install and uninstall on every host without leaving
 // the page.
+//
+// Each surface also documents the same three methods for every host — native,
+// local checkout, live development — so a method a host lacks is stated rather
+// than omitted. Four hosts times three methods is twelve headings per surface,
+// and the three a host lacks say "Not supported by".
 //
 // Defensive reads: a missing file → "" so content assertions FAIL cleanly
 // rather than throwing ENOENT (the mechanical gate rejects crashes).
@@ -19,20 +24,29 @@ const REPO_ROOT = process.cwd();
 const README_MD = join(REPO_ROOT, "README.md");
 const DOCS_INDEX_MD = join(REPO_ROOT, "docs", "index.md");
 
+const HOST_COUNT = 4;
+
 function readIf(path: string): string {
   return existsSync(path) ? read(path) : "";
 }
 
-describe("docs-install-parity: README.md and docs/index.md each carry all fifteen install/uninstall command strings verbatim", () => {
-  test("README.md carries all fifteen install/uninstall command strings verbatim", () => {
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("docs-install-parity: README.md and docs/index.md each carry all eighteen install/uninstall command strings verbatim", () => {
+  test("README.md carries all eighteen install/uninstall command strings verbatim", () => {
     const readme = readIf(README_MD);
     // Guard: a missing README must fail cleanly, not vacuously pass.
     expect(readme.length).toBeGreaterThan(0);
 
+    expect(readme).toContain("claude plugin marketplace add bostonaholic/team");
     expect(readme).toContain("claude plugin marketplace add /path/to/team");
     expect(readme).toContain("claude plugin install team@team-dev");
+    expect(readme).toContain("claude --plugin-dir /path/to/team");
     expect(readme).toContain("script/dev-install claude");
     expect(readme).toContain("script/dev-uninstall claude");
+    expect(readme).toContain("codex plugin marketplace add bostonaholic/team");
     expect(readme).toContain("codex plugin marketplace add /path/to/team");
     expect(readme).toContain("codex plugin add team@team-dev");
     expect(readme).toContain("codex plugin remove team@team-dev");
@@ -46,15 +60,18 @@ describe("docs-install-parity: README.md and docs/index.md each carry all fiftee
     expect(readme).toContain("script/dev-uninstall opencode");
   });
 
-  test("docs/index.md carries all fifteen install/uninstall command strings verbatim", () => {
+  test("docs/index.md carries all eighteen install/uninstall command strings verbatim", () => {
     const docsIndex = readIf(DOCS_INDEX_MD);
     // Guard: a missing docs page must fail cleanly, not vacuously pass.
     expect(docsIndex.length).toBeGreaterThan(0);
 
+    expect(docsIndex).toContain("claude plugin marketplace add bostonaholic/team");
     expect(docsIndex).toContain("claude plugin marketplace add /path/to/team");
     expect(docsIndex).toContain("claude plugin install team@team-dev");
+    expect(docsIndex).toContain("claude --plugin-dir /path/to/team");
     expect(docsIndex).toContain("script/dev-install claude");
     expect(docsIndex).toContain("script/dev-uninstall claude");
+    expect(docsIndex).toContain("codex plugin marketplace add bostonaholic/team");
     expect(docsIndex).toContain("codex plugin marketplace add /path/to/team");
     expect(docsIndex).toContain("codex plugin add team@team-dev");
     expect(docsIndex).toContain("codex plugin remove team@team-dev");
@@ -66,5 +83,19 @@ describe("docs-install-parity: README.md and docs/index.md each carry all fiftee
     expect(docsIndex).toContain("script/dev-uninstall antigravity");
     expect(docsIndex).toContain("script/dev-install opencode");
     expect(docsIndex).toContain("script/dev-uninstall opencode");
+  });
+
+  test.each([
+    ["README.md", README_MD],
+    ["docs/index.md", DOCS_INDEX_MD],
+  ])("%s documents all three install methods for every host", (_label, path) => {
+    const surface = readIf(path);
+    expect(surface.length).toBeGreaterThan(0);
+
+    expect(occurrences(surface, "#### Native plugin installation")).toBe(HOST_COUNT);
+    expect(occurrences(surface, "#### Local git checkout installation")).toBe(HOST_COUNT);
+    expect(occurrences(surface, "#### Live development installation")).toBe(HOST_COUNT);
+    // Codex has no live load; Antigravity and OpenCode have no remote source.
+    expect(occurrences(surface, "Not supported by")).toBe(3);
   });
 });


### PR DESCRIPTION
## Why

The install docs told you how to install from a local checkout on each host and left the other methods to inference. A reader could not tell whether installing straight from GitHub was possible on their host, or whether they had to reinstall after every skill edit. Three of those answers are "no", and nothing said so.

## What

Every host section in `README.md` and `docs/index.md` now covers the same three methods in the same order: native plugin installation, local git checkout installation, live development installation. A host that lacks one says "Not supported by <harness>." rather than omitting the heading.

New content, all verified on this machine against a throwaway `HOME` so no real install state was touched:

- Claude Code and Codex CLI install from GitHub. Claude clones the repo as a marketplace; Codex registers it as a Git marketplace. Both then install `team@team-dev`.
- Claude Code loads a checkout for one session with `claude --plugin-dir`, with no registration, no cachebuster, and no copy.
- Antigravity CLI has no remote install: `agy plugin install` rejects a non-directory target.
- OpenCode has no published package, and its checkout install is already the live one, since registration links rather than copies.
- Codex CLI has no session-scoped load. The reinstall-and-new-thread loop is the whole story, and [openai/codex#40457](https://github.com/openai/codex/issues/40457) tracks the request.

Also documents a collision a reader would otherwise discover the hard way: the GitHub and local-checkout sources both declare the marketplace name `team-dev`, so Claude Code and Codex hold one or the other, never both.

Dev-only change, so no version bump. `.github/scripts/version-bump-required.sh` agrees: `runtime_changed=false bumped=false`.

## Test plan

- `tests/docs-install-parity.test.ts` grew from fifteen pinned command strings to eighteen, adding the two `bostonaholic/team` marketplace commands and `claude --plugin-dir`. A new structural case asserts each surface carries all twelve method headings (four hosts times three methods) and exactly three "Not supported by" statements, so dropping a method from one surface fails the gate.
- That file passes 4/4, and the four install script test files pass 50/50.
- Full suite: 2565 pass, 1 fail. The failure is `tests/dev-install-pull-hooks.test.ts` → "a merge-based pull reruns the Claude installer", which timed out at 5002ms against its 5000ms limit. It passes 6/6 when that file runs alone, and this branch changes only markdown and one test file. Pre-existing flake, not introduced here — worth a separate look at how close that limit runs.
- Both native install paths were exercised for real: Claude Code cloned and installed `team@team-dev`, and Codex installed 0.104.0, each under a sandboxed `HOME` that was deleted afterward. The Antigravity refusal is its actual error text. The OpenCode claim is the one inference in the set, read from `opencode/team.js` and the lifecycle docs, because `opencode` is not installed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
