### PR TITLE
refactor(dev-install): run pull hooks for every harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The clone-local pull hooks now re-run `script/dev-install` for every harness, and install for every target rather than only `claude`.** A merge or rebase pull refreshes whichever harnesses that checkout installed, so a Codex-only install gets the same auto-refresh Claude had. Because the hooks serve the whole clone, only a full `script/dev-uninstall` removes them; a targeted one leaves them for the harnesses that remain. The hook file moves from `script/dev-install-claude-pull-hook` to `script/dev-install-pull-hook`. **What this asks of you:** nothing; re-running `script/dev-install` replaces the old hook.
+
 ## [0.104.0] - 2026-09-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ at the latest version" when it has not moved, so the install stamps a
 installs, restores the manifests, and prunes the copy the last run left. The
 install is a copy either way, so **re-run it after changing a skill.**
 
-It also adds clone-local hooks that re-run it after merge and rebase pulls.
+It also adds clone-local hooks that re-run the install after merge and rebase pulls.
 Existing non-Team hooks and a `core.hooksPath` outside the clone are never
 overwritten: the install still completes, and reports that it skipped the hooks
 and how to wire them up yourself. Remove the install and Team-owned hooks with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ at the latest version" when it has not moved, so the install stamps a
 installs, restores the manifests, and prunes the copy the last run left. The
 install is a copy either way, so **re-run it after changing a skill.**
 
-It also adds clone-local hooks that re-run it after merge and rebase pulls.
+It also adds clone-local hooks that re-run the install after merge and rebase pulls.
 Existing non-Team hooks and a `core.hooksPath` outside the clone are never
 overwritten: the install still completes, and reports that it skipped the hooks
 and how to wire them up yourself. Remove the install and Team-owned hooks with:

--- a/script/dev-install
+++ b/script/dev-install
@@ -9,20 +9,19 @@ set -euo pipefail
 # Each harness has its own script beside this one, because each host installs
 # a plugin its own way. Adding a harness means adding `dev-install-<name>` and
 # `dev-uninstall-<name>`, then listing it below.
-# The Claude target also installs clone-local hooks that reinstall after
-# merge-based and rebase-based pulls. Claude Code and Codex both install by
-# copying, so a pull moves the checkout without moving what either host serves;
-# the hooks exist so that at least one host stays current without being asked.
-# They are Claude-only because Claude Code is the host that runs the pipeline,
-# so a stale copy there is the one that costs a run. Codex and Antigravity are
-# re-run by hand. That asymmetry is an implementation detail — keep it out of
-# the output the user reads.
+# Every target also installs clone-local hooks that re-run the whole dev
+# install after merge-based and rebase-based pulls. Claude Code and Codex
+# install by copying, so a pull moves the checkout without moving what either
+# host serves; the hooks keep every installed harness current without being
+# asked. The hooks are host-neutral, so they belong to the install rather than
+# to any one harness — keep harness names out of the skip message the user
+# reads.
 
 HARNESSES=(claude codex antigravity opencode)
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(dirname "$HERE")"
 HOOK_MARKER="# Managed by Team dev install."
-PULL_HOOK_SOURCE="${HERE}/dev-install-claude-pull-hook"
+PULL_HOOK_SOURCE="${HERE}/dev-install-pull-hook"
 
 resolve_pull_hooks_dir() {
   local common_dir hooks_dir
@@ -66,9 +65,9 @@ preflight_pull_hooks() {
 
 report_skipped_pull_hooks() {
   # Names the command the user actually typed, so the remedy never asks them to
-  # care that Claude is the only harness a pull can strand.
+  # care which harness installs by copying.
   echo "Skipped this clone's Git hooks (see the warning above)." >&2
-  echo "Every targeted harness installed. To keep the install current, either" >&2
+  echo "Every requested harness installed. To keep the install current, either" >&2
   echo "re-run '${INVOCATION}' after each pull, or call it from your own" >&2
   echo "post-merge and post-rewrite hooks." >&2
 }
@@ -113,19 +112,12 @@ case "${1:-}" in
     ;;
 esac
 
-CLAUDE_TARGETED=false
-for harness in "${targets[@]}"; do
-  if [ "$harness" = "claude" ]; then
-    CLAUDE_TARGETED=true
-    break
-  fi
-done
 # Decide the pull hooks before the harness output scrolls by, but never gate the
-# install on them: they only re-run the Claude installer after a pull, so a
-# hooks surface Team cannot own is a skip, not a failure.
+# install on them: they only re-run the installer after a pull, so a hooks
+# surface Team cannot own is a skip, not a failure.
 # See skills/principle-optimization-never-dependency/SKILL.md.
 PULL_HOOKS_OWNED=false
-if [ "$CLAUDE_TARGETED" = true ] && preflight_pull_hooks; then
+if preflight_pull_hooks; then
   PULL_HOOKS_OWNED=true
 fi
 
@@ -143,8 +135,6 @@ if [ ${#failed[@]} -gt 0 ]; then
   exit 1
 fi
 
-if [ "$CLAUDE_TARGETED" = true ]; then
-  if [ "$PULL_HOOKS_OWNED" = false ] || ! install_pull_hooks; then
-    report_skipped_pull_hooks
-  fi
+if [ "$PULL_HOOKS_OWNED" = false ] || ! install_pull_hooks; then
+  report_skipped_pull_hooks
 fi

--- a/script/dev-install-pull-hook
+++ b/script/dev-install-pull-hook
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Managed by Team dev install.
-# Re-run the Claude installer after merge pulls and rebase pulls.
+# Re-run the dev installer after merge pulls and rebase pulls.
 [ "${TEAM_DEV_INSTALL_HOOK_RUNNING:-}" != "1" ] || exit 0
 
 HOOK_NAME="${0##*/}"
@@ -22,4 +22,4 @@ ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   exit 1
 }
 
-TEAM_DEV_INSTALL_HOOK_RUNNING=1 "$ROOT/script/dev-install" claude
+TEAM_DEV_INSTALL_HOOK_RUNNING=1 "$ROOT/script/dev-install"

--- a/script/dev-uninstall
+++ b/script/dev-uninstall
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Dev uninstall, across the harnesses Team supports. Mirrors script/dev-install,
-# including removal of the clone-local hooks installed for Claude.
+# including removal of the clone-local pull hooks.
 #
 #   script/dev-uninstall          every harness
 #   script/dev-uninstall codex    just that one
@@ -14,9 +14,11 @@ HOOK_MARKER="# Managed by Team dev install."
 
 remove_pull_hooks() {
   local common_dir hooks_dir hook_name hook_path
-  common_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-common-dir) || {
-    echo "Error: cannot resolve this checkout's common Git directory." >&2
-    return 1
+  # Removing the hooks is best-effort: a checkout whose Git directory cannot be
+  # resolved, or a hooks surface Team never owned, must not fail the uninstall.
+  common_dir=$(git -C "$PLUGIN_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+    echo "Warning: cannot resolve this checkout's common Git directory; leaving Git hooks alone." >&2
+    return 0
   }
   hooks_dir="${common_dir}/hooks"
 
@@ -34,8 +36,10 @@ remove_pull_hooks() {
 case "${1:-}" in
   "")
     targets=("${HARNESSES[@]}")
+    FULL_UNINSTALL=true
     ;;
   *)
+    FULL_UNINSTALL=false
     for known in "${HARNESSES[@]}"; do
       [ "$1" = "$known" ] && targets=("$1") && break
     done
@@ -45,14 +49,6 @@ case "${1:-}" in
     fi
     ;;
 esac
-
-CLAUDE_TARGETED=false
-for harness in "${targets[@]}"; do
-  if [ "$harness" = "claude" ]; then
-    CLAUDE_TARGETED=true
-    break
-  fi
-done
 
 failed=()
 for harness in "${targets[@]}"; do
@@ -68,6 +64,8 @@ if [ ${#failed[@]} -gt 0 ]; then
   exit 1
 fi
 
-if [ "$CLAUDE_TARGETED" = true ]; then
+# The pull hooks serve the whole clone, so a targeted uninstall leaves them for
+# the harnesses that remain. Only a full uninstall removes them.
+if [ "$FULL_UNINSTALL" = true ]; then
   remove_pull_hooks
 fi

--- a/tests/dev-install-opencode.test.ts
+++ b/tests/dev-install-opencode.test.ts
@@ -107,7 +107,7 @@ function dispatcher(f: Fixture, operation: "install" | "uninstall", args: string
     write(path, `#!/bin/sh\nprintf '%s\\n' '${host}' >> '${calls}'\nexit ${host === fail ? 7 : 0}\n`);
     chmodSync(path, 0o755);
   }
-  const hook = join(f.checkout, "script/dev-install-claude-pull-hook");
+  const hook = join(f.checkout, "script/dev-install-pull-hook");
   write(hook, `#!/bin/sh\nprintf 'hook\\n' >> '${calls}'\n`); chmodSync(hook, 0o755);
   const result = spawnSync("/bin/bash", [join(f.checkout, "script", `dev-${operation}`), ...args], { cwd: f.checkout, env: f.env, encoding: "utf8" });
   return { status: result.status ?? -1, output: `${result.stdout}${result.stderr}`, calls: existsSync(calls) ? readFileSync(calls, "utf8").trim().split("\n") : [] };

--- a/tests/dev-install-pull-hooks.test.ts
+++ b/tests/dev-install-pull-hooks.test.ts
@@ -22,8 +22,9 @@ const UNINSTALL_SOURCE = join(REPO_ROOT, "script", "dev-uninstall");
 const PULL_HOOK_SOURCE = join(
   REPO_ROOT,
   "script",
-  "dev-install-claude-pull-hook",
+  "dev-install-pull-hook",
 );
+const HARNESSES = ["claude", "codex", "antigravity", "opencode"] as const;
 const tempDirs: string[] = [];
 
 type Fixture = {
@@ -92,17 +93,19 @@ function newFixture(): Fixture {
     readFileSync(UNINSTALL_SOURCE, "utf8"),
   );
   writeExecutable(
-    join(upstream, "script", "dev-install-claude-pull-hook"),
+    join(upstream, "script", "dev-install-pull-hook"),
     readFileSync(PULL_HOOK_SOURCE, "utf8"),
   );
-  writeExecutable(
-    join(upstream, "script", "dev-install-claude"),
-    '#!/usr/bin/env bash\nprintf "install\\n" >> "$HOME/install-calls"\n',
-  );
-  writeExecutable(
-    join(upstream, "script", "dev-uninstall-claude"),
-    '#!/usr/bin/env bash\nprintf "uninstall\\n" >> "$HOME/uninstall-calls"\n',
-  );
+  for (const harness of HARNESSES) {
+    writeExecutable(
+      join(upstream, "script", `dev-install-${harness}`),
+      `#!/usr/bin/env bash\nprintf "%s\\n" "${harness}" >> "$HOME/install-calls"\n`,
+    );
+    writeExecutable(
+      join(upstream, "script", `dev-uninstall-${harness}`),
+      `#!/usr/bin/env bash\nprintf "%s\\n" "${harness}" >> "$HOME/uninstall-calls"\n`,
+    );
+  }
   writeFileSync(join(upstream, "VERSION"), "one\n");
   git(upstream, "add", "-A");
   git(upstream, "commit", "-q", "-m", "initial");
@@ -134,7 +137,7 @@ function uninstall(fixture: Fixture) {
   return run(
     fixture.checkout,
     join(fixture.checkout, "script", "dev-uninstall"),
-    ["claude"],
+    [],
     fixtureEnv(fixture),
   );
 }
@@ -162,11 +165,11 @@ afterAll(() => {
 });
 
 describe("dev install: refresh after pulls (#312)", () => {
-  test("a merge-based pull reruns the Claude installer", () => {
+  test("a merge-based pull reruns the installer for every harness", () => {
     const fixture = newFixture();
     expect(install(fixture).status).toBe(0);
     expect(statSync(hookPath(fixture, "post-merge")).mode & 0o111).not.toBe(0);
-    expect(installCalls(fixture)).toHaveLength(1);
+    expect(installCalls(fixture)).toEqual(["claude"]);
 
     advanceUpstream(fixture, "two");
     const pull = run(
@@ -177,10 +180,10 @@ describe("dev install: refresh after pulls (#312)", () => {
     );
 
     expect(pull.status).toBe(0);
-    expect(installCalls(fixture)).toHaveLength(2);
+    expect(installCalls(fixture)).toEqual(["claude", ...HARNESSES]);
   });
 
-  test("a rebase-based pull reruns the Claude installer", () => {
+  test("a rebase-based pull reruns the installer for every harness", () => {
     const fixture = newFixture();
     expect(install(fixture).status).toBe(0);
     expect(statSync(hookPath(fixture, "post-rewrite")).mode & 0o111).not.toBe(
@@ -200,7 +203,7 @@ describe("dev install: refresh after pulls (#312)", () => {
     );
 
     expect(pull.status).toBe(0);
-    expect(installCalls(fixture)).toHaveLength(2);
+    expect(installCalls(fixture)).toEqual(["claude", ...HARNESSES]);
   });
 
   // The hooks live in the shared .git/hooks, so a rebase inside a linked
@@ -239,7 +242,7 @@ describe("dev install: refresh after pulls (#312)", () => {
     const first = readFileSync(hookPath(fixture, "post-merge"), "utf8");
     expect(first).toBe(
       readFileSync(
-        join(fixture.checkout, "script", "dev-install-claude-pull-hook"),
+        join(fixture.checkout, "script", "dev-install-pull-hook"),
         "utf8",
       ),
     );
@@ -249,6 +252,24 @@ describe("dev install: refresh after pulls (#312)", () => {
     expect(uninstall(fixture).status).toBe(0);
     expect(existsSync(hookPath(fixture, "post-merge"))).toBe(false);
     expect(existsSync(hookPath(fixture, "post-rewrite"))).toBe(false);
+  });
+
+  // The hooks serve every harness in the clone, so removing one harness must
+  // leave the refresh in place for the others.
+  test("a targeted uninstall leaves the pull hooks", () => {
+    const fixture = newFixture();
+    expect(install(fixture).status).toBe(0);
+
+    const result = run(
+      fixture.checkout,
+      join(fixture.checkout, "script", "dev-uninstall"),
+      ["codex"],
+      fixtureEnv(fixture),
+    );
+
+    expect(result.status).toBe(0);
+    expect(existsSync(hookPath(fixture, "post-merge"))).toBe(true);
+    expect(existsSync(hookPath(fixture, "post-rewrite"))).toBe(true);
   });
 
   // A hooks surface Team does not own is preserved, and the pull-hook refresh

--- a/tests/regression-314-foreign-hooks-path.test.ts
+++ b/tests/regression-314-foreign-hooks-path.test.ts
@@ -1,5 +1,5 @@
 // Regression test for issue #314. A hooks surface Team cannot own must not
-// abort the plugin install. The pull hook re-runs the Claude installer after a
+// abort the plugin install. The pull hook re-runs the dev install after a
 // pull; nothing about installing a harness depends on it, so its absence skips
 // loudly and the install proceeds (principle-optimization-never-dependency).
 //
@@ -24,7 +24,7 @@ const REPO_ROOT = join(import.meta.dir, "..");
 const HARNESSES = ["claude", "codex", "antigravity", "opencode"] as const;
 const COPIED_SCRIPTS = [
   "dev-install",
-  "dev-install-claude-pull-hook",
+  "dev-install-pull-hook",
 ] as const;
 const tempDirs: string[] = [];
 


### PR DESCRIPTION
## Why

The clone-local pull hooks ran `script/dev-install claude`, so a merge or rebase pull refreshed only Claude. Every other harness went stale exactly the same way — Claude Code and Codex install by copying — but the hook never touched them because it was written when Claude was the only host that ran the pipeline.

## What

- The hook now runs `script/dev-install` with no target, so a pull reinstalls every harness that checkout installed.
- Renamed `script/dev-install-claude-pull-hook` → `script/dev-install-pull-hook`, since it is no longer Claude-specific.
- `script/dev-install` installs the hooks for any target, not only `claude` (drops the `CLAUDE_TARGETED` gate).
- `script/dev-uninstall` removes the hooks only on a full (no-arg) uninstall. They serve the whole clone, so a targeted uninstall leaves them for the harnesses that remain. Resolving a non-Git checkout is a warning, not a failure.
- README, `docs/index.md`, and a `[Unreleased]` changelog bullet.

Dev-only change (`script/` is not distributed runtime), so no version bump. `.github/scripts/version-bump-required.sh` agrees: `runtime_changed=false bumped=false`.

## Test plan

- [x] `bun test` — 2567 pass, 4 skip, 0 fail.
- [x] `tsc --noEmit` — clean.
- [x] `shellcheck script/dev-install script/dev-uninstall script/dev-install-pull-hook` — clean.
- [x] `tests/dev-install-pull-hooks.test.ts` asserts a merge pull and a rebase pull each rerun all four installers, a targeted uninstall leaves the hooks, and a full uninstall removes them.